### PR TITLE
Enable embedding UDFs in skardi-cli and add SQLite/CLI flavour to rag + llm_wiki demos

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -12,6 +12,14 @@ license.workspace = true
 name = "skardi"
 path = "src/main.rs"
 
+[features]
+default = []
+candle = ["skardi/candle"]
+gguf = ["skardi/gguf"]
+onnx = ["skardi/onnx"]
+remote-embed = ["skardi/remote-embed"]
+embedding = ["skardi/embedding"]
+
 [dependencies]
 anyhow = { workspace = true }
 arrow = { version = "57.0.1", features = ["prettyprint"] }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -16,6 +16,14 @@ use object_store::azure::MicrosoftAzureBuilder;
 use object_store::gcp::GoogleCloudStorageBuilder;
 use object_store::http::HttpBuilder;
 use serde::Deserialize;
+#[cfg(feature = "candle")]
+use skardi::model::CandleModelRegistry;
+#[cfg(feature = "gguf")]
+use skardi::model::GgufModelRegistry;
+#[cfg(feature = "onnx")]
+use skardi::model::OnnxModelRegistry;
+#[cfg(feature = "remote-embed")]
+use skardi::model::RemoteEmbedRegistry;
 use skardi::sources::HierarchyLevel;
 use skardi::sources::providers::lance::fts_table_function::register_lance_fts_udtf;
 use skardi::sources::providers::lance::knn_table_function::register_lance_knn_udtf;
