### PR TITLE
fix(release): provide llama-cpp-sys build deps for linux targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,12 @@ jobs:
 
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libssl-dev:arm64 libsqlite3-dev:arm64
+
+          # llama-cpp-sys-4's build script passes the Rust triple as the cmake compiler
+          # name (aarch64-unknown-linux-gnu-gcc), but Ubuntu ships aarch64-linux-gnu-gcc.
+          sudo ln -sf /usr/bin/aarch64-linux-gnu-gcc /usr/local/bin/aarch64-unknown-linux-gnu-gcc
+          sudo ln -sf /usr/bin/aarch64-linux-gnu-g++ /usr/local/bin/aarch64-unknown-linux-gnu-g++
+
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
           echo "PKG_CONFIG_SYSROOT_DIR=/usr/aarch64-linux-gnu" >> $GITHUB_ENV
           echo "PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig" >> $GITHUB_ENV

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN apt-get update && apt-get install -y \
     cmake \
     protobuf-compiler \
     g++ \
+    clang \
+    libclang-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
The embedding Docker variant needs libclang for bindgen, and the aarch64-unknown-linux-gnu binary build needs the cross compiler reachable under its Rust-triple name because llama-cpp-sys-4 passes it verbatim to cmake.