### PR TITLE
Revert "fix: use DataFusion parameterized queries to prevent SQL placeholder corruption (#89)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8091,7 +8091,6 @@ dependencies = [
  "clap",
  "cookie",
  "datafusion",
- "datafusion-common",
  "datafusion-federation",
  "datafusion-tracing",
  "lance",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -31,7 +31,6 @@ chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.4", features = ["derive"] }
 cookie = { workspace = true }
 datafusion = { workspace = true }
-datafusion-common = { workspace = true }
 datafusion-federation = { workspace = true }
 datafusion-tracing = "52.0.0"
 lance = { workspace = true }

--- a/crates/server/src/handlers.rs
+++ b/crates/server/src/handlers.rs
@@ -6,7 +6,6 @@ use axum::{
     http::StatusCode,
 };
 use datafusion::prelude::SessionContext;
-use datafusion_common::ScalarValue;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use skardi::engine::Engine;
@@ -457,76 +456,6 @@ pub async fn get_data_sources(
     })))
 }
 
-/// Convert `{param_name}` placeholders to `$param_name` for DataFusion
-/// parameterized queries. Uses single-pass brace-token parsing to avoid
-/// the prefix-collision bug inherent in iterative `str::replace`.
-fn convert_placeholders_to_params(sql: &str) -> String {
-    let mut result = String::with_capacity(sql.len());
-    let mut chars = sql.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c == '{' {
-            let mut name = String::new();
-            let mut found_close = false;
-            for inner in chars.by_ref() {
-                if inner == '}' {
-                    found_close = true;
-                    break;
-                }
-                name.push(inner);
-            }
-            if found_close
-                && !name.is_empty()
-                && name.chars().all(|ch| ch.is_alphanumeric() || ch == '_')
-            {
-                result.push('$');
-                result.push_str(&name);
-            } else {
-                // Not a valid placeholder — preserve original text
-                result.push('{');
-                result.push_str(&name);
-                if found_close {
-                    result.push('}');
-                }
-            }
-        } else {
-            result.push(c);
-        }
-    }
-    result
-}
-
-/// Convert a JSON value to a DataFusion `ScalarValue` for parameterized binding.
-fn json_to_scalar(param_name: &str, value: &Value) -> std::result::Result<ScalarValue, String> {
-    match value {
-        Value::String(s) => Ok(ScalarValue::Utf8(Some(s.clone()))),
-        Value::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                Ok(ScalarValue::Int64(Some(i)))
-            } else if let Some(f) = n.as_f64() {
-                Ok(ScalarValue::Float64(Some(f)))
-            } else {
-                Err(format!("{}: {:?}", param_name, value))
-            }
-        }
-        Value::Bool(b) => Ok(ScalarValue::Boolean(Some(*b))),
-        Value::Null => Ok(ScalarValue::Utf8(None)),
-        Value::Array(arr) if !arr.is_empty() => {
-            // Convert JSON array to ScalarValue::List (used for vectors in lance_knn)
-            let scalars: std::result::Result<Vec<ScalarValue>, String> =
-                arr.iter().map(|v| json_to_scalar(param_name, v)).collect();
-            let scalars = scalars?;
-            let data_type = scalars[0].data_type();
-            Ok(ScalarValue::List(ScalarValue::new_list(
-                &scalars, &data_type, true,
-            )))
-        }
-        _ => {
-            tracing::error!("Unsupported parameter type for {}: {:?}", param_name, value);
-            Err(format!("{}: {:?}", param_name, value))
-        }
-    }
-}
-
 /// Execute pipeline endpoint - POST /:name/execute
 pub async fn execute_pipeline_by_name(
     State(app_state): State<AppState>,
@@ -588,26 +517,50 @@ pub async fn execute_pipeline_by_name(
         (query_def.sql.clone(), expected_params)
     };
 
-    // Convert {param} placeholders to $param for DataFusion parameterized queries.
-    // We parse brace-delimited tokens in a single pass to avoid prefix collisions
-    // (e.g. {user} vs {user_id}) that plagued the old str::replace approach.
-    let sql = convert_placeholders_to_params(&sql_template);
+    let mut sql = sql_template;
 
-    // Validate parameters and convert JSON values to DataFusion ScalarValues
+    // Validate that all required parameters are provided
     let mut missing_params = Vec::new();
     let mut unsupported_params = Vec::new();
-    let mut param_values: Vec<(String, ScalarValue)> = Vec::new();
 
+    // Replace parameter placeholders with actual values
     for param_name in &expected_params {
+        let placeholder = format!("{{{}}}", param_name);
+
         if let Some(param_value) = request.parameters.get(param_name) {
-            let scalar = match json_to_scalar(param_name, param_value) {
-                Ok(sv) => sv,
-                Err(msg) => {
-                    unsupported_params.push(msg);
+            // Convert JSON value to SQL-safe string
+            let sql_value = match param_value {
+                Value::String(s) => format!("'{}'", s.replace("'", "''")), // Escape single quotes
+                Value::Number(n) => n.to_string(),
+                Value::Bool(b) => b.to_string(),
+                Value::Null => "NULL".to_string(),
+                Value::Array(arr) if !arr.is_empty() => {
+                    // Convert JSON array to SQL array literal, e.g. [0.1, 0.2, ...]
+                    // Used for passing vectors to lance_knn
+                    let elements: Vec<String> = arr
+                        .iter()
+                        .map(|v| match v {
+                            Value::Number(n) => n.to_string(),
+                            Value::String(s) => format!("'{}'", s.replace("'", "''")),
+                            Value::Bool(b) => b.to_string(),
+                            Value::Null => "NULL".to_string(),
+                            other => other.to_string(),
+                        })
+                        .collect();
+                    format!("[{}]", elements.join(", "))
+                }
+                _ => {
+                    tracing::error!(
+                        "Unsupported parameter type for {}: {:?}",
+                        param_name,
+                        param_value
+                    );
+                    unsupported_params.push(format!("{}: {:?}", param_name, param_value));
                     continue;
                 }
             };
-            param_values.push((param_name.clone(), scalar));
+
+            sql = sql.replace(&placeholder, &sql_value);
         } else {
             tracing::error!("Missing required parameter: {}", param_name);
             missing_params.push(param_name.clone());
@@ -653,12 +606,8 @@ pub async fn execute_pipeline_by_name(
         ));
     }
 
-    // Execute the query using DataFusion's native parameterized query support
-    let record_batch = match app_state
-        .engine
-        .execute_with_params(&sql, param_values)
-        .await
-    {
+    // Execute the query using the DataFusion engine
+    let record_batch = match app_state.engine.execute(&sql).await {
         Ok(batch) => batch,
         Err(e) => {
             tracing::error!("Query execution failed: {}", e);
@@ -1268,133 +1217,5 @@ query: |
         } else {
             panic!("Expected second row to be an object");
         }
-    }
-
-    // ----- Placeholder conversion tests -----
-
-    #[test]
-    fn convert_placeholders_rewrites_simple_braces() {
-        let sql = "SELECT * FROM t WHERE id = {user_id}";
-        assert_eq!(
-            convert_placeholders_to_params(sql),
-            "SELECT * FROM t WHERE id = $user_id"
-        );
-    }
-
-    #[test]
-    fn convert_placeholders_handles_prefix_collision() {
-        // This is the bug the fix targets: with str::replace, substituting {user}
-        // first would corrupt {user_id}. The single-pass parser must preserve both.
-        let sql = "SELECT * FROM users WHERE id = {user_id} AND name = {user}";
-        assert_eq!(
-            convert_placeholders_to_params(sql),
-            "SELECT * FROM users WHERE id = $user_id AND name = $user"
-        );
-    }
-
-    #[test]
-    fn convert_placeholders_handles_multiple_occurrences() {
-        let sql = "SELECT {x}, {x} + 1 FROM t WHERE a = {x}";
-        assert_eq!(
-            convert_placeholders_to_params(sql),
-            "SELECT $x, $x + 1 FROM t WHERE a = $x"
-        );
-    }
-
-    #[test]
-    fn convert_placeholders_preserves_non_placeholder_braces() {
-        // Braces enclosing non-identifier content (e.g. JSON literals, array syntax)
-        // must be left alone so they can't collide with parameter names.
-        let sql = "SELECT '{\"key\": \"value\"}' FROM t WHERE arr = [1, 2, 3]";
-        assert_eq!(convert_placeholders_to_params(sql), sql);
-    }
-
-    #[test]
-    fn convert_placeholders_preserves_empty_braces() {
-        let sql = "SELECT {} FROM t";
-        assert_eq!(convert_placeholders_to_params(sql), "SELECT {} FROM t");
-    }
-
-    #[test]
-    fn convert_placeholders_preserves_unclosed_brace() {
-        let sql = "SELECT {foo FROM t";
-        assert_eq!(convert_placeholders_to_params(sql), "SELECT {foo FROM t");
-    }
-
-    #[test]
-    fn convert_placeholders_no_placeholders_unchanged() {
-        let sql = "SELECT 1, 2, 3 FROM t";
-        assert_eq!(convert_placeholders_to_params(sql), sql);
-    }
-
-    // ----- JSON → ScalarValue conversion tests -----
-
-    #[test]
-    fn json_to_scalar_converts_string() {
-        let v = Value::String("alice".to_string());
-        assert_eq!(
-            json_to_scalar("name", &v).unwrap(),
-            ScalarValue::Utf8(Some("alice".to_string()))
-        );
-    }
-
-    #[test]
-    fn json_to_scalar_converts_integer() {
-        let v = Value::Number(serde_json::Number::from(42));
-        assert_eq!(
-            json_to_scalar("id", &v).unwrap(),
-            ScalarValue::Int64(Some(42))
-        );
-    }
-
-    #[test]
-    fn json_to_scalar_converts_float() {
-        let v = Value::Number(serde_json::Number::from_f64(3.14).unwrap());
-        assert_eq!(
-            json_to_scalar("ratio", &v).unwrap(),
-            ScalarValue::Float64(Some(3.14))
-        );
-    }
-
-    #[test]
-    fn json_to_scalar_converts_bool() {
-        let v = Value::Bool(true);
-        assert_eq!(
-            json_to_scalar("enabled", &v).unwrap(),
-            ScalarValue::Boolean(Some(true))
-        );
-    }
-
-    #[test]
-    fn json_to_scalar_converts_null() {
-        let v = Value::Null;
-        assert_eq!(json_to_scalar("x", &v).unwrap(), ScalarValue::Utf8(None));
-    }
-
-    #[test]
-    fn json_to_scalar_converts_float_array() {
-        use arrow::array::Array;
-        let v = serde_json::json!([0.1, 0.2, 0.3]);
-        let result = json_to_scalar("vec", &v).unwrap();
-        match result {
-            ScalarValue::List(arr) => {
-                assert_eq!(arr.len(), 1);
-                assert_eq!(arr.value(0).len(), 3);
-            }
-            other => panic!("Expected ScalarValue::List, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn json_to_scalar_rejects_empty_object() {
-        let v = serde_json::json!({});
-        assert!(json_to_scalar("obj", &v).is_err());
-    }
-
-    #[test]
-    fn json_to_scalar_rejects_empty_array() {
-        let v = serde_json::json!([]);
-        // Empty array falls through to the catch-all error branch
-        assert!(json_to_scalar("arr", &v).is_err());
     }
 }

--- a/crates/skardi/src/engine/datafusion.rs
+++ b/crates/skardi/src/engine/datafusion.rs
@@ -8,7 +8,6 @@ use anyhow::Result;
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use datafusion::prelude::*;
-use datafusion_common::ScalarValue;
 use std::sync::Arc;
 
 /// DataFusion implementation of the Engine trait
@@ -86,12 +85,35 @@ impl DataFusionEngine {
     }
 }
 
-impl DataFusionEngine {
-    /// Collect a DataFrame into a single RecordBatch
-    fn collect_batches(
-        schema: arrow::datatypes::SchemaRef,
-        batches: Vec<RecordBatch>,
-    ) -> Result<RecordBatch> {
+#[async_trait]
+impl Engine for DataFusionEngine {
+    /// Execute a SQL query using DataFusion
+    ///
+    /// # Arguments
+    ///
+    /// * `sql` - The SQL query string to execute
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result<RecordBatch>` containing the query results
+    async fn execute(&self, sql: &str) -> Result<RecordBatch> {
+        // Execute the SQL query against the registered tables
+        let dataframe = self
+            .ctx
+            .sql(sql)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to execute SQL query: {}", e))?;
+
+        // Get the schema before collecting (clone to avoid borrow issues)
+        let schema = dataframe.schema().inner().clone();
+        tracing::debug!("Query schema: {:?}", schema);
+
+        // Collect the results into RecordBatches
+        let batches = dataframe.collect().await.map_err(|e| {
+            tracing::error!("Failed to collect query results. Schema: {:?}", schema);
+            anyhow::anyhow!("Failed to collect query results: {}", e)
+        })?;
+
         tracing::debug!("Collected {} batches", batches.len());
         for (i, batch) in batches.iter().enumerate() {
             tracing::debug!(
@@ -102,13 +124,22 @@ impl DataFusionEngine {
             );
         }
 
+        // Handle the result based on the number of batches returned
         match batches.len() {
-            0 => Ok(RecordBatch::new_empty(schema)),
-            1 => Ok(batches
-                .into_iter()
-                .next()
-                .expect("len == 1 guarantees first element")),
+            0 => {
+                // No results - create an empty RecordBatch with the query's schema
+                let empty_batch = RecordBatch::new_empty(schema);
+                Ok(empty_batch)
+            }
+            1 => {
+                // Single batch - return it directly
+                Ok(batches
+                    .into_iter()
+                    .next()
+                    .expect("len == 1 guarantees first element"))
+            }
             _ => {
+                // Multiple batches - concatenate them into a single RecordBatch
                 use arrow::compute::concat_batches;
                 let batch_schema = batches[0].schema();
                 let concatenated = concat_batches(&batch_schema, &batches)
@@ -116,136 +147,5 @@ impl DataFusionEngine {
                 Ok(concatenated)
             }
         }
-    }
-}
-
-#[async_trait]
-impl Engine for DataFusionEngine {
-    async fn execute(&self, sql: &str) -> Result<RecordBatch> {
-        let dataframe = self
-            .ctx
-            .sql(sql)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to execute SQL query: {}", e))?;
-
-        let schema = dataframe.schema().inner().clone();
-        tracing::debug!("Query schema: {:?}", schema);
-
-        let batches = dataframe.collect().await.map_err(|e| {
-            tracing::error!("Failed to collect query results. Schema: {:?}", schema);
-            anyhow::anyhow!("Failed to collect query results: {}", e)
-        })?;
-
-        Self::collect_batches(schema, batches)
-    }
-
-    async fn execute_with_params(
-        &self,
-        sql: &str,
-        params: Vec<(String, ScalarValue)>,
-    ) -> Result<RecordBatch> {
-        let dataframe = self
-            .ctx
-            .sql(sql)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to execute SQL query: {}", e))?;
-
-        let schema = dataframe.schema().inner().clone();
-        tracing::debug!("Query schema: {:?}", schema);
-
-        let dataframe = dataframe
-            .with_param_values(params)
-            .map_err(|e| anyhow::anyhow!("Failed to bind parameter values: {}", e))?;
-
-        let batches = dataframe.collect().await.map_err(|e| {
-            tracing::error!("Failed to collect query results. Schema: {:?}", schema);
-            anyhow::anyhow!("Failed to collect query results: {}", e)
-        })?;
-
-        Self::collect_batches(schema, batches)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use arrow::array::{Int64Array, StringArray};
-    use arrow::datatypes::{DataType, Field, Schema};
-
-    fn make_engine_with_users() -> DataFusionEngine {
-        let ctx = SessionContext::new();
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("id", DataType::Int64, false),
-            Field::new("name", DataType::Utf8, false),
-        ]));
-        let batch = RecordBatch::try_new(
-            schema,
-            vec![
-                Arc::new(Int64Array::from(vec![1, 2, 3])),
-                Arc::new(StringArray::from(vec!["alice", "bob", "carol"])),
-            ],
-        )
-        .unwrap();
-        ctx.register_batch("users", batch).unwrap();
-        DataFusionEngine::new(ctx)
-    }
-
-    #[tokio::test]
-    async fn execute_with_params_binds_named_parameters() {
-        let engine = make_engine_with_users();
-        let sql = "SELECT name FROM users WHERE id = $user_id";
-        let params = vec![("user_id".to_string(), ScalarValue::Int64(Some(2)))];
-
-        let batch = engine.execute_with_params(sql, params).await.unwrap();
-        assert_eq!(batch.num_rows(), 1);
-        let names = batch
-            .column(0)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        assert_eq!(names.value(0), "bob");
-    }
-
-    #[tokio::test]
-    async fn execute_with_params_resists_prefix_collision() {
-        // Regression guard: $user and $user_id must each bind independently,
-        // no matter which order the caller passes them in.
-        let engine = make_engine_with_users();
-        let sql = "SELECT id FROM users WHERE id = $user_id AND name = $user";
-
-        // Pass $user first — this would have corrupted the SQL under the old
-        // str::replace approach (replacing {user} inside {user_id}).
-        let params = vec![
-            (
-                "user".to_string(),
-                ScalarValue::Utf8(Some("bob".to_string())),
-            ),
-            ("user_id".to_string(), ScalarValue::Int64(Some(2))),
-        ];
-
-        let batch = engine.execute_with_params(sql, params).await.unwrap();
-        assert_eq!(batch.num_rows(), 1);
-        let ids = batch
-            .column(0)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .unwrap();
-        assert_eq!(ids.value(0), 2);
-    }
-
-    #[tokio::test]
-    async fn execute_with_params_escapes_sql_injection() {
-        // A value containing a closing quote + OR 1=1 must be treated as a
-        // literal string, not executed as SQL.
-        let engine = make_engine_with_users();
-        let sql = "SELECT id FROM users WHERE name = $name";
-        let params = vec![(
-            "name".to_string(),
-            ScalarValue::Utf8(Some("alice' OR '1'='1".to_string())),
-        )];
-
-        let batch = engine.execute_with_params(sql, params).await.unwrap();
-        // No row matches the literal injection string → empty result
-        assert_eq!(batch.num_rows(), 0);
     }
 }

--- a/crates/skardi/src/engine/mod.rs
+++ b/crates/skardi/src/engine/mod.rs
@@ -3,7 +3,6 @@
 use anyhow::Result;
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
-use datafusion_common::ScalarValue;
 
 pub mod datafusion;
 
@@ -39,20 +38,4 @@ pub trait Engine: Send + Sync {
     /// }
     /// ```
     async fn execute(&self, sql: &str) -> Result<RecordBatch>;
-
-    /// Execute a SQL query with named parameter values
-    ///
-    /// Uses DataFusion's native parameterised query support (`$param_name`
-    /// placeholders) instead of string interpolation, which avoids
-    /// ordering-dependent placeholder corruption and SQL injection.
-    ///
-    /// # Arguments
-    ///
-    /// * `sql` - SQL query with `$name` placeholders
-    /// * `params` - Named parameter values to bind
-    async fn execute_with_params(
-        &self,
-        sql: &str,
-        params: Vec<(String, ScalarValue)>,
-    ) -> Result<RecordBatch>;
 }


### PR DESCRIPTION
This reverts commit e23f303f35efd9ce4040ab81121e2dcd0fee3742.