@@ -90,6 +98,18 @@ struct LocalDataSource {
     options: Option<HashMap<String, String>>,
     #[serde(default)]
     hierarchy_level: HierarchyLevel,
+    /// "read" (default) or "read_write". Currently honored by the SQLite source.
+    #[serde(default)]
+    access_mode: Option<String>,
+}
+
+impl LocalDataSource {
+    fn is_read_write(&self) -> bool {
+        matches!(
+            self.access_mode.as_deref(),
+            Some("read_write") | Some("readwrite") | Some("rw")
+        )
+    }
 }
 
 fn resolve_ctx_path(override_path: Option<PathBuf>) -> Result<PathBuf> {
@@ -340,6 +360,28 @@ fn new_session_context() -> (SessionContext, DatasetRegistry) {
     register_sqlite_knn_udtf(&ctx, Arc::clone(&dataset_registry));
     register_sqlite_fts_udtf(&ctx, Arc::clone(&dataset_registry));
     register_vec_to_binary_udf(&mut ctx);
+
+    // Embedding UDFs (gated by feature flags, lazy model loading on first call).
+    #[cfg(feature = "onnx")]
+    {
+        let registry = Arc::new(OnnxModelRegistry::new());
+        registry.register_onnx_predict_udf(&mut ctx);
+    }
+    #[cfg(feature = "remote-embed")]
+    {
+        let registry = Arc::new(RemoteEmbedRegistry::new());
+        registry.register_remote_embed_udf(&mut ctx);
+    }
+    #[cfg(feature = "gguf")]
+    {
+        let registry = Arc::new(GgufModelRegistry::new());
+        registry.register_gguf_udf(&mut ctx);
+    }
+    #[cfg(feature = "candle")]
+    {
+        let registry = Arc::new(CandleModelRegistry::new());
+        registry.register_candle_udf(&mut ctx);
+    }
 
     (ctx, dataset_registry)
 }
@@ -592,7 +634,7 @@ async fn register_source(
                 &source.name,
                 &resolved,
                 source.options.as_ref(),
-                false,
+                source.is_read_write(),
                 Some(dataset_registry),
                 source.hierarchy_level,
             )

--- a/demo/llm_wiki/README.md
+++ b/demo/llm_wiki/README.md
@@ -1,5 +1,218 @@
 # LLM Wiki Demo
 
+This demo has two flavours: a **CLI / SQLite** version that runs entirely through
+`skardi-cli` against a local file (no server, no Docker), and the **server / PostgreSQL** version below.
+
+---
+
+## CLI version — `skardi-cli` + SQLite + `sqlite-vec` + FTS5
+
+The same wiki primitives (`create`, `update`, `get`, `grep`, `ls`) run end-to-end
+through `skardi query`. A regular `wiki_pages` table holds canonical state
+(slug, title, page_type, content, embedding); `AFTER INSERT` / `AFTER UPDATE`
+triggers fan rows out to an FTS5 virtual table for keyword search and a
+[`sqlite-vec`](https://github.com/asg017/sqlite-vec) `vec0` virtual table for
+KNN — so a single `INSERT` (or `UPDATE`) keeps content and embedding in sync.
+Embeddings are computed inline by the `candle()` UDF (same model as the server
+version).
+
+### 1. Install the CLI with embedding support
+
+```bash
+cargo install --path crates/cli --features candle
+```
+
+### 2. Get the `sqlite-vec` extension
+
+Build or download the `vec0` shared library — see the
+[sqlite-vec install guide](https://alexgarcia.xyz/sqlite-vec/installation.html).
+Then:
+
+```bash
+export SQLITE_VEC_PATH=/absolute/path/to/vec0.dylib   # or .so / .dll
+
+#    If using the pip package:
+export SQLITE_VEC_PATH=$(python -c "import sqlite_vec; print(sqlite_vec.loadable_path())")
+```
+
+### 3. Download the embedding model
+
+```bash
+pip install huggingface_hub
+python -c "
+from huggingface_hub import hf_hub_download
+import os
+model_dir = 'models/generated/bge-small-en-v1.5'
+os.makedirs(model_dir, exist_ok=True)
+for f in ['model.safetensors', 'config.json', 'tokenizer.json']:
+    hf_hub_download('BAAI/bge-small-en-v1.5', f, local_dir=model_dir)
+"
+```
+
+### 4. Create the database
+
+```bash
+pip install sqlite-vec
+python demo/llm_wiki/setup.py
+```
+
+The script loads the `sqlite-vec` extension via the `sqlite_vec` Python
+package  and drops any prior `demo/llm_wiki/wiki.db`. `vec0` requires an
+`INTEGER` rowid, so the human-readable `slug` lives on the base `wiki_pages`
+table (and as an `UNINDEXED` FTS5 column) and the integer `id` carries the
+JOIN. The script also creates `wiki_pages_fts`, `wiki_pages_vec`, the
+`wiki_log` activity table, and `AFTER INSERT` / `AFTER UPDATE` triggers that
+keep both mirrors in sync. See [setup.py](setup.py) for the schema.
+
+### 5. Context file
+
+One source in `catalog` mode auto-discovers every table, loads `sqlite-vec`
+once on the shared connection pool, and registers each table under
+`<catalog>.main.<table>` for both SQL and `sqlite_knn` / `sqlite_fts` lookups.
+
+```yaml
+data_sources:
+  - name: wiki
+    type: sqlite
+    path: demo/llm_wiki/wiki.db
+    access_mode: read_write
+    hierarchy_level: catalog
+    options:
+      extensions_env: SQLITE_VEC_PATH
+```
+
+### 6. `create` — write a new page
+
+```bash
+skardi query --ctx demo/llm_wiki/cli-ctx.yaml --sql "
+  INSERT INTO wiki.main.wiki_pages (slug, title, page_type, content, embedding)
+  SELECT slug, title, page_type, content,
+         vec_to_binary(candle('models/generated/bge-small-en-v1.5', content))
+  FROM (
+    SELECT 'entity/alan-turing' AS slug, 'Alan Turing' AS title, 'entity' AS page_type,
+           '# Alan Turing\n\nBritish mathematician and logician who formalized the concepts of algorithm and computation with the Turing machine.' AS content
+    UNION ALL
+    SELECT 'concept/turing-machine', 'Turing Machine', 'concept',
+           '# Turing Machine\n\nAn abstract computational model introduced by Alan Turing in 1936.'
+  ) AS t
+"
+```
+
+> Why `UNION ALL` of `SELECT`s instead of `VALUES`? DataFusion's INSERT planner
+> currently propagates the INSERT target schema (here, 5 columns) down into any
+> immediate-child `VALUES` clause and validates row width against it, ignoring
+> the intermediate `SELECT` projection that adds `vec_to_binary(candle(...))`.
+> Wrapping the seed rows as `SELECT … UNION ALL SELECT …` keeps the subquery's
+> own schema in scope and the projection lands the row at full width.
+
+`candle()` produces the embedding inline; `vec_to_binary()` packs it for `vec0`;
+the `AFTER INSERT` trigger atomically mirrors the row to `wiki_pages_fts` and
+`wiki_pages_vec`.
+
+### 7. `update` — edit an existing page (delete + re-insert)
+
+DataFusion's UPDATE planner unparses each `SET` expression back to SQL for the
+underlying SQLite connection to execute, and it can't currently render a Binary
+scalar (the packed-f32 embedding from `vec_to_binary(candle(...))`) as a SQL
+literal. The portable workaround is **delete + re-insert** in two statements —
+the `AFTER DELETE` trigger cleans both mirrors, the `AFTER INSERT` trigger
+repopulates them, and the new row picks up a fresh `updated_at` from the
+column default.
+
+```bash
+skardi query --ctx demo/llm_wiki/cli-ctx.yaml --sql "
+  DELETE FROM wiki.main.wiki_pages WHERE slug = 'entity/alan-turing'
+"
+
+skardi query --ctx demo/llm_wiki/cli-ctx.yaml --sql "
+  INSERT INTO wiki.main.wiki_pages (slug, title, page_type, content, embedding)
+  SELECT slug, title, page_type, content,
+         vec_to_binary(candle('models/generated/bge-small-en-v1.5', content))
+  FROM (
+    SELECT 'entity/alan-turing' AS slug, 'Alan Turing' AS title, 'entity' AS page_type,
+           '# Alan Turing\n\nBritish mathematician, logician, and cryptanalyst who broke the Enigma cipher at Bletchley Park.' AS content
+  ) AS t
+"
+```
+
+If you'd rather edit the row in place from a SQLite client (e.g. `sqlite3`),
+the original `AFTER UPDATE` trigger is still installed and will refresh both
+mirrors when an `UPDATE wiki_pages SET ...` runs against the underlying
+database directly — only the DataFusion path needs the delete-and-reinsert
+dance.
+
+### 8. `get` — fetch one page by slug
+
+```bash
+skardi query --ctx demo/llm_wiki/cli-ctx.yaml --sql "
+  SELECT slug, title, page_type, content, updated_at
+  FROM wiki.main.wiki_pages WHERE slug = 'entity/alan-turing'
+"
+```
+
+### 9. `grep` — hybrid search (RRF over FTS + vector)
+
+```bash
+skardi query --ctx demo/llm_wiki/cli-ctx.yaml --sql "
+  WITH vec AS (
+    SELECT id, ROW_NUMBER() OVER (ORDER BY _score ASC) AS rk
+    FROM sqlite_knn('wiki.main.wiki_pages_vec', 'embedding',
+        (SELECT candle('models/generated/bge-small-en-v1.5',
+                       'who invented the theoretical model of a computer?')),
+        80)
+  ),
+  fts AS (
+    SELECT id, slug, title, page_type,
+           ROW_NUMBER() OVER (ORDER BY _score DESC) AS rk
+    FROM sqlite_fts('wiki.main.wiki_pages_fts', 'content',
+                    'turing machine computation', 60)
+  )
+  SELECT
+    COALESCE(f.slug, p.slug)         AS slug,
+    COALESCE(f.title, p.title)       AS title,
+    COALESCE(f.page_type, p.page_type) AS page_type,
+    COALESCE(0.5 / (60.0 + v.rk), 0)
+      + COALESCE(0.5 / (60.0 + f.rk), 0) AS rrf_score
+  FROM vec v
+  FULL OUTER JOIN fts f ON v.id = f.id
+  LEFT JOIN wiki.main.wiki_pages p ON p.id = COALESCE(v.id, f.id)
+  ORDER BY rrf_score DESC
+  LIMIT 10
+"
+```
+
+### 10. `ls` — browse by type or slug prefix
+
+```bash
+skardi query --ctx demo/llm_wiki/cli-ctx.yaml --sql "
+  SELECT slug, title, page_type, updated_at
+  FROM wiki.main.wiki_pages
+  WHERE page_type LIKE 'entity'
+    AND slug      LIKE '%'
+  ORDER BY updated_at DESC
+  LIMIT 100
+"
+```
+
+### 11. `log` — append an activity entry
+
+```bash
+skardi query --ctx demo/llm_wiki/cli-ctx.yaml --sql "
+  INSERT INTO wiki.main.wiki_log (event_type, slug, message)
+  VALUES ('ingest', 'entity/alan-turing', 'Created from Wikipedia article.')
+"
+```
+
+### Cleanup
+
+```bash
+rm demo/llm_wiki/wiki.db
+```
+
+---
+
+## Server version — `skardi-server` + PostgreSQL + pgvector
+
 A data layer for Karpathy's [LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)
 idea, built on Skardi. The wiki is stored in a **single PostgreSQL table** that
 holds markdown content + pgvector embedding on the same row, so every page is

--- a/demo/llm_wiki/cli-ctx.yaml
+++ b/demo/llm_wiki/cli-ctx.yaml
@@ -1,0 +1,8 @@
+data_sources:
+  - name: wiki
+    type: sqlite
+    path: demo/llm_wiki/wiki.db
+    access_mode: read_write
+    hierarchy_level: catalog
+    options:
+      extensions_env: SQLITE_VEC_PATH

--- a/demo/llm_wiki/setup.py
+++ b/demo/llm_wiki/setup.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Create the SQLite database for the LLM Wiki CLI demo.
+
+Builds the schema only — pages and embeddings are written later through
+`skardi query` (which uses the `candle()` UDF for inline embedding).
+
+`vec0` requires an INTEGER rowid, so the human-readable `slug` lives on the
+base `wiki_pages` table (and as an UNINDEXED FTS5 column) and the integer `id`
+carries the JOIN to the vector mirror.
+
+Schema:
+    wiki_pages        canonical pages, slug UNIQUE, embedding BLOB
+    wiki_pages_fts    FTS5 mirror (id/slug/title/page_type UNINDEXED, content indexed)
+    wiki_pages_vec    sqlite-vec vec0 mirror, float[384] embeddings
+    wiki_log          append-only activity log
+    wiki_pages_ai     AFTER INSERT trigger fanning rows to both mirrors
+    wiki_pages_au     AFTER UPDATE trigger refreshing both mirrors
+
+Usage:
+    pip install sqlite-vec
+    python demo/llm_wiki/setup.py
+"""
+
+import os
+import sqlite3
+
+import sqlite_vec
+
+DB_PATH = "demo/llm_wiki/wiki.db"
+
+SCHEMA = """
+CREATE TABLE wiki_pages (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    slug       TEXT NOT NULL UNIQUE,
+    title      TEXT NOT NULL,
+    page_type  TEXT NOT NULL,
+    content    TEXT NOT NULL,
+    embedding  BLOB NOT NULL,
+    updated_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE VIRTUAL TABLE wiki_pages_fts USING fts5(
+    id UNINDEXED, slug UNINDEXED, title UNINDEXED, page_type UNINDEXED,
+    content
+);
+
+CREATE VIRTUAL TABLE wiki_pages_vec USING vec0(
+    id        INTEGER PRIMARY KEY,
+    embedding float[384]
+);
+
+CREATE TRIGGER wiki_pages_ai AFTER INSERT ON wiki_pages BEGIN
+    INSERT INTO wiki_pages_fts(id, slug, title, page_type, content)
+        VALUES (NEW.id, NEW.slug, NEW.title, NEW.page_type, NEW.content);
+    INSERT INTO wiki_pages_vec(id, embedding)
+        VALUES (NEW.id, NEW.embedding);
+END;
+
+CREATE TRIGGER wiki_pages_au AFTER UPDATE ON wiki_pages BEGIN
+    DELETE FROM wiki_pages_fts WHERE id = OLD.id;
+    INSERT INTO wiki_pages_fts(id, slug, title, page_type, content)
+        VALUES (NEW.id, NEW.slug, NEW.title, NEW.page_type, NEW.content);
+    DELETE FROM wiki_pages_vec WHERE id = OLD.id;
+    INSERT INTO wiki_pages_vec(id, embedding)
+        VALUES (NEW.id, NEW.embedding);
+END;
+
+CREATE TRIGGER wiki_pages_ad AFTER DELETE ON wiki_pages BEGIN
+    DELETE FROM wiki_pages_fts WHERE id = OLD.id;
+    DELETE FROM wiki_pages_vec WHERE id = OLD.id;
+END;
+
+CREATE TABLE wiki_log (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_type  TEXT NOT NULL,
+    slug        TEXT NOT NULL,
+    message     TEXT NOT NULL,
+    created_at  TEXT DEFAULT (datetime('now'))
+);
+"""
+
+
+def main():
+    os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+    if os.path.exists(DB_PATH):
+        os.remove(DB_PATH)
+
+    db = sqlite3.connect(DB_PATH)
+    db.enable_load_extension(True)
+    sqlite_vec.load(db)
+    db.enable_load_extension(False)
+
+    db.executescript(SCHEMA)
+    db.commit()
+    db.close()
+
+    print(f"Created {DB_PATH}")
+    print(
+        "  wiki_pages, wiki_pages_fts, wiki_pages_vec, wiki_log ready for ingest via skardi query"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/rag/README.md
+++ b/demo/rag/README.md
@@ -1,5 +1,154 @@
 # Hybrid Search / RAG Demo
 
+This demo has two flavours: a **CLI / SQLite** version that runs entirely through
+`skardi-cli` against a local file (no server, no Docker), and the **server / PostgreSQL** version below.
+
+---
+
+## CLI version — `skardi-cli` + SQLite + `sqlite-vec` + FTS5
+
+The same hybrid search pipeline (vector + FTS + RRF) runs end-to-end through
+`skardi query`. Vectors live in a [`sqlite-vec`](https://github.com/asg017/sqlite-vec)
+`vec0` virtual table, text lives in an FTS5 virtual table, and a regular
+`documents` table with `AFTER INSERT` triggers fans new rows out to both — so a
+single `INSERT` keeps content and embedding in sync. Embeddings are computed
+inline by the `candle()` UDF (same model as the server version).
+
+### 1. Install the CLI with embedding support
+
+```bash
+cargo install --path crates/cli --features candle
+```
+
+### 2. Get the `sqlite-vec` extension
+
+Build or download the `vec0` shared library — see the
+[sqlite-vec install guide](https://alexgarcia.xyz/sqlite-vec/installation.html).
+Then point Skardi at it:
+
+```bash
+export SQLITE_VEC_PATH=/absolute/path/to/vec0.dylib   # or .so / .dll
+
+#    If using the pip package:
+export SQLITE_VEC_PATH=$(python -c "import sqlite_vec; print(sqlite_vec.loadable_path())")
+```
+
+### 3. Download the embedding model
+
+```bash
+pip install huggingface_hub
+python -c "
+from huggingface_hub import hf_hub_download
+import os
+model_dir = 'models/generated/bge-small-en-v1.5'
+os.makedirs(model_dir, exist_ok=True)
+for f in ['model.safetensors', 'config.json', 'tokenizer.json']:
+    hf_hub_download('BAAI/bge-small-en-v1.5', f, local_dir=model_dir)
+"
+```
+
+### 4. Create the database
+
+```bash
+pip install sqlite-vec
+python demo/rag/setup.py
+```
+
+The script loads the `sqlite-vec` extension via the `sqlite_vec` Python
+package (sidestepping the `sqlite3` CLI's missing `enable_load_extension` on
+many systems), drops any prior `demo/rag/rag.db`, and creates the `documents`
+base table, the `documents_fts` FTS5 mirror, the `documents_vec` `vec0`
+mirror, and the `AFTER INSERT` trigger that fans new rows out to both mirrors
+atomically. See [setup.py](setup.py) for the schema.
+
+### 5. Context file
+
+One source in `catalog` mode auto-discovers every table in the database, loads
+the `sqlite-vec` extension once on the shared connection pool, and registers
+each table under `<catalog>.main.<table>` for both SQL and `sqlite_knn` /
+`sqlite_fts` lookups. Save as `demo/rag/cli-ctx.yaml`:
+
+```yaml
+data_sources:
+  - name: rag
+    type: sqlite
+    path: demo/rag/rag.db
+    access_mode: read_write
+    hierarchy_level: catalog
+    options:
+      extensions_env: SQLITE_VEC_PATH
+```
+
+### 6. Ingest — one statement, embedding computed inline
+
+```bash
+skardi query --ctx demo/rag/cli-ctx.yaml --sql "
+  INSERT INTO rag.main.documents (id, content, embedding)
+  SELECT id, content,
+         vec_to_binary(candle('models/generated/bge-small-en-v1.5', content))
+  FROM (
+    SELECT 1 AS id, 'Vector databases store high-dimensional vectors and enable fast similarity search at scale.' AS content
+    UNION ALL
+    SELECT 2, 'Retrieval-Augmented Generation combines retrieval with a language model to ground responses in factual content.'
+    UNION ALL
+    SELECT 3, 'The Transformer architecture introduced multi-head self-attention to replace recurrent networks.'
+  ) AS t
+"
+```
+
+> Why `UNION ALL` of `SELECT`s instead of `VALUES`? DataFusion's INSERT planner
+> currently propagates the INSERT target schema (here, 3 columns) down into any
+> immediate-child `VALUES` clause and validates row width against it, ignoring
+> the intermediate `SELECT` projection that adds `vec_to_binary(candle(...))`.
+> Wrapping the seed rows as `SELECT … UNION ALL SELECT …` keeps the subquery's
+> own schema in scope and the projection lands the row at full width.
+
+`candle()` produces a `List<Float32>`; `vec_to_binary()` packs it to the
+little-endian f32 BLOB that `vec0` expects. The `AFTER INSERT` trigger then
+mirrors the row to `documents_fts` and `documents_vec` atomically.
+
+### 7. Hybrid search (RRF in one DataFusion query)
+
+```bash
+skardi query --ctx demo/rag/cli-ctx.yaml --sql "
+  WITH vec AS (
+    SELECT id, ROW_NUMBER() OVER (ORDER BY _score ASC) AS rk
+    FROM sqlite_knn('rag.main.documents_vec', 'embedding',
+        (SELECT candle('models/generated/bge-small-en-v1.5',
+                       'how does similarity search work?')),
+        80)
+  ),
+  fts AS (
+    SELECT id, content, ROW_NUMBER() OVER (ORDER BY _score DESC) AS rk
+    FROM sqlite_fts('rag.main.documents_fts', 'content', 'vector similarity search', 60)
+  )
+  SELECT
+    COALESCE(v.id, f.id) AS id,
+    COALESCE(f.content, d.content) AS content,
+    COALESCE(0.5 / (60.0 + v.rk), 0)
+      + COALESCE(0.5 / (60.0 + f.rk), 0) AS rrf_score
+  FROM vec v
+  FULL OUTER JOIN fts f ON v.id = f.id
+  LEFT JOIN rag.main.documents d ON d.id = v.id
+  ORDER BY rrf_score DESC
+  LIMIT 10
+"
+```
+
+The structure mirrors the server's `search_hybrid.yaml` exactly — `sqlite_knn`
+and `sqlite_fts` replace `pg_knn` / `pg_fts`, RRF is the same SQL, and `candle()`
+is reused unchanged for the query embedding.
+
+### Cleanup
+
+```bash
+rm demo/rag/rag.db
+```
+
+---
+
+## Server version — `skardi-server` + PostgreSQL + pgvector
+
 This demo shows a complete hybrid search pipeline using Skardi,
 backed by a **single PostgreSQL table** that holds both the raw content and
 the vector embedding:

--- a/demo/rag/cli-ctx.yaml
+++ b/demo/rag/cli-ctx.yaml
@@ -1,0 +1,8 @@
+data_sources:
+  - name: rag
+    type: sqlite
+    path: demo/rag/rag.db
+    access_mode: read_write
+    hierarchy_level: catalog
+    options:
+      extensions_env: SQLITE_VEC_PATH

--- a/demo/rag/setup.py
+++ b/demo/rag/setup.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Create the SQLite database for the RAG CLI demo.
+
+Builds the schema only — content and embeddings are ingested later through
+`skardi query` (which uses the `candle()` UDF for inline embedding).
+
+Schema:
+    documents       canonical content + packed-f32 embedding BLOB
+    documents_fts   FTS5 mirror (id UNINDEXED so PRAGMA introspection sees it)
+    documents_vec   sqlite-vec vec0 mirror, float[384] embeddings
+    documents_ai    AFTER INSERT trigger fanning rows out to both mirrors
+
+Usage:
+    pip install sqlite-vec
+    python demo/rag/setup.py
+"""
+
+import os
+import sqlite3
+
+import sqlite_vec
+
+DB_PATH = "demo/rag/rag.db"
+
+SCHEMA = """
+CREATE TABLE documents (
+    id        INTEGER PRIMARY KEY,
+    content   TEXT NOT NULL,
+    embedding BLOB NOT NULL
+);
+
+CREATE VIRTUAL TABLE documents_fts USING fts5(id UNINDEXED, content);
+
+CREATE VIRTUAL TABLE documents_vec USING vec0(
+    id        INTEGER PRIMARY KEY,
+    embedding float[384]
+);
+
+CREATE TRIGGER documents_ai AFTER INSERT ON documents BEGIN
+    INSERT INTO documents_fts(id, content) VALUES (NEW.id, NEW.content);
+    INSERT INTO documents_vec(id, embedding) VALUES (NEW.id, NEW.embedding);
+END;
+"""
+
+
+def main():
+    os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+    if os.path.exists(DB_PATH):
+        os.remove(DB_PATH)
+
+    db = sqlite3.connect(DB_PATH)
+    db.enable_load_extension(True)
+    sqlite_vec.load(db)
+    db.enable_load_extension(False)
+
+    db.executescript(SCHEMA)
+    db.commit()
+    db.close()
+
+    print(f"Created {DB_PATH}")
+    print("  documents, documents_fts, documents_vec ready for ingest via skardi query")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Wires the candle / gguf / onnx / remote-embed UDFs into skardi-cli behind feature flags that pass through to the skardi crate, mirroring the server. Adds access_mode parsing to the CLI's LocalDataSource so SQLite sources can be declared read_write from a ctx file (matching the simple_backend convention).

With those two pieces in place, both the rag and llm_wiki demos now ship a CLI / SQLite version that runs end-to-end through `skardi query` against a local file (sqlite-vec for vectors, FTS5 for text, RRF in DataFusion SQL), documented at the top of each demo README alongside the existing PostgreSQL / server flow. Each demo gets a `setup.py` that creates the schema + triggers, and a `cli-ctx.yaml` declaring a single catalog-mode SQLite source so all tables (base + FTS5 + vec0 + log) are auto-discovered under one entry.