### PR TITLE
Fix mismatch 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8002,7 +8002,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skardi"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -8055,7 +8055,7 @@ dependencies = [
 
 [[package]]
 name = "skardi-cli"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -8077,7 +8077,7 @@ dependencies = [
 
 [[package]]
 name = "skardi-server"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.2.0-rc.1"
+version = "0.2.0"
 edition = "2024"
 description = "High performance query engine for both offline compute and online serving"
 authors = ["btnokami"]


### PR DESCRIPTION
The release is still targeting at rc1, manually bump it.