### PR TITLE
Add catalog provider for postgres

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -22,6 +22,7 @@ use skardi::sources::providers::mongo::fts_table_function::register_mongo_fts_ud
 use skardi::sources::providers::sqlx::{register_pg_fts_udtf, register_pg_knn_udtf};
 use skardi::sources::providers::{
     DatasetRegistry, iceberg::register_iceberg_table, lance::register_lance_table,
+    mongo::register_mongo_tables, mysql::register_mysql_tables, sqlite::register_sqlite_tables,
     sqlx::postgres::register_postgres_tables,
 };
 use sources::HierarchyLevel;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -16,6 +16,7 @@ use object_store::azure::MicrosoftAzureBuilder;
 use object_store::gcp::GoogleCloudStorageBuilder;
 use object_store::http::HttpBuilder;
 use serde::Deserialize;
+use skardi::sources::HierarchyLevel;
 use skardi::sources::providers::lance::fts_table_function::register_lance_fts_udtf;
 use skardi::sources::providers::lance::knn_table_function::register_lance_knn_udtf;
 use skardi::sources::providers::mongo::fts_table_function::register_mongo_fts_udtf;
@@ -25,7 +26,6 @@ use skardi::sources::providers::{
     mongo::register_mongo_tables, mysql::register_mysql_tables, sqlite::register_sqlite_tables,
     sqlx::postgres::register_postgres_tables,
 };
-use sources::HierarchyLevel;
 use std::collections::HashMap;
 use std::fmt;
 use std::path::{Path, PathBuf};

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -22,9 +22,9 @@ use skardi::sources::providers::mongo::fts_table_function::register_mongo_fts_ud
 use skardi::sources::providers::sqlx::{register_pg_fts_udtf, register_pg_knn_udtf};
 use skardi::sources::providers::{
     DatasetRegistry, iceberg::register_iceberg_table, lance::register_lance_table,
-    mongo::register_mongo_tables, mysql::register_mysql_tables, sqlite::register_sqlite_tables,
     sqlx::postgres::register_postgres_tables,
 };
+use sources::HierarchyLevel;
 use std::collections::HashMap;
 use std::fmt;
 use std::path::{Path, PathBuf};
@@ -80,6 +80,8 @@ struct LocalDataSource {
     path: Option<String>,
     connection_string: Option<String>,
     options: Option<HashMap<String, String>>,
+    #[serde(default)]
+    hierarchy_level: Option<HierarchyLevel>,
 }
 
 fn resolve_ctx_path(override_path: Option<PathBuf>) -> Result<PathBuf> {
@@ -509,6 +511,7 @@ async fn register_source(
                 source.options.as_ref(),
                 false,
                 Some(dataset_registry),
+                source.hierarchy_level,
             )
             .await
             .with_context(|| format!("Failed to register Postgres '{}'", source.name))?;

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -19,6 +19,7 @@ use thiserror::Error;
 
 use crate::remote_storage::{RemoteStorage, S3Storage};
 pub use skardi::sources::AccessMode;
+pub use skardi::sources::HierarchyLevel;
 
 /// CLI arguments for the Skardi server
 #[derive(Parser, Debug)]
@@ -73,6 +74,9 @@ pub struct DataSource {
     pub schema: Option<HashMap<String, String>>,
     /// Optional format-specific options
     pub options: Option<HashMap<String, String>>,
+    /// Registration hierarchy level for database sources (`None` / omitted → table)
+    #[serde(default)]
+    pub hierarchy_level: Option<HierarchyLevel>,
     /// Access mode: read_only (default) or read_write
     #[serde(default)]
     pub access_mode: AccessMode,
@@ -167,6 +171,12 @@ pub enum ConfigError {
 
     #[error("Write operation not allowed on data source '{table_name}'. The data source is configured with 'read_only' access mode. Set access_mode to 'read_write' to enable write operations.")]
     WriteOperationNotAllowed { table_name: String },
+
+    #[error("Data source '{name}' uses hierarchy_level 'catalog' but also specifies the '{option}' option. In catalog mode use 'allowed_schemas' to filter schemas; 'table' and 'schema' are not allowed.")]
+    CatalogModeConflictingOptions { name: String, option: String },
+
+    #[error("Data source '{name}' has an empty 'allowed_schemas' option. Either omit it to load all schemas, or provide a non-empty comma-separated list such as \"public,analytics\".")]
+    EmptyAllowedSchemas { name: String },
 }
 
 // ============================================================================
@@ -536,6 +546,41 @@ fn validate_data_sources(data_sources: &[DataSource]) -> Result<()> {
             .into());
         }
 
+        // Catalog mode must not mix with per-table / per-schema options
+        if source.source_type == DataSourceType::Postgres
+            && source.hierarchy_level == Some(HierarchyLevel::Catalog)
+        {
+            for conflicting in &["table", "schema"] {
+                if source
+                    .options
+                    .as_ref()
+                    .map(|o| o.contains_key(*conflicting))
+                    .unwrap_or(false)
+                {
+                    return Err(ConfigError::CatalogModeConflictingOptions {
+                        name: source.name.clone(),
+                        option: conflicting.to_string(),
+                    }
+                    .into());
+                }
+            }
+
+            // allowed_schemas, if present, must not be an empty string
+            if let Some(value) = source
+                .options
+                .as_ref()
+                .and_then(|o| o.get("allowed_schemas"))
+            {
+                let has_entry = value.split(',').any(|s| !s.trim().is_empty());
+                if !has_entry {
+                    return Err(ConfigError::EmptyAllowedSchemas {
+                        name: source.name.clone(),
+                    }
+                    .into());
+                }
+            }
+        }
+
         match (&source.source_type, s3_storage.is_remote_path(&source.path)) {
             (DataSourceType::Csv | DataSourceType::Parquet | DataSourceType::Lance, true) => {
                 // Validate S3 configuration for S3 paths
@@ -816,6 +861,7 @@ async fn register_data_source(
                 source.options.as_ref(),
                 source.access_mode.is_read_write(),
                 pg_knn_registry.as_ref(),
+                source.hierarchy_level,
             )
             .await
             .map_err(|e| {

--- a/crates/server/src/handlers.rs
+++ b/crates/server/src/handlers.rs
@@ -948,6 +948,7 @@ query: |
             }),
             access_mode: AccessMode::default(),
             enable_cache: false,
+            hierarchy_level: None,
         };
 
         // Create pipeline that queries the registered data source

--- a/crates/server/src/optimizer_registry.rs
+++ b/crates/server/src/optimizer_registry.rs
@@ -224,6 +224,7 @@ mod tests {
             options: None,
             access_mode: crate::config::AccessMode::default(),
             enable_cache: false,
+            hierarchy_level: None,
         }];
 
         // Should not register Lance functions for CSV-only data sources

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -287,6 +287,7 @@ query: |
             options: None,
             access_mode: AccessMode::default(),
             enable_cache: false,
+            hierarchy_level: None,
         }];
 
         let pipeline = create_test_pipeline().await;

--- a/crates/skardi/src/sources/hierarchy_level.rs
+++ b/crates/skardi/src/sources/hierarchy_level.rs
@@ -1,0 +1,21 @@
+use serde::{Deserialize, Serialize};
+
+/// How much of an upstream database to expose in DataFusion (single table vs whole catalog).
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, Hash, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum HierarchyLevel {
+    /// One table under the default catalog.
+    #[default]
+    Table,
+    /// Whole database as a named catalog (schemas + tables).
+    Catalog,
+}
+
+impl HierarchyLevel {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Table => "table",
+            Self::Catalog => "catalog",
+        }
+    }
+}

--- a/crates/skardi/src/sources/mod.rs
+++ b/crates/skardi/src/sources/mod.rs
@@ -1,6 +1,8 @@
 pub mod access_mode;
+pub mod hierarchy_level;
 pub mod providers;
 pub mod sql_validator;
 
 // Re-export commonly used types
 pub use access_mode::AccessMode;
+pub use hierarchy_level::HierarchyLevel;

--- a/crates/skardi/src/sources/providers/sqlx/pg/fts_table_function.rs
+++ b/crates/skardi/src/sources/providers/sqlx/pg/fts_table_function.rs
@@ -482,6 +482,7 @@ mod tests {
             Some(&options),
             false,
             Some(&registry),
+            None
         )
         .await
         .expect("register articles table failed");

--- a/crates/skardi/src/sources/providers/sqlx/pg/fts_table_function.rs
+++ b/crates/skardi/src/sources/providers/sqlx/pg/fts_table_function.rs
@@ -482,7 +482,7 @@ mod tests {
             Some(&options),
             false,
             Some(&registry),
-            None
+            None,
         )
         .await
         .expect("register articles table failed");

--- a/crates/skardi/src/sources/providers/sqlx/pg/postgres.rs
+++ b/crates/skardi/src/sources/providers/sqlx/pg/postgres.rs
@@ -1228,6 +1228,7 @@ mod tests {
                 None,
                 false,
                 None,
+                None,
             )
             .await;
 
@@ -1641,6 +1642,7 @@ mod tests {
             "postgresql://127.0.0.1:19999/nonexistent",
             None,
             false,
+            None,
             Some(crate::sources::HierarchyLevel::Catalog),
         )
         .await;
@@ -1661,6 +1663,7 @@ mod tests {
             "postgresql://localhost:5432/db",
             None,
             false,
+            None,
             Some(crate::sources::HierarchyLevel::Table),
         )
         .await;
@@ -1684,6 +1687,7 @@ mod tests {
             "postgresql://localhost:5432/db",
             None,
             false,
+            None,
             None, // None → Table
         )
         .await;
@@ -1765,6 +1769,7 @@ mod tests {
             "postgresql://127.0.0.1:5432/mydb?sslmode=disable",
             Some(&options),
             true,
+            None,
             None,
         )
         .await

--- a/crates/skardi/src/sources/providers/sqlx/pg/postgres.rs
+++ b/crates/skardi/src/sources/providers/sqlx/pg/postgres.rs
@@ -1,4 +1,5 @@
-use crate::sources::providers::DatasetRegistry;
+use crate::sources::providers::sqlx::pg::knn_table_function::{PgKnnEntry, fetch_table_columns};
+use crate::sources::providers::{DatasetEntry, DatasetRegistry};
 use anyhow::{Context, Result};
 use arrow::array::{RecordBatch, UInt64Array};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
