### PR TITLE
Allow pipeline parameter binding for k in lance_knn and pg_knn

### DIFF
--- a/crates/skardi/src/sources/providers/knn_utils.rs
+++ b/crates/skardi/src/sources/providers/knn_utils.rs
@@ -9,11 +9,47 @@ pub const MAX_KNN_K: usize = 500;
 use arrow::array::{
     Array, BinaryArray, FixedSizeListArray, Float32Array, Float64Array, ListArray, StringArray,
 };
+use datafusion::common::{ScalarValue, plan_err};
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::execution::TaskContext;
+use datafusion::logical_expr::Expr;
 use datafusion::physical_plan::{ExecutionPlan, execute_stream};
 use futures::StreamExt;
 use std::sync::Arc;
+
+/// Extract the `k` argument for a KNN table function from a planning-time expression.
+///
+/// Accepts positive integer literals (`Int32`, `Int64`, `UInt64`) and enforces the
+/// global [`MAX_KNN_K`] upper bound. During pipeline schema inference, pipeline
+/// `{param}` placeholders are converted to SQL `?` which reach the table function
+/// as `ScalarValue::Null` — in that case we return a dummy value of `1` so inference
+/// succeeds. The real integer is substituted textually at request time before
+/// re-planning, so the dummy value never runs.
+///
+/// `fn_name` is used as the error-message prefix (e.g. `"sqlite_knn"`).
+pub fn extract_k(expr: &Expr, fn_name: &str) -> DFResult<usize> {
+    let k = match expr {
+        Expr::Literal(ScalarValue::Int64(Some(v @ 1..)), _) => *v as usize,
+        Expr::Literal(ScalarValue::Int64(Some(v)), _) => {
+            return plan_err!("{fn_name}: k must be a positive integer, got {v}");
+        }
+        Expr::Literal(ScalarValue::Int32(Some(v @ 1..)), _) => *v as usize,
+        Expr::Literal(ScalarValue::Int32(Some(v)), _) => {
+            return plan_err!("{fn_name}: k must be a positive integer, got {v}");
+        }
+        Expr::Literal(ScalarValue::UInt64(Some(v)), _) if *v > 0 => *v as usize,
+        // Pipeline `{k}` parameter arrives as `?` → Null during schema inference.
+        // Return a dummy value; the real k is substituted textually at execute time.
+        Expr::Literal(ScalarValue::Null, _) => 1,
+        _ => {
+            return plan_err!("{fn_name}: k must be a positive integer literal");
+        }
+    };
+    if k > MAX_KNN_K {
+        return plan_err!("{fn_name}: k must be between 1 and {MAX_KNN_K}, got {k}");
+    }
+    Ok(k)
+}
 
 /// Execute a child plan and extract the first row's first column as `Vec<f32>`.
 ///

--- a/crates/skardi/src/sources/providers/lance/knn_table_function.rs
+++ b/crates/skardi/src/sources/providers/lance/knn_table_function.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 
 use super::knn_exec::LanceKnnExec;
 use super::utils::expr_to_lance_sql;
-use crate::sources::providers::knn_utils::MAX_KNN_K;
+use crate::sources::providers::knn_utils::extract_k;
 use crate::sources::providers::{DatasetEntry, DatasetRegistry};
 
 /// Table function that creates KNN search on Lance tables