@@ -65,8 +66,15 @@ pub async fn register_postgres_tables(
     let hierarchy_level = hierarchy_level.unwrap_or_default();
     match hierarchy_level {
         crate::sources::HierarchyLevel::Catalog => {
-            register_postgres_catalog(session_ctx, name, connection_string, options, read_write)
-                .await
+            register_postgres_catalog(
+                session_ctx,
+                name,
+                connection_string,
+                options,
+                read_write,
+                pg_knn_registry,
+            )
+            .await
         }
         crate::sources::HierarchyLevel::Table => {
             register_single_postgres_table(
@@ -75,6 +83,7 @@ pub async fn register_postgres_tables(
                 connection_string,
                 options,
                 read_write,
+                pg_knn_registry,
             )
             .await
         }
@@ -88,6 +97,7 @@ async fn register_single_postgres_table(
     connection_string: &str,
     options: Option<&HashMap<String, String>>,
     read_write: bool,
+    pg_knn_registry: Option<&DatasetRegistry>,
 ) -> Result<()> {
     let mode_str = if read_write {
         "read-write"
@@ -117,6 +127,19 @@ async fn register_single_postgres_table(
                 format!("Failed to create PostgreSQL connection pool for '{}'", name)
             })?,
     );
+
+    // Build the sqlx pool when needed for writes or KNN registry population.
+    let sqlx_pool = if read_write || pg_knn_registry.is_some() {
+        let sqlx_url = build_sqlx_connection_url(connection_string, options)?;
+        Some(
+            PgPool::connect(&sqlx_url)
+                .await
+                .with_context(|| format!("Failed to create sqlx PgPool for '{}'", name))?,
+        )
+    } else {
+        None
+    };
+
     let factory = PostgresTableFactory::new(Arc::clone(&read_pool));
     let table_reference = TableReference::partial(schema_name.as_str(), table_name.as_str());
     let table_provider = build_postgres_table_provider(
@@ -125,13 +148,19 @@ async fn register_single_postgres_table(
         options,
         table_reference,
         read_write,
-        None,
+        sqlx_pool.as_ref(),
     )
     .await?;
 
     session_ctx
         .register_table(name, table_provider)
         .with_context(|| format!("Failed to register table '{}' with DataFusion", name))?;
+
+    if let (Some(registry), Some(pool)) = (pg_knn_registry, &sqlx_pool) {
+        register_table_in_knn_registry(pool, registry, name, &schema_name, table_name)
+            .await
+            .with_context(|| format!("Failed to register '{}' in pg_knn registry", name))?;
+    }
 
     tracing::info!(
         "Successfully registered PostgreSQL table '{}.{}' as '{}' ({})",
@@ -177,6 +206,7 @@ async fn register_postgres_catalog(
     connection_string: &str,
     options: Option<&HashMap<String, String>>,
     read_write: bool,
+    pg_knn_registry: Option<&DatasetRegistry>,
 ) -> Result<()> {
     let mode_str = if read_write {
         "read-write"
@@ -285,6 +315,18 @@ async fn register_postgres_catalog(
                 )
             })?;
 
+        if let Some(registry) = pg_knn_registry {
+            let knn_key = format!("{}.{}.{}", catalog_name, schema, table_name);
+            register_table_in_knn_registry(&sqlx_pool, registry, &knn_key, schema, table_name)
+                .await
+                .with_context(|| {
+                    format!(
+                        "Failed to register '{}.{}' in pg_knn registry for catalog '{}'",
+                        schema, table_name, catalog_name
+                    )
+                })?;
+        }
+
         tracing::debug!(
             "Prepared '{}.{}' in catalog '{}'",
             schema,
@@ -368,6 +410,51 @@ async fn build_postgres_table_provider(
         table_reference,
         auto_generated_columns,
     }))
+}
+
+/// Fetch column metadata for one table and insert a [`PgKnnEntry`] into the registry.
+///
+/// `entry_name` is the key callers use to look up the entry (e.g. the DataFusion source name
+/// in single-table mode, or `"catalog.schema.table"` in catalog mode).
+async fn register_table_in_knn_registry(
+    pool: &PgPool,
+    registry: &DatasetRegistry,
+    entry_name: &str,
+    schema_name: &str,
+    table_name: &str,
+) -> Result<()> {
+    let columns = fetch_table_columns(pool, schema_name, table_name)
+        .await
+        .with_context(|| {
+            format!(
+                "Failed to fetch columns for pg_knn registry entry '{}'",
+                entry_name
+            )
+        })?;
+
+    let qualified_table = format!(
+        "\"{}\".\"{}\"",
+        schema_name.replace('"', "\"\""),
+        table_name.replace('"', "\"\"")
+    );
+
+    let entry = PgKnnEntry {
+        pool: Arc::new(pool.clone()),
+        qualified_table,
+        columns,
+    };
+
+    registry
+        .write()
+        .map_err(|e| anyhow::anyhow!("pg_knn registry lock poisoned: {}", e))?
+        .insert(entry_name.to_string(), DatasetEntry::Postgres(entry));
+
+    tracing::info!(
+        "Registered '{}' in pg_knn registry for vector search",
+        entry_name
+    );
+
+    Ok(())
 }
 
 async fn list_postgres_tables_in_catalog(

--- a/crates/skardi/src/sources/providers/sqlx/pg/postgres.rs
+++ b/crates/skardi/src/sources/providers/sqlx/pg/postgres.rs
@@ -106,7 +106,7 @@ async fn register_single_postgres_table(
         .unwrap_or(&"public".to_string())
         .clone();
     let table_name = options.and_then(|opts| opts.get("table")).ok_or_else(|| {
-        anyhow::anyhow!("'table' option is required for PostgreSQL single-table registration")
+        anyhow::anyhow!("PostgreSQL single-table registration requires 'table' option")
     })?;
 
     let pool_params = parse_connection_params(connection_string, options)?;

--- a/crates/skardi/src/sources/providers/sqlx/pg/postgres.rs
+++ b/crates/skardi/src/sources/providers/sqlx/pg/postgres.rs
@@ -20,9 +20,10 @@ use datafusion::prelude::SessionContext;
 use datafusion::sql::TableReference;
 use datafusion::sql::unparser::Unparser;
 use datafusion::sql::unparser::dialect::PostgreSqlDialect;
-use datafusion_table_providers::postgres::PostgresTableFactory;
+use datafusion_table_providers::postgres::DynPostgresConnectionPool;
 use datafusion_table_providers::sql::arrow_sql_gen::statement::InsertBuilder;
 use datafusion_table_providers::sql::db_connection_pool::postgrespool::PostgresConnectionPool;
+use datafusion_table_providers::sql::sql_provider_datafusion::SqlTable;
 use futures::{StreamExt, stream};
 use secrecy::SecretString;
 use sqlx::PgPool;
@@ -90,6 +91,62 @@ pub async fn register_postgres_tables(
     }
 }
 
+/// Create both connection pools needed for a Postgres source.
+///
+/// Returns `(read_pool, sqlx_pool)`. The `label` is used only in error messages.
+async fn init_postgres_pools(
+    connection_string: &str,
+    options: Option<&HashMap<String, String>>,
+    label: &str,
+) -> Result<(Arc<PostgresConnectionPool>, PgPool)> {
+    let pool_params = parse_connection_params(connection_string, options)?;
+    let read_pool = Arc::new(
+        PostgresConnectionPool::new(pool_params)
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to create PostgreSQL connection pool for '{}'",
+                    label
+                )
+            })?,
+    );
+
+    // Always build the sqlx pool: needed for schema introspection (handles pgvector and other
+    // custom types), and reused for writes and KNN registry population when applicable.
+    let sqlx_url = build_sqlx_connection_url(connection_string, options)?;
+    let sqlx_pool = PgPool::connect(&sqlx_url)
+        .await
+        .with_context(|| format!("Failed to create sqlx PgPool for '{}'", label))?;
+
+    Ok((read_pool, sqlx_pool))
+}
+
+/// Build a [`TableProvider`] for one table and optionally register it in the KNN registry.
+///
+/// `knn_key` is the lookup key inserted into the registry (e.g. the DataFusion source name in
+/// single-table mode, or `"catalog.schema.table"` in catalog mode).
+async fn build_and_register_table(
+    read_pool: &Arc<PostgresConnectionPool>,
+    sqlx_pool: &PgPool,
+    schema: &str,
+    table_name: &str,
+    read_write: bool,
+    pg_knn_registry: Option<&DatasetRegistry>,
+    knn_key: &str,
+) -> Result<Arc<dyn TableProvider>> {
+    let table_reference = TableReference::partial(schema, table_name);
+    let table_provider =
+        build_postgres_table_provider(read_pool, table_reference, read_write, sqlx_pool).await?;
+
+    if let Some(registry) = pg_knn_registry {
+        register_table_in_knn_registry(sqlx_pool, registry, knn_key, schema, table_name)
+            .await
+            .with_context(|| format!("Failed to register '{}' in pg_knn registry", knn_key))?;
+    }
+
+    Ok(table_provider)
+}
+
 /// Register one logical table (`options.table`) under `name` in the default catalog.
 async fn register_single_postgres_table(
     session_ctx: &mut SessionContext,
@@ -119,48 +176,22 @@ async fn register_single_postgres_table(
         anyhow::anyhow!("PostgreSQL single-table registration requires 'table' option")
     })?;
 
-    let pool_params = parse_connection_params(connection_string, options)?;
-    let read_pool = Arc::new(
-        PostgresConnectionPool::new(pool_params)
-            .await
-            .with_context(|| {
-                format!("Failed to create PostgreSQL connection pool for '{}'", name)
-            })?,
-    );
+    let (read_pool, sqlx_pool) = init_postgres_pools(connection_string, options, name).await?;
 
-    // Build the sqlx pool when needed for writes or KNN registry population.
-    let sqlx_pool = if read_write || pg_knn_registry.is_some() {
-        let sqlx_url = build_sqlx_connection_url(connection_string, options)?;
-        Some(
-            PgPool::connect(&sqlx_url)
-                .await
-                .with_context(|| format!("Failed to create sqlx PgPool for '{}'", name))?,
-        )
-    } else {
-        None
-    };
-
-    let factory = PostgresTableFactory::new(Arc::clone(&read_pool));
-    let table_reference = TableReference::partial(schema_name.as_str(), table_name.as_str());
-    let table_provider = build_postgres_table_provider(
-        &factory,
-        connection_string,
-        options,
-        table_reference,
+    let table_provider = build_and_register_table(
+        &read_pool,
+        &sqlx_pool,
+        &schema_name,
+        table_name,
         read_write,
-        sqlx_pool.as_ref(),
+        pg_knn_registry,
+        name,
     )
     .await?;
 
     session_ctx
         .register_table(name, table_provider)
         .with_context(|| format!("Failed to register table '{}' with DataFusion", name))?;
-
-    if let (Some(registry), Some(pool)) = (pg_knn_registry, &sqlx_pool) {
-        register_table_in_knn_registry(pool, registry, name, &schema_name, table_name)
-            .await
-            .with_context(|| format!("Failed to register '{}' in pg_knn registry", name))?;
-    }
 
     tracing::info!(
         "Successfully registered PostgreSQL table '{}.{}' as '{}' ({})",
@@ -169,32 +200,6 @@ async fn register_single_postgres_table(
         name,
         mode_str,
     );
-
-    // Register in the dataset registry so pg_knn() and pg_fts() UDTFs can find this table.
-    // Reuse the sqlx_pool and columns already fetched above.
-    if let Some(registry) = pg_knn_registry {
-        let qualified_table = format!(
-            "\"{}\".\"{}\"",
-            schema_name.replace('"', "\"\""),
-            table_name.replace('"', "\"\"")
-        );
-
-        let entry = PgKnnEntry {
-            pool: Arc::new(sqlx_pool_for_knn),
-            qualified_table,
-            columns,
-        };
-
-        registry
-            .write()
-            .map_err(|e| anyhow::anyhow!("pg_knn registry lock poisoned: {}", e))?
-            .insert(name.to_string(), DatasetEntry::Postgres(entry));
-
-        tracing::info!(
-            "Registered '{}' in dataset registry for pg_knn/pg_fts",
-            name
-        );
-    }
 
     Ok(())
 }
@@ -220,27 +225,8 @@ async fn register_postgres_catalog(
         mode_str,
     );
 
-    let pool_params = parse_connection_params(connection_string, options)?;
-    let read_pool = Arc::new(
-        PostgresConnectionPool::new(pool_params)
-            .await
-            .with_context(|| {
-                format!(
-                    "Failed to create PostgreSQL connection pool for catalog '{}'",
-                    catalog_name
-                )
-            })?,
-    );
-
-    // Build the sqlx pool unconditionally: it is needed for table discovery in
-    // both read-only and read-write modes, and reused for writes when read_write=true.
-    let sqlx_url = build_sqlx_connection_url(connection_string, options)?;
-    let sqlx_pool = PgPool::connect(&sqlx_url).await.with_context(|| {
-        format!(
-            "Failed to create sqlx PgPool for catalog '{}'",
-            catalog_name
-        )
-    })?;
+    let (read_pool, sqlx_pool) =
+        init_postgres_pools(connection_string, options, catalog_name).await?;
 
     let allowed_schemas = parse_allowed_schemas(options);
     let schema_tables = list_postgres_tables_in_catalog(&sqlx_pool, allowed_schemas.as_ref())
@@ -259,20 +245,30 @@ async fn register_postgres_catalog(
         );
     }
 
-    let write_pool = if read_write { Some(&sqlx_pool) } else { None };
-
-    let factory = PostgresTableFactory::new(Arc::clone(&read_pool));
     let catalog_provider = Arc::new(MemoryCatalogProvider::new());
 
     for (schema, table_name) in &schema_tables {
+<<<<<<< HEAD
         let table_reference = TableReference::partial(schema.as_str(), table_name.as_str());
-        let table_provider = build_postgres_table_provider(
-            &factory,
-            connection_string,
-            options,
-            table_reference,
+        let table_provider =
+            build_postgres_table_provider(&read_pool, table_reference, read_write, &sqlx_pool)
+                .await
+                .with_context(|| {
+                    format!(
+                        "Failed to build table provider for '{}.{}' in catalog '{}'",
+                        schema, table_name, catalog_name
+                    )
+                })?;
+=======
+        let knn_key = format!("{}.{}.{}", catalog_name, schema, table_name);
+        let table_provider = build_and_register_table(
+            &read_pool,
+            &sqlx_pool,
+            schema,
+            table_name,
             read_write,
-            write_pool,
+            pg_knn_registry,
+            &knn_key,
         )
         .await
         .with_context(|| {
@@ -281,6 +277,7 @@ async fn register_postgres_catalog(
                 schema, table_name, catalog_name
             )
         })?;
+>>>>>>> b1fec0d (update postgres)
 
         if catalog_provider.schema(schema).is_none() {
             catalog_provider
@@ -315,18 +312,6 @@ async fn register_postgres_catalog(
                 )
             })?;
 
-        if let Some(registry) = pg_knn_registry {
-            let knn_key = format!("{}.{}.{}", catalog_name, schema, table_name);
-            register_table_in_knn_registry(&sqlx_pool, registry, &knn_key, schema, table_name)
-                .await
-                .with_context(|| {
-                    format!(
-                        "Failed to register '{}.{}' in pg_knn registry for catalog '{}'",
-                        schema, table_name, catalog_name
-                    )
-                })?;
-        }
-
         tracing::debug!(
             "Prepared '{}.{}' in catalog '{}'",
             schema,
@@ -346,54 +331,67 @@ async fn register_postgres_catalog(
     Ok(())
 }
 
+/// Build a DataFusion [`TableProvider`] for one Postgres table.
+///
+/// Uses `fetch_table_columns` to build the Arrow schema from `information_schema`, mapping
+/// unknown Postgres types (e.g. pgvector's `vector`) to `Utf8` instead of hard-erroring.
+/// In read-write mode the provider is wrapped in [`SqlxPostgresTableProvider`].
 async fn build_postgres_table_provider(
-    factory: &PostgresTableFactory,
-    connection_string: &str,
-    options: Option<&HashMap<String, String>>,
+    read_pool: &Arc<PostgresConnectionPool>,
     table_reference: TableReference,
     read_write: bool,
-    reuse_sqlx_pool: Option<&PgPool>,
+    sqlx_pool: &PgPool,
 ) -> Result<Arc<dyn TableProvider>> {
-    let read_provider: Arc<dyn TableProvider> = factory
-        .table_provider(table_reference.clone())
-        .await
-        .map_err(|e| {
-            anyhow::anyhow!(
-                "Failed to create read table provider for '{}': {}",
-                table_reference,
-                e
-            )
-        })?;
-
-    if !read_write {
-        return Ok(read_provider);
-    }
-
     let schema_name = table_reference
         .schema()
         .ok_or_else(|| {
             anyhow::anyhow!(
-                "Table reference '{}' must include a schema for read-write Postgres registration",
+                "Table reference '{}' must include a schema",
                 table_reference
             )
         })?
         .to_string();
     let table_name = table_reference.table().to_string();
 
-    let sqlx_pool = if let Some(pool) = reuse_sqlx_pool {
-        pool.clone()
-    } else {
-        let sqlx_url = build_sqlx_connection_url(connection_string, options)?;
-        PgPool::connect(&sqlx_url).await.with_context(|| {
+    // Infer schema from information_schema so that unknown Postgres types (e.g. pgvector's
+    // `vector`) are mapped to Utf8 instead of causing a hard error.
+    let columns = fetch_table_columns(sqlx_pool, &schema_name, &table_name)
+        .await
+        .with_context(|| {
             format!(
-                "Failed to create sqlx PgPool for '{}.{}'",
+                "Failed to infer schema for '{}.{}' from information_schema",
                 schema_name, table_name
             )
-        })?
-    };
+        })?;
+
+    if columns.is_empty() {
+        return Err(anyhow::anyhow!(
+            "No columns found for '{}.{}' in information_schema",
+            schema_name,
+            table_name
+        ));
+    }
+
+    let schema: SchemaRef = Arc::new(Schema::new(
+        columns
+            .iter()
+            .map(|(col, dtype)| Field::new(col.clone(), dtype.clone(), true))
+            .collect::<Vec<_>>(),
+    ));
+
+    let dyn_pool: Arc<DynPostgresConnectionPool> =
+        Arc::clone(read_pool) as Arc<DynPostgresConnectionPool>;
+    let read_provider: Arc<dyn TableProvider> = Arc::new(
+        SqlTable::new_with_schema("postgres", &dyn_pool, schema, table_reference.clone())
+            .with_dialect(Arc::new(PostgreSqlDialect {})),
+    );
+
+    if !read_write {
+        return Ok(read_provider);
+    }
 
     let auto_generated_columns =
-        detect_auto_generated_columns(&sqlx_pool, &schema_name, &table_name).await?;
+        detect_auto_generated_columns(sqlx_pool, &schema_name, &table_name).await?;
 
     if !auto_generated_columns.is_empty() {
         tracing::debug!(
@@ -406,7 +404,7 @@ async fn build_postgres_table_provider(
 
     Ok(Arc::new(SqlxPostgresTableProvider {
         read_provider,
-        sqlx_pool,
+        sqlx_pool: sqlx_pool.clone(),
         table_reference,
         auto_generated_columns,
     }))

--- a/crates/skardi/src/sources/providers/sqlx/pg/postgres.rs
+++ b/crates/skardi/src/sources/providers/sqlx/pg/postgres.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use arrow::array::{RecordBatch, UInt64Array};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use async_trait::async_trait;
-use datafusion::catalog::Session;
+use datafusion::catalog::{CatalogProvider, MemoryCatalogProvider, MemorySchemaProvider, Session};
 use datafusion::common::Constraints;
 use datafusion::datasource::{TableProvider, TableType};
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
@@ -32,10 +32,12 @@ use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
 
-/// Register PostgreSQL tables into DataFusion SessionContext using sqlx for write operations.
+/// Register PostgreSQL tables or a whole database (catalog) into a DataFusion [`SessionContext`].
 ///
-/// This provider reuses datafusion-table-providers' `SqlTable` for reads (scan/federation pushdown)
-/// and uses sqlx for writes (INSERT/UPDATE/DELETE), fixing issues with auto-generated columns.
+/// Single-table mode reuses datafusion-table-providers' `SqlTable` for reads and sqlx for writes
+/// (INSERT/UPDATE/DELETE), fixing issues with auto-generated columns. Catalog mode registers a
+/// [`MemoryCatalogProvider`] with one provider per table; read-write uses one shared sqlx pool
+/// cloned per table wrapper.
 ///
 /// # Arguments
 /// * `session_ctx` - DataFusion session context to register tables into
@@ -45,10 +47,12 @@ use std::sync::Arc;
 ///   Use `user_env` and `pass_env` options instead.
 /// * `options` - Optional configuration (e.g., table name, schema)
 /// * `read_write` - If true, register as read-write table provider (allows INSERT/UPDATE/DELETE)
+/// * `hierarchy_level` - `None` → table mode (default); `Some(HierarchyLevel::Catalog)` loads the whole DB as a catalog
 ///
 /// # Options
-/// * `table` - Specific table name to register (required)
+/// * `table` - Table name (required in table mode, the default when `hierarchy_level` is `None`)
 /// * `schema` - Schema name (default: "public")
+/// * `allowed_schemas` - Comma-separated schema allow-list (catalog mode only)
 /// * `user_env` - Environment variable name for username (optional)
 /// * `pass_env` - Environment variable name for password (optional)
 pub async fn register_postgres_tables(
@@ -58,6 +62,36 @@ pub async fn register_postgres_tables(
     options: Option<&HashMap<String, String>>,
     read_write: bool,
     pg_knn_registry: Option<&DatasetRegistry>,
+    hierarchy_level: Option<crate::HierarchyLevel>,
+) -> Result<()> {
+    let hierarchy_level = hierarchy_level.unwrap_or_default();
+    match hierarchy_level {
+        crate::HierarchyLevel::Catalog => {
+            register_postgres_catalog(session_ctx, name, connection_string, options, read_write)
+                .await
+        }
+        crate::HierarchyLevel::Table => {
+            register_single_postgres_table(
+                session_ctx,
+                name,
+                connection_string,
+                options,
+                read_write,
+            )
+            .await
+        }
+    }
+}
+
+/// Register one logical table (`options.table`) under `name` in the default catalog.
+async fn register_single_postgres_table(
+    session_ctx: &mut SessionContext,
+    name: &str,
+    connection_string: &str,
+    options: Option<&HashMap<String, String>>,
+    read_write: bool,
+    pg_knn_registry: Option<&DatasetRegistry>,
+    hierarchy_level: Option<crate::HierarchyLevel>,
 ) -> Result<()> {
     let mode_str = if read_write {
         "read-write"
@@ -70,10 +104,6 @@ pub async fn register_postgres_tables(
         connection_string,
         mode_str,
     );
-
-    let table_name = options.and_then(|opts| opts.get("table")).ok_or_else(|| {
-        anyhow::anyhow!("PostgreSQL data source '{}' requires 'table' option", name)
-    })?;
 
     let schema_name = options
         .and_then(|opts| opts.get("schema"))
@@ -161,6 +191,17 @@ pub async fn register_postgres_tables(
     } else {
         read_provider
     };
+    let factory = PostgresTableFactory::new(Arc::clone(&read_pool));
+    let table_reference = TableReference::partial(schema_name.as_str(), table_name.as_str());
+    let table_provider = build_postgres_table_provider(
+        &factory,
+        connection_string,
+        options,
+        table_reference,
+        read_write,
+        None,
+    )
+    .await?;
 
     session_ctx
         .register_table(name, table_provider)
@@ -201,6 +242,241 @@ pub async fn register_postgres_tables(
     }
 
     Ok(())
+}
+
+/// Register an entire Postgres database (catalog) as a named DataFusion catalog.
+async fn register_postgres_catalog(
+    session_ctx: &mut SessionContext,
+    catalog_name: &str,
+    connection_string: &str,
+    options: Option<&HashMap<String, String>>,
+    read_write: bool,
+) -> Result<()> {
+    let mode_str = if read_write {
+        "read-write"
+    } else {
+        "read-only"
+    };
+    tracing::info!(
+        "Registering PostgreSQL catalog (sqlx): {} with connection: {} ({})",
+        catalog_name,
+        connection_string,
+        mode_str,
+    );
+
+    let pool_params = parse_connection_params(connection_string, options)?;
+    let read_pool = Arc::new(
+        PostgresConnectionPool::new(pool_params)
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to create PostgreSQL connection pool for catalog '{}'",
+                    catalog_name
+                )
+            })?,
+    );
+
+    // Build the sqlx pool unconditionally: it is needed for table discovery in
+    // both read-only and read-write modes, and reused for writes when read_write=true.
+    let sqlx_url = build_sqlx_connection_url(connection_string, options)?;
+    let sqlx_pool = PgPool::connect(&sqlx_url).await.with_context(|| {
+        format!(
+            "Failed to create sqlx PgPool for catalog '{}'",
+            catalog_name
+        )
+    })?;
+
+    let allowed_schemas = parse_allowed_schemas(options);
+    let schema_tables = list_postgres_tables_in_catalog(&sqlx_pool, allowed_schemas.as_ref())
+        .await
+        .with_context(|| {
+            format!(
+                "Failed to list PostgreSQL tables for catalog-wide registration in source '{}'",
+                catalog_name
+            )
+        })?;
+
+    if schema_tables.is_empty() {
+        tracing::warn!(
+            "No tables found in PostgreSQL catalog for source '{}'",
+            catalog_name
+        );
+    }
+
+    let write_pool = if read_write { Some(&sqlx_pool) } else { None };
+
+    let factory = PostgresTableFactory::new(Arc::clone(&read_pool));
+    let catalog_provider = Arc::new(MemoryCatalogProvider::new());
+
+    for (schema, table_name) in &schema_tables {
+        let table_reference = TableReference::partial(schema.as_str(), table_name.as_str());
+        let table_provider = build_postgres_table_provider(
+            &factory,
+            connection_string,
+            options,
+            table_reference,
+            read_write,
+            write_pool,
+        )
+        .await
+        .with_context(|| {
+            format!(
+                "Failed to build table provider for '{}.{}' in catalog '{}'",
+                schema, table_name, catalog_name
+            )
+        })?;
+
+        if catalog_provider.schema(schema).is_none() {
+            catalog_provider
+                .register_schema(schema, Arc::new(MemorySchemaProvider::new()))
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "Failed to register schema '{}' for catalog '{}': {}",
+                        schema,
+                        catalog_name,
+                        e
+                    )
+                })?;
+        }
+
+        let schema_provider = catalog_provider.schema(schema).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Schema '{}' was not found after registration in catalog '{}'",
+                schema,
+                catalog_name
+            )
+        })?;
+
+        schema_provider
+            .register_table(table_name.to_string(), table_provider)
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to register table '{}.{}' in catalog '{}': {}",
+                    schema,
+                    table_name,
+                    catalog_name,
+                    e
+                )
+            })?;
+
+        tracing::debug!(
+            "Prepared '{}.{}' in catalog '{}'",
+            schema,
+            table_name,
+            catalog_name
+        );
+    }
+
+    session_ctx.register_catalog(catalog_name, catalog_provider);
+    tracing::info!(
+        "Registered PostgreSQL catalog '{}' with {} table(s) ({})",
+        catalog_name,
+        schema_tables.len(),
+        mode_str
+    );
+
+    Ok(())
+}
+
+async fn build_postgres_table_provider(
+    factory: &PostgresTableFactory,
+    connection_string: &str,
+    options: Option<&HashMap<String, String>>,
+    table_reference: TableReference,
+    read_write: bool,
+    reuse_sqlx_pool: Option<&PgPool>,
+) -> Result<Arc<dyn TableProvider>> {
+    let read_provider = factory
+        .table_provider(table_reference.clone())
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to create read table provider for '{}': {}",
+                table_reference,
+                e
+            )
+        })?;
+
+    if !read_write {
+        return Ok(read_provider);
+    }
+
+    let schema_name = table_reference
+        .schema()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Table reference '{}' must include a schema for read-write Postgres registration",
+                table_reference
+            )
+        })?
+        .to_string();
+    let table_name = table_reference.table().to_string();
+
+    let sqlx_pool = if let Some(pool) = reuse_sqlx_pool {
+        pool.clone()
+    } else {
+        let sqlx_url = build_sqlx_connection_url(connection_string, options)?;
+        PgPool::connect(&sqlx_url).await.with_context(|| {
+            format!(
+                "Failed to create sqlx PgPool for '{}.{}'",
+                schema_name, table_name
+            )
+        })?
+    };
+
+    let auto_generated_columns =
+        detect_auto_generated_columns(&sqlx_pool, &schema_name, &table_name).await?;
+
+    if !auto_generated_columns.is_empty() {
+        tracing::debug!(
+            "Detected auto-generated columns for '{}.{}': {:?}",
+            schema_name,
+            table_name,
+            auto_generated_columns
+        );
+    }
+
+    Ok(Arc::new(SqlxPostgresTableProvider {
+        read_provider,
+        sqlx_pool,
+        table_reference,
+        auto_generated_columns,
+    }))
+}
+
+async fn list_postgres_tables_in_catalog(
+    pool: &PgPool,
+    allowed_schemas: Option<&Vec<String>>,
+) -> Result<Vec<(String, String)>> {
+    let mut rows: Vec<(String, String)> = sqlx::query_as(
+        "SELECT table_schema, table_name
+         FROM information_schema.tables
+         WHERE table_type = 'BASE TABLE'
+           AND table_schema NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
+           AND table_schema NOT LIKE 'pg_temp_%'
+         ORDER BY table_schema, table_name",
+    )
+    .fetch_all(pool)
+    .await?;
+    if let Some(allowed) = allowed_schemas {
+        rows.retain(|(schema, _)| allowed.iter().any(|s| s == schema));
+    }
+    Ok(rows)
+}
+
+fn parse_allowed_schemas(options: Option<&HashMap<String, String>>) -> Option<Vec<String>> {
+    let value = options.and_then(|opts| opts.get("allowed_schemas"))?;
+    let values = value
+        .split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .collect::<Vec<_>>();
+    if values.is_empty() {
+        None
+    } else {
+        Some(values)
+    }
 }
 
 // ─── SqlxPostgresTableProvider ──────────────────────────────────────────────
@@ -1307,6 +1583,242 @@ mod tests {
         assert!(sql.contains("NULL"));
         assert!(sql.contains("Alice"));
         assert!(sql.contains("25"));
+    }
+
+    // ─── parse_allowed_schemas tests ────────────────────────────────────
+
+    #[test]
+    fn test_parse_allowed_schemas_none_options() {
+        let result = parse_allowed_schemas(None);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_parse_allowed_schemas_missing_key() {
+        let options: HashMap<String, String> = HashMap::new();
+        let result = parse_allowed_schemas(Some(&options));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_parse_allowed_schemas_empty_value() {
+        let mut options = HashMap::new();
+        options.insert("allowed_schemas".to_string(), "".to_string());
+        let result = parse_allowed_schemas(Some(&options));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_parse_allowed_schemas_whitespace_only() {
+        let mut options = HashMap::new();
+        options.insert("allowed_schemas".to_string(), "  ,  ,  ".to_string());
+        let result = parse_allowed_schemas(Some(&options));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_parse_allowed_schemas_single() {
+        let mut options = HashMap::new();
+        options.insert("allowed_schemas".to_string(), "public".to_string());
+        let result = parse_allowed_schemas(Some(&options)).unwrap();
+        assert_eq!(result, vec!["public"]);
+    }
+
+    #[test]
+    fn test_parse_allowed_schemas_multiple() {
+        let mut options = HashMap::new();
+        options.insert(
+            "allowed_schemas".to_string(),
+            "public,private,analytics".to_string(),
+        );
+        let result = parse_allowed_schemas(Some(&options)).unwrap();
+        assert_eq!(result, vec!["public", "private", "analytics"]);
+    }
+
+    #[test]
+    fn test_parse_allowed_schemas_whitespace_trimming() {
+        let mut options = HashMap::new();
+        options.insert(
+            "allowed_schemas".to_string(),
+            " public , private , analytics ".to_string(),
+        );
+        let result = parse_allowed_schemas(Some(&options)).unwrap();
+        assert_eq!(result, vec!["public", "private", "analytics"]);
+    }
+
+    #[test]
+    fn test_parse_allowed_schemas_empty_segments_filtered() {
+        let mut options = HashMap::new();
+        options.insert(
+            "allowed_schemas".to_string(),
+            "public,,analytics".to_string(),
+        );
+        let result = parse_allowed_schemas(Some(&options)).unwrap();
+        assert_eq!(result, vec!["public", "analytics"]);
+    }
+
+    // ─── HierarchyLevel tests ────────────────────────────────────────────
+
+    #[test]
+    fn test_hierarchy_level_default_is_table() {
+        assert_eq!(
+            crate::HierarchyLevel::default(),
+            crate::HierarchyLevel::Table
+        );
+    }
+
+    #[test]
+    fn test_hierarchy_level_as_str_table() {
+        assert_eq!(crate::HierarchyLevel::Table.as_str(), "table");
+    }
+
+    #[test]
+    fn test_hierarchy_level_as_str_catalog() {
+        assert_eq!(crate::HierarchyLevel::Catalog.as_str(), "catalog");
+    }
+
+    #[test]
+    fn test_hierarchy_level_serde_roundtrip() {
+        let table = crate::HierarchyLevel::Table;
+        let serialized = serde_json::to_string(&table).unwrap();
+        let deserialized: crate::HierarchyLevel = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, crate::HierarchyLevel::Table);
+
+        let catalog = crate::HierarchyLevel::Catalog;
+        let serialized = serde_json::to_string(&catalog).unwrap();
+        let deserialized: crate::HierarchyLevel = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, crate::HierarchyLevel::Catalog);
+    }
+
+    #[test]
+    fn test_hierarchy_level_serde_lowercase_strings() {
+        let table: crate::HierarchyLevel = serde_json::from_str("\"table\"").unwrap();
+        assert_eq!(table, crate::HierarchyLevel::Table);
+
+        let catalog: crate::HierarchyLevel = serde_json::from_str("\"catalog\"").unwrap();
+        assert_eq!(catalog, crate::HierarchyLevel::Catalog);
+    }
+
+    // ─── Catalog dispatch tests (unit) ──────────────────────────────────
+
+    /// Catalog mode should never fail with "requires 'table' option" — that error
+    /// is exclusive to single-table mode when no `table` key is provided.
+    #[tokio::test]
+    async fn test_catalog_mode_error_is_not_missing_table_option() {
+        let mut session_ctx = SessionContext::new();
+        let result = register_postgres_tables(
+            &mut session_ctx,
+            "mydb",
+            // Use an unreachable address to guarantee a connection failure without hanging.
+            "postgresql://127.0.0.1:19999/nonexistent",
+            None,
+            false,
+            Some(crate::HierarchyLevel::Catalog),
+        )
+        .await;
+
+        assert!(result.is_err());
+        let error_msg = result.unwrap_err().to_string();
+        // Catalog path must never surface the single-table "requires 'table' option" message.
+        assert!(!error_msg.contains("requires 'table' option"));
+    }
+
+    /// Table mode without a `table` option always fails with a descriptive error.
+    #[tokio::test]
+    async fn test_table_mode_requires_table_option() {
+        let mut session_ctx = SessionContext::new();
+        let result = register_postgres_tables(
+            &mut session_ctx,
+            "test_source",
+            "postgresql://localhost:5432/db",
+            None,
+            false,
+            Some(crate::HierarchyLevel::Table),
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("requires 'table' option")
+        );
+    }
+
+    /// `None` for `hierarchy_level` defaults to table mode.
+    #[tokio::test]
+    async fn test_hierarchy_level_none_defaults_to_table_mode() {
+        let mut session_ctx = SessionContext::new();
+        let result = register_postgres_tables(
+            &mut session_ctx,
+            "test_source",
+            "postgresql://localhost:5432/db",
+            None,
+            false,
+            None, // None → Table
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("requires 'table' option")
+        );
+    }
+
+    // ─── allowed_schemas filtering logic tests ───────────────────────────
+
+    /// Unit-test the schema filtering logic exercised inside `list_postgres_tables_in_catalog`.
+    #[test]
+    fn test_allowed_schemas_filter_retains_matching_rows() {
+        let rows = vec![
+            ("public".to_string(), "users".to_string()),
+            ("private".to_string(), "secrets".to_string()),
+            ("analytics".to_string(), "events".to_string()),
+        ];
+
+        let allowed = vec!["public".to_string(), "analytics".to_string()];
+        let mut filtered = rows.clone();
+        filtered.retain(|(schema, _)| allowed.iter().any(|s| s == schema));
+
+        assert_eq!(filtered.len(), 2);
+        assert!(filtered.contains(&("public".to_string(), "users".to_string())));
+        assert!(filtered.contains(&("analytics".to_string(), "events".to_string())));
+        assert!(!filtered.iter().any(|(s, _)| s == "private"));
+    }
+
+    #[test]
+    fn test_allowed_schemas_filter_with_no_match() {
+        let rows = vec![
+            ("public".to_string(), "users".to_string()),
+            ("private".to_string(), "secrets".to_string()),
+        ];
+
+        let allowed = vec!["analytics".to_string()];
+        let mut filtered = rows.clone();
+        filtered.retain(|(schema, _)| allowed.iter().any(|s| s == schema));
+
+        assert!(filtered.is_empty());
+    }
+
+    #[test]
+    fn test_allowed_schemas_filter_none_retains_all() {
+        // When `allowed_schemas` is None the retain is skipped and all rows are kept.
+        let rows = vec![
+            ("public".to_string(), "users".to_string()),
+            ("private".to_string(), "secrets".to_string()),
+        ];
+        let allowed: Option<Vec<String>> = None;
+        let mut filtered = rows.clone();
+        if let Some(allowed) = &allowed {
+            filtered.retain(|(schema, _)| allowed.iter().any(|s| s == schema));
+        }
+        assert_eq!(filtered.len(), 2);
+        assert!(filtered.contains(&("public".to_string(), "users".to_string())));
+        assert!(filtered.contains(&("private".to_string(), "secrets".to_string())));
     }
 
     // ─── Integration test helpers ────────────────────────────────────────

--- a/crates/skardi/src/sources/providers/sqlx/pg/postgres.rs
+++ b/crates/skardi/src/sources/providers/sqlx/pg/postgres.rs
@@ -247,18 +247,6 @@ async fn register_postgres_catalog(
     let catalog_provider = Arc::new(MemoryCatalogProvider::new());
 
     for (schema, table_name) in &schema_tables {
-<<<<<<< HEAD
-        let table_reference = TableReference::partial(schema.as_str(), table_name.as_str());
-        let table_provider =
-            build_postgres_table_provider(&read_pool, table_reference, read_write, &sqlx_pool)
-                .await
-                .with_context(|| {
-                    format!(
-                        "Failed to build table provider for '{}.{}' in catalog '{}'",
-                        schema, table_name, catalog_name
-                    )
-                })?;
-=======
         let knn_key = format!("{}.{}.{}", catalog_name, schema, table_name);
         let table_provider = build_and_register_table(
             &read_pool,
@@ -276,7 +264,6 @@ async fn register_postgres_catalog(
                 schema, table_name, catalog_name
             )
         })?;
->>>>>>> b1fec0d (update postgres)
 
         if catalog_provider.schema(schema).is_none() {
             catalog_provider

--- a/crates/skardi/src/sources/providers/sqlx/pg/postgres.rs
+++ b/crates/skardi/src/sources/providers/sqlx/pg/postgres.rs
@@ -1,5 +1,6 @@
 use crate::sources::providers::sqlx::pg::knn_table_function::{PgKnnEntry, fetch_table_columns};
 use crate::sources::providers::{DatasetEntry, DatasetRegistry};
+use HierarchyLevel;
 use anyhow::{Context, Result};
 use arrow::array::{RecordBatch, UInt64Array};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
@@ -62,11 +63,11 @@ pub async fn register_postgres_tables(
     options: Option<&HashMap<String, String>>,
     read_write: bool,
     pg_knn_registry: Option<&DatasetRegistry>,
-    hierarchy_level: Option<crate::sources::HierarchyLevel>,
+    hierarchy_level: Option<HierarchyLevel>,
 ) -> Result<()> {
     let hierarchy_level = hierarchy_level.unwrap_or_default();
     match hierarchy_level {
-        crate::sources::HierarchyLevel::Catalog => {
+        HierarchyLevel::Catalog => {
             register_postgres_catalog(
                 session_ctx,
                 name,
@@ -77,7 +78,7 @@ pub async fn register_postgres_tables(
             )
             .await
         }
-        crate::sources::HierarchyLevel::Table => {
+        HierarchyLevel::Table => {
             register_single_postgres_table(
                 session_ctx,
                 name,
@@ -162,16 +163,15 @@ async fn register_single_postgres_table(
         "read-only"
     };
     tracing::info!(
-        "Registering PostgreSQL table (sqlx): {} with connection: {} ({})",
+        "Registering PostgreSQL table (sqlx): {} ({})",
         name,
-        connection_string,
         mode_str,
     );
 
     let schema_name = options
         .and_then(|opts| opts.get("schema"))
-        .unwrap_or(&"public".to_string())
-        .clone();
+        .map(|s| s.clone())
+        .unwrap_or_else(|| "public".to_string());
     let table_name = options.and_then(|opts| opts.get("table")).ok_or_else(|| {
         anyhow::anyhow!("PostgreSQL single-table registration requires 'table' option")
     })?;
@@ -219,9 +219,8 @@ async fn register_postgres_catalog(
         "read-only"
     };
     tracing::info!(
-        "Registering PostgreSQL catalog (sqlx): {} with connection: {} ({})",
+        "Registering PostgreSQL catalog (sqlx): {} ({})",
         catalog_name,
-        connection_string,
         mode_str,
     );
 
@@ -459,19 +458,27 @@ async fn list_postgres_tables_in_catalog(
     pool: &PgPool,
     allowed_schemas: Option<&Vec<String>>,
 ) -> Result<Vec<(String, String)>> {
-    let mut rows: Vec<(String, String)> = sqlx::query_as(
-        "SELECT table_schema, table_name
+    const BASE_QUERY: &str = "SELECT table_schema, table_name
          FROM information_schema.tables
-         WHERE table_type = 'BASE TABLE'
+         WHERE table_type IN ('BASE TABLE', 'VIEW')
            AND table_schema NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
-           AND table_schema NOT LIKE 'pg_temp_%'
-         ORDER BY table_schema, table_name",
-    )
-    .fetch_all(pool)
-    .await?;
-    if let Some(allowed) = allowed_schemas {
-        rows.retain(|(schema, _)| allowed.iter().any(|s| s == schema));
-    }
+           AND table_schema NOT LIKE 'pg_temp_%'";
+
+    let rows: Vec<(String, String)> = match allowed_schemas {
+        Some(allowed) => {
+            sqlx::query_as(&format!(
+                "{BASE_QUERY} AND table_schema = ANY($1) ORDER BY table_schema, table_name"
+            ))
+            .bind(allowed)
+            .fetch_all(pool)
+            .await?
+        }
+        None => {
+            sqlx::query_as(&format!("{BASE_QUERY} ORDER BY table_schema, table_name"))
+                .fetch_all(pool)
+                .await?
+        }
+    };
     Ok(rows)
 }
 
@@ -1274,8 +1281,8 @@ mod tests {
         let options: HashMap<String, String> = HashMap::new();
         let schema_name = options
             .get("schema")
-            .unwrap_or(&"public".to_string())
-            .clone();
+            .map(|s| s.clone())
+            .unwrap_or_else(|| "public".to_string());
 
         assert_eq!(schema_name, "public");
     }
@@ -1287,8 +1294,8 @@ mod tests {
 
         let schema_name = options
             .get("schema")
-            .unwrap_or(&"public".to_string())
-            .clone();
+            .map(|s| s.clone())
+            .unwrap_or_else(|| "public".to_string());
 
         assert_eq!(schema_name, "custom_schema");
     }
@@ -1673,44 +1680,39 @@ mod tests {
 
     #[test]
     fn test_hierarchy_level_default_is_table() {
-        assert_eq!(
-            crate::sources::HierarchyLevel::default(),
-            crate::sources::HierarchyLevel::Table
-        );
+        assert_eq!(HierarchyLevel::default(), HierarchyLevel::Table);
     }
 
     #[test]
     fn test_hierarchy_level_as_str_table() {
-        assert_eq!(crate::sources::HierarchyLevel::Table.as_str(), "table");
+        assert_eq!(HierarchyLevel::Table.as_str(), "table");
     }
 
     #[test]
     fn test_hierarchy_level_as_str_catalog() {
-        assert_eq!(crate::sources::HierarchyLevel::Catalog.as_str(), "catalog");
+        assert_eq!(HierarchyLevel::Catalog.as_str(), "catalog");
     }
 
     #[test]
     fn test_hierarchy_level_serde_roundtrip() {
-        let table = crate::sources::HierarchyLevel::Table;
+        let table = HierarchyLevel::Table;
         let serialized = serde_json::to_string(&table).unwrap();
-        let deserialized: crate::sources::HierarchyLevel =
-            serde_json::from_str(&serialized).unwrap();
-        assert_eq!(deserialized, crate::sources::HierarchyLevel::Table);
+        let deserialized: HierarchyLevel = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, HierarchyLevel::Table);
 
-        let catalog = crate::sources::HierarchyLevel::Catalog;
+        let catalog = HierarchyLevel::Catalog;
         let serialized = serde_json::to_string(&catalog).unwrap();
-        let deserialized: crate::sources::HierarchyLevel =
-            serde_json::from_str(&serialized).unwrap();
-        assert_eq!(deserialized, crate::sources::HierarchyLevel::Catalog);
+        let deserialized: HierarchyLevel = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, HierarchyLevel::Catalog);
     }
 
     #[test]
     fn test_hierarchy_level_serde_lowercase_strings() {
-        let table: crate::sources::HierarchyLevel = serde_json::from_str("\"table\"").unwrap();
-        assert_eq!(table, crate::sources::HierarchyLevel::Table);
+        let table: HierarchyLevel = serde_json::from_str("\"table\"").unwrap();
+        assert_eq!(table, HierarchyLevel::Table);
 
-        let catalog: crate::sources::HierarchyLevel = serde_json::from_str("\"catalog\"").unwrap();
-        assert_eq!(catalog, crate::sources::HierarchyLevel::Catalog);
+        let catalog: HierarchyLevel = serde_json::from_str("\"catalog\"").unwrap();
+        assert_eq!(catalog, HierarchyLevel::Catalog);
     }
 
     // ─── Catalog dispatch tests (unit) ──────────────────────────────────
@@ -1728,7 +1730,7 @@ mod tests {
             None,
             false,
             None,
-            Some(crate::sources::HierarchyLevel::Catalog),
+            Some(HierarchyLevel::Catalog),
         )
         .await;
 
@@ -1749,7 +1751,7 @@ mod tests {
             None,
             false,
             None,
-            Some(crate::sources::HierarchyLevel::Table),
+            Some(HierarchyLevel::Table),
         )
         .await;
 
@@ -1787,55 +1789,32 @@ mod tests {
     }
 
     // ─── allowed_schemas filtering logic tests ───────────────────────────
+    // Filtering is pushed into SQL via `AND table_schema = ANY($1)` when
+    // `allowed_schemas` is Some.  These tests verify that `parse_allowed_schemas`
+    // produces the correct bind value that will be passed to the query.
 
-    /// Unit-test the schema filtering logic exercised inside `list_postgres_tables_in_catalog`.
     #[test]
-    fn test_allowed_schemas_filter_retains_matching_rows() {
-        let rows = vec![
-            ("public".to_string(), "users".to_string()),
-            ("private".to_string(), "secrets".to_string()),
-            ("analytics".to_string(), "events".to_string()),
-        ];
-
-        let allowed = vec!["public".to_string(), "analytics".to_string()];
-        let mut filtered = rows.clone();
-        filtered.retain(|(schema, _)| allowed.iter().any(|s| s == schema));
-
-        assert_eq!(filtered.len(), 2);
-        assert!(filtered.contains(&("public".to_string(), "users".to_string())));
-        assert!(filtered.contains(&("analytics".to_string(), "events".to_string())));
-        assert!(!filtered.iter().any(|(s, _)| s == "private"));
+    fn test_allowed_schemas_parsed_values_are_used_as_sql_bind() {
+        let mut options = HashMap::new();
+        options.insert(
+            "allowed_schemas".to_string(),
+            "public,analytics".to_string(),
+        );
+        let allowed = parse_allowed_schemas(Some(&options)).unwrap();
+        assert_eq!(allowed, vec!["public", "analytics"]);
     }
 
     #[test]
-    fn test_allowed_schemas_filter_with_no_match() {
-        let rows = vec![
-            ("public".to_string(), "users".to_string()),
-            ("private".to_string(), "secrets".to_string()),
-        ];
-
-        let allowed = vec!["analytics".to_string()];
-        let mut filtered = rows.clone();
-        filtered.retain(|(schema, _)| allowed.iter().any(|s| s == schema));
-
-        assert!(filtered.is_empty());
+    fn test_allowed_schemas_none_means_no_sql_filter() {
+        // None → the unrestricted SQL branch is used; no bind parameter.
+        assert!(parse_allowed_schemas(None).is_none());
     }
 
     #[test]
-    fn test_allowed_schemas_filter_none_retains_all() {
-        // When `allowed_schemas` is None the retain is skipped and all rows are kept.
-        let rows = vec![
-            ("public".to_string(), "users".to_string()),
-            ("private".to_string(), "secrets".to_string()),
-        ];
-        let allowed: Option<Vec<String>> = None;
-        let mut filtered = rows.clone();
-        if let Some(allowed) = &allowed {
-            filtered.retain(|(schema, _)| allowed.iter().any(|s| s == schema));
-        }
-        assert_eq!(filtered.len(), 2);
-        assert!(filtered.contains(&("public".to_string(), "users".to_string())));
-        assert!(filtered.contains(&("private".to_string(), "secrets".to_string())));
+    fn test_allowed_schemas_empty_value_means_no_sql_filter() {
+        let mut options = HashMap::new();
+        options.insert("allowed_schemas".to_string(), "".to_string());
+        assert!(parse_allowed_schemas(Some(&options)).is_none());
     }
 
     // ─── Integration test helpers ────────────────────────────────────────

--- a/crates/skardi/src/sources/providers/sqlx/pg/postgres.rs
+++ b/crates/skardi/src/sources/providers/sqlx/pg/postgres.rs
@@ -1,5 +1,4 @@
-use crate::sources::providers::sqlx::pg::knn_table_function::{PgKnnEntry, fetch_table_columns};
-use crate::sources::providers::{DatasetEntry, DatasetRegistry};
+use crate::sources::providers::DatasetRegistry;
 use anyhow::{Context, Result};
 use arrow::array::{RecordBatch, UInt64Array};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
@@ -20,10 +19,9 @@ use datafusion::prelude::SessionContext;
 use datafusion::sql::TableReference;
 use datafusion::sql::unparser::Unparser;
 use datafusion::sql::unparser::dialect::PostgreSqlDialect;
-use datafusion_table_providers::postgres::DynPostgresConnectionPool;
+use datafusion_table_providers::postgres::PostgresTableFactory;
 use datafusion_table_providers::sql::arrow_sql_gen::statement::InsertBuilder;
 use datafusion_table_providers::sql::db_connection_pool::postgrespool::PostgresConnectionPool;
-use datafusion_table_providers::sql::sql_provider_datafusion::SqlTable;
 use futures::{StreamExt, stream};
 use secrecy::SecretString;
 use sqlx::PgPool;
@@ -62,15 +60,15 @@ pub async fn register_postgres_tables(
     options: Option<&HashMap<String, String>>,
     read_write: bool,
     pg_knn_registry: Option<&DatasetRegistry>,
-    hierarchy_level: Option<crate::HierarchyLevel>,
+    hierarchy_level: Option<crate::sources::HierarchyLevel>,
 ) -> Result<()> {
     let hierarchy_level = hierarchy_level.unwrap_or_default();
     match hierarchy_level {
-        crate::HierarchyLevel::Catalog => {
+        crate::sources::HierarchyLevel::Catalog => {
             register_postgres_catalog(session_ctx, name, connection_string, options, read_write)
                 .await
         }
-        crate::HierarchyLevel::Table => {
+        crate::sources::HierarchyLevel::Table => {
             register_single_postgres_table(
                 session_ctx,
                 name,
@@ -90,8 +88,6 @@ async fn register_single_postgres_table(
     connection_string: &str,
     options: Option<&HashMap<String, String>>,
     read_write: bool,
-    pg_knn_registry: Option<&DatasetRegistry>,
-    hierarchy_level: Option<crate::HierarchyLevel>,
 ) -> Result<()> {
     let mode_str = if read_write {
         "read-write"
@@ -109,46 +105,10 @@ async fn register_single_postgres_table(
         .and_then(|opts| opts.get("schema"))
         .unwrap_or(&"public".to_string())
         .clone();
-
-    // Build connection pools.
-    // sqlx pool is used for: write operations, schema inference (information_schema),
-    // and the pg_knn registry. We create it upfront so it can be reused everywhere.
-    let sqlx_url = build_sqlx_connection_url(connection_string, options)?;
-    let sqlx_pool = PgPool::connect(&sqlx_url).await.with_context(|| {
-        format!(
-            "Failed to create sqlx PgPool for '{}.{}'",
-            schema_name, table_name
-        )
+    let table_name = options.and_then(|opts| opts.get("table")).ok_or_else(|| {
+        anyhow::anyhow!("'table' option is required for PostgreSQL single-table registration")
     })?;
 
-    // Infer schema from information_schema.columns so that unknown Postgres types
-    // (e.g. pgvector's `vector`) are mapped to Utf8 instead of causing a hard error.
-    // Use pg_knn() for actual similarity search on vector columns.
-    let columns = fetch_table_columns(&sqlx_pool, &schema_name, table_name)
-        .await
-        .with_context(|| {
-            format!(
-                "Failed to infer schema for '{}.{}' from information_schema",
-                schema_name, table_name
-            )
-        })?;
-
-    if columns.is_empty() {
-        return Err(anyhow::anyhow!(
-            "No columns found for '{}.{}' in information_schema",
-            schema_name,
-            table_name
-        ));
-    }
-
-    let schema: SchemaRef = Arc::new(Schema::new(
-        columns
-            .iter()
-            .map(|(name, dtype)| Field::new(name.clone(), dtype.clone(), true))
-            .collect::<Vec<_>>(),
-    ));
-
-    // datafusion-table-providers read pool (used by SqlTable for SELECT push-down).
     let pool_params = parse_connection_params(connection_string, options)?;
     let read_pool = Arc::new(
         PostgresConnectionPool::new(pool_params)
@@ -157,40 +117,6 @@ async fn register_single_postgres_table(
                 format!("Failed to create PostgreSQL connection pool for '{}'", name)
             })?,
     );
-
-    let table_reference = TableReference::partial(schema_name.as_str(), table_name.as_str());
-    let dyn_pool: Arc<DynPostgresConnectionPool> = read_pool;
-    let read_provider: Arc<dyn TableProvider> = Arc::new(
-        SqlTable::new_with_schema("postgres", &dyn_pool, schema, table_reference.clone())
-            .with_dialect(Arc::new(PostgreSqlDialect {})),
-    );
-
-    // Clone before potential move into SqlxPostgresTableProvider; PgPool is Arc-backed.
-    let sqlx_pool_for_knn = sqlx_pool.clone();
-
-    let table_provider: Arc<dyn TableProvider> = if read_write {
-        // Detect auto-generated columns at registration time
-        let auto_generated_columns =
-            detect_auto_generated_columns(&sqlx_pool, &schema_name, table_name).await?;
-
-        if !auto_generated_columns.is_empty() {
-            tracing::debug!(
-                "Detected auto-generated columns for '{}.{}': {:?}",
-                schema_name,
-                table_name,
-                auto_generated_columns
-            );
-        }
-
-        Arc::new(SqlxPostgresTableProvider {
-            read_provider,
-            sqlx_pool,
-            table_reference,
-            auto_generated_columns,
-        })
-    } else {
-        read_provider
-    };
     let factory = PostgresTableFactory::new(Arc::clone(&read_pool));
     let table_reference = TableReference::partial(schema_name.as_str(), table_name.as_str());
     let table_provider = build_postgres_table_provider(
@@ -386,7 +312,7 @@ async fn build_postgres_table_provider(
     read_write: bool,
     reuse_sqlx_pool: Option<&PgPool>,
 ) -> Result<Arc<dyn TableProvider>> {
-    let read_provider = factory
+    let read_provider: Arc<dyn TableProvider> = factory
         .table_provider(table_reference.clone())
         .await
         .map_err(|e| {
@@ -1662,41 +1588,43 @@ mod tests {
     #[test]
     fn test_hierarchy_level_default_is_table() {
         assert_eq!(
-            crate::HierarchyLevel::default(),
-            crate::HierarchyLevel::Table
+            crate::sources::HierarchyLevel::default(),
+            crate::sources::HierarchyLevel::Table
         );
     }
 
     #[test]
     fn test_hierarchy_level_as_str_table() {
-        assert_eq!(crate::HierarchyLevel::Table.as_str(), "table");
+        assert_eq!(crate::sources::HierarchyLevel::Table.as_str(), "table");
     }
 
     #[test]
     fn test_hierarchy_level_as_str_catalog() {
-        assert_eq!(crate::HierarchyLevel::Catalog.as_str(), "catalog");
+        assert_eq!(crate::sources::HierarchyLevel::Catalog.as_str(), "catalog");
     }
 
     #[test]
     fn test_hierarchy_level_serde_roundtrip() {
-        let table = crate::HierarchyLevel::Table;
+        let table = crate::sources::HierarchyLevel::Table;
         let serialized = serde_json::to_string(&table).unwrap();
-        let deserialized: crate::HierarchyLevel = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(deserialized, crate::HierarchyLevel::Table);
+        let deserialized: crate::sources::HierarchyLevel =
+            serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, crate::sources::HierarchyLevel::Table);
 
-        let catalog = crate::HierarchyLevel::Catalog;
+        let catalog = crate::sources::HierarchyLevel::Catalog;
         let serialized = serde_json::to_string(&catalog).unwrap();
-        let deserialized: crate::HierarchyLevel = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(deserialized, crate::HierarchyLevel::Catalog);
+        let deserialized: crate::sources::HierarchyLevel =
+            serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, crate::sources::HierarchyLevel::Catalog);
     }
 
     #[test]
     fn test_hierarchy_level_serde_lowercase_strings() {
-        let table: crate::HierarchyLevel = serde_json::from_str("\"table\"").unwrap();
-        assert_eq!(table, crate::HierarchyLevel::Table);
+        let table: crate::sources::HierarchyLevel = serde_json::from_str("\"table\"").unwrap();
+        assert_eq!(table, crate::sources::HierarchyLevel::Table);
 
-        let catalog: crate::HierarchyLevel = serde_json::from_str("\"catalog\"").unwrap();
-        assert_eq!(catalog, crate::HierarchyLevel::Catalog);
+        let catalog: crate::sources::HierarchyLevel = serde_json::from_str("\"catalog\"").unwrap();
+        assert_eq!(catalog, crate::sources::HierarchyLevel::Catalog);
     }
 
     // ─── Catalog dispatch tests (unit) ──────────────────────────────────
@@ -1713,7 +1641,7 @@ mod tests {
             "postgresql://127.0.0.1:19999/nonexistent",
             None,
             false,
-            Some(crate::HierarchyLevel::Catalog),
+            Some(crate::sources::HierarchyLevel::Catalog),
         )
         .await;
 
@@ -1733,7 +1661,7 @@ mod tests {
             "postgresql://localhost:5432/db",
             None,
             false,
-            Some(crate::HierarchyLevel::Table),
+            Some(crate::sources::HierarchyLevel::Table),
         )
         .await;
 

--- a/crates/skardi/src/sources/providers/sqlx/pg/postgres.rs
+++ b/crates/skardi/src/sources/providers/sqlx/pg/postgres.rs
@@ -1,6 +1,6 @@
+use crate::sources::HierarchyLevel;
 use crate::sources::providers::sqlx::pg::knn_table_function::{PgKnnEntry, fetch_table_columns};
 use crate::sources::providers::{DatasetEntry, DatasetRegistry};
-use HierarchyLevel;
 use anyhow::{Context, Result};
 use arrow::array::{RecordBatch, UInt64Array};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
@@ -66,6 +66,11 @@ pub async fn register_postgres_tables(
     hierarchy_level: Option<HierarchyLevel>,
 ) -> Result<()> {
     let hierarchy_level = hierarchy_level.unwrap_or_default();
+    let mode_str = if read_write {
+        "read-write"
+    } else {
+        "read-only"
+    };
     match hierarchy_level {
         HierarchyLevel::Catalog => {
             register_postgres_catalog(
@@ -75,6 +80,7 @@ pub async fn register_postgres_tables(
                 options,
                 read_write,
                 pg_knn_registry,
+                mode_str,
             )
             .await
         }
@@ -86,6 +92,7 @@ pub async fn register_postgres_tables(
                 options,
                 read_write,
                 pg_knn_registry,
+                mode_str,
             )
             .await
         }
@@ -156,12 +163,8 @@ async fn register_single_postgres_table(
     options: Option<&HashMap<String, String>>,
     read_write: bool,
     pg_knn_registry: Option<&DatasetRegistry>,
+    mode_str: &str,
 ) -> Result<()> {
-    let mode_str = if read_write {
-        "read-write"
-    } else {
-        "read-only"
-    };
     tracing::info!(
         "Registering PostgreSQL table (sqlx): {} ({})",
         name,
@@ -212,12 +215,8 @@ async fn register_postgres_catalog(
     options: Option<&HashMap<String, String>>,
     read_write: bool,
     pg_knn_registry: Option<&DatasetRegistry>,
+    mode_str: &str,
 ) -> Result<()> {
-    let mode_str = if read_write {
-        "read-write"
-    } else {
-        "read-only"
-    };
     tracing::info!(
         "Registering PostgreSQL catalog (sqlx): {} ({})",
         catalog_name,

--- a/demo/postgres/README.md
+++ b/demo/postgres/README.md
@@ -848,12 +848,12 @@ For the context above:
 # Join users ↔ orders (both from the public schema)
 curl -X POST http://localhost:8080/list_all_users_and_orders/execute \
   -H "Content-Type: application/json" \
-  -d '{}'
+  -d '{}' | jq .
 
 # Join mydb.public.users ↔ mydb.analytics.monthly_revenue (cross-schema)
 curl -X POST http://localhost:8080/cross_schema_summary/execute \
   -H "Content-Type: application/json" \
-  -d '{}'
+  -d '{}' | jq .
 ```
 
 The pipeline SQLs use fully qualified paths so there is no ambiguity when

--- a/demo/postgres/README.md
+++ b/demo/postgres/README.md
@@ -747,15 +747,18 @@ data_sources:
 ### Quick Start with Catalog Mode
 
 ```bash
-# 1. Start PostgreSQL and create tables in two schemas
+# 1. Start PostgreSQL with pgvector (required for vector search in catalog mode)
 docker run --name postgres-skardi \
   -e POSTGRES_DB=mydb \
   -e POSTGRES_USER=skardi_user \
   -e POSTGRES_PASSWORD=skardi_pass \
   -p 5432:5432 \
-  -d postgres:16
+  -d pgvector/pgvector:pg16
 
 docker exec -i postgres-skardi psql -U skardi_user -d mydb << 'EOF'
+-- Enable pgvector (safe to run even if the extension is already present)
+CREATE EXTENSION IF NOT EXISTS vector;
+
 -- public schema tables (same as regular demo)
 CREATE TABLE users (
     id SERIAL PRIMARY KEY,
@@ -785,6 +788,20 @@ INSERT INTO orders (user_id, product, amount) VALUES
     (2, 'Keyboard', 79.99),
     (3, 'Monitor', 299.99);
 
+-- Vector search table: loaded automatically by catalog mode because it is in public schema
+CREATE TABLE documents (
+    id BIGSERIAL PRIMARY KEY,
+    content TEXT NOT NULL,
+    metadata TEXT,
+    embedding vector(4)   -- use your actual dimension (e.g. 1536 for OpenAI)
+);
+CREATE INDEX ON documents USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64);
+INSERT INTO documents (content, metadata, embedding) VALUES
+    ('Rust systems programming',                    'doc-1', '[0.6, 0.8, 0.0, 0.0]'),
+    ('Systems programming at scale with Rust',      'doc-2', '[3.0, 4.0, 0.0, 0.0]'),
+    ('Introduction to programming languages',       'doc-3', '[0.5, 0.5, 0.5, 0.5]'),
+    ('Database query optimization',                 'doc-4', '[0.0, 0.0, 0.6, 0.8]');
+
 -- analytics schema tables (second schema, same DB)
 CREATE SCHEMA analytics;
 CREATE TABLE analytics.monthly_revenue (
@@ -812,7 +829,8 @@ cargo run --bin skardi-server -- \
 At startup Skardi logs something like:
 
 ```
-Registered PostgreSQL catalog 'mydb' with 4 table(s) (read-write)
+Registered PostgreSQL catalog 'mydb' with 5 table(s) (read-write)
+Registered 'mydb.public.documents' in pg_knn registry for vector search
 ```
 
 ### Querying Across Tables and Schemas
@@ -840,6 +858,65 @@ curl -X POST http://localhost:8080/cross_schema_summary/execute \
 
 The pipeline SQLs use fully qualified paths so there is no ambiguity when
 tables from multiple schemas are in scope at the same time.
+
+### Vector Search in Catalog Mode
+
+When a table has a `vector` column it is automatically registered in the `pg_knn` registry as part of catalog loading — no extra configuration needed. The registry key uses the three-part catalog name, so `pg_knn` calls must use `'catalog.schema.table'` as the first argument:
+
+```sql
+-- mydb.public.documents was loaded as part of the catalog entry named "mydb"
+SELECT id, content, metadata, _score
+FROM pg_knn('mydb.public.documents', 'embedding',
+    [0.6, 0.8, 0.0, 0.0],
+    '<=>', 10)
+ORDER BY _score
+LIMIT {limit}
+```
+
+> **Note on the query vector:** In catalog mode the subquery seed-vector form (e.g. `SELECT embedding FROM mydb.public.documents WHERE id = {seed_id}`) cannot be used because DataFusion would unparse the three-part table reference to PostgreSQL SQL which only understands `schema.table`. Pass the query vector as a literal float array instead.
+
+A ready-made pipeline is provided at `pipelines_for_catalog_example/vector_search_catalog.yaml`. Start the server and query it:
+
+```bash
+cargo run --bin skardi-server -- \
+  --ctx demo/postgres/ctx_postgres_catalog_demo.yaml \
+  --pipeline demo/postgres/pipelines_for_catalog_example/ \
+  --port 8080
+
+# Search with a literal query vector
+curl -X POST http://localhost:8080/vector-search-catalog/execute \
+  -H "Content-Type: application/json" \
+  -d '{"query_vector": [0.6, 0.8, 0.0, 0.0], "limit": 3}' | jq .
+```
+
+**Example response:**
+```json
+{
+  "data": [
+    {"id": 1, "content": "Rust systems programming",               "metadata": "doc-1", "_score": 0.0},
+    {"id": 2, "content": "Systems programming at scale with Rust", "metadata": "doc-2", "_score": 0.0},
+    {"id": 3, "content": "Introduction to programming languages",  "metadata": "doc-3", "_score": 0.3}
+  ],
+  "rows": 3,
+  "success": true
+}
+```
+
+At startup Skardi logs a line for each vector-enabled table registered into the KNN registry:
+
+```
+Registered 'mydb.public.documents' in pg_knn registry for vector search
+```
+
+You can mix KNN results with regular catalog tables in the same query. For example, join the nearest-neighbor documents with the users table:
+
+```sql
+SELECT d.id, d.content, d._score, u.name AS author
+FROM pg_knn('mydb.public.documents', 'embedding',
+    [0.6, 0.8, 0.0, 0.0], '<=>', 10) d
+JOIN mydb.public.users u ON u.id = d.id
+ORDER BY d._score
+```
 
 ### How It Works
 

--- a/demo/postgres/README.md
+++ b/demo/postgres/README.md
@@ -717,6 +717,143 @@ lsof -i :5432
 ```
 Either stop the conflicting service or use a different port for the Docker container.
 
+## Catalog Mode: Load an Entire Schema at Once
+
+Instead of adding one entry per table, omit the `table` option to let Skardi
+discover and register **every table and view** in the target schema
+automatically. This is called *catalog mode*.
+
+### Context file (`ctx_postgres_catalog_demo.yaml`)
+
+```yaml
+data_sources:
+  # One entry loads both schemas from the same DB.
+  # Tables are accessible as mydb.public.users, mydb.analytics.monthly_revenue, …
+  - name: "mydb"
+    type: "postgres"
+    hierarchy_level: "catalog"        # required to enable catalog mode
+    access_mode: "read_write"
+    connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
+    options:
+      allowed_schemas: "public,analytics"  # comma-separated; omit to load all schemas
+      user_env: "PG_USER"
+      pass_env: "PG_PASSWORD"
+```
+
+> **Notes:**
+> - `table` and `schema` options are rejected when `hierarchy_level: catalog` is set.
+> - `allowed_schemas` must be either absent (loads all non-system schemas) or a non-empty comma-separated string. An empty string causes a startup error.
+
+### Quick Start with Catalog Mode
+
+```bash
+# 1. Start PostgreSQL and create tables in two schemas
+docker run --name postgres-skardi \
+  -e POSTGRES_DB=mydb \
+  -e POSTGRES_USER=skardi_user \
+  -e POSTGRES_PASSWORD=skardi_pass \
+  -p 5432:5432 \
+  -d postgres:16
+
+docker exec -i postgres-skardi psql -U skardi_user -d mydb << 'EOF'
+-- public schema tables (same as regular demo)
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    email VARCHAR(100) UNIQUE NOT NULL
+);
+CREATE TABLE orders (
+    id SERIAL PRIMARY KEY,
+    user_id INT NOT NULL,
+    product VARCHAR(100) NOT NULL,
+    amount DECIMAL(10, 2) NOT NULL
+);
+CREATE TABLE user_order_stats (
+    user_id INT PRIMARY KEY,
+    user_name VARCHAR(100),
+    user_email VARCHAR(100),
+    total_orders INT,
+    total_spent DECIMAL(10, 2),
+    last_order_date VARCHAR(50)
+);
+INSERT INTO users (name, email) VALUES
+    ('Alice Smith', 'alice@example.com'),
+    ('Bob Johnson', 'bob@example.com'),
+    ('Carol Williams', 'carol@example.com');
+INSERT INTO orders (user_id, product, amount) VALUES
+    (1, 'Laptop', 999.99),
+    (2, 'Keyboard', 79.99),
+    (3, 'Monitor', 299.99);
+
+-- analytics schema tables (second schema, same DB)
+CREATE SCHEMA analytics;
+CREATE TABLE analytics.monthly_revenue (
+    user_id INT NOT NULL,
+    month VARCHAR(7) NOT NULL,   -- e.g. "2024-01"
+    revenue DECIMAL(10, 2) NOT NULL
+);
+INSERT INTO analytics.monthly_revenue VALUES
+    (1, '2024-01', 1029.98),
+    (2, '2024-01',  229.98),
+    (3, '2024-01',  389.98);
+EOF
+
+# 2. Set environment variables
+export PG_USER="skardi_user"
+export PG_PASSWORD="skardi_pass"
+
+# 3. Start Skardi using the catalog context and catalog-specific pipelines
+cargo run --bin skardi-server -- \
+  --ctx demo/postgres/ctx_postgres_catalog_demo.yaml \
+  --pipeline demo/postgres/pipelines_for_catalog_example/ \
+  --port 8080
+```
+
+At startup Skardi logs something like:
+
+```
+Registered PostgreSQL catalog 'mydb' with 4 table(s) (read-write)
+```
+
+### Querying Across Tables and Schemas
+
+In catalog mode, tables are registered under a three-part name:
+`<catalog_name>.<schema_name>.<table_name>`.
+
+For the context above:
+- `mydb.public.users`
+- `mydb.public.orders`
+- `mydb.public.user_order_stats`
+- `mydb.analytics.monthly_revenue`
+
+```bash
+# Join users ↔ orders (both from the public schema)
+curl -X POST http://localhost:8080/list_all_users_and_orders/execute \
+  -H "Content-Type: application/json" \
+  -d '{}'
+
+# Join mydb.public.users ↔ mydb.analytics.monthly_revenue (cross-schema)
+curl -X POST http://localhost:8080/cross_schema_summary/execute \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+The pipeline SQLs use fully qualified paths so there is no ambiguity when
+tables from multiple schemas are in scope at the same time.
+
+### How It Works
+
+| Config | Behavior |
+|--------|----------|
+| `hierarchy_level: table` (default) | Registers the single table named by `options.table` under the DataFusion name given by `name` |
+| `hierarchy_level: catalog` | Introspects `information_schema.tables` and registers every `BASE TABLE` as `<name>.<schema>.<table>` |
+
+Use `allowed_schemas` to restrict which schemas are loaded. Point multiple
+catalog entries at the same connection string with different `allowed_schemas`
+values to expose several schemas from one database.
+
+---
+
 ## Configuration Reference
 
 ### ctx_postgres_demo.yaml
@@ -733,14 +870,24 @@ data_sources:
       pass_env: "PG_PASSWORD"
 ```
 
-### Options
+### Options — table mode (`hierarchy_level: table`, default)
 
 | Option | Required | Default | Description |
 |--------|----------|---------|-------------|
 | `table` | Yes | - | Table name to register |
-| `schema` | No | `public` | Schema name |
+| `schema` | No | `public` | Schema containing the table |
 | `user_env` | No | - | Environment variable for username |
 | `pass_env` | No | - | Environment variable for password |
+
+### Options — catalog mode (`hierarchy_level: catalog`)
+
+| Option | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `allowed_schemas` | No | _(all non-system schemas)_ | Comma-separated list of schemas to load, e.g. `"public,analytics"` |
+| `user_env` | No | - | Environment variable for username |
+| `pass_env` | No | - | Environment variable for password |
+
+`table` and `schema` are **not allowed** in catalog mode and will cause a startup error.
 
 ### Connection String Parameters
 

--- a/demo/postgres/ctx_postgres_catalog_demo.yaml
+++ b/demo/postgres/ctx_postgres_catalog_demo.yaml
@@ -1,0 +1,27 @@
+data_sources:
+  # ── Catalog mode: load multiple schemas from one DB in a single entry ────────
+  # Setting hierarchy_level to "catalog" tells Skardi to introspect
+  # information_schema and register every BASE TABLE it finds across all
+  # schemas listed in allowed_schemas.
+  #
+  # Tables are accessible as <catalog_name>.<schema_name>.<table_name>, e.g.:
+  #   mydb.public.users
+  #   mydb.analytics.monthly_revenue
+  #
+  # "table" and "schema" options are not allowed in catalog mode.
+  - name: "mydb"
+    type: "postgres"
+    hierarchy_level: "catalog"
+    access_mode: "read_write"
+    connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
+    description: "All tables in the public and analytics schemas of mydb"
+    options:
+      allowed_schemas: "public,analytics"
+      user_env: "PG_USER"
+      pass_env: "PG_PASSWORD"
+
+  # ── CSV data source (shared with other demos for federated queries) ──────────
+  - name: "csv_orders"
+    type: "csv"
+    path: "demo/sample_data/orders.csv"
+    description: "CSV file containing order data"

--- a/demo/postgres/pipelines_for_catalog_example/cross_schema_summary.yaml
+++ b/demo/postgres/pipelines_for_catalog_example/cross_schema_summary.yaml
@@ -1,0 +1,14 @@
+metadata:
+  name: "cross_schema_summary"
+  version: "1.0"
+  description: "Join public-schema users with analytics-schema monthly_revenue — both in the same catalog entry"
+
+query: |
+  SELECT
+    u.id AS user_id,
+    u.name AS user_name,
+    r.month,
+    r.revenue
+  FROM mydb.public.users u
+  INNER JOIN mydb.analytics.monthly_revenue r ON u.id = r.user_id
+  ORDER BY r.month, u.id

--- a/demo/postgres/pipelines_for_catalog_example/list_all_users_and_orders.yaml
+++ b/demo/postgres/pipelines_for_catalog_example/list_all_users_and_orders.yaml
@@ -1,0 +1,16 @@
+metadata:
+  name: "list_all_users_and_orders"
+  version: "1.0"
+  description: "List all users with their orders using fully qualified catalog.schema.table paths"
+
+query: |
+  SELECT
+    u.id AS user_id,
+    u.name AS user_name,
+    u.email,
+    o.id AS order_id,
+    o.product,
+    o.amount
+  FROM mydb.public.users u
+  LEFT JOIN mydb.public.orders o ON u.id = o.user_id
+  ORDER BY u.id, o.id

--- a/demo/postgres/pipelines_for_catalog_example/vector_search_catalog.yaml
+++ b/demo/postgres/pipelines_for_catalog_example/vector_search_catalog.yaml
@@ -1,0 +1,21 @@
+metadata:
+  name: "vector-search-catalog"
+  version: "1.0.0"
+  description: >
+    KNN similarity search against a pgvector column loaded as part of a catalog entry.
+    In catalog mode the pg_knn registry key is "catalog.schema.table", so the first
+    argument must use the fully-qualified three-part name.
+    Pass a literal float array as {query_vector} — e.g. [0.6, 0.8, 0.0, 0.0].
+    Score is cosine distance in [0, 2] — lower means more similar.
+
+# Parameters:
+#   {query_vector} - Float array to search against, e.g. [0.6, 0.8, 0.0, 0.0]
+#   {limit}        - Maximum number of results to return
+
+query: |
+  SELECT id, content, metadata, _score
+  FROM pg_knn('mydb.public.documents', 'embedding',
+      {query_vector},
+      '<=>', 10)
+  ORDER BY _score
+  LIMIT {limit}


### PR DESCRIPTION
Adds the support for catalog provider on postgres. Note that datafusion doesn't support schema provider registration, so we will only keep the hierarchy into table & catalog for now.