@@ -56,13 +56,7 @@ impl TableFunctionImpl for LanceKnnTableFunction {
         // Extract string arguments
         let table_name = extract_string(&exprs[0], "table_name")?;
         let vector_column = extract_string(&exprs[1], "vector_column")?;
-        let k = {
-            let k = extract_int(&exprs[3], "k")?;
-            if k == 0 || k > MAX_KNN_K {
-                return plan_err!("lance_knn: k must be between 1 and {MAX_KNN_K}, got {k}");
-            }
-            k
-        };
+        let k = extract_k(&exprs[3], "lance_knn")?;
         let filter = if exprs.len() == 5 {
             Some(extract_string(&exprs[4], "filter")?)
         } else {
@@ -241,15 +235,6 @@ fn extract_string(expr: &Expr, name: &str) -> DFResult<String> {
         Expr::Literal(ScalarValue::Utf8(Some(s)), _) => Ok(s.clone()),
         Expr::Literal(ScalarValue::LargeUtf8(Some(s)), _) => Ok(s.clone()),
         _ => plan_err!("lance_knn: {} must be a string literal", name),
-    }
-}
-
-fn extract_int(expr: &Expr, name: &str) -> DFResult<usize> {
-    match expr {
-        Expr::Literal(ScalarValue::Int64(Some(n)), _) => Ok(*n as usize),
-        Expr::Literal(ScalarValue::Int32(Some(n)), _) => Ok(*n as usize),
-        Expr::Literal(ScalarValue::UInt64(Some(n)), _) => Ok(*n as usize),
-        _ => plan_err!("lance_knn: {} must be an integer literal", name),
     }
 }
 

--- a/crates/skardi/src/sources/providers/sqlite/knn_table_function.rs
+++ b/crates/skardi/src/sources/providers/sqlite/knn_table_function.rs
@@ -36,7 +36,7 @@ use tokio_rusqlite::Connection;
 
 use super::knn_exec::SqliteKnnExec;
 use super::{expr_to_sqlite_sql, extract_string};
-use crate::sources::providers::knn_utils::MAX_KNN_K;
+use crate::sources::providers::knn_utils::extract_k;
 use crate::sources::providers::{DatasetEntry, DatasetRegistry};
 
 /// Entry stored in the registry for each registered SQLite table.
@@ -76,7 +76,7 @@ impl TableFunctionImpl for SqliteKnnTableFunction {
 
         let table_name = extract_string(&exprs[0], "table")?;
         let vector_col = extract_string(&exprs[1], "vector_col")?;
-        let k = extract_k(&exprs[3])?;
+        let k = extract_k(&exprs[3], "sqlite_knn")?;
 
         // Try to extract a literal vector.
         let literal_vector = extract_vector(&exprs[2]).ok();
@@ -258,27 +258,6 @@ pub fn register_sqlite_knn_udtf(ctx: &SessionContext, registry: DatasetRegistry)
 }
 
 // ─── Argument extraction helpers ─────────────────────────────────────────────
-
-fn extract_k(expr: &Expr) -> DFResult<usize> {
-    let k = match expr {
-        Expr::Literal(ScalarValue::Int64(Some(v @ 1..)), _) => Ok(*v as usize),
-        Expr::Literal(ScalarValue::Int64(Some(v)), _) => {
-            plan_err!("sqlite_knn: k must be a positive integer, got {}", v)
-        }
-        Expr::Literal(ScalarValue::Int32(Some(v @ 1..)), _) => Ok(*v as usize),
-        Expr::Literal(ScalarValue::Int32(Some(v)), _) => {
-            plan_err!("sqlite_knn: k must be a positive integer, got {}", v)
-        }
-        Expr::Literal(ScalarValue::UInt64(Some(v)), _) => Ok(*v as usize),
-        // NULL placeholder during schema inference
-        Expr::Literal(ScalarValue::Null, _) => Ok(1),
-        _ => plan_err!("sqlite_knn: k must be a positive integer literal"),
-    }?;
-    if k > MAX_KNN_K {
-        return plan_err!("sqlite_knn: k must be between 1 and {MAX_KNN_K}, got {k}");
-    }
-    Ok(k)
-}
 
 fn extract_vector(expr: &Expr) -> DFResult<Vec<f32>> {
     let values: Arc<dyn arrow::array::Array> = match expr {

--- a/crates/skardi/src/sources/providers/sqlx/pg/knn_table_function.rs
+++ b/crates/skardi/src/sources/providers/sqlx/pg/knn_table_function.rs
@@ -41,7 +41,7 @@ use std::sync::Arc;
 
 use super::knn_exec::{DistanceMetric, PgKnnExec, PgVectorFetchExec};
 use super::utils::expr_to_pg_sql;
-use crate::sources::providers::knn_utils::MAX_KNN_K;
+use crate::sources::providers::knn_utils::extract_k;
 use crate::sources::providers::{DatasetEntry, DatasetRegistry};
 
 /// Entry stored in the registry for each registered Postgres table.
@@ -89,7 +89,7 @@ impl TableFunctionImpl for PgKnnTableFunction {
                 .map_err(datafusion::error::DataFusionError::Plan)?
         };
 
-        let k = extract_k(&exprs[4])?;
+        let k = extract_k(&exprs[4], "pg_knn")?;
 
         let inline_filter = if exprs.len() == 6 {
             extract_string(&exprs[5], "filter").ok()
@@ -466,19 +466,6 @@ fn pg_type_to_arrow(
 }
 
 // ─── Argument extraction helpers ─────────────────────────────────────────────
-
-fn extract_k(expr: &Expr) -> DFResult<usize> {
-    let k = match expr {
-        Expr::Literal(ScalarValue::Int64(Some(n)), _) => Ok(*n as usize),
-        Expr::Literal(ScalarValue::Int32(Some(n)), _) => Ok(*n as usize),
-        Expr::Literal(ScalarValue::UInt64(Some(n)), _) => Ok(*n as usize),
-        _ => plan_err!("pg_knn: k must be a positive integer literal"),
-    }?;
-    if k == 0 || k > MAX_KNN_K {
-        return plan_err!("pg_knn: k must be between 1 and {MAX_KNN_K}, got {k}");
-    }
-    Ok(k)
-}
 
 fn extract_string(expr: &Expr, name: &str) -> DFResult<String> {
     match expr {

--- a/demo/embeddings/candle/README.md
+++ b/demo/embeddings/candle/README.md
@@ -99,11 +99,12 @@ cargo run --bin skardi-server --features candle -- \
 curl -X POST http://localhost:8080/semantic-search/execute \
   -H "Content-Type: application/json" \
   -d '{
-    "query": "how does similarity search work in vector databases?"
+    "query": "how does similarity search work in vector databases?",
+    "k": 10
   }' | jq .
 ```
 
-**Response** (truncated — returns up to 10 results):
+**Response** (truncated — returns up to `k` results):
 ```json
 {
       "id": 1,
@@ -173,17 +174,17 @@ curl -X POST http://localhost:8080/semantic-search/execute \
 # Retrieval-Augmented Generation
 curl -X POST http://localhost:8080/semantic-search/execute \
   -H "Content-Type: application/json" \
-  -d '{"query": "how to ground LLM responses with retrieved documents"}' | jq .
+  -d '{"query": "how to ground LLM responses with retrieved documents", "k": 10}' | jq .
 
 # Arrow / columnar formats
 curl -X POST http://localhost:8080/semantic-search/execute \
   -H "Content-Type: application/json" \
-  -d '{"query": "columnar data formats for analytics"}' | jq .
+  -d '{"query": "columnar data formats for analytics", "k": 5}' | jq .
 
 # Model quantization
 curl -X POST http://localhost:8080/semantic-search/execute \
   -H "Content-Type: application/json" \
-  -d '{"query": "running models on CPU without a GPU"}' | jq .
+  -d '{"query": "running models on CPU without a GPU", "k": 5}' | jq .
 ```
 
 ## Pipeline Parameters
@@ -191,6 +192,7 @@ curl -X POST http://localhost:8080/semantic-search/execute \
 | Parameter | Type | Required | Description |
 |---|---|---|---|
 | `query` | string | Yes | Free-text search query |
+| `k` | integer | Yes | Number of nearest neighbours to return |
 
 ## Directory Layout
 

--- a/demo/embeddings/candle/pipelines/pipeline_semantic_search.yaml
+++ b/demo/embeddings/candle/pipelines/pipeline_semantic_search.yaml
@@ -7,13 +7,16 @@ metadata:
     the nearest documents by cosine similarity.
   author: Skardi Demo
 
+# Parameters:
+#   {query} - Natural language search query (embedded on the fly)
+#   {k}     - Number of nearest neighbours to return
+
 query: |
   SELECT id, title, content, _distance
   FROM lance_knn(
     'doc_embeddings',
     'embedding',
     candle('models/generated/bge-small-en-v1.5', {query}),
-    10
+    {k}
   )
   ORDER BY _distance
-  LIMIT 10

--- a/demo/embeddings/gguf/README.md
+++ b/demo/embeddings/gguf/README.md
@@ -104,7 +104,8 @@ cargo run --bin skardi-server --features gguf -- \
 curl -X POST http://localhost:8080/semantic-search-gguf/execute \
   -H "Content-Type: application/json" \
   -d '{
-    "query": "how does similarity search work in vector databases?"
+    "query": "how does similarity search work in vector databases?",
+    "k": 10
   }' | jq .
 ```
 
@@ -186,17 +187,17 @@ curl -X POST http://localhost:8080/semantic-search-gguf/execute \
 # Retrieval-Augmented Generation
 curl -X POST http://localhost:8080/semantic-search-gguf/execute \
   -H "Content-Type: application/json" \
-  -d '{"query": "how to ground LLM responses with retrieved documents"}' | jq .
+  -d '{"query": "how to ground LLM responses with retrieved documents", "k": 10}' | jq .
 
 # GGUF and quantisation
 curl -X POST http://localhost:8080/semantic-search-gguf/execute \
   -H "Content-Type: application/json" \
-  -d '{"query": "running quantised models on CPU without a GPU"}' | jq .
+  -d '{"query": "running quantised models on CPU without a GPU", "k": 5}' | jq .
 
 # Arrow / columnar formats
 curl -X POST http://localhost:8080/semantic-search-gguf/execute \
   -H "Content-Type: application/json" \
-  -d '{"query": "columnar data formats for analytics"}' | jq .
+  -d '{"query": "columnar data formats for analytics", "k": 5}' | jq .
 ```
 
 ## Pipeline Parameters
@@ -204,6 +205,7 @@ curl -X POST http://localhost:8080/semantic-search-gguf/execute \
 | Parameter | Type | Required | Description |
 |---|---|---|---|
 | `query` | string | Yes | Free-text search query |
+| `k` | integer | Yes | Number of nearest neighbours to return |
 
 ## Directory Layout
 

--- a/demo/embeddings/gguf/pipelines/pipeline_semantic_search_gguf.yaml
+++ b/demo/embeddings/gguf/pipelines/pipeline_semantic_search_gguf.yaml
@@ -8,13 +8,16 @@ metadata:
     the nearest documents by cosine similarity.
   author: Skardi Demo
 
+# Parameters:
+#   {query} - Natural language search query (embedded on the fly)
+#   {k}     - Number of nearest neighbours to return
+
 query: |
   SELECT id, title, content, _distance
   FROM lance_knn(
     'doc_embeddings_gguf',
     'embedding',
     gguf('models/generated/embeddinggemma-300m', {query}),
-    10
+    {k}
   )
   ORDER BY _distance
-  LIMIT 10

--- a/demo/embeddings/remote/README.md
+++ b/demo/embeddings/remote/README.md
@@ -45,7 +45,7 @@ cargo run --bin skardi-server --features remote-embed -- \
 ```bash
 curl -s "http://localhost:8080/semantic-search-remote/execute" \
   -H 'Content-Type: application/json' \
-  -d '{"query": "how does semantic search work?"}' | jq .
+  -d '{"query": "how does semantic search work?", "k": 10}' | jq .
 ```
 
 **Response**:

--- a/demo/embeddings/remote/pipelines/pipeline_semantic_search_remote.yaml
+++ b/demo/embeddings/remote/pipelines/pipeline_semantic_search_remote.yaml
@@ -7,13 +7,16 @@ metadata:
     OpenAI API; lance_knn() finds the nearest documents by cosine similarity.
   author: Skardi Demo
 
+# Parameters:
+#   {query} - Natural language search query (embedded on the fly)
+#   {k}     - Number of nearest neighbours to return
+
 query: |
   SELECT id, title, content, _distance
   FROM lance_knn(
     'doc_embeddings_openai',
     'embedding',
     remote_embed('openai', 'text-embedding-3-small', {query}),
-    10
+    {k}
   )
   ORDER BY _distance
-  LIMIT 10

--- a/demo/lance/README.md
+++ b/demo/lance/README.md
@@ -130,6 +130,7 @@ curl -X POST http://localhost:8080/lance-vector-similarity-search/execute \
   -H "Content-Type: application/json" \
   -d '{
     "reference_id": 1,
+    "k": 50,
     "min_revenue": null,
     "max_revenue": null
   }' | jq .
@@ -167,6 +168,7 @@ curl -X POST http://localhost:8080/lance-vector-similarity-search/execute \
   -H "Content-Type: application/json" \
   -d '{
     "reference_id": 1,
+    "k": 50,
     "min_revenue": 1000.0,
     "max_revenue": 5000.0
   }' | jq .
@@ -182,7 +184,8 @@ Pipeline: `pipelines/pipeline_lance_direct_vector.yaml`
 curl -X POST http://localhost:8080/lance-direct-vector-search/execute \
   -H "Content-Type: application/json" \
   -d '{
-    "query_vector": [0.0, 16.0, 35.0, 5.0, 32.0, ...]
+    "query_vector": [0.0, 16.0, 35.0, 5.0, 32.0, ...],
+    "k": 10
   }' | jq .
 ```
 
@@ -199,6 +202,7 @@ python demo/lance/test_direct_vector_search.py
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `reference_id` | integer | Yes | ID of the reference item to find similar items for |
+| `k` | integer | Yes | Number of nearest neighbours to retrieve from the ANN index |
 | `min_revenue` | double | No | Minimum revenue filter via WHERE pushdown (null = no filter) |
 | `max_revenue` | double | No | Maximum revenue filter via WHERE pushdown (null = no filter) |
 

--- a/demo/lance/pipelines/pipeline_lance.yaml
+++ b/demo/lance/pipelines/pipeline_lance.yaml
@@ -24,8 +24,9 @@ metadata:
 #
 # Parameters:
 #   {reference_id}: ID of the reference item to find similar items for
-#   {min_revenue}: Optional minimum revenue filter (null = no filter)
-#   {max_revenue}: Optional maximum revenue filter (null = no filter)
+#   {k}:            Number of nearest neighbours to retrieve from the ANN index
+#   {min_revenue}:  Optional minimum revenue filter (null = no filter)
+#   {max_revenue}:  Optional maximum revenue filter (null = no filter)
 
 query: |
   SELECT
@@ -37,7 +38,7 @@ query: |
     'sift_items',
     'vector',
     (SELECT vector FROM sift_items WHERE id = {reference_id}),
-    50
+    {k}
   ) knn
   WHERE knn.id != {reference_id}
     AND ({min_revenue} IS NULL OR knn.revenue >= {min_revenue})
@@ -49,6 +50,7 @@ query: |
 # POST /lance-vector-similarity-search/execute
 # {
 #   "reference_id": 1,
+#   "k": 50,
 #   "min_revenue": null,
 #   "max_revenue": null
 # }
@@ -57,6 +59,7 @@ query: |
 # POST /lance-vector-similarity-search/execute
 # {
 #   "reference_id": 1,
+#   "k": 50,
 #   "min_revenue": 1000.0,
 #   "max_revenue": 5000.0
 # }

--- a/demo/lance/pipelines/pipeline_lance_direct_vector.yaml
+++ b/demo/lance/pipelines/pipeline_lance_direct_vector.yaml
@@ -14,6 +14,7 @@ metadata:
 #
 # Parameters:
 #   {query_vector}: The embedding vector as a literal array, e.g. [0.1, 0.2, ...]
+#   {k}:            Number of nearest neighbours to return
 
 query: |
   SELECT
@@ -25,14 +26,15 @@ query: |
     'sift_items',
     'vector',
     {query_vector},
-    10
+    {k}
   ) knn
 
 # Example API Call:
 #
 # POST /lance-direct-vector-search/execute
 # {
-#   "query_vector": [0.1, 0.2, 0.3, ...]  (128 floats for the demo dataset)
+#   "query_vector": [0.1, 0.2, 0.3, ...],  (128 floats for the demo dataset)
+#   "k": 10
 # }
 #
 # Response:

--- a/demo/onnx_predict/README.md
+++ b/demo/onnx_predict/README.md
@@ -63,7 +63,7 @@ WITH last_watched AS (
   WHERE title = {last_watched_movie}
   LIMIT 1
 ),
--- Step 2: Find 10 similar movies via Lance KNN
+-- Step 2: Find {k} similar movies via Lance KNN
 knn_results AS (
   SELECT knn.movie_id
   FROM lance_knn(
@@ -71,7 +71,7 @@ knn_results AS (
     'embedding',
     (SELECT embedding FROM movie_embeddings
      WHERE movie_id = (SELECT movie_id FROM last_watched)),
-    10
+    {k}
   ) knn
   WHERE knn.movie_id != (SELECT movie_id FROM last_watched)
 ),
@@ -112,6 +112,7 @@ curl -X POST http://localhost:8080/movie-recommendation-pipeline/execute \
   -H "Content-Type: application/json" \
   -d '{
     "last_watched_movie": "Toy Story",
+    "k": 10,
     "user_id": 42,
     "top_n": 5
   }' | jq .
@@ -141,6 +142,7 @@ curl -X POST http://localhost:8080/movie-recommendation-pipeline/execute \
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `last_watched_movie` | string | Yes | Title of the movie to find recommendations for |
+| `k` | integer | Yes | Number of KNN candidates fetched before NCF re-ranking |
 | `user_id` | integer | Yes | User ID for personalized scoring |
 | `top_n` | integer | Yes | Number of recommendations to return |
 

--- a/demo/onnx_predict/pipelines/pipeline_movie_recommendation.yaml
+++ b/demo/onnx_predict/pipelines/pipeline_movie_recommendation.yaml
@@ -6,6 +6,11 @@ metadata:
   created_at: 2025-11-03T00:00:00.000+00:00
   updated_at: 2025-01-30T00:00:00.000+00:00
 
+# Parameters:
+#   {last_watched_movie} - Title of the last movie the user watched (seed for KNN)
+#   {k}                  - Number of KNN candidates fetched before NCF re-ranking
+#   {user_id}            - User id passed to the NCF model
+#   {top_n}              - Final number of recommendations to return
 
 query: |
   WITH last_watched AS (
@@ -20,7 +25,7 @@ query: |
       'movie_embeddings',
       'embedding',
       (SELECT embedding FROM movie_embeddings WHERE movie_id = (SELECT movie_id FROM last_watched)),
-      10
+      {k}
     ) knn
     WHERE knn.movie_id != (SELECT movie_id FROM last_watched)
   ),

--- a/demo/postgres/README.md
+++ b/demo/postgres/README.md
@@ -367,12 +367,12 @@ query: |
   SELECT id, content, metadata, _score
   FROM pg_knn('documents', 'embedding',
       (SELECT embedding FROM documents WHERE id = {seed_id}),
-      '<=>', 10)
+      '<=>', {k})
   ORDER BY _score
   LIMIT {limit}
 ```
 
-Each pipeline accepts two parameters: `seed_id` (the document to use as the query vector) and `limit` (how many results to return). `pg_knn` fetches up to 10 candidates from Postgres; `LIMIT {limit}` trims the final result set.
+Each pipeline accepts three parameters: `seed_id` (the document to use as the query vector), `k` (how many candidates `pg_knn` pulls from the ANN index), and `limit` (how many rows to return after the outer `ORDER BY`). Typically `k >= limit`.
 
 ### Start and query
 
@@ -387,17 +387,17 @@ cargo run --bin skardi-server -- \
 # Inner product
 curl -X POST http://localhost:8080/vector-search-inner-product/execute \
   -H "Content-Type: application/json" \
-  -d '{"seed_id": 1, "limit": 3}' | jq .
+  -d '{"seed_id": 1, "k": 10, "limit": 3}' | jq .
 
 # L2 (Euclidean)
 curl -X POST http://localhost:8080/vector-search-l2/execute \
   -H "Content-Type: application/json" \
-  -d '{"seed_id": 1, "limit": 3}' | jq .
+  -d '{"seed_id": 1, "k": 10, "limit": 3}' | jq .
 
 # Cosine
 curl -X POST http://localhost:8080/vector-search-cosine/execute \
   -H "Content-Type: application/json" \
-  -d '{"seed_id": 1, "limit": 3}' | jq .
+  -d '{"seed_id": 1, "k": 10, "limit": 3}' | jq .
 ```
 
 **`<#>` inner product** — doc-2 ranks first: same direction as doc-1 but 5× larger magnitude boosts the dot product.
@@ -886,7 +886,7 @@ cargo run --bin skardi-server -- \
 # Search with a literal query vector
 curl -X POST http://localhost:8080/vector-search-catalog/execute \
   -H "Content-Type: application/json" \
-  -d '{"query_vector": [0.6, 0.8, 0.0, 0.0], "limit": 3}' | jq .
+  -d '{"query_vector": [0.6, 0.8, 0.0, 0.0], "k": 10, "limit": 3}' | jq .
 ```
 
 **Example response:**

--- a/demo/postgres/pipelines/vector_demo/vector_search_cosine.yaml
+++ b/demo/postgres/pipelines/vector_demo/vector_search_cosine.yaml
@@ -8,12 +8,13 @@ metadata:
 
 # Parameters:
 #   {seed_id} - ID of the document whose embedding is used as the query vector
-#   {limit}   - Maximum number of results to return
+#   {k}       - Number of candidates pg_knn fetches from the ANN index
+#   {limit}   - Maximum number of results to return (trims the final result set)
 
 query: |
   SELECT id, content, metadata, _score
   FROM pg_knn('documents', 'embedding',
       (SELECT embedding FROM documents WHERE id = {seed_id}),
-      '<=>', 10)
+      '<=>', {k})
   ORDER BY _score
   LIMIT {limit}

--- a/demo/postgres/pipelines/vector_demo/vector_search_inner_product.yaml
+++ b/demo/postgres/pipelines/vector_demo/vector_search_inner_product.yaml
@@ -8,12 +8,13 @@ metadata:
 
 # Parameters:
 #   {seed_id} - ID of the document whose embedding is used as the query vector
-#   {limit}   - Maximum number of results to return
+#   {k}       - Number of candidates pg_knn fetches from the ANN index
+#   {limit}   - Maximum number of results to return (trims the final result set)
 
 query: |
   SELECT id, content, metadata, _score
   FROM pg_knn('documents', 'embedding',
       (SELECT embedding FROM documents WHERE id = {seed_id}),
-      '<#>', 10)
+      '<#>', {k})
   ORDER BY _score
   LIMIT {limit}

--- a/demo/postgres/pipelines/vector_demo/vector_search_l2.yaml
+++ b/demo/postgres/pipelines/vector_demo/vector_search_l2.yaml
@@ -8,12 +8,13 @@ metadata:
 
 # Parameters:
 #   {seed_id} - ID of the document whose embedding is used as the query vector
-#   {limit}   - Maximum number of results to return
+#   {k}       - Number of candidates pg_knn fetches from the ANN index
+#   {limit}   - Maximum number of results to return (trims the final result set)
 
 query: |
   SELECT id, content, metadata, _score
   FROM pg_knn('documents', 'embedding',
       (SELECT embedding FROM documents WHERE id = {seed_id}),
-      '<->', 10)
+      '<->', {k})
   ORDER BY _score
   LIMIT {limit}

--- a/demo/postgres/pipelines_for_catalog_example/vector_search_catalog.yaml
+++ b/demo/postgres/pipelines_for_catalog_example/vector_search_catalog.yaml
@@ -10,12 +10,13 @@ metadata:
 
 # Parameters:
 #   {query_vector} - Float array to search against, e.g. [0.6, 0.8, 0.0, 0.0]
-#   {limit}        - Maximum number of results to return
+#   {k}            - Number of candidates pg_knn fetches from the ANN index
+#   {limit}        - Maximum number of results to return (trims the final result set)
 
 query: |
   SELECT id, content, metadata, _score
   FROM pg_knn('mydb.public.documents', 'embedding',
       {query_vector},
-      '<=>', 10)
+      '<=>', {k})
   ORDER BY _score
   LIMIT {limit}


### PR DESCRIPTION
lance_knn and pg_knn rejected non-literal k at planning time, so pipeline `{k}` parameters (which surface as NULL during schema inference) could not be used — unlike sqlite_knn which already had a NULL fallback. Hoist the parsing into a shared knn_utils::extract_k helper that handles the NULL inference placeholder and the MAX_KNN_K bound check, and adopt it in all three KNN table functions. Update the lance/pg demo pipelines and their READMEs to take k (and keep limit where it was already a parameter).