### PR TITLE
refactor(config): unify all resource YAMLs onto `{ kind, metadata, spec }` envelope

### DIFF
--- a/crates/cli/src/alias_store.rs
+++ b/crates/cli/src/alias_store.rs
@@ -1,17 +1,25 @@
 //! Load/save the CLI aliases file.
 //!
-//! Aliases are stored as a top-level YAML map keyed by alias name:
+//! Aliases are stored as a Kubernetes-style manifest: a `kind: aliases`
+//! discriminator at the root, a `metadata:` block, and the actual alias
+//! entries under `spec:`:
 //!
 //! ```yaml
-//! grep:
-//!   pipeline: wiki-search-hybrid
-//!   positional: [query]
-//!   defaults:
-//!     text_query: "{query}"
-//!     limit: "10"
-//! ls:
-//!   pipeline: wiki-list
-//!   ...
+//! kind: aliases
+//! metadata:
+//!   name: wiki-cli-aliases
+//!   version: 1.0.0
+//!   description: Shortcuts for the llm_wiki CLI
+//! spec:
+//!   grep:
+//!     pipeline: wiki-search-hybrid
+//!     positional: [query]
+//!     defaults:
+//!       text_query: "{query}"
+//!       limit: "10"
+//!   ls:
+//!     pipeline: wiki-list
+//!     ...
 //! ```
 //!
 //! The file path is resolved in this order:
@@ -24,13 +32,78 @@
 //!    is enough to locate the sibling `aliases.yaml`.
 //! 4. `~/.skardi/config/aliases.yaml`.
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use crate::alias::AliasDef;
 
 pub type AliasMap = BTreeMap<String, AliasDef>;
+
+/// Root-level `kind:` discriminator. Only `aliases` is accepted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AliasFileKind {
+    Aliases,
+}
+
+impl Default for AliasFileKind {
+    fn default() -> Self {
+        Self::Aliases
+    }
+}
+
+fn default_version() -> String {
+    "1.0.0".to_string()
+}
+
+fn default_metadata_name() -> String {
+    "aliases".to_string()
+}
+
+/// `metadata:` block. `name` and `version` are required on load; `save`
+/// fills in sensible defaults for freshly-created files.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AliasMetadata {
+    #[serde(default = "default_metadata_name")]
+    pub name: String,
+    #[serde(default = "default_version")]
+    pub version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+impl Default for AliasMetadata {
+    fn default() -> Self {
+        Self {
+            name: default_metadata_name(),
+            version: default_version(),
+            description: None,
+        }
+    }
+}
+
+/// Full on-disk shape of an aliases YAML file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AliasFile {
+    #[serde(default)]
+    pub kind: AliasFileKind,
+    #[serde(default)]
+    pub metadata: AliasMetadata,
+    #[serde(default)]
+    pub spec: AliasMap,
+}
+
+impl Default for AliasFile {
+    fn default() -> Self {
+        Self {
+            kind: AliasFileKind::default(),
+            metadata: AliasMetadata::default(),
+            spec: AliasMap::new(),
+        }
+    }
+}
 
 /// Resolve the aliases file path. Returns `None` when neither an explicit
 /// override nor a default home is available.
@@ -79,24 +152,48 @@ pub fn resolve_aliases_path(
     Some(home_default)
 }
 
-/// Load aliases from disk. A missing file is not an error — it yields an
-/// empty map, which is the correct starting state for a brand-new project.
-pub fn load(path: &Path) -> Result<AliasMap> {
+/// Load the aliases file. A missing or empty file is not an error — it
+/// yields a default `AliasFile` with an empty `spec`, which is the correct
+/// starting state for a brand-new project. The file's `kind:` must be
+/// `aliases` when present.
+pub fn load(path: &Path) -> Result<AliasFile> {
     if !path.exists() {
-        return Ok(AliasMap::new());
+        return Ok(AliasFile::default());
     }
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("Failed to read aliases file: {}", path.display()))?;
     if content.trim().is_empty() {
-        return Ok(AliasMap::new());
+        return Ok(AliasFile::default());
     }
-    let map: AliasMap = serde_yaml::from_str(&content)
+
+    // Peek at `kind:` first so we can give a clear error when someone points
+    // us at the wrong type of YAML (e.g. a pipeline) rather than a confusing
+    // serde mismatch.
+    let root: serde_yaml::Value = serde_yaml::from_str(&content)
         .with_context(|| format!("Failed to parse aliases YAML: {}", path.display()))?;
-    Ok(map)
+    if let Some(kind) = root.get("kind") {
+        let kind_str = kind.as_str().unwrap_or("");
+        if kind_str != "aliases" {
+            return Err(anyhow!(
+                "Expected `kind: aliases` in {}, got `kind: {kind_str}`",
+                path.display()
+            ));
+        }
+    } else {
+        return Err(anyhow!(
+            "Aliases file {} is missing `kind: aliases` at the root. \
+             The file format now requires a `kind`, `metadata`, and `spec` envelope.",
+            path.display()
+        ));
+    }
+
+    let file: AliasFile = serde_yaml::from_value(root)
+        .with_context(|| format!("Failed to parse aliases YAML: {}", path.display()))?;
+    Ok(file)
 }
 
-/// Save aliases to disk, creating parent directories as needed.
-pub fn save(path: &Path, map: &AliasMap) -> Result<()> {
+/// Save the aliases file to disk, creating parent directories as needed.
+pub fn save(path: &Path, file: &AliasFile) -> Result<()> {
     if let Some(parent) = path.parent() {
         if !parent.as_os_str().is_empty() {
             std::fs::create_dir_all(parent).with_context(|| {
@@ -104,7 +201,7 @@ pub fn save(path: &Path, map: &AliasMap) -> Result<()> {
             })?;
         }
     }
-    let yaml = serde_yaml::to_string(map).context("Failed to serialize aliases map to YAML")?;
+    let yaml = serde_yaml::to_string(file).context("Failed to serialize aliases file to YAML")?;
     std::fs::write(path, yaml)
         .with_context(|| format!("Failed to write aliases file: {}", path.display()))?;
     Ok(())
@@ -127,34 +224,64 @@ mod tests {
         }
     }
 
+    fn sample_file() -> AliasFile {
+        let mut file = AliasFile::default();
+        file.metadata.name = "test-aliases".to_string();
+        file.metadata.description = Some("Unit test fixture".to_string());
+        file.spec.insert("grep".to_string(), sample_alias());
+        file
+    }
+
     #[test]
     fn save_then_load_roundtrip() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("aliases.yaml");
-        let mut map = AliasMap::new();
-        map.insert("grep".to_string(), sample_alias());
-        save(&path, &map).unwrap();
+        save(&path, &sample_file()).unwrap();
 
         let loaded = load(&path).unwrap();
-        assert_eq!(loaded.len(), 1);
-        let grep = &loaded["grep"];
+        assert_eq!(loaded.kind, AliasFileKind::Aliases);
+        assert_eq!(loaded.metadata.name, "test-aliases");
+        assert_eq!(loaded.metadata.version, "1.0.0");
+        assert_eq!(loaded.spec.len(), 1);
+        let grep = &loaded.spec["grep"];
         assert_eq!(grep.pipeline, "wiki-search-hybrid");
         assert_eq!(grep.positional, vec!["query".to_string()]);
         assert_eq!(grep.defaults["limit"], "10");
     }
 
     #[test]
-    fn load_missing_file_returns_empty_map() {
+    fn load_missing_file_returns_empty_default() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("does-not-exist.yaml");
         let loaded = load(&path).unwrap();
-        assert!(loaded.is_empty());
+        assert!(loaded.spec.is_empty());
+        assert_eq!(loaded.kind, AliasFileKind::Aliases);
+    }
+
+    #[test]
+    fn load_legacy_flat_map_errors_with_clear_message() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("aliases.yaml");
+        std::fs::write(
+            &path,
+            "grep:\n  pipeline: wiki-search-hybrid\n  positional: [query]\n",
+        )
+        .unwrap();
+        let err = load(&path).unwrap_err().to_string();
+        assert!(err.contains("kind: aliases"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn load_wrong_kind_errors() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("aliases.yaml");
+        std::fs::write(&path, "kind: pipeline\nmetadata:\n  name: p\n").unwrap();
+        let err = load(&path).unwrap_err().to_string();
+        assert!(err.contains("kind: aliases"), "unexpected error: {err}");
     }
 
     /// Regression guard: the bundled demo alias files should continue to load
-    /// under the `BTreeMap<String, String>` defaults shape. They were
-    /// hand-written before the HashMap→BTreeMap switch, so this catches any
-    /// deserialization drift (e.g. a key type mismatch, rename, …).
+    /// under the new envelope shape.
     #[test]
     fn demo_alias_files_still_load() {
         // Walk up from `crates/cli/src/` to the repo root so the test works
@@ -172,13 +299,14 @@ mod tests {
             let path = repo_root.join(rel);
             let loaded =
                 load(&path).unwrap_or_else(|e| panic!("failed to load {}: {e:?}", path.display()));
+            assert_eq!(loaded.kind, AliasFileKind::Aliases);
             assert!(
-                !loaded.is_empty(),
+                !loaded.spec.is_empty(),
                 "{} parsed but produced no aliases",
                 path.display()
             );
             // Every entry must have a non-empty pipeline target.
-            for (name, def) in &loaded {
+            for (name, def) in &loaded.spec {
                 assert!(
                     !def.pipeline.is_empty(),
                     "alias {name} in {} has empty pipeline",

--- a/crates/cli/src/alias_store.rs
+++ b/crates/cli/src/alias_store.rs
@@ -41,17 +41,14 @@ use crate::alias::AliasDef;
 
 pub type AliasMap = BTreeMap<String, AliasDef>;
 
-/// Root-level `kind:` discriminator. Only `aliases` is accepted.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum AliasFileKind {
-    Aliases,
-}
+/// Required value of the root `kind:` key. Aliases files only accept this
+/// one discriminator; [`load`] enforces it via a pre-parse peek so the
+/// error message can include the file path and the actual offending
+/// value, which serde's native "unknown variant" diagnostic does not.
+pub const ALIASES_KIND: &str = "aliases";
 
-impl Default for AliasFileKind {
-    fn default() -> Self {
-        Self::Aliases
-    }
+fn default_kind() -> String {
+    ALIASES_KIND.to_string()
 }
 
 fn default_version() -> String {
@@ -87,8 +84,8 @@ impl Default for AliasMetadata {
 /// Full on-disk shape of an aliases YAML file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AliasFile {
-    #[serde(default)]
-    pub kind: AliasFileKind,
+    #[serde(default = "default_kind")]
+    pub kind: String,
     #[serde(default)]
     pub metadata: AliasMetadata,
     #[serde(default)]
@@ -98,7 +95,7 @@ pub struct AliasFile {
 impl Default for AliasFile {
     fn default() -> Self {
         Self {
-            kind: AliasFileKind::default(),
+            kind: default_kind(),
             metadata: AliasMetadata::default(),
             spec: AliasMap::new(),
         }
@@ -173,7 +170,7 @@ pub fn load(path: &Path) -> Result<AliasFile> {
         .with_context(|| format!("Failed to parse aliases YAML: {}", path.display()))?;
     if let Some(kind) = root.get("kind") {
         let kind_str = kind.as_str().unwrap_or("");
-        if kind_str != "aliases" {
+        if kind_str != ALIASES_KIND {
             return Err(anyhow!(
                 "Expected `kind: aliases` in {}, got `kind: {kind_str}`",
                 path.display()
@@ -239,7 +236,7 @@ mod tests {
         save(&path, &sample_file()).unwrap();
 
         let loaded = load(&path).unwrap();
-        assert_eq!(loaded.kind, AliasFileKind::Aliases);
+        assert_eq!(loaded.kind, ALIASES_KIND);
         assert_eq!(loaded.metadata.name, "test-aliases");
         assert_eq!(loaded.metadata.version, "1.0.0");
         assert_eq!(loaded.spec.len(), 1);
@@ -255,7 +252,7 @@ mod tests {
         let path = dir.path().join("does-not-exist.yaml");
         let loaded = load(&path).unwrap();
         assert!(loaded.spec.is_empty());
-        assert_eq!(loaded.kind, AliasFileKind::Aliases);
+        assert_eq!(loaded.kind, ALIASES_KIND);
     }
 
     #[test]
@@ -299,7 +296,7 @@ mod tests {
             let path = repo_root.join(rel);
             let loaded =
                 load(&path).unwrap_or_else(|e| panic!("failed to load {}: {e:?}", path.display()));
-            assert_eq!(loaded.kind, AliasFileKind::Aliases);
+            assert_eq!(loaded.kind, ALIASES_KIND);
             assert!(
                 !loaded.spec.is_empty(),
                 "{} parsed but produced no aliases",

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -161,7 +161,7 @@ enum AliasCmd {
         #[arg(long)]
         ctx: Option<PathBuf>,
     },
-    /// Show one alias in YAML form
+    /// Show one alias as a YAML fragment (not a loadable aliases file)
     Show {
         name: String,
         #[arg(long)]
@@ -181,11 +181,19 @@ enum AliasCmd {
 
 /// Top-level envelope for context YAML files. Shares the
 /// `{ kind, metadata, spec }` shape with pipelines, jobs, and aliases.
+///
+/// `kind` is `Option` rather than required so a missing discriminator
+/// produces the same "Missing `kind: context`" diagnostic as the server,
+/// instead of serde's generic "missing field `kind`" message. `metadata`
+/// is required — a missing or typo'd key (e.g. `metdata:`) surfaces at
+/// parse time; the value is retained as an opaque `serde_yaml::Value`
+/// because nothing at runtime reads inside it.
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 struct LocalContextFile {
-    kind: String,
     #[serde(default)]
-    metadata: Option<serde_yaml::Value>,
+    kind: Option<String>,
+    metadata: serde_yaml::Value,
     spec: LocalContextConfig,
 }
 
@@ -715,15 +723,18 @@ fn read_context_file(ctx_path: &Path) -> Result<LocalContextConfig> {
         .with_context(|| format!("Failed to read context file: {}", ctx_path.display()))?;
     let file: LocalContextFile =
         serde_yaml::from_str(&content).context("Failed to parse context YAML")?;
-    if file.kind != "context" {
-        anyhow::bail!(
+    match file.kind.as_deref() {
+        Some("context") => {}
+        Some(other) => anyhow::bail!(
             "Expected `kind: context` in {}, got `kind: {}`",
             ctx_path.display(),
-            file.kind
-        );
+            other,
+        ),
+        None => anyhow::bail!(
+            "Missing `kind: context` at the root of {}",
+            ctx_path.display(),
+        ),
     }
-    // `metadata` is read for shape validation but otherwise unused at runtime.
-    let _ = file.metadata;
     Ok(file.spec)
 }
 
@@ -1589,8 +1600,11 @@ fn alias_show(name: String, aliases: Option<PathBuf>, ctx: Option<PathBuf>) -> R
         .get(&name)
         .ok_or_else(|| anyhow::anyhow!("Alias '{name}' not found in {}", path.display()))?;
 
-    // Print just the `<name>: <def>` entry, not the full file envelope —
-    // the envelope is noise when the user asked for a single alias.
+    // Print just the `<name>: <def>` entry, not the full `{ kind, metadata,
+    // spec }` envelope — the envelope is noise when the user asked for a
+    // single alias. The output is deliberately a fragment, not a loadable
+    // aliases file; `alias show`'s contract is human inspection, not
+    // round-tripping through `alias_store::load`.
     let mut single = AliasMap::new();
     single.insert(name.clone(), def.clone());
     let yaml = serde_yaml::to_string(&single).context("Failed to render alias to YAML")?;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -179,6 +179,16 @@ enum AliasCmd {
     },
 }
 
+/// Top-level envelope for context YAML files. Shares the
+/// `{ kind, metadata, spec }` shape with pipelines, jobs, and aliases.
+#[derive(Debug, Deserialize)]
+struct LocalContextFile {
+    kind: String,
+    #[serde(default)]
+    metadata: Option<serde_yaml::Value>,
+    spec: LocalContextConfig,
+}
+
 #[derive(Debug, Deserialize)]
 struct LocalContextConfig {
     data_sources: Vec<LocalDataSource>,
@@ -581,8 +591,8 @@ async fn main() -> Result<()> {
                 aliases_override.as_deref(),
                 ctx_override.as_deref().or_else(|| default_ctx.as_deref()),
             );
-            let alias_map = match &aliases_path {
-                Some(p) => alias_store::load(p)?,
+            let alias_map: AliasMap = match &aliases_path {
+                Some(p) => alias_store::load(p)?.spec,
                 None => AliasMap::new(),
             };
 
@@ -685,10 +695,7 @@ async fn load_and_register_all(
     session_ctx: &mut SessionContext,
     dataset_registry: &DatasetRegistry,
 ) -> Result<LocalContextConfig> {
-    let content = std::fs::read_to_string(ctx_path)
-        .with_context(|| format!("Failed to read context file: {}", ctx_path.display()))?;
-    let config: LocalContextConfig =
-        serde_yaml::from_str(&content).context("Failed to parse context YAML")?;
+    let config = read_context_file(ctx_path)?;
 
     for source in &config.data_sources {
         register_source(session_ctx, source, dataset_registry)
@@ -697,6 +704,27 @@ async fn load_and_register_all(
     }
 
     Ok(config)
+}
+
+/// Parse a context YAML file into its `spec:` body, rejecting anything that
+/// isn't a `kind: context` document. All three CLI entry points that load a
+/// ctx (startup, `alias add` parameter preview, alias `show` annotation) go
+/// through this helper so the envelope is enforced consistently.
+fn read_context_file(ctx_path: &Path) -> Result<LocalContextConfig> {
+    let content = std::fs::read_to_string(ctx_path)
+        .with_context(|| format!("Failed to read context file: {}", ctx_path.display()))?;
+    let file: LocalContextFile =
+        serde_yaml::from_str(&content).context("Failed to parse context YAML")?;
+    if file.kind != "context" {
+        anyhow::bail!(
+            "Expected `kind: context` in {}, got `kind: {}`",
+            ctx_path.display(),
+            file.kind
+        );
+    }
+    // `metadata` is read for shape validation but otherwise unused at runtime.
+    let _ = file.metadata;
+    Ok(file.spec)
 }
 
 /// Register a single data source into the session context.
@@ -1206,11 +1234,7 @@ async fn run_pipeline_with_params(
     // registering data sources — errors on the pipeline side should surface
     // before we pay the cost of connecting to Postgres/Mongo/etc.
     let ctx_cfg: Option<LocalContextConfig> = match &ctx_path_for_load {
-        Some(p) => {
-            let content = std::fs::read_to_string(p)
-                .with_context(|| format!("Failed to read context file: {}", p.display()))?;
-            Some(serde_yaml::from_str(&content).context("Failed to parse context YAML")?)
-        }
+        Some(p) => Some(read_context_file(p)?),
         None => None,
     };
 
@@ -1378,12 +1402,12 @@ fn alias_add(
 ) -> Result<()> {
     let path = resolve_aliases_path(aliases.as_deref(), ctx.as_deref())
         .ok_or_else(|| anyhow::anyhow!("Could not resolve aliases file path"))?;
-    let mut map = alias_store::load(&path)?;
-    if map.contains_key(&name) && !force {
+    let mut file = alias_store::load(&path)?;
+    if file.spec.contains_key(&name) && !force {
         anyhow::bail!(
             "Alias '{name}' already exists. Use --force to overwrite. \
              Current target: {}",
-            map[&name].pipeline
+            file.spec[&name].pipeline
         );
     }
 
@@ -1430,7 +1454,7 @@ fn alias_add(
         }
     }
 
-    map.insert(
+    file.spec.insert(
         name.clone(),
         AliasDef {
             pipeline: pipeline.clone(),
@@ -1439,7 +1463,7 @@ fn alias_add(
             description,
         },
     );
-    alias_store::save(&path, &map)?;
+    alias_store::save(&path, &file)?;
     println!(
         "Alias '{}' → pipeline '{}' saved to {}",
         name,
@@ -1458,11 +1482,7 @@ fn try_load_pipeline_params(
     // Parse ctx if provided so `pipelines_dir` can point us at the pipelines.
     let ctx_path = resolve_ctx_path(ctx_override).filter(|p| p.exists());
     let ctx_cfg: Option<LocalContextConfig> = match &ctx_path {
-        Some(p) => {
-            let content = std::fs::read_to_string(p)
-                .with_context(|| format!("Failed to read context file: {}", p.display()))?;
-            Some(serde_yaml::from_str(&content).context("Failed to parse context YAML")?)
-        }
+        Some(p) => Some(read_context_file(p)?),
         None => None,
     };
 
@@ -1541,13 +1561,13 @@ fn report_alias_coverage(
 fn alias_list(aliases: Option<PathBuf>, ctx: Option<PathBuf>) -> Result<()> {
     let path = resolve_aliases_path(aliases.as_deref(), ctx.as_deref())
         .ok_or_else(|| anyhow::anyhow!("Could not resolve aliases file path"))?;
-    let map = alias_store::load(&path)?;
-    if map.is_empty() {
+    let file = alias_store::load(&path)?;
+    if file.spec.is_empty() {
         println!("No aliases defined (file: {})", path.display());
         return Ok(());
     }
     println!("Aliases from {}:", path.display());
-    for (name, def) in &map {
+    for (name, def) in &file.spec {
         let desc = def.description.as_deref().unwrap_or("");
         println!(
             "  {:<12} → run {}{}{}",
@@ -1563,12 +1583,14 @@ fn alias_list(aliases: Option<PathBuf>, ctx: Option<PathBuf>) -> Result<()> {
 fn alias_show(name: String, aliases: Option<PathBuf>, ctx: Option<PathBuf>) -> Result<()> {
     let path = resolve_aliases_path(aliases.as_deref(), ctx.as_deref())
         .ok_or_else(|| anyhow::anyhow!("Could not resolve aliases file path"))?;
-    let map = alias_store::load(&path)?;
-    let def = map
+    let file = alias_store::load(&path)?;
+    let def = file
+        .spec
         .get(&name)
         .ok_or_else(|| anyhow::anyhow!("Alias '{name}' not found in {}", path.display()))?;
 
-    // Print the stored alias YAML verbatim.
+    // Print just the `<name>: <def>` entry, not the full file envelope —
+    // the envelope is noise when the user asked for a single alias.
     let mut single = AliasMap::new();
     single.insert(name.clone(), def.clone());
     let yaml = serde_yaml::to_string(&single).context("Failed to render alias to YAML")?;
@@ -1677,11 +1699,11 @@ fn print_alias_help(alias_name: &str, def: &AliasDef, pipeline_params: Option<&[
 fn alias_remove(name: String, aliases: Option<PathBuf>, ctx: Option<PathBuf>) -> Result<()> {
     let path = resolve_aliases_path(aliases.as_deref(), ctx.as_deref())
         .ok_or_else(|| anyhow::anyhow!("Could not resolve aliases file path"))?;
-    let mut map = alias_store::load(&path)?;
-    if map.remove(&name).is_none() {
+    let mut file = alias_store::load(&path)?;
+    if file.spec.remove(&name).is_none() {
         anyhow::bail!("Alias '{name}' not found in {}", path.display());
     }
-    alias_store::save(&path, &map)?;
+    alias_store::save(&path, &file)?;
     println!("Alias '{}' removed from {}", name, path.display());
     Ok(())
 }
@@ -2007,10 +2029,13 @@ mod tests {
             write_pipeline(
                 tmp.path(),
                 "echo.yaml",
-                r#"metadata:
+                r#"kind: pipeline
+metadata:
   name: "echo"
-query: |
-  SELECT {x} AS val, {msg} AS note
+  version: "1.0.0"
+spec:
+  query: |
+    SELECT {x} AS val, {msg} AS note
 "#,
             );
 
@@ -2033,10 +2058,13 @@ query: |
             write_pipeline(
                 tmp.path(),
                 "needs.yaml",
-                r#"metadata:
+                r#"kind: pipeline
+metadata:
   name: "needs"
-query: |
-  SELECT {required} AS val
+  version: "1.0.0"
+spec:
+  query: |
+    SELECT {required} AS val
 "#,
             );
 
@@ -2057,9 +2085,12 @@ query: |
             write_pipeline(
                 tmp.path(),
                 "only_this_one.yaml",
-                r#"metadata:
+                r#"kind: pipeline
+metadata:
   name: "only-this-one"
-query: "SELECT 1"
+  version: "1.0.0"
+spec:
+  query: "SELECT 1"
 "#,
             );
 

--- a/crates/cli/src/pipeline.rs
+++ b/crates/cli/src/pipeline.rs
@@ -55,7 +55,16 @@ pub struct PipelineFile {
 pub fn load_pipeline_from_path(path: &Path) -> Result<PipelineFile> {
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("Failed to read pipeline file: {}", path.display()))?;
-    let env: PipelineEnvelope = serde_yaml::from_str(&content)
+    let value: serde_yaml::Value = serde_yaml::from_str(&content)
+        .with_context(|| format!("Failed to parse pipeline YAML: {}", path.display()))?;
+    pipeline_from_value(path, value)
+}
+
+/// Build a `PipelineFile` from an already-parsed YAML root, enforcing the
+/// `kind: pipeline` discriminator. Shared between the single-file loader
+/// and directory discovery so each file is read and parsed only once.
+fn pipeline_from_value(path: &Path, value: serde_yaml::Value) -> Result<PipelineFile> {
+    let env: PipelineEnvelope = serde_yaml::from_value(value)
         .with_context(|| format!("Failed to parse pipeline YAML: {}", path.display()))?;
     if env.kind != "pipeline" {
         anyhow::bail!(
@@ -76,7 +85,9 @@ pub fn load_pipeline_from_path(path: &Path) -> Result<PipelineFile> {
 ///
 /// Files whose root `kind:` is anything other than `pipeline` (e.g.
 /// `kind: job`) are skipped silently — a pipelines dir is expected to
-/// hold a mixed bag of resource YAMLs.
+/// hold a mixed bag of resource YAMLs. Files that fail to parse as YAML,
+/// however, are a hard error: staying silent on those would hide typos in
+/// bundled pipelines behind a confusing "pipeline not found" later.
 pub fn discover_pipelines(dirs: &[PathBuf]) -> Result<HashMap<String, (PathBuf, PipelineFile)>> {
     let mut out: HashMap<String, (PathBuf, PipelineFile)> = HashMap::new();
     for dir in dirs {
@@ -99,20 +110,14 @@ pub fn discover_pipelines(dirs: &[PathBuf]) -> Result<HashMap<String, (PathBuf, 
             if ext != "yaml" && ext != "yml" {
                 continue;
             }
-            // Peek at `kind:` so non-pipeline files (jobs, contexts, etc.)
-            // that happen to sit in the pipelines dir are skipped rather
-            // than erroring out the whole discovery pass.
             let raw = std::fs::read_to_string(&p)
                 .with_context(|| format!("Failed to read pipeline file: {}", p.display()))?;
-            let peek: serde_yaml::Value = match serde_yaml::from_str(&raw) {
-                Ok(v) => v,
-                Err(_) => continue,
-            };
-            if peek.get("kind").and_then(|v| v.as_str()) != Some("pipeline") {
+            let value: serde_yaml::Value = serde_yaml::from_str(&raw)
+                .with_context(|| format!("Failed to parse pipeline YAML: {}", p.display()))?;
+            if value.get("kind").and_then(|v| v.as_str()) != Some("pipeline") {
                 continue;
             }
-
-            let pipeline = load_pipeline_from_path(&p)?;
+            let pipeline = pipeline_from_value(&p, value)?;
             out.insert(pipeline.metadata.name.clone(), (p, pipeline));
         }
     }
@@ -357,6 +362,66 @@ pub fn parse_param_flag(raw: &str) -> Result<(String, ScalarValue)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
+
+    fn write(dir: &Path, name: &str, body: &str) {
+        std::fs::write(dir.join(name), body).unwrap();
+    }
+
+    #[test]
+    fn discover_pipelines_skips_non_pipeline_kinds() {
+        // A pipelines directory can hold other resource YAMLs (jobs,
+        // contexts) side-by-side; discovery must skip those silently while
+        // still registering real pipelines.
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        write(
+            dir,
+            "real.yaml",
+            "kind: pipeline\nmetadata:\n  name: real\nspec:\n  query: SELECT 1\n",
+        );
+        write(
+            dir,
+            "a_job.yaml",
+            "kind: job\nmetadata:\n  name: j\nspec:\n  query: SELECT 1\n  destination:\n    table: t\n",
+        );
+        write(
+            dir,
+            "a_ctx.yaml",
+            "kind: context\nmetadata:\n  name: c\nspec:\n  data_sources: []\n",
+        );
+        // Non-YAML extensions should be ignored outright.
+        write(dir, "README.md", "# not yaml\n");
+
+        let out = discover_pipelines(&[dir.to_path_buf()]).unwrap();
+        assert_eq!(out.len(), 1, "only the real pipeline should register");
+        assert!(out.contains_key("real"));
+    }
+
+    #[test]
+    fn discover_pipelines_errors_on_malformed_yaml() {
+        // A file that cannot be parsed as YAML used to be silently
+        // swallowed. That hid typos in bundled pipelines — the caller only
+        // saw "pipeline not found" later. Discovery now surfaces the parse
+        // error with file context.
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        write(
+            dir,
+            "good.yaml",
+            "kind: pipeline\nmetadata:\n  name: g\nspec:\n  query: SELECT 1\n",
+        );
+        // Valid pipeline kind, but the YAML itself is malformed
+        // (unterminated flow mapping).
+        write(dir, "broken.yaml", "kind: pipeline\nmetadata: { name: ");
+
+        let err = discover_pipelines(&[dir.to_path_buf()]).unwrap_err();
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("broken.yaml"),
+            "error should name the offending file, got: {chain}"
+        );
+    }
 
     #[test]
     fn extract_param_names_preserves_order_and_dedups() {

--- a/crates/cli/src/pipeline.rs
+++ b/crates/cli/src/pipeline.rs
@@ -3,12 +3,14 @@
 //! The CLI reuses the server's pipeline YAML format:
 //!
 //! ```yaml
+//! kind: pipeline
 //! metadata:
 //!   name: "wiki-search-hybrid"
 //!   version: "1.0.0"
 //!   description: "..."
-//! query: |
-//!   SELECT ... WHERE slug = {slug} LIMIT {limit}
+//! spec:
+//!   query: |
+//!     SELECT ... WHERE slug = {slug} LIMIT {limit}
 //! ```
 //!
 //! Placeholders of the form `{name}` in the SQL are converted to DataFusion's
@@ -27,23 +29,54 @@ pub struct PipelineMetadata {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct PipelineSpec {
+    pub query: String,
+}
+
+/// On-disk envelope for a pipeline YAML.
+#[derive(Debug, Deserialize)]
+struct PipelineEnvelope {
+    kind: String,
+    metadata: PipelineMetadata,
+    spec: PipelineSpec,
+}
+
+#[derive(Debug)]
 pub struct PipelineFile {
     pub metadata: PipelineMetadata,
     pub query: String,
 }
 
 /// Load a single pipeline YAML from disk.
+///
+/// Returns an error if the file is not a `kind: pipeline` document —
+/// `kind: job` files have their own loader path (`JobDefinition`), and
+/// any other kind is unsupported here.
 pub fn load_pipeline_from_path(path: &Path) -> Result<PipelineFile> {
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("Failed to read pipeline file: {}", path.display()))?;
-    let pipeline: PipelineFile = serde_yaml::from_str(&content)
+    let env: PipelineEnvelope = serde_yaml::from_str(&content)
         .with_context(|| format!("Failed to parse pipeline YAML: {}", path.display()))?;
-    Ok(pipeline)
+    if env.kind != "pipeline" {
+        anyhow::bail!(
+            "Expected `kind: pipeline` in {}, got `kind: {}`",
+            path.display(),
+            env.kind
+        );
+    }
+    Ok(PipelineFile {
+        metadata: env.metadata,
+        query: env.spec.query,
+    })
 }
 
 /// Scan a set of directories for `*.yaml` / `*.yml` pipeline files and
 /// return a map keyed by `metadata.name`. Later directories shadow earlier
 /// ones on name collision so per-project dirs can override shared ones.
+///
+/// Files whose root `kind:` is anything other than `pipeline` (e.g.
+/// `kind: job`) are skipped silently — a pipelines dir is expected to
+/// hold a mixed bag of resource YAMLs.
 pub fn discover_pipelines(dirs: &[PathBuf]) -> Result<HashMap<String, (PathBuf, PipelineFile)>> {
     let mut out: HashMap<String, (PathBuf, PipelineFile)> = HashMap::new();
     for dir in dirs {
@@ -66,6 +99,19 @@ pub fn discover_pipelines(dirs: &[PathBuf]) -> Result<HashMap<String, (PathBuf, 
             if ext != "yaml" && ext != "yml" {
                 continue;
             }
+            // Peek at `kind:` so non-pipeline files (jobs, contexts, etc.)
+            // that happen to sit in the pipelines dir are skipped rather
+            // than erroring out the whole discovery pass.
+            let raw = std::fs::read_to_string(&p)
+                .with_context(|| format!("Failed to read pipeline file: {}", p.display()))?;
+            let peek: serde_yaml::Value = match serde_yaml::from_str(&raw) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            if peek.get("kind").and_then(|v| v.as_str()) != Some("pipeline") {
+                continue;
+            }
+
             let pipeline = load_pipeline_from_path(&p)?;
             out.insert(pipeline.metadata.name.clone(), (p, pipeline));
         }

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -112,12 +112,19 @@ pub struct DataSource {
 
 /// Top-level envelope for context YAML files:
 /// `{ kind: context, metadata: {...}, spec: { data_sources: [...] } }`.
+///
+/// `kind` is an `Option` so the loader can distinguish "missing kind" from
+/// "wrong kind" and produce a targeted error for each. `metadata` is
+/// required — making it mandatory means a missing or typo'd key (e.g.
+/// `metdata:`) surfaces at parse time rather than being silently dropped.
+/// The value is kept as an opaque `serde_yaml::Value` because nothing at
+/// runtime reads inside it.
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 struct ContextFile {
     #[serde(default)]
     kind: Option<String>,
-    #[serde(default)]
-    metadata: Option<serde_yaml::Value>,
+    metadata: serde_yaml::Value,
     spec: ContextSpec,
 }
 
@@ -613,9 +620,6 @@ fn load_context_config(path: &Path) -> Result<Vec<DataSource>> {
             .into());
         }
     }
-    // `metadata` is read but otherwise unused at runtime — kept so misshapen
-    // files fail at parse time rather than silently dropping keys.
-    let _ = context_file.metadata;
 
     // Validate data sources
     validate_data_sources(&context_file.spec.data_sources)?;

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -110,9 +110,20 @@ pub struct DataSource {
     pub enable_cache: bool,
 }
 
-/// Context configuration file structure
+/// Top-level envelope for context YAML files:
+/// `{ kind: context, metadata: {...}, spec: { data_sources: [...] } }`.
 #[derive(Debug, Deserialize)]
-struct ContextConfig {
+struct ContextFile {
+    #[serde(default)]
+    kind: Option<String>,
+    #[serde(default)]
+    metadata: Option<serde_yaml::Value>,
+    spec: ContextSpec,
+}
+
+/// Context configuration file structure (`spec:` block).
+#[derive(Debug, Deserialize)]
+struct ContextSpec {
     data_sources: Vec<DataSource>,
 }
 
@@ -480,9 +491,14 @@ fn extract_pipeline_sql(path: &Path) -> Result<(String, String)> {
     }
 
     #[derive(Deserialize)]
+    struct MinimalSpec {
+        query: String,
+    }
+
+    #[derive(Deserialize)]
     struct MinimalPipeline {
         metadata: PipelineMetadata,
-        query: String,
+        spec: MinimalSpec,
     }
 
     let content = std::fs::read_to_string(path)
@@ -491,7 +507,7 @@ fn extract_pipeline_sql(path: &Path) -> Result<(String, String)> {
     let pipeline: MinimalPipeline = serde_yaml::from_str(&content)
         .with_context(|| format!("Failed to parse pipeline YAML: {:?}", path))?;
 
-    Ok((pipeline.metadata.name, pipeline.query))
+    Ok((pipeline.metadata.name, pipeline.spec.query))
 }
 
 /// Load pipeline configuration from YAML file
@@ -573,20 +589,43 @@ fn load_context_config(path: &Path) -> Result<Vec<DataSource>> {
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("Failed to read context file: {:?}", path))?;
 
-    let context_config: ContextConfig =
+    let context_file: ContextFile =
         serde_yaml::from_str(&content).map_err(|e| ConfigError::InvalidContextYaml {
             error: e.to_string(),
         })?;
 
+    // The envelope is uniform with pipelines/jobs/aliases: `kind: context`,
+    // then `metadata:` and `spec:`. The kind check is strict — unknown or
+    // missing values are rejected so a misfiled pipeline/job does not get
+    // silently partially-loaded as a context.
+    match context_file.kind.as_deref() {
+        Some("context") => {}
+        Some(other) => {
+            return Err(ConfigError::InvalidContextYaml {
+                error: format!("Expected `kind: context`, got `kind: {other}`"),
+            }
+            .into());
+        }
+        None => {
+            return Err(ConfigError::InvalidContextYaml {
+                error: "Missing `kind: context` at the root of the context file".to_string(),
+            }
+            .into());
+        }
+    }
+    // `metadata` is read but otherwise unused at runtime — kept so misshapen
+    // files fail at parse time rather than silently dropping keys.
+    let _ = context_file.metadata;
+
     // Validate data sources
-    validate_data_sources(&context_config.data_sources)?;
+    validate_data_sources(&context_file.spec.data_sources)?;
 
     tracing::info!(
         "Loaded {} data sources from context",
-        context_config.data_sources.len()
+        context_file.spec.data_sources.len()
     );
 
-    Ok(context_config.data_sources)
+    Ok(context_file.spec.data_sources)
 }
 
 /// Data source types that support catalog (whole-database) registration mode.
@@ -1315,16 +1354,17 @@ mod tests {
 
     fn create_test_pipeline_file(dir: &TempDir) -> PathBuf {
         let pipeline_content = r#"
+kind: pipeline
 metadata:
   name: "test-pipeline"
   version: "1.0.0"
   description: "Test pipeline for configuration testing"
-
-query: |
-  SELECT date, category, value
-  FROM sample_data
-  WHERE date >= {date_filter}
-    AND ({category_filter} IS NULL OR category = {category_filter})
+spec:
+  query: |
+    SELECT date, category, value
+    FROM sample_data
+    WHERE date >= {date_filter}
+      AND ({category_filter} IS NULL OR category = {category_filter})
 "#;
 
         let pipeline_path = dir.path().join("test-pipeline.yaml");
@@ -1334,13 +1374,14 @@ query: |
 
     fn create_test_simple_pipeline_file(dir: &TempDir) -> PathBuf {
         let pipeline_content = r#"
+kind: pipeline
 metadata:
   name: "test-pipeline"
   version: "1.0.0"
   description: "Simple test pipeline without external table dependencies"
-
-query: |
-  SELECT 1 as id, 'test' as name
+spec:
+  query: |
+    SELECT 1 as id, 'test' as name
 "#;
 
         let pipeline_path = dir.path().join("simple-pipeline.yaml");
@@ -1365,23 +1406,28 @@ query: |
         // Create context content with correct paths (both CSV for simplicity)
         let context_content = format!(
             r#"
-data_sources:
-  - name: "sample_data"
-    type: "csv"
-    path: "{}"
-    schema:
-      date: "timestamp"
-      value: "float64"
-      category: "string"
-    options:
-      has_header: true
-      delimiter: ","
-  - name: "reference_data"
-    type: "csv"
-    path: "{}"
-    options:
-      has_header: true
-      delimiter: ","
+kind: context
+metadata:
+  name: test-context
+  version: 1.0.0
+spec:
+  data_sources:
+    - name: "sample_data"
+      type: "csv"
+      path: "{}"
+      schema:
+        date: "timestamp"
+        value: "float64"
+        category: "string"
+      options:
+        has_header: true
+        delimiter: ","
+    - name: "reference_data"
+      type: "csv"
+      path: "{}"
+      options:
+        has_header: true
+        delimiter: ","
 "#,
             csv_path.display(),
             csv2_path.display()
@@ -1564,25 +1610,27 @@ data_sources:
 
         // Create first pipeline
         let pipeline1_content = r#"
+kind: pipeline
 metadata:
   name: "test-pipeline"
   version: "1.0.0"
   description: "First test pipeline"
-
-query: |
-  SELECT 1 as id, 'test' as name
+spec:
+  query: |
+    SELECT 1 as id, 'test' as name
 "#;
         fs::write(pipelines_dir.join("first-pipeline.yaml"), pipeline1_content).unwrap();
 
         // Create second pipeline with different name
         let pipeline2_content = r#"
+kind: pipeline
 metadata:
   name: "second-pipeline"
   version: "2.0.0"
   description: "Second test pipeline"
-
-query: |
-  SELECT 2 as id, 'test2' as name
+spec:
+  query: |
+    SELECT 2 as id, 'test2' as name
 "#;
         fs::write(pipelines_dir.join("second-pipeline.yml"), pipeline2_content).unwrap();
 

--- a/crates/server/src/pipeline_handlers.rs
+++ b/crates/server/src/pipeline_handlers.rs
@@ -738,15 +738,16 @@ mod tests {
     async fn create_test_pipeline_with_params() -> StandardPipeline {
         let temp_dir = TempDir::new().unwrap();
         let pipeline_content = r#"
+kind: pipeline
 metadata:
   name: "test-pipeline"
   version: "1.0.0"
   description: "Test pipeline for handler testing"
-
-query: |
-  SELECT user_id, name, category
-  FROM test_data
-  WHERE user_id = {user_id} AND category = {category}
+spec:
+  query: |
+    SELECT user_id, name, category
+    FROM test_data
+    WHERE user_id = {user_id} AND category = {category}
 "#;
 
         let pipeline_path = temp_dir.path().join("test-pipeline.yaml");

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -312,15 +312,16 @@ mod tests {
     async fn create_test_pipeline() -> StandardPipeline {
         let temp_dir = TempDir::new().unwrap();
         let pipeline_content = r#"
+kind: pipeline
 metadata:
   name: "test-pipeline"
   version: "1.0.0"
   description: "Test pipeline for server testing"
-
-query: |
-  SELECT date
-  FROM test_data
-  WHERE date >= {date_filter}
+spec:
+  query: |
+    SELECT date
+    FROM test_data
+    WHERE date >= {date_filter}
 "#;
 
         let pipeline_path = temp_dir.path().join("test-pipeline.yaml");

--- a/crates/server/tests/jobs_e2e.rs
+++ b/crates/server/tests/jobs_e2e.rs
@@ -97,12 +97,13 @@ kind: job
 metadata:
   name: "ingest-lake"
   version: "1.0.0"
-query: |
-  SELECT id, name FROM src WHERE id >= {min_id}
-destination:
-  table: "wiki_lake"
-  mode: append
-  create_if_missing: true
+spec:
+  query: |
+    SELECT id, name FROM src WHERE id >= {min_id}
+  destination:
+    table: "wiki_lake"
+    mode: append
+    create_if_missing: true
 "#,
     );
 
@@ -188,11 +189,12 @@ kind: job
 metadata:
   name: "replace"
   version: "1.0.0"
-query: |
-  SELECT 1 AS id
-destination:
-  table: "t"
-  mode: overwrite
+spec:
+  query: |
+    SELECT 1 AS id
+  destination:
+    table: "t"
+    mode: overwrite
 "#,
     );
 
@@ -238,11 +240,12 @@ kind: job
 metadata:
   name: "mismatch"
   version: "1.0.0"
-query: |
-  SELECT id AS id_wrong, name FROM src
-destination:
-  table: "wiki_lake"
-  mode: append
+spec:
+  query: |
+    SELECT id AS id_wrong, name FROM src
+  destination:
+    table: "wiki_lake"
+    mode: append
 "#,
     );
 
@@ -293,12 +296,13 @@ kind: job
 metadata:
   name: "db-ingest"
   version: "1.0.0"
-query: |
-  SELECT id FROM src
-destination:
-  table: "missing.public.never_exists"
-  mode: append
-  create_if_missing: true
+spec:
+  query: |
+    SELECT id FROM src
+  destination:
+    table: "missing.public.never_exists"
+    mode: append
+    create_if_missing: true
 "#,
     );
 
@@ -348,12 +352,13 @@ kind: job
 metadata:
   name: "strict"
   version: "1.0.0"
-query: |
-  SELECT id FROM src
-destination:
-  table: "lake"
-  mode: append
-  create_if_missing: false
+spec:
+  query: |
+    SELECT id FROM src
+  destination:
+    table: "lake"
+    mode: append
+    create_if_missing: false
 "#,
     );
 
@@ -432,11 +437,12 @@ kind: job
 metadata:
   name: "db-ingest"
   version: "1.0.0"
-query: |
-  SELECT id FROM src WHERE id >= {min_id}
-destination:
-  table: "dest"
-  mode: append
+spec:
+  query: |
+    SELECT id FROM src WHERE id >= {min_id}
+  destination:
+    table: "dest"
+    mode: append
 "#,
     );
 
@@ -512,11 +518,12 @@ kind: job
 metadata:
   name: "nontx"
   version: "1.0.0"
-query: |
-  SELECT id FROM src
-destination:
-  table: "redis_cache"
-  mode: append
+spec:
+  query: |
+    SELECT id FROM src
+  destination:
+    table: "redis_cache"
+    mode: append
 "#,
     );
 

--- a/crates/server/tests/jobs_http.rs
+++ b/crates/server/tests/jobs_http.rs
@@ -59,11 +59,12 @@ kind: job
 metadata:
   name: "ingest-all"
   version: "1.0.0"
-query: |
-  SELECT id FROM src
-destination:
-  table: "dest"
-  mode: append
+spec:
+  query: |
+    SELECT id FROM src
+  destination:
+    table: "dest"
+    mode: append
 "#,
         );
         let job = JobDefinition::load_from_file(&yaml_path, Arc::clone(&ctx))

--- a/crates/server/tests/pipelines_e2e.rs
+++ b/crates/server/tests/pipelines_e2e.rs
@@ -1,0 +1,266 @@
+//! End-to-end tests for the pipeline loader and execution path:
+//! write a YAML to disk → load through `StandardPipeline::load_from_file`
+//! → execute against DataFusion → verify the result.
+//!
+//! Companion to `jobs_e2e.rs` on the pipeline side. Covers the envelope
+//! contract (`kind: pipeline` required, wrong kind rejected, metadata/spec
+//! surfaces wired through) and the happy path through the SQL engine.
+
+use arrow::array::{Array, Int64Array, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use datafusion::prelude::SessionContext;
+use skardi::pipeline::pipeline::{Pipeline, StandardPipeline};
+use std::io::Write;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+fn write_yaml(path: &std::path::Path, content: &str) {
+    let mut f = std::fs::File::create(path).unwrap();
+    f.write_all(content.as_bytes()).unwrap();
+}
+
+/// `orders` fact table keyed on user_id, used by the federated test below
+/// and the single-source happy path.
+fn orders_batch() -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("order_id", DataType::Int64, false),
+        Field::new("user_id", DataType::Int64, false),
+        Field::new("amount", DataType::Int64, false),
+    ]));
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(vec![101i64, 102, 103, 104])),
+            Arc::new(Int64Array::from(vec![1i64, 1, 2, 3])),
+            Arc::new(Int64Array::from(vec![50i64, 75, 200, 10])),
+        ],
+    )
+    .unwrap()
+}
+
+/// `users` dimension table — joined with `orders` in the federated test.
+fn users_batch() -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("user_id", DataType::Int64, false),
+        Field::new("name", DataType::Utf8, false),
+    ]));
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(vec![1i64, 2, 3])),
+            Arc::new(StringArray::from(vec!["Alice", "Bob", "Carol"])),
+        ],
+    )
+    .unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Happy path: load from disk, then execute against a registered MemTable.
+// Confirms the envelope round-trips through the loader and that inferred
+// placeholders bind correctly when substituted into the SQL.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn pipeline_loads_from_yaml_and_executes() {
+    let tmp = TempDir::new().unwrap();
+    let yaml_path = tmp.path().join("orders-by-user.yaml");
+    write_yaml(
+        &yaml_path,
+        r#"
+kind: pipeline
+metadata:
+  name: "orders-by-user"
+  version: "1.0.0"
+  description: "Total spend per user, filtered by user_id."
+spec:
+  query: |
+    SELECT user_id, SUM(amount) AS total
+    FROM orders
+    WHERE user_id = {user_id}
+    GROUP BY user_id
+"#,
+    );
+
+    let ctx = Arc::new(SessionContext::new());
+    ctx.register_batch("orders", orders_batch()).unwrap();
+
+    let pipeline = StandardPipeline::load_from_file(&yaml_path, Arc::clone(&ctx))
+        .await
+        .expect("pipeline should load");
+    assert_eq!(pipeline.name(), "orders-by-user");
+    assert_eq!(pipeline.version(), "1.0.0");
+
+    // Inferred request schema surfaces the `{user_id}` placeholder.
+    let param_names: Vec<&String> = pipeline.request_schema().fields.keys().collect();
+    assert_eq!(param_names, vec!["user_id"]);
+
+    // Inline-substitute and execute. User 1 has orders 101+102 = 125.
+    let sql = pipeline.query_definition().sql.replace("{user_id}", "1");
+    let batches = ctx.sql(&sql).await.unwrap().collect().await.unwrap();
+    assert_eq!(batches.len(), 1);
+    let total = batches[0]
+        .column_by_name("total")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap()
+        .value(0);
+    assert_eq!(total, 125);
+}
+
+// ---------------------------------------------------------------------------
+// Envelope validation: missing `kind:` at root is rejected with a message
+// that points the user at the required shape.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn pipeline_rejects_yaml_without_kind() {
+    let tmp = TempDir::new().unwrap();
+    let yaml_path = tmp.path().join("no-kind.yaml");
+    write_yaml(
+        &yaml_path,
+        r#"
+metadata:
+  name: "p1"
+  version: "1.0.0"
+spec:
+  query: "SELECT 1"
+"#,
+    );
+    let ctx = Arc::new(SessionContext::new());
+    let err = StandardPipeline::load_from_file(&yaml_path, ctx)
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.to_lowercase().contains("kind"),
+        "error should mention the missing kind, got: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Envelope validation: `kind: context` is not a pipeline — the loader must
+// reject it rather than ignore the mismatch.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn pipeline_rejects_wrong_kind() {
+    let tmp = TempDir::new().unwrap();
+    let yaml_path = tmp.path().join("wrong-kind.yaml");
+    write_yaml(
+        &yaml_path,
+        r#"
+kind: context
+metadata:
+  name: "ctx"
+  version: "1.0.0"
+spec:
+  query: "SELECT 1"
+"#,
+    );
+    let ctx = Arc::new(SessionContext::new());
+    let err = StandardPipeline::load_from_file(&yaml_path, ctx)
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.to_lowercase().contains("kind") && err.to_lowercase().contains("context"),
+        "error should name the wrong kind, got: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Envelope validation: `spec:` is required. A pre-envelope pipeline (query
+// at the root) must fail rather than silently no-op.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn pipeline_rejects_legacy_flat_shape() {
+    let tmp = TempDir::new().unwrap();
+    let yaml_path = tmp.path().join("flat.yaml");
+    write_yaml(
+        &yaml_path,
+        r#"
+kind: pipeline
+metadata:
+  name: "legacy"
+  version: "1.0.0"
+query: "SELECT 1"
+"#,
+    );
+    let ctx = Arc::new(SessionContext::new());
+    let err = StandardPipeline::load_from_file(&yaml_path, ctx)
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.to_lowercase().contains("spec"),
+        "error should name the missing spec block, got: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Federated-style pipeline: a JOIN across two registered tables still
+// loads and executes end-to-end. Less a feature test than a smoke test
+// that the loader's inferred schemas handle multi-source SQL.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn pipeline_executes_federated_join() {
+    let tmp = TempDir::new().unwrap();
+    let yaml_path = tmp.path().join("top-spenders.yaml");
+    write_yaml(
+        &yaml_path,
+        r#"
+kind: pipeline
+metadata:
+  name: "top-spenders"
+  version: "1.0.0"
+  description: "Users whose total spend exceeds a threshold."
+spec:
+  query: |
+    SELECT u.name, SUM(o.amount) AS total
+    FROM users u
+    JOIN orders o ON o.user_id = u.user_id
+    GROUP BY u.name
+    HAVING SUM(o.amount) > {min_total}
+    ORDER BY total DESC
+"#,
+    );
+
+    let ctx = Arc::new(SessionContext::new());
+    ctx.register_batch("orders", orders_batch()).unwrap();
+    ctx.register_batch("users", users_batch()).unwrap();
+
+    let pipeline = StandardPipeline::load_from_file(&yaml_path, Arc::clone(&ctx))
+        .await
+        .expect("federated pipeline should load");
+    let sql = pipeline
+        .query_definition()
+        .sql
+        .replace("{min_total}", "100");
+    let batches = ctx.sql(&sql).await.unwrap().collect().await.unwrap();
+    assert_eq!(batches.len(), 1);
+
+    let names = batches[0]
+        .column_by_name("name")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    let totals = batches[0]
+        .column_by_name("total")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap();
+
+    // Alice has 125, Bob has 200 — both > 100; Carol has 10 and is filtered.
+    // Bob's 200 > Alice's 125, so Bob sorts first.
+    assert_eq!(names.len(), 2);
+    assert_eq!(names.value(0), "Bob");
+    assert_eq!(totals.value(0), 200);
+    assert_eq!(names.value(1), "Alice");
+    assert_eq!(totals.value(1), 125);
+}

--- a/crates/server/tests/pipelines_http.rs
+++ b/crates/server/tests/pipelines_http.rs
@@ -1,0 +1,384 @@
+//! HTTP integration tests for pipeline endpoints — boots the same
+//! `configure_routes` axum router the binary does, loads a pipeline from
+//! an envelope-format YAML, and exercises the request/response surface.
+//!
+//! Mirrors `jobs_http.rs`.
+
+use arrow::array::{Float64Array, Int64Array, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use datafusion::prelude::SessionContext;
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use skardi::pipeline::pipeline::{Pipeline, StandardPipeline};
+use std::collections::HashMap;
+use std::io::Write;
+use std::sync::{Arc, RwLock};
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+use skardi_server::auth::layer::AuthLayer;
+use skardi_server::config::{CliArgs, ServerConfig};
+use skardi_server::metrics::PipelineMetrics;
+use skardi_server::server::{AppState, configure_routes};
+
+fn write_yaml(path: &std::path::Path, content: &str) {
+    let mut f = std::fs::File::create(path).unwrap();
+    f.write_all(content.as_bytes()).unwrap();
+}
+
+/// Five-row `products` MemTable: id, brand, price, category. Used as the
+/// fact table for the pipeline's SELECT.
+fn products_batch() -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("brand", DataType::Utf8, false),
+        Field::new("price", DataType::Float64, false),
+        Field::new("category", DataType::Utf8, false),
+    ]));
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(vec![1i64, 2, 3, 4, 5])),
+            Arc::new(StringArray::from(vec![
+                "Apple", "Sony", "Apple", "Samsung", "Apple",
+            ])),
+            Arc::new(Float64Array::from(vec![
+                1299.0, 199.0, 999.0, 599.0, 2499.0,
+            ])),
+            Arc::new(StringArray::from(vec![
+                "Electronics",
+                "Audio",
+                "Electronics",
+                "Electronics",
+                "Electronics",
+            ])),
+        ],
+    )
+    .unwrap()
+}
+
+/// Build an `AppState` with a `products` MemTable and — when requested —
+/// a `product-search` pipeline loaded from disk in envelope format.
+async fn make_app_state(with_pipeline: bool) -> (AppState, TempDir) {
+    let tmp = TempDir::new().unwrap();
+    let ctx = Arc::new(SessionContext::new());
+    ctx.register_batch("products", products_batch()).unwrap();
+
+    let mut pipelines: HashMap<String, StandardPipeline> = HashMap::new();
+    if with_pipeline {
+        let yaml_path = tmp.path().join("product-search.yaml");
+        write_yaml(
+            &yaml_path,
+            r#"
+kind: pipeline
+metadata:
+  name: "product-search"
+  version: "1.0.0"
+  description: "Filter products by brand + max price"
+spec:
+  query: |
+    SELECT id, brand, price, category
+    FROM products
+    WHERE brand = {brand} AND price <= {max_price}
+    ORDER BY price DESC
+"#,
+        );
+        let pipeline = StandardPipeline::load_from_file(&yaml_path, Arc::clone(&ctx))
+            .await
+            .unwrap();
+        pipelines.insert(pipeline.name().to_string(), pipeline);
+    }
+
+    let engine = Arc::new(skardi::engine::datafusion::DataFusionEngine::new_with_arc(
+        Arc::clone(&ctx),
+    ));
+    let config = ServerConfig {
+        pipelines,
+        jobs: HashMap::new(),
+        data_sources: vec![],
+        args: CliArgs {
+            pipeline_path: None,
+            jobs_path: None,
+            jobs_db_path: None,
+            ctx_file: None,
+            port: 0,
+        },
+    };
+    let state = AppState {
+        config: Arc::new(RwLock::new(config)),
+        engine,
+        session_ctx: Arc::clone(&ctx),
+        metrics: PipelineMetrics::new(),
+        auth_layer: AuthLayer::None,
+        jobs: None,
+    };
+    (state, tmp)
+}
+
+async fn body_to_json(resp: axum::response::Response) -> Value {
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// POST /:name/execute — happy path.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn http_execute_pipeline_returns_matching_rows() {
+    let (state, _tmp) = make_app_state(true).await;
+    let app = configure_routes(state);
+
+    // `ExecuteRequest` uses `#[serde(flatten)]`, so params live at the
+    // root of the JSON body, not inside a `parameters` wrapper.
+    let req_body = json!({
+        "brand": "Apple",
+        "max_price": 1500.0,
+    });
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/product-search/execute")
+                .header("content-type", "application/json")
+                .body(Body::from(req_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_to_json(resp).await;
+    assert_eq!(body["success"], true, "body: {body}");
+    // Two Apple rows are <= 1500 (ids 1 and 3); the third Apple (id=5) is
+    // 2499 and must be filtered out.
+    assert_eq!(body["rows"].as_u64(), Some(2), "body: {body}");
+    let data = body["data"].as_array().unwrap();
+    let ids: Vec<i64> = data.iter().map(|row| row["id"].as_i64().unwrap()).collect();
+    assert_eq!(
+        ids,
+        vec![1, 3],
+        "expected price-desc ordering, got: {data:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Missing required parameter → 400 with a structured error body.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn http_execute_missing_param_returns_400() {
+    let (state, _tmp) = make_app_state(true).await;
+    let app = configure_routes(state);
+
+    let req_body = json!({ "brand": "Apple" }); // missing max_price
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/product-search/execute")
+                .header("content-type", "application/json")
+                .body(Body::from(req_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = body_to_json(resp).await;
+    let msg = body["error"].as_str().unwrap_or_default();
+    assert!(
+        msg.contains("max_price"),
+        "error should name the missing param, got: {body}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Parameter value of an unsupported JSON type (e.g. a nested object) → 400.
+// Extra keys not referenced by the SQL are silently ignored, which is a
+// separate contract; this test exercises the type-validation path.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn http_execute_unsupported_param_type_returns_400() {
+    let (state, _tmp) = make_app_state(true).await;
+    let app = configure_routes(state);
+
+    let req_body = json!({
+        "brand": { "nested": "object" },   // object is not a scalar → rejected
+        "max_price": 1500.0,
+    });
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/product-search/execute")
+                .header("content-type", "application/json")
+                .body(Body::from(req_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = body_to_json(resp).await;
+    let msg = body["error"].as_str().unwrap_or_default();
+    assert!(
+        msg.to_lowercase().contains("brand") || msg.to_lowercase().contains("unsupported"),
+        "error should flag the brand parameter, got: {body}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Unknown pipeline → 404 with `available_pipelines` listed in the details.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn http_execute_unknown_pipeline_returns_404() {
+    let (state, _tmp) = make_app_state(true).await;
+    let app = configure_routes(state);
+
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/does-not-exist/execute")
+                .header("content-type", "application/json")
+                .body(Body::from("{\"parameters\":{}}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let body = body_to_json(resp).await;
+    let available = body["details"]["available_pipelines"]
+        .as_array()
+        .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>())
+        .unwrap_or_default();
+    assert!(
+        available.contains(&"product-search"),
+        "404 body should enumerate registered pipelines, got: {body}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// GET /pipelines — lists registered pipelines with version + endpoint.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn http_list_pipelines_returns_registered() {
+    let (state, _tmp) = make_app_state(true).await;
+    let app = configure_routes(state);
+
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/pipelines")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_to_json(resp).await;
+    assert_eq!(body["count"].as_u64(), Some(1));
+    let entry = &body["pipelines"].as_array().unwrap()[0];
+    assert_eq!(entry["name"].as_str(), Some("product-search"));
+    assert_eq!(entry["version"].as_str(), Some("1.0.0"));
+    assert_eq!(entry["endpoint"].as_str(), Some("/product-search/execute"));
+}
+
+// ---------------------------------------------------------------------------
+// GET /pipeline/:name — metadata + inferred parameters for one pipeline.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn http_get_pipeline_info_returns_metadata_and_params() {
+    let (state, _tmp) = make_app_state(true).await;
+    let app = configure_routes(state);
+
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/pipeline/product-search")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_to_json(resp).await;
+    assert_eq!(body["success"], true);
+    assert_eq!(body["pipeline"]["name"].as_str(), Some("product-search"));
+    assert_eq!(body["pipeline"]["version"].as_str(), Some("1.0.0"));
+    // Inferred params come from `{brand}` and `{max_price}` in the SQL.
+    // The handler returns them as an array of `{ name, type }` objects;
+    // iteration order is unstable so assert by name-set rather than index.
+    let names: Vec<&str> = body["pipeline"]["parameters"]
+        .as_array()
+        .expect("parameters array")
+        .iter()
+        .map(|p| p["name"].as_str().unwrap())
+        .collect();
+    assert!(names.contains(&"brand"), "params: {names:?}");
+    assert!(names.contains(&"max_price"), "params: {names:?}");
+}
+
+// ---------------------------------------------------------------------------
+// GET /pipeline/:name — unknown name → 404.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn http_get_pipeline_info_unknown_returns_404() {
+    let (state, _tmp) = make_app_state(true).await;
+    let app = configure_routes(state);
+
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/pipeline/missing")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+// ---------------------------------------------------------------------------
+// GET /health/:name — healthy when the pipeline exists and its sources
+// are reachable. We register the `products` table directly on the session
+// context, so the data-sources check is "0 data_sources total" — the pipe
+// itself should still report accessible.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn http_pipeline_health_check_returns_ok() {
+    let (state, _tmp) = make_app_state(true).await;
+    let app = configure_routes(state);
+
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/health/product-search")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_to_json(resp).await;
+    assert_eq!(body["pipeline"]["name"].as_str(), Some("product-search"));
+    // There's a `status` field at the root — it can be "healthy" or a
+    // downgraded variant depending on data source count. Either way, the
+    // endpoint must not 5xx, and the pipeline block must echo the name.
+    assert!(body.get("status").is_some(), "health body: {body}");
+}

--- a/crates/skardi/src/jobs/definition.rs
+++ b/crates/skardi/src/jobs/definition.rs
@@ -1,25 +1,27 @@
 //! `kind: job` YAML loader.
 //!
-//! A job YAML has the same `metadata` + `query` shape as a pipeline, with
-//! two additional sections:
+//! A job YAML uses the same `{ kind, metadata, spec }` envelope as pipelines,
+//! contexts, and aliases. The `spec:` block holds the query plus the
+//! job-specific destination and execution sections:
 //!
 //! ```yaml
-//! kind: job                    # discriminator — pipelines default to `pipeline`
+//! kind: job
 //! metadata:
 //!   name: "backfill-wiki"
 //!   version: "1.0.0"
 //!   description: "Backfill wiki pages into the lake."
-//! query: |
-//!   SELECT id, title, content
-//!   FROM wiki.public.wiki_pages
-//!   WHERE updated_at >= {from_date}
-//!     AND updated_at <  {to_date}
-//! destination:
-//!   table: "wiki_lake"          # DataFusion table ident (or dotted path)
-//!   mode: append                # append (overwrite is deferred — see below)
-//!   create_if_missing: true     # lake destinations only
-//! execution:
-//!   timeout_ms: 3600000         # optional; default = no timeout
+//! spec:
+//!   query: |
+//!     SELECT id, title, content
+//!     FROM wiki.public.wiki_pages
+//!     WHERE updated_at >= {from_date}
+//!       AND updated_at <  {to_date}
+//!   destination:
+//!     table: "wiki_lake"          # DataFusion table ident (or dotted path)
+//!     mode: append                # append (overwrite is deferred — see below)
+//!     create_if_missing: true     # lake destinations only
+//!   execution:
+//!     timeout_ms: 3600000         # optional; default = no timeout
 //! ```
 //!
 //! `{placeholder}` tokens in the SQL are inferred as typed scalar params by
@@ -35,9 +37,10 @@ use std::sync::Arc;
 
 use crate::pipeline::pipeline::{Pipeline, StandardPipeline};
 
-/// Discriminator at the YAML root that tells the loader whether the file is
-/// a pipeline or a job. The default is `Pipeline` so existing pipeline
-/// YAMLs — which do not set `kind:` — continue to load unchanged.
+/// Root-level `kind:` values the job loader recognizes. Any other value —
+/// or a missing `kind:` — is an error. `Pipeline` is accepted so that
+/// `JobDefinition::load_from_file` can short-circuit with `Ok(None)` when
+/// the caller accidentally points it at a pipeline YAML.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum JobKind {
@@ -45,12 +48,6 @@ pub enum JobKind {
     Pipeline,
     #[serde(rename = "job")]
     Job,
-}
-
-impl Default for JobKind {
-    fn default() -> Self {
-        Self::Pipeline
-    }
 }
 
 /// Write mode for the destination.
@@ -140,23 +137,36 @@ impl JobDefinition {
         let root: serde_yaml::Value = serde_yaml::from_str(&content)
             .with_context(|| format!("Failed to parse job YAML: {}", path.display()))?;
 
-        let kind: JobKind = match root.get("kind") {
-            Some(v) => serde_yaml::from_value(v.clone())
-                .with_context(|| format!("Invalid `kind:` in {}", path.display()))?,
-            None => JobKind::Pipeline,
-        };
+        let kind_value = root.get("kind").ok_or_else(|| {
+            anyhow!(
+                "Missing `kind:` at root of {} — expected `kind: job` or `kind: pipeline`",
+                path.display()
+            )
+        })?;
+        let kind: JobKind = serde_yaml::from_value(kind_value.clone())
+            .with_context(|| format!("Invalid `kind:` in {}", path.display()))?;
 
         if kind != JobKind::Job {
             return Ok(None);
         }
 
-        let destination_value = root
-            .get("destination")
-            .ok_or_else(|| anyhow!("`kind: job` YAML missing `destination:` block"))?;
+        let spec = root.get("spec").ok_or_else(|| {
+            anyhow!(
+                "`kind: job` YAML {} is missing a `spec:` block",
+                path.display()
+            )
+        })?;
+
+        let destination_value = spec.get("destination").ok_or_else(|| {
+            anyhow!(
+                "`kind: job` YAML {} is missing `spec.destination`",
+                path.display()
+            )
+        })?;
         let destination: Destination = serde_yaml::from_value(destination_value.clone())
             .with_context(|| format!("Failed to parse destination block in {}", path.display()))?;
 
-        let execution: Execution = match root.get("execution") {
+        let execution: Execution = match spec.get("execution") {
             Some(v) => serde_yaml::from_value(v.clone()).with_context(|| {
                 format!("Failed to parse execution block in {}", path.display())
             })?,
@@ -164,9 +174,9 @@ impl JobDefinition {
         };
 
         // Reuse the pipeline loader for metadata + query + schema inference.
-        // `StandardPipeline::load_from_file` reads the file itself, so it
-        // happily ignores extra top-level keys like `kind`, `destination`,
-        // and `execution`.
+        // `StandardPipeline::load_from_file` reads the file itself and
+        // accepts both `kind: pipeline` and `kind: job` at the root; it
+        // pulls the SQL out of `spec.query` either way.
         let pipeline = StandardPipeline::load_from_file(path, ctx)
             .await
             .with_context(|| format!("Failed to load pipeline section of {}", path.display()))?;
@@ -197,11 +207,13 @@ mod tests {
     #[tokio::test]
     async fn pipeline_yaml_loads_as_none() {
         let yaml = r#"
+kind: pipeline
 metadata:
   name: "p1"
   version: "1.0.0"
-query: |
-  SELECT 1 AS v
+spec:
+  query: |
+    SELECT 1 AS v
 "#;
         let ctx = Arc::new(SessionContext::new());
         let res = write_and_load(yaml, ctx).await.unwrap();
@@ -216,14 +228,15 @@ metadata:
   name: "ingest-j1"
   version: "1.0.0"
   description: "Ingest job"
-query: |
-  SELECT 1 AS id, 'a' AS name
-destination:
-  table: "target_table"
-  mode: append
-  create_if_missing: true
-execution:
-  timeout_ms: 60000
+spec:
+  query: |
+    SELECT 1 AS id, 'a' AS name
+  destination:
+    table: "target_table"
+    mode: append
+    create_if_missing: true
+  execution:
+    timeout_ms: 60000
 "#;
         let ctx = Arc::new(SessionContext::new());
         let res = write_and_load(yaml, ctx).await.unwrap().unwrap();
@@ -241,9 +254,10 @@ kind: job
 metadata:
   name: "ingest-j2"
   version: "1.0.0"
-query: "SELECT 1 AS id"
-destination:
-  table: "target_table"
+spec:
+  query: "SELECT 1 AS id"
+  destination:
+    table: "target_table"
 "#;
         let ctx = Arc::new(SessionContext::new());
         let res = write_and_load(yaml, ctx).await.unwrap().unwrap();
@@ -260,10 +274,11 @@ kind: job
 metadata:
   name: "bad"
   version: "1.0.0"
-query: "SELECT 1"
-destination:
-  table: "t"
-  mode: overwrite
+spec:
+  query: "SELECT 1"
+  destination:
+    table: "t"
+    mode: overwrite
 "#;
         let ctx = Arc::new(SessionContext::new());
         // Format with the alternate Display so the full anyhow cause chain
@@ -283,7 +298,8 @@ kind: job
 metadata:
   name: "bad-job"
   version: "1.0.0"
-query: "SELECT 1"
+spec:
+  query: "SELECT 1"
 "#;
         let ctx = Arc::new(SessionContext::new());
         let err = write_and_load(yaml, ctx).await.unwrap_err().to_string();
@@ -297,7 +313,8 @@ kind: stream
 metadata:
   name: "bad"
   version: "1.0.0"
-query: "SELECT 1"
+spec:
+  query: "SELECT 1"
 "#;
         let ctx = Arc::new(SessionContext::new());
         let err = write_and_load(yaml, ctx).await.unwrap_err().to_string();

--- a/crates/skardi/src/jobs/definition.rs
+++ b/crates/skardi/src/jobs/definition.rs
@@ -173,11 +173,12 @@ impl JobDefinition {
             None => Execution::default(),
         };
 
-        // Reuse the pipeline loader for metadata + query + schema inference.
-        // `StandardPipeline::load_from_file` reads the file itself and
-        // accepts both `kind: pipeline` and `kind: job` at the root; it
-        // pulls the SQL out of `spec.query` either way.
-        let pipeline = StandardPipeline::load_from_file(path, ctx)
+        // Reuse the pipeline builder for metadata + query + schema inference.
+        // We've already parsed `root` and validated `kind: job`, so we hand
+        // the parsed value straight to the shared builder rather than
+        // re-reading and re-parsing the file through the pipeline loader
+        // (which is now strict to `kind: pipeline`).
+        let pipeline = StandardPipeline::build_from_parsed(root, ctx)
             .await
             .with_context(|| format!("Failed to load pipeline section of {}", path.display()))?;
 

--- a/crates/skardi/src/jobs/executor.rs
+++ b/crates/skardi/src/jobs/executor.rs
@@ -741,11 +741,12 @@ kind: job
 metadata:
   name: "ingest"
   version: "1.0.0"
-query: |
-  SELECT id FROM src WHERE id >= {min_id}
-destination:
-  table: "dest"
-  mode: append
+spec:
+  query: |
+    SELECT id FROM src WHERE id >= {min_id}
+  destination:
+    table: "dest"
+    mode: append
 "#;
         let mut f = std::fs::File::create(&yaml_path).unwrap();
         f.write_all(yaml.as_bytes()).unwrap();
@@ -831,12 +832,13 @@ kind: job
 metadata:
   name: "ingest"
   version: "1.0.0"
-query: |
-  SELECT id FROM src
-destination:
-  table: "missing_table"
-  mode: append
-  create_if_missing: false
+spec:
+  query: |
+    SELECT id FROM src
+  destination:
+    table: "missing_table"
+    mode: append
+    create_if_missing: false
 "#;
         std::fs::File::create(&yaml_path)
             .unwrap()

--- a/crates/skardi/src/pipeline/pipeline.rs
+++ b/crates/skardi/src/pipeline/pipeline.rs
@@ -489,17 +489,35 @@ impl Pipeline for StandardPipeline {
     {
         let file_content = fs::read_to_string(file_path)?;
 
-        // Parse the optimized pipeline YAML file into a generic structure
+        // Parse the pipeline YAML file into a generic structure. The expected
+        // shape is the uniform `{ kind, metadata, spec }` envelope shared
+        // with aliases, contexts, and jobs. The job loader also calls into
+        // here to reuse the metadata + query parsing, which is why `kind: job`
+        // is accepted alongside `kind: pipeline`.
         let pipeline_yaml: serde_yaml::Value = serde_yaml::from_str(&file_content)
             .map_err(|e| anyhow!("Failed to parse pipeline YAML file: {}", e))?;
 
-        // Extract only metadata and query sections - request/response are inferred
+        let kind = pipeline_yaml
+            .get("kind")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                anyhow!("Missing 'kind' at root of pipeline YAML (expected `kind: pipeline`)")
+            })?;
+        if kind != "pipeline" && kind != "job" {
+            return Err(anyhow!(
+                "Unexpected `kind: {kind}` — expected `kind: pipeline` or `kind: job`"
+            ));
+        }
+
         let metadata_section = pipeline_yaml
             .get("metadata")
             .ok_or_else(|| anyhow!("Missing 'metadata' section in pipeline YAML"))?;
-        let query_section = pipeline_yaml
+        let spec_section = pipeline_yaml
+            .get("spec")
+            .ok_or_else(|| anyhow!("Missing 'spec' section in pipeline YAML"))?;
+        let query_section = spec_section
             .get("query")
-            .ok_or_else(|| anyhow!("Missing 'query' section in pipeline YAML"))?;
+            .ok_or_else(|| anyhow!("Missing 'spec.query' in pipeline YAML"))?;
 
         // Parse metadata directly
         let metadata: ComponentMetadata = serde_yaml::from_value(metadata_section.clone())
@@ -934,30 +952,31 @@ mod tests {
 
         // Create a temporary YAML file with pipeline definition
         let yaml_content = r#"
+kind: pipeline
 metadata:
   name: "product_search_pipeline"
   version: "1.2.0"
   description: "Advanced product search with filtering and pagination"
   created_at: "2025-01-15T10:00:00.000+00:00"
   updated_at: "2025-01-15T12:30:00.000+00:00"
-
-query: |
-  SELECT
-    product_id,
-    name as product_name,
-    brand,
-    price,
-    category,
-    stock
-  FROM products
-  WHERE 1=1
-    AND ({brand} IS NULL OR brand = {brand})
-    AND ({min_price} IS NULL OR price >= {min_price})
-    AND ({max_price} IS NULL OR price <= {max_price})
-    AND ({category} IS NULL OR category = {category})
-    AND ({min_stock} IS NULL OR stock >= {min_stock})
-  ORDER BY price DESC
-  LIMIT {limit}
+spec:
+  query: |
+    SELECT
+      product_id,
+      name as product_name,
+      brand,
+      price,
+      category,
+      stock
+    FROM products
+    WHERE 1=1
+      AND ({brand} IS NULL OR brand = {brand})
+      AND ({min_price} IS NULL OR price >= {min_price})
+      AND ({max_price} IS NULL OR price <= {max_price})
+      AND ({category} IS NULL OR category = {category})
+      AND ({min_stock} IS NULL OR stock >= {min_stock})
+    ORDER BY price DESC
+    LIMIT {limit}
 "#;
 
         // Write YAML content to temporary file

--- a/crates/skardi/src/pipeline/pipeline.rs
+++ b/crates/skardi/src/pipeline/pipeline.rs
@@ -1,5 +1,5 @@
 use crate::engine::Engine;
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use datafusion::prelude::SessionContext;
@@ -449,6 +449,54 @@ impl StandardPipeline {
     fn get_inferencer(&self) -> &SqlSchemaInferrer {
         self.inferencer.as_ref()
     }
+
+    /// Build a `StandardPipeline` from an already-parsed YAML root.
+    ///
+    /// Pulls `metadata` + `spec.query` out of the value and infers request
+    /// and response schemas against `ctx`. Does not inspect the `kind:`
+    /// discriminator — callers are expected to have already validated it.
+    /// Used by both the pipeline loader (`kind: pipeline`) and the job
+    /// loader (`kind: job`), which share the same metadata + query body.
+    pub(crate) async fn build_from_parsed(
+        root: serde_yaml::Value,
+        ctx: Arc<SessionContext>,
+    ) -> Result<Self> {
+        let metadata_section = root
+            .get("metadata")
+            .ok_or_else(|| anyhow!("Missing 'metadata' section in pipeline YAML"))?;
+        let spec_section = root
+            .get("spec")
+            .ok_or_else(|| anyhow!("Missing 'spec' section in pipeline YAML"))?;
+        let query_section = spec_section
+            .get("query")
+            .ok_or_else(|| anyhow!("Missing 'spec.query' in pipeline YAML"))?;
+
+        let metadata: ComponentMetadata = serde_yaml::from_value(metadata_section.clone())
+            .map_err(|e| anyhow!("Failed to parse metadata section: {}", e))?;
+
+        let sql_query: String = serde_yaml::from_value(query_section.clone())
+            .map_err(|e| anyhow!("Failed to parse query section: {}", e))?;
+        let query_definition = QueryDefinition {
+            sql: sql_query,
+            parameters: Vec::new(),
+        };
+
+        let inferencer = SqlSchemaInferrer::new(ctx.clone())?;
+        let request_schema = inferencer
+            .extract_request_schema(&query_definition.sql)
+            .await?;
+        let response_schema = inferencer
+            .extract_response_schema(&query_definition.sql)
+            .await?;
+
+        StandardPipeline::new(
+            metadata,
+            request_schema,
+            query_definition,
+            response_schema,
+            ctx,
+        )
+    }
 }
 
 #[async_trait]
@@ -487,69 +535,31 @@ impl Pipeline for StandardPipeline {
     where
         Self: Sized,
     {
-        let file_content = fs::read_to_string(file_path)?;
+        let path = file_path.as_ref();
+        let file_content = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read pipeline file: {}", path.display()))?;
 
-        // Parse the pipeline YAML file into a generic structure. The expected
-        // shape is the uniform `{ kind, metadata, spec }` envelope shared
-        // with aliases, contexts, and jobs. The job loader also calls into
-        // here to reuse the metadata + query parsing, which is why `kind: job`
-        // is accepted alongside `kind: pipeline`.
         let pipeline_yaml: serde_yaml::Value = serde_yaml::from_str(&file_content)
-            .map_err(|e| anyhow!("Failed to parse pipeline YAML file: {}", e))?;
+            .with_context(|| format!("Failed to parse pipeline YAML: {}", path.display()))?;
 
         let kind = pipeline_yaml
             .get("kind")
             .and_then(|v| v.as_str())
             .ok_or_else(|| {
-                anyhow!("Missing 'kind' at root of pipeline YAML (expected `kind: pipeline`)")
+                anyhow!(
+                    "Missing `kind:` at root of {} (expected `kind: pipeline`)",
+                    path.display()
+                )
             })?;
-        if kind != "pipeline" && kind != "job" {
+        if kind != "pipeline" {
             return Err(anyhow!(
-                "Unexpected `kind: {kind}` — expected `kind: pipeline` or `kind: job`"
+                "Expected `kind: pipeline` in {}, got `kind: {}`",
+                path.display(),
+                kind,
             ));
         }
 
-        let metadata_section = pipeline_yaml
-            .get("metadata")
-            .ok_or_else(|| anyhow!("Missing 'metadata' section in pipeline YAML"))?;
-        let spec_section = pipeline_yaml
-            .get("spec")
-            .ok_or_else(|| anyhow!("Missing 'spec' section in pipeline YAML"))?;
-        let query_section = spec_section
-            .get("query")
-            .ok_or_else(|| anyhow!("Missing 'spec.query' in pipeline YAML"))?;
-
-        // Parse metadata directly
-        let metadata: ComponentMetadata = serde_yaml::from_value(metadata_section.clone())
-            .map_err(|e| anyhow!("Failed to parse metadata section: {}", e))?;
-
-        // Parse query as string and create QueryDefinition with empty parameters (will be inferred)
-        let sql_query: String = serde_yaml::from_value(query_section.clone())
-            .map_err(|e| anyhow!("Failed to parse query section: {}", e))?;
-        let query_definition = QueryDefinition {
-            sql: sql_query,
-            parameters: Vec::new(), // Parameters will be inferred from SQL
-        };
-
-        // Create inferencer with the provided Arc<SessionContext>
-        let inferencer = SqlSchemaInferrer::new(ctx.clone())?;
-
-        // Infer request and response schemas from SQL query
-        let request_schema = inferencer
-            .extract_request_schema(&query_definition.sql)
-            .await?;
-        let response_schema = inferencer
-            .extract_response_schema(&query_definition.sql)
-            .await?;
-
-        // Construct the pipeline with inferred schemas
-        StandardPipeline::new(
-            metadata,
-            request_schema,
-            query_definition,
-            response_schema,
-            ctx,
-        )
+        StandardPipeline::build_from_parsed(pipeline_yaml, ctx).await
     }
 
     /// Validate the complete pipeline for internal consistency and business rules

--- a/demo/llm_wiki/README.md
+++ b/demo/llm_wiki/README.md
@@ -424,14 +424,21 @@ connection pool, and exposes each table under `<catalog>.main.<table>` for
 both SQL and `sqlite_knn` / `sqlite_fts` lookups:
 
 ```yaml
-data_sources:
-  - name: wiki
-    type: sqlite
-    path: demo/llm_wiki/wiki.db
-    access_mode: read_write
-    hierarchy_level: catalog
-    options:
-      extensions_env: SQLITE_VEC_PATH
+kind: context
+
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: wiki
+      type: sqlite
+      path: demo/llm_wiki/wiki.db
+      access_mode: read_write
+      hierarchy_level: catalog
+      options:
+        extensions_env: SQLITE_VEC_PATH
 ```
 
 The pipeline YAMLs in [cli/pipelines/](cli/pipelines/) use the same

--- a/demo/llm_wiki/cli/aliases.yaml
+++ b/demo/llm_wiki/cli/aliases.yaml
@@ -1,38 +1,46 @@
-grep:
-  pipeline: wiki-search-hybrid
-  positional:
-  - query
-  defaults:
-    text_query: '{query}'
-    vector_weight: '0.5'
-    limit: '10'
-    text_weight: '0.5'
-  description: Hybrid search over the wiki (RRF of sqlite_knn + sqlite_fts)
-log:
-  pipeline: wiki-log-append
-  defaults:
-    slug: ''
-    event_type: note
-  description: Append an activity entry to wiki_log; override --event_type --slug --message
-ls:
-  pipeline: wiki-list
-  defaults:
-    limit: '100'
-    page_type_pattern: '%'
-    slug_prefix: '%'
-  description: List wiki pages, newest first (filter with --page_type_pattern / --slug_prefix)
-open:
-  pipeline: wiki-get
-  positional:
-  - slug
-  description: Open a single wiki page by slug
-rm:
-  pipeline: wiki-delete
-  positional:
-  - slug
-  description: Delete a wiki page by slug (also clears fts + vec mirrors via trigger)
-write:
-  pipeline: wiki-create
-  defaults:
-    page_type: entity
-  description: Create a new wiki page (re-embeds content inline); use --slug --title --content
+kind: aliases
+
+metadata:
+  name: llm-wiki-cli-aliases
+  version: 1.0.0
+  description: Short-verb shortcuts for the llm_wiki demo CLI
+
+spec:
+  grep:
+    pipeline: wiki-search-hybrid
+    positional:
+      - query
+    defaults:
+      text_query: '{query}'
+      vector_weight: '0.5'
+      text_weight: '0.5'
+      limit: '10'
+    description: Hybrid search over the wiki (RRF of sqlite_knn + sqlite_fts)
+  log:
+    pipeline: wiki-log-append
+    defaults:
+      slug: ''
+      event_type: note
+    description: Append an activity entry to wiki_log; override --event_type --slug --message
+  ls:
+    pipeline: wiki-list
+    defaults:
+      limit: '100'
+      page_type_pattern: '%'
+      slug_prefix: '%'
+    description: List wiki pages, newest first (filter with --page_type_pattern / --slug_prefix)
+  open:
+    pipeline: wiki-get
+    positional:
+      - slug
+    description: Open a single wiki page by slug
+  rm:
+    pipeline: wiki-delete
+    positional:
+      - slug
+    description: Delete a wiki page by slug (also clears fts + vec mirrors via trigger)
+  write:
+    pipeline: wiki-create
+    defaults:
+      page_type: entity
+    description: Create a new wiki page (re-embeds content inline); use --slug --title --content

--- a/demo/llm_wiki/cli/ctx.yaml
+++ b/demo/llm_wiki/cli/ctx.yaml
@@ -1,12 +1,19 @@
-data_sources:
-  - name: wiki
-    type: sqlite
-    path: demo/llm_wiki/wiki.db
-    access_mode: read_write
-    hierarchy_level: catalog
-    options:
-      extensions_env: SQLITE_VEC_PATH
+kind: context
 
-# `skardi run` and the alias dispatch look inside `pipelines/` (sibling of
-# this file) by convention, so no explicit `pipelines_dir:` is needed. Set
-# one to override if the pipelines live elsewhere.
+metadata:
+  name: cli-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: wiki
+      type: sqlite
+      path: demo/llm_wiki/wiki.db
+      access_mode: read_write
+      hierarchy_level: catalog
+      options:
+        extensions_env: SQLITE_VEC_PATH
+
+  # `skardi run` and the alias dispatch look inside `pipelines/` (sibling of
+  # this file) by convention, so no explicit `pipelines_dir:` is needed. Set
+  # one to override if the pipelines live elsewhere.

--- a/demo/llm_wiki/cli/jobs/backfill_to_lake.yaml
+++ b/demo/llm_wiki/cli/jobs/backfill_to_lake.yaml
@@ -17,21 +17,20 @@ metadata:
 #   {slug_prefix}  — LIKE pattern, e.g. "entity/%" or "%"
 #   {limit}        — hard cap so a bad pattern can't rewrite everything
 
-query: |
-  SELECT slug, title, page_type, content, updated_at
-  FROM wiki.main.wiki_pages
-  WHERE slug LIKE {slug_prefix}
-  ORDER BY updated_at DESC
-  LIMIT {limit}
-
-destination:
-  # `wiki_lake` must be registered as a Lance data source in the server's
-  # ctx.yaml (see docs/jobs.md for the ctx stanza). The first submit will
-  # create the dataset with the query's output schema.
-  table: "wiki_lake"
-  mode: append
-  create_if_missing: true
-
-execution:
-  # 10 minute wall-clock cap; bumps for production backfills.
-  timeout_ms: 600000
+spec:
+  query: |
+    SELECT slug, title, page_type, content, updated_at
+    FROM wiki.main.wiki_pages
+    WHERE slug LIKE {slug_prefix}
+    ORDER BY updated_at DESC
+    LIMIT {limit}
+  destination:
+    # `wiki_lake` must be registered as a Lance data source in the server's
+    # ctx.yaml (see docs/jobs.md for the ctx stanza). The first submit will
+    # create the dataset with the query's output schema.
+    table: "wiki_lake"
+    mode: append
+    create_if_missing: true
+  execution:
+    # 10 minute wall-clock cap; bumps for production backfills.
+    timeout_ms: 600000

--- a/demo/llm_wiki/cli/pipelines/create.yaml
+++ b/demo/llm_wiki/cli/pipelines/create.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "wiki-create"
   version: "1.0.0"
@@ -20,11 +22,12 @@ metadata:
 #   {page_type}  - One of entity | concept | summary | index | schema
 #   {content}    - Markdown body (also the source for the embedding)
 
-query: |
-  INSERT INTO wiki.main.wiki_pages (slug, title, page_type, content, embedding, updated_at)
-  SELECT slug, title, page_type, content,
-         vec_to_binary(candle('models/generated/bge-small-en-v1.5', content)),
-         CAST(now() AS VARCHAR)
-  FROM (
-    SELECT {slug} AS slug, {title} AS title, {page_type} AS page_type, {content} AS content
-  ) AS t
+spec:
+  query: |
+    INSERT INTO wiki.main.wiki_pages (slug, title, page_type, content, embedding, updated_at)
+    SELECT slug, title, page_type, content,
+           vec_to_binary(candle('models/generated/bge-small-en-v1.5', content)),
+           CAST(now() AS VARCHAR)
+    FROM (
+      SELECT {slug} AS slug, {title} AS title, {page_type} AS page_type, {content} AS content
+    ) AS t

--- a/demo/llm_wiki/cli/pipelines/delete.yaml
+++ b/demo/llm_wiki/cli/pipelines/delete.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "wiki-delete"
   version: "1.0.0"
@@ -11,5 +13,6 @@ metadata:
 # Parameters:
 #   {slug}  - Canonical slug to delete
 
-query: |
-  DELETE FROM wiki.main.wiki_pages WHERE slug = {slug}
+spec:
+  query: |
+    DELETE FROM wiki.main.wiki_pages WHERE slug = {slug}

--- a/demo/llm_wiki/cli/pipelines/get.yaml
+++ b/demo/llm_wiki/cli/pipelines/get.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "wiki-get"
   version: "1.0.0"
@@ -6,7 +8,8 @@ metadata:
 # Parameters:
 #   {slug}  - Canonical slug, e.g. 'entity/alan-turing'
 
-query: |
-  SELECT slug, title, page_type, content, updated_at
-  FROM wiki.main.wiki_pages
-  WHERE slug = {slug}
+spec:
+  query: |
+    SELECT slug, title, page_type, content, updated_at
+    FROM wiki.main.wiki_pages
+    WHERE slug = {slug}

--- a/demo/llm_wiki/cli/pipelines/list.yaml
+++ b/demo/llm_wiki/cli/pipelines/list.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "wiki-list"
   version: "1.0.0"
@@ -10,10 +12,11 @@ metadata:
 #   {slug_prefix}        - SQL LIKE pattern for slug (e.g. 'concept/%', '%')
 #   {limit}              - Maximum number of pages to return
 
-query: |
-  SELECT slug, title, page_type, updated_at
-  FROM wiki.main.wiki_pages
-  WHERE page_type LIKE {page_type_pattern}
-    AND slug      LIKE {slug_prefix}
-  ORDER BY updated_at DESC
-  LIMIT {limit}
+spec:
+  query: |
+    SELECT slug, title, page_type, updated_at
+    FROM wiki.main.wiki_pages
+    WHERE page_type LIKE {page_type_pattern}
+      AND slug      LIKE {slug_prefix}
+    ORDER BY updated_at DESC
+    LIMIT {limit}

--- a/demo/llm_wiki/cli/pipelines/log_append.yaml
+++ b/demo/llm_wiki/cli/pipelines/log_append.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "wiki-log-append"
   version: "1.0.0"
@@ -12,9 +14,10 @@ metadata:
 #   {slug}        - Related page slug, or "" if not page-specific
 #   {message}     - Free-form human-readable message
 
-query: |
-  INSERT INTO wiki.main.wiki_log (event_type, slug, message, created_at)
-  SELECT event_type, slug, message, CAST(now() AS VARCHAR)
-  FROM (
-    SELECT {event_type} AS event_type, {slug} AS slug, {message} AS message
-  ) AS t
+spec:
+  query: |
+    INSERT INTO wiki.main.wiki_log (event_type, slug, message, created_at)
+    SELECT event_type, slug, message, CAST(now() AS VARCHAR)
+    FROM (
+      SELECT {event_type} AS event_type, {slug} AS slug, {message} AS message
+    ) AS t

--- a/demo/llm_wiki/cli/pipelines/search_hybrid.yaml
+++ b/demo/llm_wiki/cli/pipelines/search_hybrid.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "wiki-search-hybrid"
   version: "1.0.0"
@@ -15,26 +17,27 @@ metadata:
 #   {text_weight}    - RRF weight for text results (e.g. 0.5)
 #   {limit}          - Maximum number of fused results to return
 
-query: |
-  WITH vec AS (
-    SELECT id, ROW_NUMBER() OVER (ORDER BY _score ASC) AS rk
-    FROM sqlite_knn('wiki.main.wiki_pages_vec', 'embedding',
-        (SELECT candle('models/generated/bge-small-en-v1.5', {query})),
-        80)
-  ),
-  fts AS (
-    SELECT id, slug, title, page_type,
-           ROW_NUMBER() OVER (ORDER BY _score DESC) AS rk
-    FROM sqlite_fts('wiki.main.wiki_pages_fts', 'content', {text_query}, 60)
-  )
-  SELECT
-    COALESCE(f.slug, p.slug)           AS slug,
-    COALESCE(f.title, p.title)         AS title,
-    COALESCE(f.page_type, p.page_type) AS page_type,
-    COALESCE({vector_weight} / (60.0 + v.rk), 0)
-      + COALESCE({text_weight} / (60.0 + f.rk), 0) AS rrf_score
-  FROM vec v
-  FULL OUTER JOIN fts f ON v.id = f.id
-  LEFT JOIN wiki.main.wiki_pages p ON p.id = COALESCE(v.id, f.id)
-  ORDER BY rrf_score DESC
-  LIMIT {limit}
+spec:
+  query: |
+    WITH vec AS (
+      SELECT id, ROW_NUMBER() OVER (ORDER BY _score ASC) AS rk
+      FROM sqlite_knn('wiki.main.wiki_pages_vec', 'embedding',
+          (SELECT candle('models/generated/bge-small-en-v1.5', {query})),
+          80)
+    ),
+    fts AS (
+      SELECT id, slug, title, page_type,
+             ROW_NUMBER() OVER (ORDER BY _score DESC) AS rk
+      FROM sqlite_fts('wiki.main.wiki_pages_fts', 'content', {text_query}, 60)
+    )
+    SELECT
+      COALESCE(f.slug, p.slug)           AS slug,
+      COALESCE(f.title, p.title)         AS title,
+      COALESCE(f.page_type, p.page_type) AS page_type,
+      COALESCE({vector_weight} / (60.0 + v.rk), 0)
+        + COALESCE({text_weight} / (60.0 + f.rk), 0) AS rrf_score
+    FROM vec v
+    FULL OUTER JOIN fts f ON v.id = f.id
+    LEFT JOIN wiki.main.wiki_pages p ON p.id = COALESCE(v.id, f.id)
+    ORDER BY rrf_score DESC
+    LIMIT {limit}

--- a/demo/llm_wiki/server/ctx.yaml
+++ b/demo/llm_wiki/server/ctx.yaml
@@ -1,16 +1,23 @@
-data_sources:
-  # Catalog mode: this Postgres database is dedicated to the LLM Wiki demo,
-  # so we register the entire `public` schema in one entry instead of listing
-  # `wiki_pages` and `wiki_log` individually. Skardi introspects
-  # information_schema and exposes every BASE TABLE as
-  #   wikidb.<schema>.<table>, e.g. wikidb.public.wiki_pages
-  - name: "wikidb"
-    type: "postgres"
-    hierarchy_level: "catalog"
-    access_mode: "read_write"
-    connection_string: "postgresql://localhost:5432/wikidb?sslmode=disable"
-    description: "LLM Wiki catalog — wiki_pages (content + pgvector + FTS) and wiki_log"
-    options:
-      allowed_schemas: "public"
-      user_env: "PG_USER"
-      pass_env: "PG_PASSWORD"
+kind: context
+
+metadata:
+  name: server-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    # Catalog mode: this Postgres database is dedicated to the LLM Wiki demo,
+    # so we register the entire `public` schema in one entry instead of listing
+    # `wiki_pages` and `wiki_log` individually. Skardi introspects
+    # information_schema and exposes every BASE TABLE as
+    #   wikidb.<schema>.<table>, e.g. wikidb.public.wiki_pages
+    - name: "wikidb"
+      type: "postgres"
+      hierarchy_level: "catalog"
+      access_mode: "read_write"
+      connection_string: "postgresql://localhost:5432/wikidb?sslmode=disable"
+      description: "LLM Wiki catalog — wiki_pages (content + pgvector + FTS) and wiki_log"
+      options:
+        allowed_schemas: "public"
+        user_env: "PG_USER"
+        pass_env: "PG_PASSWORD"

--- a/demo/llm_wiki/server/pipelines/create.yaml
+++ b/demo/llm_wiki/server/pipelines/create.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "wiki-create"
   version: "1.0.0"
@@ -14,13 +16,14 @@ metadata:
 #   {page_type} - entity | concept | summary | index | schema
 #   {content}   - Markdown body (used for both FTS and vector embedding)
 
-query: |
-  INSERT INTO wikidb.public.wiki_pages (slug, title, page_type, content, embedding, updated_at)
-  VALUES (
-    {slug},
-    {title},
-    {page_type},
-    {content},
-    candle('models/generated/bge-small-en-v1.5', {content}),
-    now()
-  )
+spec:
+  query: |
+    INSERT INTO wikidb.public.wiki_pages (slug, title, page_type, content, embedding, updated_at)
+    VALUES (
+      {slug},
+      {title},
+      {page_type},
+      {content},
+      candle('models/generated/bge-small-en-v1.5', {content}),
+      now()
+    )

--- a/demo/llm_wiki/server/pipelines/get.yaml
+++ b/demo/llm_wiki/server/pipelines/get.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "wiki-get"
   version: "1.0.0"
@@ -9,7 +11,8 @@ metadata:
 # Parameters:
 #   {slug} - Page identifier returned by wiki-search-hybrid or wiki-list
 
-query: |
-  SELECT slug, title, page_type, content
-  FROM wikidb.public.wiki_pages
-  WHERE slug = {slug}
+spec:
+  query: |
+    SELECT slug, title, page_type, content
+    FROM wikidb.public.wiki_pages
+    WHERE slug = {slug}

--- a/demo/llm_wiki/server/pipelines/list.yaml
+++ b/demo/llm_wiki/server/pipelines/list.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "wiki-list"
   version: "1.0.0"
@@ -11,10 +13,11 @@ metadata:
 #   {slug_prefix}       - LIKE pattern for slug,      e.g. "entity/%" or "%"
 #   {limit}             - Maximum number of rows to return
 
-query: |
-  SELECT slug, title, page_type
-  FROM wikidb.public.wiki_pages
-  WHERE page_type LIKE {page_type_pattern}
-    AND slug      LIKE {slug_prefix}
-  ORDER BY slug
-  LIMIT {limit}
+spec:
+  query: |
+    SELECT slug, title, page_type
+    FROM wikidb.public.wiki_pages
+    WHERE page_type LIKE {page_type_pattern}
+      AND slug      LIKE {slug_prefix}
+    ORDER BY slug
+    LIMIT {limit}

--- a/demo/llm_wiki/server/pipelines/log_append.yaml
+++ b/demo/llm_wiki/server/pipelines/log_append.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "wiki-log-append"
   version: "1.0.0"
@@ -12,11 +14,12 @@ metadata:
 #   {slug}       - Related wiki page slug, or "" if not page-specific
 #   {message}    - Free-form markdown message describing the event
 
-query: |
-  INSERT INTO wikidb.public.wiki_log (event_type, slug, message, created_at)
-  VALUES (
-    {event_type},
-    {slug},
-    {message},
-    now()
-  )
+spec:
+  query: |
+    INSERT INTO wikidb.public.wiki_log (event_type, slug, message, created_at)
+    VALUES (
+      {event_type},
+      {slug},
+      {message},
+      now()
+    )

--- a/demo/llm_wiki/server/pipelines/search_hybrid.yaml
+++ b/demo/llm_wiki/server/pipelines/search_hybrid.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "wiki-search-hybrid"
   version: "1.0.0"
@@ -15,24 +17,25 @@ metadata:
 #   {text_weight}    - Weight for text results (e.g. 0.5)
 #   {limit}          - Maximum number of fused results to return
 
-query: |
-  SELECT
-    COALESCE(v.slug, t.slug)           AS slug,
-    COALESCE(v.title, t.title)         AS title,
-    COALESCE(v.page_type, t.page_type) AS page_type,
-    COALESCE({vector_weight} / (60.0 + v.rk), 0)
-      + COALESCE({text_weight} / (60.0 + t.rk), 0) AS rrf_score
-  FROM (
-    SELECT slug, title, page_type,
-           ROW_NUMBER() OVER (ORDER BY _score ASC) AS rk
-    FROM pg_knn('wikidb.public.wiki_pages', 'embedding',
-        candle('models/generated/bge-small-en-v1.5', {query}),
-        '<=>', 80)
-  ) v
-  FULL OUTER JOIN (
-    SELECT slug, title, page_type,
-           ROW_NUMBER() OVER (ORDER BY _score DESC) AS rk
-    FROM pg_fts('wikidb.public.wiki_pages', 'content', {text_query}, 60)
-  ) t ON v.slug = t.slug
-  ORDER BY rrf_score DESC
-  LIMIT {limit}
+spec:
+  query: |
+    SELECT
+      COALESCE(v.slug, t.slug)           AS slug,
+      COALESCE(v.title, t.title)         AS title,
+      COALESCE(v.page_type, t.page_type) AS page_type,
+      COALESCE({vector_weight} / (60.0 + v.rk), 0)
+        + COALESCE({text_weight} / (60.0 + t.rk), 0) AS rrf_score
+    FROM (
+      SELECT slug, title, page_type,
+             ROW_NUMBER() OVER (ORDER BY _score ASC) AS rk
+      FROM pg_knn('wikidb.public.wiki_pages', 'embedding',
+          candle('models/generated/bge-small-en-v1.5', {query}),
+          '<=>', 80)
+    ) v
+    FULL OUTER JOIN (
+      SELECT slug, title, page_type,
+             ROW_NUMBER() OVER (ORDER BY _score DESC) AS rk
+      FROM pg_fts('wikidb.public.wiki_pages', 'content', {text_query}, 60)
+    ) t ON v.slug = t.slug
+    ORDER BY rrf_score DESC
+    LIMIT {limit}

--- a/demo/llm_wiki/server/pipelines/update.yaml
+++ b/demo/llm_wiki/server/pipelines/update.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "wiki-update"
   version: "1.0.0"
@@ -13,11 +15,12 @@ metadata:
 #   {page_type} - New page_type
 #   {content}   - New markdown body (re-embedded inline)
 
-query: |
-  UPDATE wikidb.public.wiki_pages
-  SET title      = {title},
-      page_type  = {page_type},
-      content    = {content},
-      embedding  = candle('models/generated/bge-small-en-v1.5', {content}),
-      updated_at = now()
-  WHERE slug = {slug}
+spec:
+  query: |
+    UPDATE wikidb.public.wiki_pages
+    SET title      = {title},
+        page_type  = {page_type},
+        content    = {content},
+        embedding  = candle('models/generated/bge-small-en-v1.5', {content}),
+        updated_at = now()
+    WHERE slug = {slug}

--- a/demo/movie_recommendation/README.md
+++ b/demo/movie_recommendation/README.md
@@ -30,14 +30,21 @@ Top-N personalized recommendations
 ## Data Sources
 
 ```yaml
-data_sources:
-  - name: "movies"
-    type: "csv"
-    path: "docs/sample_data/movies.csv"
+kind: context
 
-  - name: "movie_embeddings"
-    type: "lance"
-    path: "data/movie_embeddings.lance"
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "movies"
+      type: "csv"
+      path: "docs/sample_data/movies.csv"
+
+    - name: "movie_embeddings"
+      type: "lance"
+      path: "data/movie_embeddings.lance"
 ```
 
 ## Pipeline

--- a/demo/movie_recommendation/ctx_movie_recommendation.yaml
+++ b/demo/movie_recommendation/ctx_movie_recommendation.yaml
@@ -1,10 +1,17 @@
-data_sources:
-  - name: "movies"
-    type: "csv"
-    path: "docs/sample_data/movies.csv"
-    description: "CSV file with movie_id, title, genres, year, and genres_list"
+kind: context
 
-  - name: "movie_embeddings"
-    type: "lance"
-    path: "data/movie_embeddings.lance"
-    description: "Lance dataset with 128-dimensional embeddings for movies, schema [movie_id, embedding]"
+metadata:
+  name: ctx_movie_recommendation
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "movies"
+      type: "csv"
+      path: "docs/sample_data/movies.csv"
+      description: "CSV file with movie_id, title, genres, year, and genres_list"
+
+    - name: "movie_embeddings"
+      type: "lance"
+      path: "data/movie_embeddings.lance"
+      description: "Lance dataset with 128-dimensional embeddings for movies, schema [movie_id, embedding]"

--- a/demo/movie_recommendation/pipelines/pipeline_movie_recommendation.yaml
+++ b/demo/movie_recommendation/pipelines/pipeline_movie_recommendation.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: movie-recommendation-pipeline
   version: 2.0.0
@@ -12,37 +14,38 @@ metadata:
 #   {user_id}            - User id passed to the NCF model
 #   {top_n}              - Final number of recommendations to return
 
-query: |
-  WITH last_watched AS (
-    SELECT movie_id, title
-    FROM movies
-    WHERE title = {last_watched_movie}
-    LIMIT 1
-  ),
-  knn_results AS (
-    SELECT knn.movie_id
-    FROM lance_knn(
-      'movie_embeddings',
-      'embedding',
-      (SELECT embedding FROM movie_embeddings WHERE movie_id = (SELECT movie_id FROM last_watched)),
-      {k}
-    ) knn
-    WHERE knn.movie_id != (SELECT movie_id FROM last_watched)
-  ),
-  ranked_recommendations AS (
+spec:
+  query: |
+    WITH last_watched AS (
+      SELECT movie_id, title
+      FROM movies
+      WHERE title = {last_watched_movie}
+      LIMIT 1
+    ),
+    knn_results AS (
+      SELECT knn.movie_id
+      FROM lance_knn(
+        'movie_embeddings',
+        'embedding',
+        (SELECT embedding FROM movie_embeddings WHERE movie_id = (SELECT movie_id FROM last_watched)),
+        {k}
+      ) knn
+      WHERE knn.movie_id != (SELECT movie_id FROM last_watched)
+    ),
+    ranked_recommendations AS (
+      SELECT
+        kr.movie_id,
+        onnx_predict('models/ncf.onnx', CAST({user_id} AS BIGINT), CAST(kr.movie_id AS BIGINT)) AS prediction_score
+      FROM knn_results kr
+    )
     SELECT
-      kr.movie_id,
-      onnx_predict('models/ncf.onnx', CAST({user_id} AS BIGINT), CAST(kr.movie_id AS BIGINT)) AS prediction_score
-    FROM knn_results kr
-  )
-  SELECT
-    m.movie_id,
-    m.title,
-    m.genres,
-    m.year,
-    m.genres_list,
-    rr.prediction_score
-  FROM ranked_recommendations rr
-  JOIN movies m ON rr.movie_id = m.movie_id
-  ORDER BY rr.prediction_score DESC
-  LIMIT {top_n}
+      m.movie_id,
+      m.title,
+      m.genres,
+      m.year,
+      m.genres_list,
+      rr.prediction_score
+    FROM ranked_recommendations rr
+    JOIN movies m ON rr.movie_id = m.movie_id
+    ORDER BY rr.prediction_score DESC
+    LIMIT {top_n}

--- a/demo/rag/README.md
+++ b/demo/rag/README.md
@@ -340,14 +340,21 @@ connection pool, and exposes each table under `<catalog>.main.<table>` for
 both SQL and `sqlite_knn` / `sqlite_fts` lookups:
 
 ```yaml
-data_sources:
-  - name: rag
-    type: sqlite
-    path: demo/rag/rag.db
-    access_mode: read_write
-    hierarchy_level: catalog
-    options:
-      extensions_env: SQLITE_VEC_PATH
+kind: context
+
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: rag
+      type: sqlite
+      path: demo/rag/rag.db
+      access_mode: read_write
+      hierarchy_level: catalog
+      options:
+        extensions_env: SQLITE_VEC_PATH
 ```
 
 The pipeline YAMLs in [cli/pipelines/](cli/pipelines/) use the same

--- a/demo/rag/cli/aliases.yaml
+++ b/demo/rag/cli/aliases.yaml
@@ -1,30 +1,38 @@
-ingest:
-  pipeline: ingest
-  positional:
-    - doc_id
-    - content
-  description: Insert one document (id, content) — computes embedding inline
-grep:
-  pipeline: search-hybrid
-  positional:
-    - query
-  defaults:
-    text_query: "{query}"
-    vector_weight: "0.5"
-    text_weight: "0.5"
-    limit: "10"
-  description: Hybrid search (RRF of sqlite_knn + sqlite_fts)
-vec:
-  pipeline: search-vector
-  positional:
-    - query
-  defaults:
-    limit: "10"
-  description: Vector-only KNN via sqlite_knn
-fts:
-  pipeline: search-fulltext
-  positional:
-    - query
-  defaults:
-    limit: "10"
-  description: Full-text-only search via sqlite_fts
+kind: aliases
+
+metadata:
+  name: rag-cli-aliases
+  version: 1.0.0
+  description: Short-verb shortcuts for the rag demo CLI
+
+spec:
+  ingest:
+    pipeline: ingest
+    positional:
+      - doc_id
+      - content
+    description: Insert one document (id, content) — computes embedding inline
+  grep:
+    pipeline: search-hybrid
+    positional:
+      - query
+    defaults:
+      text_query: "{query}"
+      vector_weight: "0.5"
+      text_weight: "0.5"
+      limit: "10"
+    description: Hybrid search (RRF of sqlite_knn + sqlite_fts)
+  vec:
+    pipeline: search-vector
+    positional:
+      - query
+    defaults:
+      limit: "10"
+    description: Vector-only KNN via sqlite_knn
+  fts:
+    pipeline: search-fulltext
+    positional:
+      - query
+    defaults:
+      limit: "10"
+    description: Full-text-only search via sqlite_fts

--- a/demo/rag/cli/ctx.yaml
+++ b/demo/rag/cli/ctx.yaml
@@ -1,8 +1,15 @@
-data_sources:
-  - name: rag
-    type: sqlite
-    path: demo/rag/rag.db
-    access_mode: read_write
-    hierarchy_level: catalog
-    options:
-      extensions_env: SQLITE_VEC_PATH
+kind: context
+
+metadata:
+  name: cli-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: rag
+      type: sqlite
+      path: demo/rag/rag.db
+      access_mode: read_write
+      hierarchy_level: catalog
+      options:
+        extensions_env: SQLITE_VEC_PATH

--- a/demo/rag/cli/pipelines/ingest.yaml
+++ b/demo/rag/cli/pipelines/ingest.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "ingest"
   version: "1.0.0"
@@ -14,10 +16,11 @@ metadata:
 #   {doc_id}   - Integer primary key for the documents table
 #   {content}  - Document text (also the source for the embedding)
 
-query: |
-  INSERT INTO rag.main.documents (id, content, embedding)
-  SELECT id, content,
-         vec_to_binary(candle('models/generated/bge-small-en-v1.5', content))
-  FROM (
-    SELECT {doc_id} AS id, {content} AS content
-  ) AS t
+spec:
+  query: |
+    INSERT INTO rag.main.documents (id, content, embedding)
+    SELECT id, content,
+           vec_to_binary(candle('models/generated/bge-small-en-v1.5', content))
+    FROM (
+      SELECT {doc_id} AS id, {content} AS content
+    ) AS t

--- a/demo/rag/cli/pipelines/search_fulltext.yaml
+++ b/demo/rag/cli/pipelines/search_fulltext.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "search-fulltext"
   version: "1.0.0"
@@ -10,7 +12,8 @@ metadata:
 #   {query}  - FTS5 query (term, "phrase", +must -mustnot, fuzzy~1)
 #   {limit}  - Maximum number of results
 
-query: |
-  SELECT id, content, _score
-  FROM sqlite_fts('rag.main.documents_fts', 'content', {query}, {limit})
-  ORDER BY _score DESC
+spec:
+  query: |
+    SELECT id, content, _score
+    FROM sqlite_fts('rag.main.documents_fts', 'content', {query}, {limit})
+    ORDER BY _score DESC

--- a/demo/rag/cli/pipelines/search_hybrid.yaml
+++ b/demo/rag/cli/pipelines/search_hybrid.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "search-hybrid"
   version: "1.0.0"
@@ -15,24 +17,25 @@ metadata:
 #   {text_weight}    - RRF weight for text results (e.g. 0.5)
 #   {limit}          - Maximum number of fused results
 
-query: |
-  WITH vec AS (
-    SELECT id, ROW_NUMBER() OVER (ORDER BY _score ASC) AS rk
-    FROM sqlite_knn('rag.main.documents_vec', 'embedding',
-        (SELECT candle('models/generated/bge-small-en-v1.5', {query})),
-        80)
-  ),
-  fts AS (
-    SELECT id, content, ROW_NUMBER() OVER (ORDER BY _score DESC) AS rk
-    FROM sqlite_fts('rag.main.documents_fts', 'content', {text_query}, 60)
-  )
-  SELECT
-    COALESCE(v.id, f.id)                   AS id,
-    COALESCE(f.content, d.content)         AS content,
-    COALESCE({vector_weight} / (60.0 + v.rk), 0)
-      + COALESCE({text_weight} / (60.0 + f.rk), 0) AS rrf_score
-  FROM vec v
-  FULL OUTER JOIN fts f ON v.id = f.id
-  LEFT JOIN rag.main.documents d ON d.id = COALESCE(v.id, f.id)
-  ORDER BY rrf_score DESC
-  LIMIT {limit}
+spec:
+  query: |
+    WITH vec AS (
+      SELECT id, ROW_NUMBER() OVER (ORDER BY _score ASC) AS rk
+      FROM sqlite_knn('rag.main.documents_vec', 'embedding',
+          (SELECT candle('models/generated/bge-small-en-v1.5', {query})),
+          80)
+    ),
+    fts AS (
+      SELECT id, content, ROW_NUMBER() OVER (ORDER BY _score DESC) AS rk
+      FROM sqlite_fts('rag.main.documents_fts', 'content', {text_query}, 60)
+    )
+    SELECT
+      COALESCE(v.id, f.id)                   AS id,
+      COALESCE(f.content, d.content)         AS content,
+      COALESCE({vector_weight} / (60.0 + v.rk), 0)
+        + COALESCE({text_weight} / (60.0 + f.rk), 0) AS rrf_score
+    FROM vec v
+    FULL OUTER JOIN fts f ON v.id = f.id
+    LEFT JOIN rag.main.documents d ON d.id = COALESCE(v.id, f.id)
+    ORDER BY rrf_score DESC
+    LIMIT {limit}

--- a/demo/rag/cli/pipelines/search_vector.yaml
+++ b/demo/rag/cli/pipelines/search_vector.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "search-vector"
   version: "1.0.0"
@@ -10,10 +12,11 @@ metadata:
 #   {query}  - Natural-language query (embedded with candle for sqlite_knn)
 #   {limit}  - Maximum number of results
 
-query: |
-  SELECT d.id, d.content, v._score
-  FROM sqlite_knn('rag.main.documents_vec', 'embedding',
-      (SELECT candle('models/generated/bge-small-en-v1.5', {query})),
-      {limit}) v
-  LEFT JOIN rag.main.documents d ON d.id = v.id
-  ORDER BY v._score
+spec:
+  query: |
+    SELECT d.id, d.content, v._score
+    FROM sqlite_knn('rag.main.documents_vec', 'embedding',
+        (SELECT candle('models/generated/bge-small-en-v1.5', {query})),
+        {limit}) v
+    LEFT JOIN rag.main.documents d ON d.id = v.id
+    ORDER BY v._score

--- a/demo/rag/server/ctx.yaml
+++ b/demo/rag/server/ctx.yaml
@@ -1,14 +1,21 @@
-data_sources:
-  # Single PostgreSQL table holds both the raw content (searched via pg_fts)
-  # and the pgvector embedding (searched via pg_knn). One INSERT writes both,
-  # and hybrid search joins both signals from the same row.
-  - name: "documents"
-    type: "postgres"
-    access_mode: "read_write"
-    connection_string: "postgresql://localhost:5432/ragdb?sslmode=disable"
-    description: "PostgreSQL table with pgvector embeddings and full-text search over content"
-    options:
-      table: "documents"
-      schema: "public"
-      user_env: "PG_USER"
-      pass_env: "PG_PASSWORD"
+kind: context
+
+metadata:
+  name: server-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    # Single PostgreSQL table holds both the raw content (searched via pg_fts)
+    # and the pgvector embedding (searched via pg_knn). One INSERT writes both,
+    # and hybrid search joins both signals from the same row.
+    - name: "documents"
+      type: "postgres"
+      access_mode: "read_write"
+      connection_string: "postgresql://localhost:5432/ragdb?sslmode=disable"
+      description: "PostgreSQL table with pgvector embeddings and full-text search over content"
+      options:
+        table: "documents"
+        schema: "public"
+        user_env: "PG_USER"
+        pass_env: "PG_PASSWORD"

--- a/demo/rag/server/pipelines/ingest.yaml
+++ b/demo/rag/server/pipelines/ingest.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "ingest"
   version: "1.0.0"
@@ -10,10 +12,11 @@ metadata:
 #   {doc_id}  - Unique document ID
 #   {content} - Document text (used for both FTS and vector embedding)
 
-query: |
-  INSERT INTO documents (id, content, embedding)
-  VALUES (
-    {doc_id},
-    {content},
-    candle('models/generated/bge-small-en-v1.5', {content})
-  )
+spec:
+  query: |
+    INSERT INTO documents (id, content, embedding)
+    VALUES (
+      {doc_id},
+      {content},
+      candle('models/generated/bge-small-en-v1.5', {content})
+    )

--- a/demo/rag/server/pipelines/search_fulltext.yaml
+++ b/demo/rag/server/pipelines/search_fulltext.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "search-fulltext"
   version: "1.0.0"
@@ -12,7 +14,8 @@ metadata:
 #   {query} - Search terms (web-search syntax: AND, "phrase", or, -not)
 #   {limit} - Maximum number of results
 
-query: |
-  SELECT id, content, _score
-  FROM pg_fts('documents', 'content', {query}, {limit})
-  ORDER BY _score DESC
+spec:
+  query: |
+    SELECT id, content, _score
+    FROM pg_fts('documents', 'content', {query}, {limit})
+    ORDER BY _score DESC

--- a/demo/rag/server/pipelines/search_hybrid.yaml
+++ b/demo/rag/server/pipelines/search_hybrid.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "search-hybrid"
   version: "1.0.0"
@@ -15,21 +17,22 @@ metadata:
 #   {text_weight}    - Weight for text results (e.g. 0.5)
 #   {limit}          - Maximum number of results
 
-query: |
-  SELECT
-    COALESCE(v.id, t.id) AS id,
-    COALESCE(v.content, t.content) AS content,
-    COALESCE({vector_weight} / (60.0 + v.rk), 0)
-      + COALESCE({text_weight} / (60.0 + t.rk), 0) AS rrf_score
-  FROM (
-    SELECT id, content, ROW_NUMBER() OVER (ORDER BY _score ASC) AS rk
-    FROM pg_knn('documents', 'embedding',
-        candle('models/generated/bge-small-en-v1.5', {query}),
-        '<=>', 80)
-  ) v
-  FULL OUTER JOIN (
-    SELECT id, content, ROW_NUMBER() OVER (ORDER BY _score DESC) AS rk
-    FROM pg_fts('documents', 'content', {text_query}, 60)
-  ) t ON v.id = t.id
-  ORDER BY rrf_score DESC
-  LIMIT {limit}
+spec:
+  query: |
+    SELECT
+      COALESCE(v.id, t.id) AS id,
+      COALESCE(v.content, t.content) AS content,
+      COALESCE({vector_weight} / (60.0 + v.rk), 0)
+        + COALESCE({text_weight} / (60.0 + t.rk), 0) AS rrf_score
+    FROM (
+      SELECT id, content, ROW_NUMBER() OVER (ORDER BY _score ASC) AS rk
+      FROM pg_knn('documents', 'embedding',
+          candle('models/generated/bge-small-en-v1.5', {query}),
+          '<=>', 80)
+    ) v
+    FULL OUTER JOIN (
+      SELECT id, content, ROW_NUMBER() OVER (ORDER BY _score DESC) AS rk
+      FROM pg_fts('documents', 'content', {text_query}, 60)
+    ) t ON v.id = t.id
+    ORDER BY rrf_score DESC
+    LIMIT {limit}

--- a/demo/rag/server/pipelines/search_vector.yaml
+++ b/demo/rag/server/pipelines/search_vector.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "search-vector"
   version: "1.0.0"
@@ -9,9 +11,10 @@ metadata:
 #   {query} - Natural language search query
 #   {limit} - Maximum number of results
 
-query: |
-  SELECT id, content, _score
-  FROM pg_knn('documents', 'embedding',
-      candle('models/generated/bge-small-en-v1.5', {query}),
-      '<=>', 10)
-  ORDER BY _score
+spec:
+  query: |
+    SELECT id, content, _score
+    FROM pg_knn('documents', 'embedding',
+        candle('models/generated/bge-small-en-v1.5', {query}),
+        '<=>', 10)
+    ORDER BY _score

--- a/demo/simple_backend/ctx.yaml
+++ b/demo/simple_backend/ctx.yaml
@@ -1,16 +1,23 @@
-data_sources:
-  - name: "tasks"
-    type: "sqlite"
-    access_mode: "read_write"
-    path: "demo/simple_backend/backend.db"
-    description: "Tasks table"
-    options:
-      table: "tasks"
+kind: context
 
-  - name: "users"
-    type: "sqlite"
-    access_mode: "read_write"
-    path: "demo/simple_backend/backend.db"
-    description: "Users table"
-    options:
-      table: "users"
+metadata:
+  name: simple_backend-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "tasks"
+      type: "sqlite"
+      access_mode: "read_write"
+      path: "demo/simple_backend/backend.db"
+      description: "Tasks table"
+      options:
+        table: "tasks"
+
+    - name: "users"
+      type: "sqlite"
+      access_mode: "read_write"
+      path: "demo/simple_backend/backend.db"
+      description: "Users table"
+      options:
+        table: "users"

--- a/demo/simple_backend/pipelines/complete_task.yaml
+++ b/demo/simple_backend/pipelines/complete_task.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "complete-task"
   version: "1.0.0"
@@ -6,5 +8,6 @@ metadata:
 # Parameters:
 #   {id} - Task ID to mark done
 
-query: |
-  UPDATE tasks SET done = 1 WHERE id = {id}
+spec:
+  query: |
+    UPDATE tasks SET done = 1 WHERE id = {id}

--- a/demo/simple_backend/pipelines/create_task.yaml
+++ b/demo/simple_backend/pipelines/create_task.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "create-task"
   version: "1.0.0"
@@ -7,6 +9,7 @@ metadata:
 #   {user_id} - Owner user ID
 #   {title}   - Task title
 
-query: |
-  INSERT INTO tasks (user_id, title)
-  VALUES ({user_id}, {title})
+spec:
+  query: |
+    INSERT INTO tasks (user_id, title)
+    VALUES ({user_id}, {title})

--- a/demo/simple_backend/pipelines/delete_task.yaml
+++ b/demo/simple_backend/pipelines/delete_task.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "delete-task"
   version: "1.0.0"
@@ -6,5 +8,6 @@ metadata:
 # Parameters:
 #   {id} - Task ID to delete
 
-query: |
-  DELETE FROM tasks WHERE id = {id}
+spec:
+  query: |
+    DELETE FROM tasks WHERE id = {id}

--- a/demo/simple_backend/pipelines/list_tasks.yaml
+++ b/demo/simple_backend/pipelines/list_tasks.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "list-tasks"
   version: "1.0.0"
@@ -7,8 +9,9 @@ metadata:
 #   {user_id}  - User ID to filter tasks for
 #   {done}     - Optional: 0 for open, 1 for completed (omit for all)
 
-query: |
-  SELECT t.id, t.title, t.done, t.created_at
-  FROM tasks t
-  WHERE t.user_id = {user_id}
-  ORDER BY t.created_at DESC
+spec:
+  query: |
+    SELECT t.id, t.title, t.done, t.created_at
+    FROM tasks t
+    WHERE t.user_id = {user_id}
+    ORDER BY t.created_at DESC

--- a/docs/S3_USAGE.md
+++ b/docs/S3_USAGE.md
@@ -25,21 +25,28 @@ export AWS_PROFILE="your_profile_name"
 Create a context YAML file with only the AWS region:
 
 ```yaml
-data_sources:
-  - name: "sales_data"
-    type: "parquet"
-    location: "remote_s3"
-    path: "s3://my-bucket/sales/2024/sales.parquet"
-    description: "Sales data in S3"
+kind: context
 
-  - name: "customer_events"
-    type: "csv"
-    location: "remote_s3"
-    path: "s3://analytics-bucket/events/events.csv"
-    options:
-      has_header: true
-      delimiter: ","
-    description: "Customer events CSV in S3"
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "sales_data"
+      type: "parquet"
+      location: "remote_s3"
+      path: "s3://my-bucket/sales/2024/sales.parquet"
+      description: "Sales data in S3"
+
+    - name: "customer_events"
+      type: "csv"
+      location: "remote_s3"
+      path: "s3://analytics-bucket/events/events.csv"
+      options:
+        has_header: true
+        delimiter: ","
+      description: "Customer events CSV in S3"
 ```
 
 ### 3. Run the Server

--- a/docs/auth/pipelines/active-users.yaml
+++ b/docs/auth/pipelines/active-users.yaml
@@ -1,15 +1,18 @@
+kind: pipeline
+
 metadata:
   name: active-users
   version: 1.0.0
   description: Lists users who currently have an active session
 
-query: |
-  SELECT
-    u.id,
-    u.name,
-    u.email,
-    s.expires_at
-  FROM auth.users u
-  JOIN auth.sessions s ON s.user_id = u.id
-  WHERE s.expires_at > NOW()
-  LIMIT {limit}
+spec:
+  query: |
+    SELECT
+      u.id,
+      u.name,
+      u.email,
+      s.expires_at
+    FROM auth.users u
+    JOIN auth.sessions s ON s.user_id = u.id
+    WHERE s.expires_at > NOW()
+    LIMIT {limit}

--- a/docs/basic/README.md
+++ b/docs/basic/README.md
@@ -21,15 +21,19 @@ The example uses a `products.csv` dataset with 10,000+ product records containin
 ### Schema Structure
 ```yaml
 # Simple, minimal schema - everything else is inferred automatically
+
+kind: pipeline
+
 metadata:
   name: "product-search-demo"
   version: "1.0.0"
   description: "Demonstrates SQL serving pipeline"
 
-query: |
-  SELECT columns FROM table
-  WHERE condition = {parameter}
-  LIMIT {limit}
+spec:
+  query: |
+    SELECT columns FROM table
+    WHERE condition = {parameter}
+    LIMIT {limit}
 ```
 
 ### What's Automatically Inferred

--- a/docs/basic/ctx.yaml
+++ b/docs/basic/ctx.yaml
@@ -1,9 +1,16 @@
-data_sources:
-  - name: "products"
-    type: "csv"
-    path: "data/products.csv"
-    options:
-      has_header: true
-      delimiter: ","
-      schema_infer_max_records: 1000
-    description: "Product catalog dataset with comprehensive product information including pricing, inventory, and categorization"
+kind: context
+
+metadata:
+  name: basic-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "products"
+      type: "csv"
+      path: "data/products.csv"
+      options:
+        has_header: true
+        delimiter: ","
+        schema_infer_max_records: 1000
+      description: "Product catalog dataset with comprehensive product information including pricing, inventory, and categorization"

--- a/docs/basic/ctx_multi_sources.yaml
+++ b/docs/basic/ctx_multi_sources.yaml
@@ -1,17 +1,24 @@
-data_sources:
-  - name: "orders"
-    type: "csv"
-    path: "docs/sample_data/orders.csv"
-    options:
-      has_header: true
-      delimiter: ","
-      schema_infer_max_records: 1000
-    description: "CSV order data with user purchases"
-  - name: "inventory"
-    type: "csv"
-    path: "docs/sample_data/product_inventory.csv"
-    options:
-      has_header: true
-      delimiter: ","
-      schema_infer_max_records: 1000
-    description: "CSV product inventory data with warehouse stock levels"
+kind: context
+
+metadata:
+  name: ctx_multi_sources
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "orders"
+      type: "csv"
+      path: "docs/sample_data/orders.csv"
+      options:
+        has_header: true
+        delimiter: ","
+        schema_infer_max_records: 1000
+      description: "CSV order data with user purchases"
+    - name: "inventory"
+      type: "csv"
+      path: "docs/sample_data/product_inventory.csv"
+      options:
+        has_header: true
+        delimiter: ","
+        schema_infer_max_records: 1000
+      description: "CSV product inventory data with warehouse stock levels"

--- a/docs/basic/ctx_s3_examples.yaml
+++ b/docs/basic/ctx_s3_examples.yaml
@@ -1,101 +1,108 @@
-data_sources:
-  - name: "products"
-    type: "csv"
-    path: "s3://datafusion-eval/products.csv"
-    options:
-      has_header: true
-      delimiter: ","
-      schema_infer_max_records: 1000
-    description: "Product catalog dataset with comprehensive product information including pricing, inventory, and categorization"
+kind: context
 
-# AWS Configuration for S3 Data Sources
-#
-# SECURITY NOTICE: All AWS configuration must come from environment variables.
-# The system will reject any configuration that includes AWS fields in the config file.
-#
-# REQUIRED ENVIRONMENT VARIABLES:
-#   - AWS credentials: One of the authentication methods below
-#   - AWS region: Set AWS_REGION or AWS_DEFAULT_REGION
-#
-# AUTHENTICATION METHODS (all via environment variables):
-#
-# Method 1: Environment Variables (Recommended for development/testing)
-#   Set these environment variables before running the server:
-#   export AWS_ACCESS_KEY_ID="your_access_key_id"
-#   export AWS_SECRET_ACCESS_KEY="your_secret_access_key"
-#   export AWS_REGION="us-east-1"  # or AWS_DEFAULT_REGION
-#   export AWS_SESSION_TOKEN="your_session_token"  # Optional for temporary credentials
-#
-# Method 2: AWS CLI Profiles (Recommended for local development)
-#   First, configure AWS CLI profiles (~/.aws/credentials and ~/.aws/config):
-#
-#   ~/.aws/credentials:
-#   [your-profile]
-#   aws_access_key_id = your_access_key_id
-#   aws_secret_access_key = your_secret_access_key
-#
-#   ~/.aws/config:
-#   [profile your-profile]
-#   region = us-east-1
-#
-#   Then set environment variables:
-#   export AWS_PROFILE="your-profile"
-#   export AWS_REGION="us-east-1"  # Still required to override profile region if needed
-#
-# Method 3: AWS SSO/Identity Center (Modern authentication)
-#   Configure via AWS CLI SSO:
-#   aws configure sso
-#   aws sso login --profile your-sso-profile
-#
-#   Then set:
-#   export AWS_PROFILE="your-sso-profile"
-#   export AWS_REGION="us-east-1"
-#
-# Method 4: IAM Roles/Instance Profiles (Recommended for production on AWS)
-#   No explicit credentials needed - uses AWS instance metadata service
-#   Perfect for EC2, ECS, Lambda, etc.
-#   Still requires: export AWS_REGION="us-east-1"
-#
-# S3 PATH REQUIREMENTS:
-#   - Must start with "s3://" prefix
-#   - Will be validated and connectivity tested at startup
-#   - Examples:
-#     * "s3://bucket-name/file.parquet"
-#     * "s3://bucket-name/path/to/data.csv"
-#     * "s3://bucket-name/partitioned/year=2024/month=11/data.parquet"
-#
-# SUPPORTED S3 FILE TYPES:
-#   - CSV files (type: "csv", location: "remote_s3")
-#   - Parquet files (type: "parquet", location: "remote_s3")
-#   - Lance datasets (type: "lance", location: "remote_s3")
-#
-# CONNECTIVITY VERIFICATION:
-#   The system will test S3 connectivity at startup by attempting to access each S3 path.
-#   This ensures that:
-#   - AWS credentials are valid
-#   - S3 paths exist and are accessible
-#   - IAM permissions are correctly configured
-#   - Network connectivity to S3 is working
-#
-# REQUIRED IAM PERMISSIONS:
-#   Your AWS credentials must have at minimum:
-#   - s3:GetObject (to read files)
-#   - s3:HeadObject (for connectivity testing and metadata)
-#   - s3:ListBucket (if using directory-like paths)
-#
-# Example IAM Policy:
-# {
-#   "Version": "2012-10-17",
-#   "Statement": [
-#     {
-#       "Effect": "Allow",
-#       "Action": ["s3:GetObject", "s3:HeadObject"],
-#       "Resource": "arn:aws:s3:::your-bucket-name/*"
-#     },
-#     {
-#       "Effect": "Allow",
-#       "Action": "s3:ListBucket",
-#       "Resource": "arn:aws:s3:::your-bucket-name"
-#     }
-#   ]
-# }
+metadata:
+  name: ctx_s3_examples
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "products"
+      type: "csv"
+      path: "s3://datafusion-eval/products.csv"
+      options:
+        has_header: true
+        delimiter: ","
+        schema_infer_max_records: 1000
+      description: "Product catalog dataset with comprehensive product information including pricing, inventory, and categorization"
+
+  # AWS Configuration for S3 Data Sources
+  #
+  # SECURITY NOTICE: All AWS configuration must come from environment variables.
+  # The system will reject any configuration that includes AWS fields in the config file.
+  #
+  # REQUIRED ENVIRONMENT VARIABLES:
+  #   - AWS credentials: One of the authentication methods below
+  #   - AWS region: Set AWS_REGION or AWS_DEFAULT_REGION
+  #
+  # AUTHENTICATION METHODS (all via environment variables):
+  #
+  # Method 1: Environment Variables (Recommended for development/testing)
+  #   Set these environment variables before running the server:
+  #   export AWS_ACCESS_KEY_ID="your_access_key_id"
+  #   export AWS_SECRET_ACCESS_KEY="your_secret_access_key"
+  #   export AWS_REGION="us-east-1"  # or AWS_DEFAULT_REGION
+  #   export AWS_SESSION_TOKEN="your_session_token"  # Optional for temporary credentials
+  #
+  # Method 2: AWS CLI Profiles (Recommended for local development)
+  #   First, configure AWS CLI profiles (~/.aws/credentials and ~/.aws/config):
+  #
+  #   ~/.aws/credentials:
+  #   [your-profile]
+  #   aws_access_key_id = your_access_key_id
+  #   aws_secret_access_key = your_secret_access_key
+  #
+  #   ~/.aws/config:
+  #   [profile your-profile]
+  #   region = us-east-1
+  #
+  #   Then set environment variables:
+  #   export AWS_PROFILE="your-profile"
+  #   export AWS_REGION="us-east-1"  # Still required to override profile region if needed
+  #
+  # Method 3: AWS SSO/Identity Center (Modern authentication)
+  #   Configure via AWS CLI SSO:
+  #   aws configure sso
+  #   aws sso login --profile your-sso-profile
+  #
+  #   Then set:
+  #   export AWS_PROFILE="your-sso-profile"
+  #   export AWS_REGION="us-east-1"
+  #
+  # Method 4: IAM Roles/Instance Profiles (Recommended for production on AWS)
+  #   No explicit credentials needed - uses AWS instance metadata service
+  #   Perfect for EC2, ECS, Lambda, etc.
+  #   Still requires: export AWS_REGION="us-east-1"
+  #
+  # S3 PATH REQUIREMENTS:
+  #   - Must start with "s3://" prefix
+  #   - Will be validated and connectivity tested at startup
+  #   - Examples:
+  #     * "s3://bucket-name/file.parquet"
+  #     * "s3://bucket-name/path/to/data.csv"
+  #     * "s3://bucket-name/partitioned/year=2024/month=11/data.parquet"
+  #
+  # SUPPORTED S3 FILE TYPES:
+  #   - CSV files (type: "csv", location: "remote_s3")
+  #   - Parquet files (type: "parquet", location: "remote_s3")
+  #   - Lance datasets (type: "lance", location: "remote_s3")
+  #
+  # CONNECTIVITY VERIFICATION:
+  #   The system will test S3 connectivity at startup by attempting to access each S3 path.
+  #   This ensures that:
+  #   - AWS credentials are valid
+  #   - S3 paths exist and are accessible
+  #   - IAM permissions are correctly configured
+  #   - Network connectivity to S3 is working
+  #
+  # REQUIRED IAM PERMISSIONS:
+  #   Your AWS credentials must have at minimum:
+  #   - s3:GetObject (to read files)
+  #   - s3:HeadObject (for connectivity testing and metadata)
+  #   - s3:ListBucket (if using directory-like paths)
+  #
+  # Example IAM Policy:
+  # {
+  #   "Version": "2012-10-17",
+  #   "Statement": [
+  #     {
+  #       "Effect": "Allow",
+  #       "Action": ["s3:GetObject", "s3:HeadObject"],
+  #       "Resource": "arn:aws:s3:::your-bucket-name/*"
+  #     },
+  #     {
+  #       "Effect": "Allow",
+  #       "Action": "s3:ListBucket",
+  #       "Resource": "arn:aws:s3:::your-bucket-name"
+  #     }
+  #   ]
+  # }

--- a/docs/basic/pipeline.yaml
+++ b/docs/basic/pipeline.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: product-search-demo
   version: 1.0.0
@@ -6,26 +8,27 @@ metadata:
   created_at: 2025-01-15T00:00:00.000+00:00
   updated_at: 2025-01-15T00:00:00.000+00:00
 
-query: |
-  SELECT
-    "Index" as product_id,
-    "Name" as product_name,
-    "Description" as description,
-    "Brand" as brand,
-    "Category" as category,
-    "Price" as price,
-    "Currency" as currency,
-    "Stock" as stock_quantity,
-    "Color" as color,
-    "Size" as size,
-    "Availability" as availability_status
-  FROM products
-  WHERE 1=1
-    AND ({brand} IS NULL OR "Brand" = {brand})
-    AND ({max_price} IS NULL OR "Price" < {max_price})
-    AND ({min_price} IS NULL OR "Price" >= {min_price})
-    AND ({color} IS NULL OR "Color" = {color})
-    AND ({category} IS NULL OR "Category" = {category})
-    AND ({availability} IS NULL OR "Availability" = {availability})
-  ORDER BY "Price" ASC
-  LIMIT {limit}
+spec:
+  query: |
+    SELECT
+      "Index" as product_id,
+      "Name" as product_name,
+      "Description" as description,
+      "Brand" as brand,
+      "Category" as category,
+      "Price" as price,
+      "Currency" as currency,
+      "Stock" as stock_quantity,
+      "Color" as color,
+      "Size" as size,
+      "Availability" as availability_status
+    FROM products
+    WHERE 1=1
+      AND ({brand} IS NULL OR "Brand" = {brand})
+      AND ({max_price} IS NULL OR "Price" < {max_price})
+      AND ({min_price} IS NULL OR "Price" >= {min_price})
+      AND ({color} IS NULL OR "Color" = {color})
+      AND ({category} IS NULL OR "Category" = {category})
+      AND ({availability} IS NULL OR "Availability" = {availability})
+    ORDER BY "Price" ASC
+    LIMIT {limit}

--- a/docs/basic/pipeline_multisource.yaml
+++ b/docs/basic/pipeline_multisource.yaml
@@ -1,13 +1,16 @@
+kind: pipeline
+
 metadata:
   name: order-inventory-join-demo
   version: 1.0.0
   description: Demonstrates federated SQL join across two CSV data sources
 
-query: |
-    SELECT o.order_id, o.product, o.amount, o.order_date, i.warehouse, i.quantity as stock_quantity
-    FROM orders AS o
-    JOIN inventory AS i
-    ON o.product = i.product
-    WHERE ({product} IS NULL OR o.product = {product}) AND ({warehouse} IS NULL OR i.warehouse = {warehouse})
-    ORDER BY o.order_date
-    LIMIT {limit}
+spec:
+  query: |
+      SELECT o.order_id, o.product, o.amount, o.order_date, i.warehouse, i.quantity as stock_quantity
+      FROM orders AS o
+      JOIN inventory AS i
+      ON o.product = i.product
+      WHERE ({product} IS NULL OR o.product = {product}) AND ({warehouse} IS NULL OR i.warehouse = {warehouse})
+      ORDER BY o.order_date
+      LIMIT {limit}

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -7,16 +7,23 @@ Supported for **PostgreSQL**, **MySQL**, and **SQLite**.
 ## Configuration
 
 ```yaml
-data_sources:
-  - name: "mydb_catalog"
-    type: "postgres"          # or mysql / sqlite
-    hierarchy_level: "catalog"
-    connection_string: "postgres://localhost:5432/mydb"
-    options:
-      user_env: "PG_USER"
-      pass_env: "PG_PASSWORD"
-      # Optionally restrict to specific schemas:
-      # allowed_schemas: "public,analytics"
+kind: context
+
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "mydb_catalog"
+      type: "postgres"          # or mysql / sqlite
+      hierarchy_level: "catalog"
+      connection_string: "postgres://localhost:5432/mydb"
+      options:
+        user_env: "PG_USER"
+        pass_env: "PG_PASSWORD"
+        # Optionally restrict to specific schemas:
+        # allowed_schemas: "public,analytics"
 ```
 
 ## Querying

--- a/docs/embeddings/candle/ctx.yaml
+++ b/docs/embeddings/candle/ctx.yaml
@@ -1,5 +1,12 @@
-data_sources:
-  - name: "doc_embeddings"
-    type: "lance"
-    path: "docs/embeddings/candle/data/generated/doc_embeddings.lance"
-    description: "Lance dataset with bge-small-en-v1.5 embeddings for knowledge-base docs. Schema: [id, title, content, embedding(384)]"
+kind: context
+
+metadata:
+  name: candle-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "doc_embeddings"
+      type: "lance"
+      path: "docs/embeddings/candle/data/generated/doc_embeddings.lance"
+      description: "Lance dataset with bge-small-en-v1.5 embeddings for knowledge-base docs. Schema: [id, title, content, embedding(384)]"

--- a/docs/embeddings/candle/pipelines/pipeline_semantic_search.yaml
+++ b/docs/embeddings/candle/pipelines/pipeline_semantic_search.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: semantic-search
   version: 1.0.0
@@ -11,12 +13,13 @@ metadata:
 #   {query} - Natural language search query (embedded on the fly)
 #   {k}     - Number of nearest neighbours to return
 
-query: |
-  SELECT id, title, content, _distance
-  FROM lance_knn(
-    'doc_embeddings',
-    'embedding',
-    candle('models/generated/bge-small-en-v1.5', {query}),
-    {k}
-  )
-  ORDER BY _distance
+spec:
+  query: |
+    SELECT id, title, content, _distance
+    FROM lance_knn(
+      'doc_embeddings',
+      'embedding',
+      candle('models/generated/bge-small-en-v1.5', {query}),
+      {k}
+    )
+    ORDER BY _distance

--- a/docs/embeddings/gguf/ctx.yaml
+++ b/docs/embeddings/gguf/ctx.yaml
@@ -1,5 +1,12 @@
-data_sources:
-  - name: "doc_embeddings_gguf"
-    type: "lance"
-    path: "docs/embeddings/gguf/data/generated/doc_embeddings_gguf.lance"
-    description: "Lance dataset with EmbeddingGemma-300m GGUF embeddings for knowledge-base docs. Schema: [id, title, content, embedding(256)]"
+kind: context
+
+metadata:
+  name: gguf-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "doc_embeddings_gguf"
+      type: "lance"
+      path: "docs/embeddings/gguf/data/generated/doc_embeddings_gguf.lance"
+      description: "Lance dataset with EmbeddingGemma-300m GGUF embeddings for knowledge-base docs. Schema: [id, title, content, embedding(256)]"

--- a/docs/embeddings/gguf/pipelines/pipeline_semantic_search_gguf.yaml
+++ b/docs/embeddings/gguf/pipelines/pipeline_semantic_search_gguf.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: semantic-search-gguf
   version: 1.0.0
@@ -12,12 +14,13 @@ metadata:
 #   {query} - Natural language search query (embedded on the fly)
 #   {k}     - Number of nearest neighbours to return
 
-query: |
-  SELECT id, title, content, _distance
-  FROM lance_knn(
-    'doc_embeddings_gguf',
-    'embedding',
-    gguf('models/generated/embeddinggemma-300m', {query}),
-    {k}
-  )
-  ORDER BY _distance
+spec:
+  query: |
+    SELECT id, title, content, _distance
+    FROM lance_knn(
+      'doc_embeddings_gguf',
+      'embedding',
+      gguf('models/generated/embeddinggemma-300m', {query}),
+      {k}
+    )
+    ORDER BY _distance

--- a/docs/embeddings/remote/ctx.yaml
+++ b/docs/embeddings/remote/ctx.yaml
@@ -1,5 +1,12 @@
-data_sources:
-  - name: "doc_embeddings_openai"
-    type: "lance"
-    path: "docs/embeddings/remote/data/generated/doc_embeddings_openai.lance"
-    description: "Lance dataset with OpenAI text-embedding-3-small embeddings for knowledge-base docs. Schema: [id, title, content, embedding(1536)]"
+kind: context
+
+metadata:
+  name: remote-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "doc_embeddings_openai"
+      type: "lance"
+      path: "docs/embeddings/remote/data/generated/doc_embeddings_openai.lance"
+      description: "Lance dataset with OpenAI text-embedding-3-small embeddings for knowledge-base docs. Schema: [id, title, content, embedding(1536)]"

--- a/docs/embeddings/remote/pipelines/pipeline_semantic_search_remote.yaml
+++ b/docs/embeddings/remote/pipelines/pipeline_semantic_search_remote.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: semantic-search-remote
   version: 1.0.0
@@ -11,12 +13,13 @@ metadata:
 #   {query} - Natural language search query (embedded on the fly)
 #   {k}     - Number of nearest neighbours to return
 
-query: |
-  SELECT id, title, content, _distance
-  FROM lance_knn(
-    'doc_embeddings_openai',
-    'embedding',
-    remote_embed('openai', 'text-embedding-3-small', {query}),
-    {k}
-  )
-  ORDER BY _distance
+spec:
+  query: |
+    SELECT id, title, content, _distance
+    FROM lance_knn(
+      'doc_embeddings_openai',
+      'embedding',
+      remote_embed('openai', 'text-embedding-3-small', {query}),
+      {k}
+    )
+    ORDER BY _distance

--- a/docs/federated-queries.md
+++ b/docs/federated-queries.md
@@ -7,22 +7,25 @@ One of Skardi's most powerful features is the ability to JOIN data across differ
 Join a CSV file with a PostgreSQL table and write results back to PostgreSQL:
 
 ```yaml
+kind: pipeline
+
 metadata:
   name: "federated_join_and_insert"
   version: "1.0"
 
-query: |
-  INSERT INTO user_order_stats (user_id, user_name, total_orders, total_spent)
-  SELECT
-    u.id as user_id,
-    u.name as user_name,
-    COUNT(o.order_id) as total_orders,
-    SUM(o.amount) as total_spent
-  FROM users u                    -- PostgreSQL table
-  INNER JOIN csv_orders o         -- CSV file
-    ON u.id = o.user_id
-  WHERE u.name = {name}
-  GROUP BY u.id, u.name
+spec:
+  query: |
+    INSERT INTO user_order_stats (user_id, user_name, total_orders, total_spent)
+    SELECT
+      u.id as user_id,
+      u.name as user_name,
+      COUNT(o.order_id) as total_orders,
+      SUM(o.amount) as total_spent
+    FROM users u                    -- PostgreSQL table
+    INNER JOIN csv_orders o         -- CSV file
+      ON u.id = o.user_id
+    WHERE u.name = {name}
+    GROUP BY u.id, u.name
 ```
 
 ## More Examples

--- a/docs/iceberg/README.md
+++ b/docs/iceberg/README.md
@@ -90,18 +90,25 @@ deactivate
 Create a context file (`ctx_iceberg_demo.yaml`):
 
 ```yaml
-data_sources:
-  - name: "nyc_taxi"
-    type: "iceberg"
-    path: "/tmp/iceberg-warehouse"
-    description: "NYC taxi trips Iceberg catalog"
-    options:
-      namespace: "nyc"
-      table: "trips"
-  - name: "zones"
-    type: "csv"
-    path: "docs/sample_data/taxi_zones.csv"
-    description: "NYC taxi zone lookup"
+kind: context
+
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "nyc_taxi"
+      type: "iceberg"
+      path: "/tmp/iceberg-warehouse"
+      description: "NYC taxi trips Iceberg catalog"
+      options:
+        namespace: "nyc"
+        table: "trips"
+    - name: "zones"
+      type: "csv"
+      path: "docs/sample_data/taxi_zones.csv"
+      description: "NYC taxi zone lookup"
 ```
 
 ### 3. Start Skardi Server
@@ -182,41 +189,47 @@ SELECT * FROM nyc_taxi t JOIN zones z ON t.pickup_location_id = z.location_id
 ### Query Trips by Date
 
 ```yaml
+kind: pipeline
+
 metadata:
   name: "query-trips-by-date"
   version: "1.0.0"
 
-query: |
-  SELECT
-    trip_id,
-    pickup_datetime,
-    passenger_count,
-    trip_distance,
-    total_amount
-  FROM nyc_taxi
-  WHERE pickup_datetime >= {start_date}
-    AND pickup_datetime < {end_date}
-  ORDER BY pickup_datetime
-  LIMIT {limit}
+spec:
+  query: |
+    SELECT
+      trip_id,
+      pickup_datetime,
+      passenger_count,
+      trip_distance,
+      total_amount
+    FROM nyc_taxi
+    WHERE pickup_datetime >= {start_date}
+      AND pickup_datetime < {end_date}
+    ORDER BY pickup_datetime
+    LIMIT {limit}
 ```
 
 ### Trip Statistics by Location
 
 ```yaml
+kind: pipeline
+
 metadata:
   name: "trip-statistics"
   version: "1.0.0"
 
-query: |
-  SELECT
-    pickup_location_id,
-    COUNT(*) as total_trips,
-    AVG(trip_distance) as avg_distance,
-    AVG(fare_amount) as avg_fare,
-    SUM(total_amount) as total_revenue
-  FROM nyc_taxi
-  WHERE pickup_location_id = {location_id}
-  GROUP BY pickup_location_id
+spec:
+  query: |
+    SELECT
+      pickup_location_id,
+      COUNT(*) as total_trips,
+      AVG(trip_distance) as avg_distance,
+      AVG(fare_amount) as avg_fare,
+      SUM(total_amount) as total_revenue
+    FROM nyc_taxi
+    WHERE pickup_location_id = {location_id}
+    GROUP BY pickup_location_id
 ```
 
 ### Federated Query: Join with CSV
@@ -224,21 +237,24 @@ query: |
 Join Iceberg trip data with a CSV zone lookup file:
 
 ```yaml
+kind: pipeline
+
 metadata:
   name: "federated-join-zones"
   version: "1.0.0"
 
-query: |
-  SELECT
-    t.trip_id,
-    t.pickup_datetime,
-    z.zone_name as pickup_zone,
-    z.borough as pickup_borough,
-    t.total_amount
-  FROM nyc_taxi t
-  INNER JOIN zones z ON t.pickup_location_id = z.location_id
-  WHERE z.borough = {borough}
-  LIMIT {limit}
+spec:
+  query: |
+    SELECT
+      t.trip_id,
+      t.pickup_datetime,
+      z.zone_name as pickup_zone,
+      z.borough as pickup_borough,
+      t.total_amount
+    FROM nyc_taxi t
+    INNER JOIN zones z ON t.pickup_location_id = z.location_id
+    WHERE z.borough = {borough}
+    LIMIT {limit}
 ```
 
 ```bash
@@ -252,16 +268,23 @@ curl -X POST http://localhost:8080/federated-join-zones/execute \
 For Iceberg tables stored on S3:
 
 ```yaml
-data_sources:
-  - name: "s3_iceberg"
-    type: "iceberg"
-    path: "s3://my-bucket/iceberg-warehouse"
-    options:
-      namespace: "production"
-      table: "events"
-      aws_region: "us-east-1"
-      aws_access_key_id_env: "AWS_ACCESS_KEY_ID"
-      aws_secret_access_key_env: "AWS_SECRET_ACCESS_KEY"
+kind: context
+
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "s3_iceberg"
+      type: "iceberg"
+      path: "s3://my-bucket/iceberg-warehouse"
+      options:
+        namespace: "production"
+        table: "events"
+        aws_region: "us-east-1"
+        aws_access_key_id_env: "AWS_ACCESS_KEY_ID"
+        aws_secret_access_key_env: "AWS_SECRET_ACCESS_KEY"
 ```
 
 ```bash

--- a/docs/iceberg/ctx_iceberg_demo.yaml
+++ b/docs/iceberg/ctx_iceberg_demo.yaml
@@ -1,14 +1,21 @@
-data_sources:
-  - name: "nyc_taxi"
-    type: "iceberg"
-    path: "/tmp/iceberg-warehouse"
-    description: "NYC taxi trips Iceberg catalog"
-    options:
-      namespace: "nyc"
-      table: "trips"
+kind: context
 
-  # Optional: CSV for federated queries
-  - name: "zones"
-    type: "csv"
-    path: "docs/sample_data/taxi_zones.csv"
-    description: "NYC taxi zone lookup"
+metadata:
+  name: ctx_iceberg_demo
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "nyc_taxi"
+      type: "iceberg"
+      path: "/tmp/iceberg-warehouse"
+      description: "NYC taxi trips Iceberg catalog"
+      options:
+        namespace: "nyc"
+        table: "trips"
+
+    # Optional: CSV for federated queries
+    - name: "zones"
+      type: "csv"
+      path: "docs/sample_data/taxi_zones.csv"
+      description: "NYC taxi zone lookup"

--- a/docs/iceberg/pipelines/federated_join_zones.yaml
+++ b/docs/iceberg/pipelines/federated_join_zones.yaml
@@ -1,19 +1,22 @@
+kind: pipeline
+
 metadata:
   name: "federated-join-zones"
   version: "1.0.0"
   description: "Join Iceberg trips data with CSV zone lookup for enriched results"
 
-query: |
-  SELECT
-    t.trip_id,
-    t.pickup_datetime,
-    z.zone_name as pickup_zone,
-    z.borough as pickup_borough,
-    t.passenger_count,
-    t.trip_distance,
-    t.total_amount
-  FROM nyc_taxi t
-  INNER JOIN zones z ON t.pickup_location_id = z.location_id
-  WHERE z.borough = {borough}
-  ORDER BY t.pickup_datetime DESC
-  LIMIT {limit}
+spec:
+  query: |
+    SELECT
+      t.trip_id,
+      t.pickup_datetime,
+      z.zone_name as pickup_zone,
+      z.borough as pickup_borough,
+      t.passenger_count,
+      t.trip_distance,
+      t.total_amount
+    FROM nyc_taxi t
+    INNER JOIN zones z ON t.pickup_location_id = z.location_id
+    WHERE z.borough = {borough}
+    ORDER BY t.pickup_datetime DESC
+    LIMIT {limit}

--- a/docs/iceberg/pipelines/query_trips_by_date.yaml
+++ b/docs/iceberg/pipelines/query_trips_by_date.yaml
@@ -1,20 +1,23 @@
+kind: pipeline
+
 metadata:
   name: "query-trips-by-date"
   version: "1.0.0"
   description: "Query NYC taxi trips for a specific date range"
 
-query: |
-  SELECT
-    trip_id,
-    pickup_datetime,
-    dropoff_datetime,
-    passenger_count,
-    trip_distance,
-    fare_amount,
-    tip_amount,
-    total_amount
-  FROM nyc_taxi
-  WHERE pickup_datetime >= {start_date}
-    AND pickup_datetime < {end_date}
-  ORDER BY pickup_datetime
-  LIMIT {limit}
+spec:
+  query: |
+    SELECT
+      trip_id,
+      pickup_datetime,
+      dropoff_datetime,
+      passenger_count,
+      trip_distance,
+      fare_amount,
+      tip_amount,
+      total_amount
+    FROM nyc_taxi
+    WHERE pickup_datetime >= {start_date}
+      AND pickup_datetime < {end_date}
+    ORDER BY pickup_datetime
+    LIMIT {limit}

--- a/docs/iceberg/pipelines/trip_statistics.yaml
+++ b/docs/iceberg/pipelines/trip_statistics.yaml
@@ -1,16 +1,19 @@
+kind: pipeline
+
 metadata:
   name: "trip-statistics"
   version: "1.0.0"
   description: "Get aggregated trip statistics by pickup location"
 
-query: |
-  SELECT
-    pickup_location_id,
-    COUNT(*) as total_trips,
-    AVG(trip_distance) as avg_distance,
-    AVG(fare_amount) as avg_fare,
-    SUM(total_amount) as total_revenue,
-    AVG(passenger_count) as avg_passengers
-  FROM nyc_taxi
-  WHERE pickup_location_id = {location_id}
-  GROUP BY pickup_location_id
+spec:
+  query: |
+    SELECT
+      pickup_location_id,
+      COUNT(*) as total_trips,
+      AVG(trip_distance) as avg_distance,
+      AVG(fare_amount) as avg_fare,
+      SUM(total_amount) as total_revenue,
+      AVG(passenger_count) as avg_passengers
+    FROM nyc_taxi
+    WHERE pickup_location_id = {location_id}
+    GROUP BY pickup_location_id

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -40,28 +40,29 @@ metadata:
 
 # {placeholder} tokens are inferred as typed scalar params, exactly the
 # way pipelines work. No separate `parameters:` block.
-query: |
-  SELECT slug, title, page_type, content, updated_at
-  FROM wiki.main.wiki_pages
-  WHERE updated_at >= {from_date}
-    AND updated_at <  {to_date}
 
-destination:
-  table: "wiki_lake"          # DataFusion table identifier — bare or dotted
-  mode: append                # append is the only supported mode in MVP
-  create_if_missing: true     # lake destinations only (see below)
-
-execution:
-  timeout_ms: 3600000         # optional wall-clock cap; default = no timeout
+spec:
+  query: |
+    SELECT slug, title, page_type, content, updated_at
+    FROM wiki.main.wiki_pages
+    WHERE updated_at >= {from_date}
+      AND updated_at <  {to_date}
+  destination:
+    table: "wiki_lake"          # DataFusion table identifier — bare or dotted
+    mode: append                # append is the only supported mode in MVP
+    create_if_missing: true     # lake destinations only (see below)
+  execution:
+    timeout_ms: 3600000         # optional wall-clock cap; default = no timeout
 ```
 
 ### `kind:`
 
-`kind: job` tells the loader to treat the file as a job. Plain pipeline
-YAMLs either omit this field or set it to `pipeline`. A server started
-with `--jobs <dir>` scans every `.yaml` / `.yml` file in the directory
-and silently skips files that are not `kind: job`, so it's safe to
-intermix pipelines and jobs on disk.
+Every resource YAML carries a `kind:` discriminator at the root. `kind: job`
+tells the loader to treat the file as a job; pipeline YAMLs set
+`kind: pipeline`, contexts set `kind: context`, and alias files set
+`kind: aliases`. A server started with `--jobs <dir>` scans every
+`.yaml` / `.yml` file in the directory and silently skips files that are
+not `kind: job`, so it's safe to intermix pipelines and jobs on disk.
 
 ### `destination.table`
 
@@ -347,20 +348,24 @@ Lance dataset:
 
 ```yaml
 # demo/llm_wiki/cli/jobs/backfill_to_lake.yaml (excerpt)
+
 kind: job
+
 metadata:
   name: "wiki-backfill-to-lake"
   version: "1.0.0"
-query: |
-  SELECT slug, title, page_type, content, updated_at
-  FROM wiki.main.wiki_pages
-  WHERE slug LIKE {slug_prefix}
-  ORDER BY updated_at DESC
-  LIMIT {limit}
-destination:
-  table: "wiki_lake"
-  mode: append
-  create_if_missing: true
+
+spec:
+  query: |
+    SELECT slug, title, page_type, content, updated_at
+    FROM wiki.main.wiki_pages
+    WHERE slug LIKE {slug_prefix}
+    ORDER BY updated_at DESC
+    LIMIT {limit}
+  destination:
+    table: "wiki_lake"
+    mode: append
+    create_if_missing: true
 ```
 
 To run it end-to-end, boot the server with `--jobs` pointing at the
@@ -368,10 +373,10 @@ demo's job directory and with a Lance data source named `wiki_lake` in
 your ctx:
 
 ```yaml
-# ctx.yaml (add this to the demo's ctx.yaml)
-  - name: wiki_lake
-    type: lance
-    path: demo/llm_wiki/wiki_lake.lance
+# ctx.yaml — add this entry under `spec.data_sources:`
+    - name: wiki_lake
+      type: lance
+      path: demo/llm_wiki/wiki_lake.lance
 ```
 
 Then:

--- a/docs/lance/README.md
+++ b/docs/lance/README.md
@@ -439,32 +439,42 @@ Verify the INVERTED index was created with `with_position=True`. Without positio
 ### 1. Create Context Configuration
 
 ```yaml
-data_sources:
-  - name: "my_vectors"
-    type: "lance"
-    path: "data/my_vectors.lance/"
-    description: "My vector embeddings"
+kind: context
+
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "my_vectors"
+      type: "lance"
+      path: "data/my_vectors.lance/"
+      description: "My vector embeddings"
 ```
 
 ### 2. Create Pipeline Configuration
 
 ```yaml
+kind: pipeline
+
 metadata:
   name: my-vector-search
   version: 1.0.0
 
-query: |
-  SELECT
-    knn.id,
-    knn.item_id,
-    knn._distance as similarity
-  FROM lance_knn(
-    'my_vectors',
-    'vector',
-    (SELECT vector FROM my_vectors WHERE id = {query_id}),
-    {k}
-  ) knn
-  WHERE knn.id != {query_id}
+spec:
+  query: |
+    SELECT
+      knn.id,
+      knn.item_id,
+      knn._distance as similarity
+    FROM lance_knn(
+      'my_vectors',
+      'vector',
+      (SELECT vector FROM my_vectors WHERE id = {query_id}),
+      {k}
+    ) knn
+    WHERE knn.id != {query_id}
 ```
 
 ### 3. Run Your Pipeline

--- a/docs/lance/ctx_lance.yaml
+++ b/docs/lance/ctx_lance.yaml
@@ -1,65 +1,72 @@
-data_sources:
-  - name: "sift_items"
-    type: "lance"
-    path: "data/vec_data.lance/"
-    description: "Lance dataset with vector embeddings for similarity search"
-    # Schema:
-    #   - id: int64 (unique identifier)
-    #   - vector: fixed_size_list<item: float>[128] (embedding vector)
-    #   - item_id: int64 (reference to item)
-    #   - revenue: double (revenue associated with item)
+kind: context
 
-  - name: "fts_data"
-    type: "lance"
-    path: "data/test_data.lance/"
-    description: "Lance dataset with text descriptions and INVERTED FTS index"
-    # Schema:
-    #   - id: int64 (unique identifier)
-    #   - vector: fixed_size_list<item: float>[128] (embedding vector)
-    #   - item_id: int64 (reference to item)
-    #   - revenue: double (revenue associated with item)
-    #   - description: string (text description with FTS index)
-    #   - category: string (category label)
-    #
-    # To regenerate this dataset:
-    #   python scripts/prepare_fts_test_data.py
+metadata:
+  name: ctx_lance
+  version: 1.0.0
 
-# Lance Features:
-#
-# 1. lance_knn Table Function (Vector Search):
-#    - Explicit KNN search via SQL table function
-#    - Syntax: lance_knn(table_name, vector_column, query_vector, k, [filter])
-#    - Query vector can be a literal array or scalar subquery
-#    - Results include _distance column (lower = more similar)
-#
-# 2. lance_fts Table Function (Full-Text Search):
-#    - BM25-scored full-text search via SQL table function
-#    - Syntax: lance_fts(table_name, text_column, query, limit)
-#    - Supports term, phrase, fuzzy, and boolean queries
-#    - Results include _score column (higher = more relevant)
-#    - WHERE clause filters are pushed down to Lance for efficiency
-#
-# 3. Index Support:
-#    - Vector: IVF-PQ, HNSW, and other Lance index types
-#    - Text: INVERTED index with optional position tracking for phrase search
-#
-# Example Query Patterns:
-#
-# KNN Search:
-#   SELECT knn.id, knn.item_id, knn._distance
-#   FROM lance_knn('sift_items', 'vector',
-#     (SELECT vector FROM sift_items WHERE id = 1), 10) knn
-#   WHERE knn.id != 1
-#
-# Full-Text Search:
-#   SELECT id, description, _score
-#   FROM lance_fts('fts_data', 'description', 'search terms', 10)
-#
-# Phrase Search:
-#   SELECT * FROM lance_fts('fts_data', 'description', '"exact phrase"', 10)
-#
-# FTS with Filter Pushdown:
-#   SELECT * FROM lance_fts('fts_data', 'description', 'search terms', 10)
-#   WHERE category = 'electronics'
-#
-# For complete pipeline examples, see pipelines/
+spec:
+  data_sources:
+    - name: "sift_items"
+      type: "lance"
+      path: "data/vec_data.lance/"
+      description: "Lance dataset with vector embeddings for similarity search"
+      # Schema:
+      #   - id: int64 (unique identifier)
+      #   - vector: fixed_size_list<item: float>[128] (embedding vector)
+      #   - item_id: int64 (reference to item)
+      #   - revenue: double (revenue associated with item)
+
+    - name: "fts_data"
+      type: "lance"
+      path: "data/test_data.lance/"
+      description: "Lance dataset with text descriptions and INVERTED FTS index"
+      # Schema:
+      #   - id: int64 (unique identifier)
+      #   - vector: fixed_size_list<item: float>[128] (embedding vector)
+      #   - item_id: int64 (reference to item)
+      #   - revenue: double (revenue associated with item)
+      #   - description: string (text description with FTS index)
+      #   - category: string (category label)
+      #
+      # To regenerate this dataset:
+      #   python scripts/prepare_fts_test_data.py
+
+  # Lance Features:
+  #
+  # 1. lance_knn Table Function (Vector Search):
+  #    - Explicit KNN search via SQL table function
+  #    - Syntax: lance_knn(table_name, vector_column, query_vector, k, [filter])
+  #    - Query vector can be a literal array or scalar subquery
+  #    - Results include _distance column (lower = more similar)
+  #
+  # 2. lance_fts Table Function (Full-Text Search):
+  #    - BM25-scored full-text search via SQL table function
+  #    - Syntax: lance_fts(table_name, text_column, query, limit)
+  #    - Supports term, phrase, fuzzy, and boolean queries
+  #    - Results include _score column (higher = more relevant)
+  #    - WHERE clause filters are pushed down to Lance for efficiency
+  #
+  # 3. Index Support:
+  #    - Vector: IVF-PQ, HNSW, and other Lance index types
+  #    - Text: INVERTED index with optional position tracking for phrase search
+  #
+  # Example Query Patterns:
+  #
+  # KNN Search:
+  #   SELECT knn.id, knn.item_id, knn._distance
+  #   FROM lance_knn('sift_items', 'vector',
+  #     (SELECT vector FROM sift_items WHERE id = 1), 10) knn
+  #   WHERE knn.id != 1
+  #
+  # Full-Text Search:
+  #   SELECT id, description, _score
+  #   FROM lance_fts('fts_data', 'description', 'search terms', 10)
+  #
+  # Phrase Search:
+  #   SELECT * FROM lance_fts('fts_data', 'description', '"exact phrase"', 10)
+  #
+  # FTS with Filter Pushdown:
+  #   SELECT * FROM lance_fts('fts_data', 'description', 'search terms', 10)
+  #   WHERE category = 'electronics'
+  #
+  # For complete pipeline examples, see pipelines/

--- a/docs/lance/pipelines/pipeline_lance.yaml
+++ b/docs/lance/pipelines/pipeline_lance.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: lance-vector-similarity-search
   version: 2.0.0
@@ -28,53 +30,54 @@ metadata:
 #   {min_revenue}:  Optional minimum revenue filter (null = no filter)
 #   {max_revenue}:  Optional maximum revenue filter (null = no filter)
 
-query: |
-  SELECT
-    knn.id,
-    knn.item_id,
-    knn.revenue,
-    knn._distance as distance
-  FROM lance_knn(
-    'sift_items',
-    'vector',
-    (SELECT vector FROM sift_items WHERE id = {reference_id}),
-    {k}
-  ) knn
-  WHERE knn.id != {reference_id}
-    AND ({min_revenue} IS NULL OR knn.revenue >= {min_revenue})
-    AND ({max_revenue} IS NULL OR knn.revenue <= {max_revenue})
+spec:
+  query: |
+    SELECT
+      knn.id,
+      knn.item_id,
+      knn.revenue,
+      knn._distance as distance
+    FROM lance_knn(
+      'sift_items',
+      'vector',
+      (SELECT vector FROM sift_items WHERE id = {reference_id}),
+      {k}
+    ) knn
+    WHERE knn.id != {reference_id}
+      AND ({min_revenue} IS NULL OR knn.revenue >= {min_revenue})
+      AND ({max_revenue} IS NULL OR knn.revenue <= {max_revenue})
 
-# Example API Calls:
-#
-# Basic search (no revenue filter):
-# POST /lance-vector-similarity-search/execute
-# {
-#   "reference_id": 1,
-#   "k": 50,
-#   "min_revenue": null,
-#   "max_revenue": null
-# }
-#
-# Filtered search:
-# POST /lance-vector-similarity-search/execute
-# {
-#   "reference_id": 1,
-#   "k": 50,
-#   "min_revenue": 1000.0,
-#   "max_revenue": 5000.0
-# }
-#
-# Response:
-# {
-#   "data": [
-#     {
-#       "id": 42,
-#       "item_id": 1337,
-#       "revenue": 2500.50,
-#       "distance": 0.125
-#     },
-#     ...
-#   ],
-#   "rows_affected": 10,
-#   "execution_time_ms": 15
-# }
+  # Example API Calls:
+  #
+  # Basic search (no revenue filter):
+  # POST /lance-vector-similarity-search/execute
+  # {
+  #   "reference_id": 1,
+  #   "k": 50,
+  #   "min_revenue": null,
+  #   "max_revenue": null
+  # }
+  #
+  # Filtered search:
+  # POST /lance-vector-similarity-search/execute
+  # {
+  #   "reference_id": 1,
+  #   "k": 50,
+  #   "min_revenue": 1000.0,
+  #   "max_revenue": 5000.0
+  # }
+  #
+  # Response:
+  # {
+  #   "data": [
+  #     {
+  #       "id": 42,
+  #       "item_id": 1337,
+  #       "revenue": 2500.50,
+  #       "distance": 0.125
+  #     },
+  #     ...
+  #   ],
+  #   "rows_affected": 10,
+  #   "execution_time_ms": 15
+  # }

--- a/docs/lance/pipelines/pipeline_lance_direct_vector.yaml
+++ b/docs/lance/pipelines/pipeline_lance_direct_vector.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: lance-direct-vector-search
   version: 1.0.0
@@ -16,38 +18,39 @@ metadata:
 #   {query_vector}: The embedding vector as a literal array, e.g. [0.1, 0.2, ...]
 #   {k}:            Number of nearest neighbours to return
 
-query: |
-  SELECT
-    knn.id,
-    knn.item_id,
-    knn.revenue,
-    knn._distance as distance
-  FROM lance_knn(
-    'sift_items',
-    'vector',
-    {query_vector},
-    {k}
-  ) knn
+spec:
+  query: |
+    SELECT
+      knn.id,
+      knn.item_id,
+      knn.revenue,
+      knn._distance as distance
+    FROM lance_knn(
+      'sift_items',
+      'vector',
+      {query_vector},
+      {k}
+    ) knn
 
-# Example API Call:
-#
-# POST /lance-direct-vector-search/execute
-# {
-#   "query_vector": [0.1, 0.2, 0.3, ...],  (128 floats for the demo dataset)
-#   "k": 10
-# }
-#
-# Response:
-# {
-#   "data": [
-#     {
-#       "id": 42,
-#       "item_id": 1337,
-#       "revenue": 2500.50,
-#       "distance": 0.125
-#     },
-#     ...
-#   ],
-#   "rows_affected": 10,
-#   "execution_time_ms": 15
-# }
+  # Example API Call:
+  #
+  # POST /lance-direct-vector-search/execute
+  # {
+  #   "query_vector": [0.1, 0.2, 0.3, ...],  (128 floats for the demo dataset)
+  #   "k": 10
+  # }
+  #
+  # Response:
+  # {
+  #   "data": [
+  #     {
+  #       "id": 42,
+  #       "item_id": 1337,
+  #       "revenue": 2500.50,
+  #       "distance": 0.125
+  #     },
+  #     ...
+  #   ],
+  #   "rows_affected": 10,
+  #   "execution_time_ms": 15
+  # }

--- a/docs/lance/pipelines/pipeline_lance_fts.yaml
+++ b/docs/lance/pipelines/pipeline_lance_fts.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: lance-full-text-search
   version: 1.0.0
@@ -23,51 +25,52 @@ metadata:
 #   {category}: Optional category filter (null = no filter)
 #   {limit}: Maximum number of results to return
 
-query: |
-  SELECT
-    fts.id,
-    fts.item_id,
-    fts.revenue,
-    fts.description,
-    fts.category,
-    fts._score as relevance
-  FROM lance_fts(
-    'fts_data',
-    'description',
-    {search_query},
-    {limit}
-  ) fts
-  WHERE ({category} IS NULL OR fts.category = {category})
+spec:
+  query: |
+    SELECT
+      fts.id,
+      fts.item_id,
+      fts.revenue,
+      fts.description,
+      fts.category,
+      fts._score as relevance
+    FROM lance_fts(
+      'fts_data',
+      'description',
+      {search_query},
+      {limit}
+    ) fts
+    WHERE ({category} IS NULL OR fts.category = {category})
 
-# Example API Calls:
-#
-# Basic search:
-# POST /lance-full-text-search/execute
-# {
-#   "search_query": "premium wireless",
-#   "category": null,
-#   "limit": 10
-# }
-#
-# Search with category filter:
-# POST /lance-full-text-search/execute
-# {
-#   "search_query": "umbrella",
-#   "category": "outdoor",
-#   "limit": 5
-# }
-#
-# Phrase search:
-# POST /lance-full-text-search/execute
-# {
-#   "search_query": "\"train to boston\"",
-#   "category": null,
-#   "limit": 10
-# }
-#
-# Query Syntax:
-#   "foo bar"           -> OR search (any term matches)
-#   "+foo bar"          -> AND search (all terms must match)
-#   "\"foo bar\""       -> Phrase search (exact phrase match)
-#   "foo~"              -> Fuzzy search (typo-tolerant)
-#   "+foo -bar"         -> Boolean search (MUST/MUST_NOT)
+  # Example API Calls:
+  #
+  # Basic search:
+  # POST /lance-full-text-search/execute
+  # {
+  #   "search_query": "premium wireless",
+  #   "category": null,
+  #   "limit": 10
+  # }
+  #
+  # Search with category filter:
+  # POST /lance-full-text-search/execute
+  # {
+  #   "search_query": "umbrella",
+  #   "category": "outdoor",
+  #   "limit": 5
+  # }
+  #
+  # Phrase search:
+  # POST /lance-full-text-search/execute
+  # {
+  #   "search_query": "\"train to boston\"",
+  #   "category": null,
+  #   "limit": 10
+  # }
+  #
+  # Query Syntax:
+  #   "foo bar"           -> OR search (any term matches)
+  #   "+foo bar"          -> AND search (all terms must match)
+  #   "\"foo bar\""       -> Phrase search (exact phrase match)
+  #   "foo~"              -> Fuzzy search (typo-tolerant)
+  #   "+foo -bar"         -> Boolean search (MUST/MUST_NOT)

--- a/docs/mongo/README.md
+++ b/docs/mongo/README.md
@@ -323,17 +323,25 @@ export MONGO_PASS=rootpass
 
 ```yaml
 # ctx_mongo_fts_demo.yaml
-data_sources:
-  - name: "dataset_data_texts"
-    type: "mongo"
-    access_mode: "read_write"
-    connection_string: "mongodb://localhost:27017"
-    options:
-      database: "mydb"
-      collection: "dataset_data_texts"
-      primary_key: "dataId"
-      user_env: "MONGO_USER"
-      pass_env: "MONGO_PASS"
+
+kind: context
+
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "dataset_data_texts"
+      type: "mongo"
+      access_mode: "read_write"
+      connection_string: "mongodb://localhost:27017"
+      options:
+        database: "mydb"
+        collection: "dataset_data_texts"
+        primary_key: "dataId"
+        user_env: "MONGO_USER"
+        pass_env: "MONGO_PASS"
 ```
 
 ### Pipelines
@@ -466,16 +474,23 @@ pkill -f skardi-server
 MongoDB credentials are read from environment variables for security. Do not embed credentials in the connection string.
 
 ```yaml
-data_sources:
-  - name: "products"
-    type: "mongo"
-    connection_string: "mongodb://localhost:27017"
-    options:
-      database: "mydb"
-      collection: "products"
-      primary_key: "product_id"
-      user_env: "MONGO_USER"      # Environment variable for username
-      pass_env: "MONGO_PASS"      # Environment variable for password
+kind: context
+
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "products"
+      type: "mongo"
+      connection_string: "mongodb://localhost:27017"
+      options:
+        database: "mydb"
+        collection: "products"
+        primary_key: "product_id"
+        user_env: "MONGO_USER"      # Environment variable for username
+        pass_env: "MONGO_PASS"      # Environment variable for password
 ```
 
 ```bash
@@ -487,26 +502,33 @@ export MONGO_PASS=mypassword
 ### Multiple Databases
 
 ```yaml
-data_sources:
-  - name: "prod_products"
-    type: "mongo"
-    connection_string: "mongodb://prod-server:27017"
-    options:
-      database: "production"
-      collection: "products"
-      primary_key: "product_id"
-      user_env: "PROD_MONGO_USER"
-      pass_env: "PROD_MONGO_PASS"
+kind: context
 
-  - name: "staging_products"
-    type: "mongo"
-    connection_string: "mongodb://staging-server:27017"
-    options:
-      database: "staging"
-      collection: "products"
-      primary_key: "product_id"
-      user_env: "STAGING_MONGO_USER"
-      pass_env: "STAGING_MONGO_PASS"
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "prod_products"
+      type: "mongo"
+      connection_string: "mongodb://prod-server:27017"
+      options:
+        database: "production"
+        collection: "products"
+        primary_key: "product_id"
+        user_env: "PROD_MONGO_USER"
+        pass_env: "PROD_MONGO_PASS"
+
+    - name: "staging_products"
+      type: "mongo"
+      connection_string: "mongodb://staging-server:27017"
+      options:
+        database: "staging"
+        collection: "products"
+        primary_key: "product_id"
+        user_env: "STAGING_MONGO_USER"
+        pass_env: "STAGING_MONGO_PASS"
 ```
 
 ### Schema Inference
@@ -538,14 +560,21 @@ This is especially important for write-first workflows (e.g. RAG ingestion) wher
 ### MongoDB Atlas
 
 ```yaml
-data_sources:
-  - name: "products"
-    type: "mongo"
-    connection_string: "mongodb+srv://cluster0.xxxxx.mongodb.net"
-    options:
-      database: "mydb"
-      collection: "products"
-      primary_key: "product_id"
-      user_env: "ATLAS_USER"
-      pass_env: "ATLAS_PASS"
+kind: context
+
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "products"
+      type: "mongo"
+      connection_string: "mongodb+srv://cluster0.xxxxx.mongodb.net"
+      options:
+        database: "mydb"
+        collection: "products"
+        primary_key: "product_id"
+        user_env: "ATLAS_USER"
+        pass_env: "ATLAS_PASS"
 ```

--- a/docs/mongo/ctx_mongo_demo.yaml
+++ b/docs/mongo/ctx_mongo_demo.yaml
@@ -1,30 +1,37 @@
-data_sources:
-  - name: "products"
-    type: "mongo"
-    access_mode: "read_write"
-    connection_string: "mongodb://localhost:27017"
-    description: "MongoDB products collection"
-    options:
-      database: "mydb"
-      collection: "products"
-      primary_key: "product_id"
-      user_env: "MONGO_USER"
-      pass_env: "MONGO_PASS"
+kind: context
 
-  - name: "product_stats"
-    type: "mongo"
-    access_mode: "read_write"
-    connection_string: "mongodb://localhost:27017"
-    description: "MongoDB collection for aggregated product statistics"
-    options:
-      database: "mydb"
-      collection: "product_stats"
-      primary_key: "stat_id"
-      user_env: "MONGO_USER"
-      pass_env: "MONGO_PASS"
+metadata:
+  name: ctx_mongo_demo
+  version: 1.0.0
 
-  # CSV data source (for federated query demo)
-  - name: "csv_inventory"
-    type: "csv"
-    path: "docs/sample_data/product_inventory.csv"
-    description: "CSV file containing product inventory data"
+spec:
+  data_sources:
+    - name: "products"
+      type: "mongo"
+      access_mode: "read_write"
+      connection_string: "mongodb://localhost:27017"
+      description: "MongoDB products collection"
+      options:
+        database: "mydb"
+        collection: "products"
+        primary_key: "product_id"
+        user_env: "MONGO_USER"
+        pass_env: "MONGO_PASS"
+
+    - name: "product_stats"
+      type: "mongo"
+      access_mode: "read_write"
+      connection_string: "mongodb://localhost:27017"
+      description: "MongoDB collection for aggregated product statistics"
+      options:
+        database: "mydb"
+        collection: "product_stats"
+        primary_key: "stat_id"
+        user_env: "MONGO_USER"
+        pass_env: "MONGO_PASS"
+
+    # CSV data source (for federated query demo)
+    - name: "csv_inventory"
+      type: "csv"
+      path: "docs/sample_data/product_inventory.csv"
+      description: "CSV file containing product inventory data"

--- a/docs/mongo/ctx_mongo_fts_demo.yaml
+++ b/docs/mongo/ctx_mongo_fts_demo.yaml
@@ -1,12 +1,19 @@
-data_sources:
-  - name: "dataset_data_texts"
-    type: "mongo"
-    access_mode: "read_write"
-    connection_string: "mongodb://localhost:27017"
-    description: "MongoDB collection with text index for full-text search"
-    options:
-      database: "mydb"
-      collection: "dataset_data_texts"
-      primary_key: "dataId"
-      user_env: "MONGO_USER"
-      pass_env: "MONGO_PASS"
+kind: context
+
+metadata:
+  name: ctx_mongo_fts_demo
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "dataset_data_texts"
+      type: "mongo"
+      access_mode: "read_write"
+      connection_string: "mongodb://localhost:27017"
+      description: "MongoDB collection with text index for full-text search"
+      options:
+        database: "mydb"
+        collection: "dataset_data_texts"
+        primary_key: "dataId"
+        user_env: "MONGO_USER"
+        pass_env: "MONGO_PASS"

--- a/docs/mongo/pipelines/delete_product.yaml
+++ b/docs/mongo/pipelines/delete_product.yaml
@@ -1,7 +1,10 @@
+kind: pipeline
+
 metadata:
   name: "delete_product"
   version: "1.0"
   description: "Delete a product from the MongoDB products collection by product ID"
 
-query: |
-  DELETE FROM products WHERE product_id = {product_id}
+spec:
+  query: |
+    DELETE FROM products WHERE product_id = {product_id}

--- a/docs/mongo/pipelines/federated_join_and_insert.yaml
+++ b/docs/mongo/pipelines/federated_join_and_insert.yaml
@@ -1,17 +1,20 @@
+kind: pipeline
+
 metadata:
   name: "federated_join_and_insert"
   version: "1.0"
   description: "Join CSV inventory with MongoDB products and write aggregated stats"
 
-query: |
-  INSERT INTO product_stats (stat_id, category, total_products, total_value, avg_price)
-  SELECT
-    {category} as stat_id,
-    p.category,
-    COUNT(DISTINCT p.product_id) as total_products,
-    SUM(i.quantity * p.price) as total_value,
-    AVG(p.price) as avg_price
-  FROM products p
-  INNER JOIN csv_inventory i ON p.product_id = i.product_id
-  WHERE p.category = {category}
-  GROUP BY p.category
+spec:
+  query: |
+    INSERT INTO product_stats (stat_id, category, total_products, total_value, avg_price)
+    SELECT
+      {category} as stat_id,
+      p.category,
+      COUNT(DISTINCT p.product_id) as total_products,
+      SUM(i.quantity * p.price) as total_value,
+      AVG(p.price) as avg_price
+    FROM products p
+    INNER JOIN csv_inventory i ON p.product_id = i.product_id
+    WHERE p.category = {category}
+    GROUP BY p.category

--- a/docs/mongo/pipelines/fts_demo/fts_search.yaml
+++ b/docs/mongo/pipelines/fts_demo/fts_search.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "fts-search"
   version: "1.0.0"
@@ -9,7 +11,8 @@ metadata:
 #   {query} - Search terms (space-separated for OR, "quoted" for phrase match)
 #   {limit} - Maximum number of results to return
 
-query: |
-  SELECT "dataId", "teamId", "datasetId", "collectionId", "fullTextToken", _score
-  FROM mongo_fts('dataset_data_texts', {query}, {limit})
-  ORDER BY _score DESC
+spec:
+  query: |
+    SELECT "dataId", "teamId", "datasetId", "collectionId", "fullTextToken", _score
+    FROM mongo_fts('dataset_data_texts', {query}, {limit})
+    ORDER BY _score DESC

--- a/docs/mongo/pipelines/fts_demo/fts_search_with_filter.yaml
+++ b/docs/mongo/pipelines/fts_demo/fts_search_with_filter.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "fts-search-with-filter"
   version: "1.0.0"
@@ -10,8 +12,9 @@ metadata:
 #   {team_id} - Team ID to filter by
 #   {limit}   - Maximum number of results to return
 
-query: |
-  SELECT "dataId", "teamId", "datasetId", "collectionId", "fullTextToken", _score
-  FROM mongo_fts('dataset_data_texts', {query}, {limit})
-  WHERE "teamId" = {team_id}
-  ORDER BY _score DESC
+spec:
+  query: |
+    SELECT "dataId", "teamId", "datasetId", "collectionId", "fullTextToken", _score
+    FROM mongo_fts('dataset_data_texts', {query}, {limit})
+    WHERE "teamId" = {team_id}
+    ORDER BY _score DESC

--- a/docs/mongo/pipelines/insert_product.yaml
+++ b/docs/mongo/pipelines/insert_product.yaml
@@ -1,8 +1,11 @@
+kind: pipeline
+
 metadata:
   name: "insert_product"
   version: "1.0"
   description: "Insert a single product"
 
-query: |
-  INSERT INTO products (product_id, name, category, price, in_stock)
-  VALUES ({product_id}, {name}, {category}, {price}, {in_stock})
+spec:
+  query: |
+    INSERT INTO products (product_id, name, category, price, in_stock)
+    VALUES ({product_id}, {name}, {category}, {price}, {in_stock})

--- a/docs/mongo/pipelines/insert_products_from_select.yaml
+++ b/docs/mongo/pipelines/insert_products_from_select.yaml
@@ -1,11 +1,14 @@
+kind: pipeline
+
 metadata:
   name: "insert_products_from_select"
   version: "1.0"
   description: "Insert multiple products from a VALUES clause"
 
-query: |
-  INSERT INTO products (product_id, name, category, price, in_stock)
-  SELECT * FROM (VALUES
-    ({product_id_1}, {name_1}, {category_1}, {price_1}, {in_stock_1}),
-    ({product_id_2}, {name_2}, {category_2}, {price_2}, {in_stock_2})
-  ) AS t(product_id, name, category, price, in_stock)
+spec:
+  query: |
+    INSERT INTO products (product_id, name, category, price, in_stock)
+    SELECT * FROM (VALUES
+      ({product_id_1}, {name_1}, {category_1}, {price_1}, {in_stock_1}),
+      ({product_id_2}, {name_2}, {category_2}, {price_2}, {in_stock_2})
+    ) AS t(product_id, name, category, price, in_stock)

--- a/docs/mongo/pipelines/list_all_products.yaml
+++ b/docs/mongo/pipelines/list_all_products.yaml
@@ -1,6 +1,9 @@
+kind: pipeline
+
 metadata:
   name: "list_all_products"
   version: "1.0"
   description: "List all products in the catalog (full scan)"
 
-query: "SELECT product_id, name, category, price, in_stock FROM products ORDER BY name"
+spec:
+  query: "SELECT product_id, name, category, price, in_stock FROM products ORDER BY name"

--- a/docs/mongo/pipelines/query_product_by_id.yaml
+++ b/docs/mongo/pipelines/query_product_by_id.yaml
@@ -1,6 +1,9 @@
+kind: pipeline
+
 metadata:
   name: "query_product_by_id"
   version: "1.0"
   description: "Query a specific product by ID (point lookup)"
 
-query: "SELECT * FROM products WHERE product_id = {product_id}"
+spec:
+  query: "SELECT * FROM products WHERE product_id = {product_id}"

--- a/docs/mongo/pipelines/update_product_price.yaml
+++ b/docs/mongo/pipelines/update_product_price.yaml
@@ -1,7 +1,10 @@
+kind: pipeline
+
 metadata:
   name: "update_product_price"
   version: "1.0"
   description: "Update a product's price by product ID"
 
-query: |
-  UPDATE products SET price = {price} WHERE product_id = {product_id}
+spec:
+  query: |
+    UPDATE products SET price = {price} WHERE product_id = {product_id}

--- a/docs/mysql/README.md
+++ b/docs/mysql/README.md
@@ -253,25 +253,28 @@ CSV File (orders.csv)         MySQL (users table)
 Create `federated_join.yaml`:
 
 ```yaml
+kind: pipeline
+
 metadata:
   name: "federated_join_and_insert"
   version: "1.0"
   description: "Join CSV orders with MySQL users (filtered by name) and write aggregated results to MySQL"
 
-query: |
-  INSERT INTO user_order_stats (user_id, user_name, user_email, total_orders, total_spent, last_order_date)
-  SELECT
-    u.id as user_id,
-    u.name as user_name,
-    u.email as user_email,
-    COUNT(o.order_id) as total_orders,
-    SUM(o.amount) as total_spent,
-    MAX(o.order_date) as last_order_date
-  FROM users u                    -- MySQL table
-  INNER JOIN csv_orders o         -- CSV file
-    ON u.id = o.user_id
-  WHERE u.name = {name}           -- Filter by user name (HTTP parameter)
-  GROUP BY u.id, u.name, u.email
+spec:
+  query: |
+    INSERT INTO user_order_stats (user_id, user_name, user_email, total_orders, total_spent, last_order_date)
+    SELECT
+      u.id as user_id,
+      u.name as user_name,
+      u.email as user_email,
+      COUNT(o.order_id) as total_orders,
+      SUM(o.amount) as total_spent,
+      MAX(o.order_date) as last_order_date
+    FROM users u                    -- MySQL table
+    INNER JOIN csv_orders o         -- CSV file
+      ON u.id = o.user_id
+    WHERE u.name = {name}           -- Filter by user name (HTTP parameter)
+    GROUP BY u.id, u.name, u.email
 ```
 
 ### Execute
@@ -338,18 +341,26 @@ automatically, and you query them with the three-part `catalog.schema.table` syn
 
 ```yaml
 # docs/mysql/ctx_mysql_catalog_demo.yaml
-data_sources:
-  - name: "mydb_catalog"
-    type: "mysql"
-    hierarchy_level: "catalog"
-    connection_string: "mysql://localhost:3306/mydb"
-    description: "Entire mydb database registered as a DataFusion catalog"
-    options:
-      user_env: "MYSQL_USER"
-      pass_env: "MYSQL_PASSWORD"
-      ssl_mode: "disabled"
-      # Optionally restrict to specific schemas:
-      # allowed_schemas: "mydb,analytics"
+
+kind: context
+
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "mydb_catalog"
+      type: "mysql"
+      hierarchy_level: "catalog"
+      connection_string: "mysql://localhost:3306/mydb"
+      description: "Entire mydb database registered as a DataFusion catalog"
+      options:
+        user_env: "MYSQL_USER"
+        pass_env: "MYSQL_PASSWORD"
+        ssl_mode: "disabled"
+        # Optionally restrict to specific schemas:
+        # allowed_schemas: "mydb,analytics"
 ```
 
 ### Start the server
@@ -481,20 +492,27 @@ docker run --name mysql-skardi \
 ### Multiple Databases
 
 ```yaml
-data_sources:
-  - name: "prod_users"
-    type: "mysql"
-    connection_string: "mysql://prod-server:3306/production"
-    options:
-      table: "users"
-      user_env: "PROD_MYSQL_USER"
-      pass_env: "PROD_MYSQL_PASSWORD"
+kind: context
 
-  - name: "staging_users"
-    type: "mysql"
-    connection_string: "mysql://staging-server:3306/staging"
-    options:
-      table: "users"
-      user_env: "STAGING_MYSQL_USER"
-      pass_env: "STAGING_MYSQL_PASSWORD"
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "prod_users"
+      type: "mysql"
+      connection_string: "mysql://prod-server:3306/production"
+      options:
+        table: "users"
+        user_env: "PROD_MYSQL_USER"
+        pass_env: "PROD_MYSQL_PASSWORD"
+
+    - name: "staging_users"
+      type: "mysql"
+      connection_string: "mysql://staging-server:3306/staging"
+      options:
+        table: "users"
+        user_env: "STAGING_MYSQL_USER"
+        pass_env: "STAGING_MYSQL_PASSWORD"
 ```

--- a/docs/mysql/ctx_mysql_catalog_demo.yaml
+++ b/docs/mysql/ctx_mysql_catalog_demo.yaml
@@ -1,15 +1,22 @@
-data_sources:
-  # Expose the entire mydb database as a DataFusion catalog.
-  # Every table and view in non-system schemas is registered automatically.
-  # Query tables with the three-part reference: mydb_catalog.mydb.<table>
-  - name: "mydb_catalog"
-    type: "mysql"
-    hierarchy_level: "catalog"
-    connection_string: "mysql://localhost:3306/mydb"
-    description: "Entire mydb MySQL database registered as a named DataFusion catalog"
-    options:
-      user_env: "MYSQL_USER"
-      pass_env: "MYSQL_PASSWORD"
-      ssl_mode: "disabled"
-      # Restrict to specific schemas (optional — omit to include all user schemas):
-      # allowed_schemas: "mydb,analytics"
+kind: context
+
+metadata:
+  name: ctx_mysql_catalog_demo
+  version: 1.0.0
+
+spec:
+  data_sources:
+    # Expose the entire mydb database as a DataFusion catalog.
+    # Every table and view in non-system schemas is registered automatically.
+    # Query tables with the three-part reference: mydb_catalog.mydb.<table>
+    - name: "mydb_catalog"
+      type: "mysql"
+      hierarchy_level: "catalog"
+      connection_string: "mysql://localhost:3306/mydb"
+      description: "Entire mydb MySQL database registered as a named DataFusion catalog"
+      options:
+        user_env: "MYSQL_USER"
+        pass_env: "MYSQL_PASSWORD"
+        ssl_mode: "disabled"
+        # Restrict to specific schemas (optional — omit to include all user schemas):
+        # allowed_schemas: "mydb,analytics"

--- a/docs/mysql/ctx_mysql_demo.yaml
+++ b/docs/mysql/ctx_mysql_demo.yaml
@@ -1,41 +1,48 @@
-data_sources:
-  # MySQL data sources
-  - name: "users"
-    type: "mysql"
-    access_mode: "read_write"
-    connection_string: "mysql://localhost:3306/mydb"
-    description: "MySQL users table"
-    options:
-      table: "users"
-      user_env: "MYSQL_USER"
-      pass_env: "MYSQL_PASSWORD"
-      ssl_mode: "disabled"
+kind: context
 
-  - name: "orders"
-    type: "mysql"
-    connection_string: "mysql://localhost:3306/mydb"
-    description: "MySQL orders table"
-    options:
-      table: "orders"
-      schema: "mydb"
-      user_env: "MYSQL_USER"
-      pass_env: "MYSQL_PASSWORD"
-      ssl_mode: "disabled"
+metadata:
+  name: ctx_mysql_demo
+  version: 1.0.0
 
-  - name: "user_order_stats"
-    type: "mysql"
-    access_mode: "read_write"
-    connection_string: "mysql://localhost:3306/mydb"
-    description: "MySQL table for aggregated user order statistics"
-    options:
-      table: "user_order_stats"
-      user_env: "MYSQL_USER"
-      pass_env: "MYSQL_PASSWORD"
-      ssl_mode: "disabled"
+spec:
+  data_sources:
+    # MySQL data sources
+    - name: "users"
+      type: "mysql"
+      access_mode: "read_write"
+      connection_string: "mysql://localhost:3306/mydb"
+      description: "MySQL users table"
+      options:
+        table: "users"
+        user_env: "MYSQL_USER"
+        pass_env: "MYSQL_PASSWORD"
+        ssl_mode: "disabled"
 
-  # CSV data source (for federated query demo)
-  - name: "csv_orders"
-    type: "csv"
-    access_mode: "read_only"
-    path: "docs/sample_data/orders.csv"
-    description: "CSV file containing order data"
+    - name: "orders"
+      type: "mysql"
+      connection_string: "mysql://localhost:3306/mydb"
+      description: "MySQL orders table"
+      options:
+        table: "orders"
+        schema: "mydb"
+        user_env: "MYSQL_USER"
+        pass_env: "MYSQL_PASSWORD"
+        ssl_mode: "disabled"
+
+    - name: "user_order_stats"
+      type: "mysql"
+      access_mode: "read_write"
+      connection_string: "mysql://localhost:3306/mydb"
+      description: "MySQL table for aggregated user order statistics"
+      options:
+        table: "user_order_stats"
+        user_env: "MYSQL_USER"
+        pass_env: "MYSQL_PASSWORD"
+        ssl_mode: "disabled"
+
+    # CSV data source (for federated query demo)
+    - name: "csv_orders"
+      type: "csv"
+      access_mode: "read_only"
+      path: "docs/sample_data/orders.csv"
+      description: "CSV file containing order data"

--- a/docs/mysql/pipelines/catalog_demo/cross_table_join.yaml
+++ b/docs/mysql/pipelines/catalog_demo/cross_table_join.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "mysql-catalog-cross-table-join"
   version: "1.0.0"
@@ -9,13 +11,14 @@ metadata:
 # Parameters:
 #   {limit} - Maximum number of rows to return
 
-query: |
-  SELECT
-    u.name      AS user_name,
-    u.email     AS user_email,
-    o.product,
-    o.amount
-  FROM mydb_catalog.mydb.users  u
-  INNER JOIN mydb_catalog.mydb.orders o ON u.id = o.user_id
-  ORDER BY o.id
-  LIMIT {limit}
+spec:
+  query: |
+    SELECT
+      u.name      AS user_name,
+      u.email     AS user_email,
+      o.product,
+      o.amount
+    FROM mydb_catalog.mydb.users  u
+    INNER JOIN mydb_catalog.mydb.orders o ON u.id = o.user_id
+    ORDER BY o.id
+    LIMIT {limit}

--- a/docs/mysql/pipelines/catalog_demo/list_users.yaml
+++ b/docs/mysql/pipelines/catalog_demo/list_users.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "mysql-catalog-list-users"
   version: "1.0.0"
@@ -8,8 +10,9 @@ metadata:
 # Parameters:
 #   {limit} - Maximum number of rows to return
 
-query: |
-  SELECT id, name, email
-  FROM mydb_catalog.mydb.users
-  ORDER BY id
-  LIMIT {limit}
+spec:
+  query: |
+    SELECT id, name, email
+    FROM mydb_catalog.mydb.users
+    ORDER BY id
+    LIMIT {limit}

--- a/docs/mysql/pipelines/catalog_demo/user_order_summary.yaml
+++ b/docs/mysql/pipelines/catalog_demo/user_order_summary.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "mysql-catalog-user-order-summary"
   version: "1.0.0"
@@ -8,13 +10,14 @@ metadata:
 # Parameters:
 #   {min_orders} - Only return users with at least this many orders
 
-query: |
-  SELECT
-    u.name                  AS user_name,
-    COUNT(o.id)             AS total_orders,
-    SUM(o.amount)           AS total_spent
-  FROM mydb_catalog.mydb.users  u
-  INNER JOIN mydb_catalog.mydb.orders o ON u.id = o.user_id
-  GROUP BY u.id, u.name
-  HAVING COUNT(o.id) >= {min_orders}
-  ORDER BY total_spent DESC
+spec:
+  query: |
+    SELECT
+      u.name                  AS user_name,
+      COUNT(o.id)             AS total_orders,
+      SUM(o.amount)           AS total_spent
+    FROM mydb_catalog.mydb.users  u
+    INNER JOIN mydb_catalog.mydb.orders o ON u.id = o.user_id
+    GROUP BY u.id, u.name
+    HAVING COUNT(o.id) >= {min_orders}
+    ORDER BY total_spent DESC

--- a/docs/mysql/pipelines/delete_user.yaml
+++ b/docs/mysql/pipelines/delete_user.yaml
@@ -1,7 +1,10 @@
+kind: pipeline
+
 metadata:
   name: "delete_user"
   version: "1.0"
   description: "Delete a user from the MySQL users table by name"
 
-query: |
-  DELETE FROM users WHERE name = {name}
+spec:
+  query: |
+    DELETE FROM users WHERE name = {name}

--- a/docs/mysql/pipelines/federated_join_and_insert.yaml
+++ b/docs/mysql/pipelines/federated_join_and_insert.yaml
@@ -1,18 +1,21 @@
+kind: pipeline
+
 metadata:
   name: "federated_join_and_insert"
   version: "1.0"
   description: "Join CSV orders with MySQL users (filtered by name) and write aggregated results to MySQL"
 
-query: |
-  INSERT INTO user_order_stats (user_id, user_name, user_email, total_orders, total_spent, last_order_date)
-  SELECT
-    u.id as user_id,
-    u.name as user_name,
-    u.email as user_email,
-    COUNT(o.order_id) as total_orders,
-    SUM(o.amount) as total_spent,
-    MAX(o.order_date) as last_order_date
-  FROM users u
-  INNER JOIN csv_orders o ON u.id = o.user_id
-  WHERE u.name = {name}
-  GROUP BY u.id, u.name, u.email
+spec:
+  query: |
+    INSERT INTO user_order_stats (user_id, user_name, user_email, total_orders, total_spent, last_order_date)
+    SELECT
+      u.id as user_id,
+      u.name as user_name,
+      u.email as user_email,
+      COUNT(o.order_id) as total_orders,
+      SUM(o.amount) as total_spent,
+      MAX(o.order_date) as last_order_date
+    FROM users u
+    INNER JOIN csv_orders o ON u.id = o.user_id
+    WHERE u.name = {name}
+    GROUP BY u.id, u.name, u.email

--- a/docs/mysql/pipelines/insert_user.yaml
+++ b/docs/mysql/pipelines/insert_user.yaml
@@ -1,6 +1,9 @@
+kind: pipeline
+
 metadata:
   name: "insert_user"
   version: "1.0"
   description: "Insert a new user"
 
-query: "INSERT INTO users (name, email) VALUES ({name}, {email})"
+spec:
+  query: "INSERT INTO users (name, email) VALUES ({name}, {email})"

--- a/docs/mysql/pipelines/query_user_by_id.yaml
+++ b/docs/mysql/pipelines/query_user_by_id.yaml
@@ -1,6 +1,9 @@
+kind: pipeline
+
 metadata:
   name: "query_user_by_id"
   version: "1.0"
   description: "Query a specific user by ID"
 
-query: "SELECT id, name, email FROM users WHERE id = {user_id}"
+spec:
+  query: "SELECT id, name, email FROM users WHERE id = {user_id}"

--- a/docs/mysql/pipelines/search_users_by_email.yaml
+++ b/docs/mysql/pipelines/search_users_by_email.yaml
@@ -1,6 +1,9 @@
+kind: pipeline
+
 metadata:
   name: "search_users_by_email"
   version: "1.0"
   description: "Search users by email pattern (SQL injection safe with LIKE)"
 
-query: "SELECT id, name, email FROM users WHERE email LIKE {email_pattern}"
+spec:
+  query: "SELECT id, name, email FROM users WHERE email LIKE {email_pattern}"

--- a/docs/mysql/pipelines/update_user_email.yaml
+++ b/docs/mysql/pipelines/update_user_email.yaml
@@ -1,7 +1,10 @@
+kind: pipeline
+
 metadata:
   name: "update_user_email"
   version: "1.0"
   description: "Update a user's email address by name"
 
-query: |
-  UPDATE users SET email = {new_email} WHERE name = {name}
+spec:
+  query: |
+    UPDATE users SET email = {new_email} WHERE name = {name}

--- a/docs/mysql/pipelines/user_orders_summary.yaml
+++ b/docs/mysql/pipelines/user_orders_summary.yaml
@@ -1,16 +1,19 @@
+kind: pipeline
+
 metadata:
   name: "user_orders_summary"
   version: "1.0"
   description: "Get user's orders with total spent"
 
-query: |
-  SELECT
-    u.id,
-    u.name,
-    u.email,
-    COUNT(o.id) as order_count,
-    COALESCE(SUM(o.amount), 0) as total_spent
-  FROM users u
-  LEFT JOIN orders o ON u.id = o.user_id
-  WHERE u.id = {user_id}
-  GROUP BY u.id, u.name, u.email
+spec:
+  query: |
+    SELECT
+      u.id,
+      u.name,
+      u.email,
+      COUNT(o.id) as order_count,
+      COALESCE(SUM(o.amount), 0) as total_spent
+    FROM users u
+    LEFT JOIN orders o ON u.id = o.user_id
+    WHERE u.id = {user_id}
+    GROUP BY u.id, u.name, u.email

--- a/docs/postgres/README.md
+++ b/docs/postgres/README.md
@@ -338,15 +338,23 @@ Add `documents` as a regular Postgres data source — `pg_knn` discovers the vec
 
 ```yaml
 # ctx_pgvector_demo.yaml
-data_sources:
-  - name: "documents"
-    type: "postgres"
-    connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
-    options:
-      table: "documents"
-      schema: "public"
-      user_env: "PG_USER"
-      pass_env: "PG_PASSWORD"
+
+kind: context
+
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "documents"
+      type: "postgres"
+      connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
+      options:
+        table: "documents"
+        schema: "public"
+        user_env: "PG_USER"
+        pass_env: "PG_PASSWORD"
 ```
 
 ### Pipelines
@@ -472,18 +480,26 @@ WHERE _score < -0.5
 
 ```yaml
 # Add to ctx_pgvector_demo.yaml
-data_sources:
-  - name: "documents"
-    type: "postgres"
-    connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
-    options:
-      table: "documents"
-      schema: "public"
-      user_env: "PG_USER"
-      pass_env: "PG_PASSWORD"
-  - name: "csv_orders"
-    type: "csv"
-    path: "docs/sample_data/orders.csv"
+
+kind: context
+
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "documents"
+      type: "postgres"
+      connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
+      options:
+        table: "documents"
+        schema: "public"
+        user_env: "PG_USER"
+        pass_env: "PG_PASSWORD"
+    - name: "csv_orders"
+      type: "csv"
+      path: "docs/sample_data/orders.csv"
 ```
 
 ```sql
@@ -539,15 +555,23 @@ Add `articles` as a regular Postgres data source — `pg_fts` discovers text col
 
 ```yaml
 # ctx_pgfts_demo.yaml
-data_sources:
-  - name: "articles"
-    type: "postgres"
-    connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
-    options:
-      table: "articles"
-      schema: "public"
-      user_env: "PG_USER"
-      pass_env: "PG_PASSWORD"
+
+kind: context
+
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "articles"
+      type: "postgres"
+      connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
+      options:
+        table: "articles"
+        schema: "public"
+        user_env: "PG_USER"
+        pass_env: "PG_PASSWORD"
 ```
 
 ### Pipelines
@@ -726,18 +750,25 @@ automatically. This is called *catalog mode*.
 ### Context file (`ctx_postgres_catalog_demo.yaml`)
 
 ```yaml
-data_sources:
-  # One entry loads both schemas from the same DB.
-  # Tables are accessible as mydb.public.users, mydb.analytics.monthly_revenue, …
-  - name: "mydb"
-    type: "postgres"
-    hierarchy_level: "catalog"        # required to enable catalog mode
-    access_mode: "read_write"
-    connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
-    options:
-      allowed_schemas: "public,analytics"  # comma-separated; omit to load all schemas
-      user_env: "PG_USER"
-      pass_env: "PG_PASSWORD"
+kind: context
+
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    # One entry loads both schemas from the same DB.
+    # Tables are accessible as mydb.public.users, mydb.analytics.monthly_revenue, …
+    - name: "mydb"
+      type: "postgres"
+      hierarchy_level: "catalog"        # required to enable catalog mode
+      access_mode: "read_write"
+      connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
+      options:
+        allowed_schemas: "public,analytics"  # comma-separated; omit to load all schemas
+        user_env: "PG_USER"
+        pass_env: "PG_PASSWORD"
 ```
 
 > **Notes:**
@@ -936,15 +967,22 @@ values to expose several schemas from one database.
 ### ctx_postgres_demo.yaml
 
 ```yaml
-data_sources:
-  - name: "users"
-    type: "postgres"
-    connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
-    options:
-      table: "users"
-      schema: "public"
-      user_env: "PG_USER"
-      pass_env: "PG_PASSWORD"
+kind: context
+
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "users"
+      type: "postgres"
+      connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
+      options:
+        table: "users"
+        schema: "public"
+        user_env: "PG_USER"
+        pass_env: "PG_PASSWORD"
 ```
 
 ### Options — table mode (`hierarchy_level: table`, default)

--- a/docs/postgres/ctx_pgfts_demo.yaml
+++ b/docs/postgres/ctx_pgfts_demo.yaml
@@ -1,10 +1,17 @@
-data_sources:
-  - name: "articles"
-    type: "postgres"
-    connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
-    description: "PostgreSQL table with text content for full-text search"
-    options:
-      table: "articles"
-      schema: "public"
-      user_env: "PG_USER"
-      pass_env: "PG_PASSWORD"
+kind: context
+
+metadata:
+  name: ctx_pgfts_demo
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "articles"
+      type: "postgres"
+      connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
+      description: "PostgreSQL table with text content for full-text search"
+      options:
+        table: "articles"
+        schema: "public"
+        user_env: "PG_USER"
+        pass_env: "PG_PASSWORD"

--- a/docs/postgres/ctx_pgvector_demo.yaml
+++ b/docs/postgres/ctx_pgvector_demo.yaml
@@ -1,10 +1,17 @@
-data_sources:
-  - name: "documents"
-    type: "postgres"
-    connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
-    description: "PostgreSQL table with pgvector embeddings"
-    options:
-      table: "documents"
-      schema: "public"
-      user_env: "PG_USER"
-      pass_env: "PG_PASSWORD"
+kind: context
+
+metadata:
+  name: ctx_pgvector_demo
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "documents"
+      type: "postgres"
+      connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
+      description: "PostgreSQL table with pgvector embeddings"
+      options:
+        table: "documents"
+        schema: "public"
+        user_env: "PG_USER"
+        pass_env: "PG_PASSWORD"

--- a/docs/postgres/ctx_postgres_catalog_demo.yaml
+++ b/docs/postgres/ctx_postgres_catalog_demo.yaml
@@ -1,27 +1,34 @@
-data_sources:
-  # ── Catalog mode: load multiple schemas from one DB in a single entry ────────
-  # Setting hierarchy_level to "catalog" tells Skardi to introspect
-  # information_schema and register every BASE TABLE it finds across all
-  # schemas listed in allowed_schemas.
-  #
-  # Tables are accessible as <catalog_name>.<schema_name>.<table_name>, e.g.:
-  #   mydb.public.users
-  #   mydb.analytics.monthly_revenue
-  #
-  # "table" and "schema" options are not allowed in catalog mode.
-  - name: "mydb"
-    type: "postgres"
-    hierarchy_level: "catalog"
-    access_mode: "read_write"
-    connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
-    description: "All tables in the public and analytics schemas of mydb"
-    options:
-      allowed_schemas: "public,analytics"
-      user_env: "PG_USER"
-      pass_env: "PG_PASSWORD"
+kind: context
 
-  # ── CSV data source (shared with other demos for federated queries) ──────────
-  - name: "csv_orders"
-    type: "csv"
-    path: "docs/sample_data/orders.csv"
-    description: "CSV file containing order data"
+metadata:
+  name: ctx_postgres_catalog_demo
+  version: 1.0.0
+
+spec:
+  data_sources:
+    # ── Catalog mode: load multiple schemas from one DB in a single entry ────────
+    # Setting hierarchy_level to "catalog" tells Skardi to introspect
+    # information_schema and register every BASE TABLE it finds across all
+    # schemas listed in allowed_schemas.
+    #
+    # Tables are accessible as <catalog_name>.<schema_name>.<table_name>, e.g.:
+    #   mydb.public.users
+    #   mydb.analytics.monthly_revenue
+    #
+    # "table" and "schema" options are not allowed in catalog mode.
+    - name: "mydb"
+      type: "postgres"
+      hierarchy_level: "catalog"
+      access_mode: "read_write"
+      connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
+      description: "All tables in the public and analytics schemas of mydb"
+      options:
+        allowed_schemas: "public,analytics"
+        user_env: "PG_USER"
+        pass_env: "PG_PASSWORD"
+
+    # ── CSV data source (shared with other demos for federated queries) ──────────
+    - name: "csv_orders"
+      type: "csv"
+      path: "docs/sample_data/orders.csv"
+      description: "CSV file containing order data"

--- a/docs/postgres/ctx_postgres_demo.yaml
+++ b/docs/postgres/ctx_postgres_demo.yaml
@@ -1,40 +1,47 @@
-data_sources:
-  # PostgreSQL data sources
-  - name: "users"
-    type: "postgres"
-    access_mode: "read_write"
-    connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
-    description: "PostgreSQL users table"
-    options:
-      table: "users"
-      schema: "public"
-      user_env: "PG_USER"
-      pass_env: "PG_PASSWORD"
+kind: context
 
-  - name: "orders"
-    type: "postgres"
-    access_mode: "read_write"
-    connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
-    description: "PostgreSQL orders table"
-    options:
-      table: "orders"
-      schema: "public"
-      user_env: "PG_USER"
-      pass_env: "PG_PASSWORD"
+metadata:
+  name: ctx_postgres_demo
+  version: 1.0.0
 
-  - name: "user_order_stats"
-    type: "postgres"
-    access_mode: "read_write"
-    connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
-    description: "PostgreSQL table for aggregated user order statistics"
-    options:
-      table: "user_order_stats"
-      schema: "public"
-      user_env: "PG_USER"
-      pass_env: "PG_PASSWORD"
+spec:
+  data_sources:
+    # PostgreSQL data sources
+    - name: "users"
+      type: "postgres"
+      access_mode: "read_write"
+      connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
+      description: "PostgreSQL users table"
+      options:
+        table: "users"
+        schema: "public"
+        user_env: "PG_USER"
+        pass_env: "PG_PASSWORD"
 
-  # CSV data source (shared with MySQL demo for federated query)
-  - name: "csv_orders"
-    type: "csv"
-    path: "docs/sample_data/orders.csv"
-    description: "CSV file containing order data"
+    - name: "orders"
+      type: "postgres"
+      access_mode: "read_write"
+      connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
+      description: "PostgreSQL orders table"
+      options:
+        table: "orders"
+        schema: "public"
+        user_env: "PG_USER"
+        pass_env: "PG_PASSWORD"
+
+    - name: "user_order_stats"
+      type: "postgres"
+      access_mode: "read_write"
+      connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
+      description: "PostgreSQL table for aggregated user order statistics"
+      options:
+        table: "user_order_stats"
+        schema: "public"
+        user_env: "PG_USER"
+        pass_env: "PG_PASSWORD"
+
+    # CSV data source (shared with MySQL demo for federated query)
+    - name: "csv_orders"
+      type: "csv"
+      path: "docs/sample_data/orders.csv"
+      description: "CSV file containing order data"

--- a/docs/postgres/pipelines/delete_user.yaml
+++ b/docs/postgres/pipelines/delete_user.yaml
@@ -1,7 +1,10 @@
+kind: pipeline
+
 metadata:
   name: "delete_user"
   version: "1.0"
   description: "Delete a user from the PostgreSQL users table by name"
 
-query: |
-  DELETE FROM users WHERE name = {name}
+spec:
+  query: |
+    DELETE FROM users WHERE name = {name}

--- a/docs/postgres/pipelines/federated_join_and_insert.yaml
+++ b/docs/postgres/pipelines/federated_join_and_insert.yaml
@@ -1,19 +1,22 @@
+kind: pipeline
+
 metadata:
   name: "federated_join_and_insert"
   version: "1.0"
   description: "Join CSV orders with PostgreSQL users (filtered by name) and write aggregated results to PostgreSQL"
 
-query: |
-  INSERT INTO user_order_stats (user_id, user_name, user_email, total_orders, total_spent, last_order_date)
-  SELECT
-    CAST(u.id AS INT) as user_id,
-    u.name as user_name,
-    u.email as user_email,
-    CAST(COUNT(*) AS INT) as total_orders,
-    CAST(SUM(o.amount) AS DECIMAL(10,2)) as total_spent,
-    MAX(o.order_date) as last_order_date
-  FROM users u
-  INNER JOIN csv_orders o
-    ON CAST(u.id AS BIGINT) = o.user_id
-  WHERE u.name = {name}
-  GROUP BY u.id, u.name, u.email
+spec:
+  query: |
+    INSERT INTO user_order_stats (user_id, user_name, user_email, total_orders, total_spent, last_order_date)
+    SELECT
+      CAST(u.id AS INT) as user_id,
+      u.name as user_name,
+      u.email as user_email,
+      CAST(COUNT(*) AS INT) as total_orders,
+      CAST(SUM(o.amount) AS DECIMAL(10,2)) as total_spent,
+      MAX(o.order_date) as last_order_date
+    FROM users u
+    INNER JOIN csv_orders o
+      ON CAST(u.id AS BIGINT) = o.user_id
+    WHERE u.name = {name}
+    GROUP BY u.id, u.name, u.email

--- a/docs/postgres/pipelines/fts_demo/fts_search.yaml
+++ b/docs/postgres/pipelines/fts_demo/fts_search.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "fts-search"
   version: "1.0.0"
@@ -9,7 +11,8 @@ metadata:
 #   {query} - Search terms (space-separated, "quoted" for phrase, OR for disjunction, -term for negation)
 #   {limit} - Maximum number of results to return
 
-query: |
-  SELECT id, title, category, _score
-  FROM pg_fts('articles', 'body', {query}, {limit})
-  ORDER BY _score DESC
+spec:
+  query: |
+    SELECT id, title, category, _score
+    FROM pg_fts('articles', 'body', {query}, {limit})
+    ORDER BY _score DESC

--- a/docs/postgres/pipelines/fts_demo/fts_search_with_filter.yaml
+++ b/docs/postgres/pipelines/fts_demo/fts_search_with_filter.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "fts-search-with-filter"
   version: "1.0.0"
@@ -10,8 +12,9 @@ metadata:
 #   {category} - Category to filter by
 #   {limit}    - Maximum number of results to return
 
-query: |
-  SELECT id, title, category, _score
-  FROM pg_fts('articles', 'body', {query}, {limit})
-  WHERE category = {category}
-  ORDER BY _score DESC
+spec:
+  query: |
+    SELECT id, title, category, _score
+    FROM pg_fts('articles', 'body', {query}, {limit})
+    WHERE category = {category}
+    ORDER BY _score DESC

--- a/docs/postgres/pipelines/insert_user.yaml
+++ b/docs/postgres/pipelines/insert_user.yaml
@@ -1,7 +1,10 @@
+kind: pipeline
+
 metadata:
   name: "insert_user"
   version: "1.0"
   description: "Insert a new user into PostgreSQL users table"
 
-query: |
-  INSERT INTO users (name, email) VALUES ({name}, {email})
+spec:
+  query: |
+    INSERT INTO users (name, email) VALUES ({name}, {email})

--- a/docs/postgres/pipelines/query_user_by_id.yaml
+++ b/docs/postgres/pipelines/query_user_by_id.yaml
@@ -1,7 +1,10 @@
+kind: pipeline
+
 metadata:
   name: "query_user_by_id"
   version: "1.0"
   description: "Query a user by their ID"
 
-query: |
-  SELECT * FROM users WHERE id = {user_id}
+spec:
+  query: |
+    SELECT * FROM users WHERE id = {user_id}

--- a/docs/postgres/pipelines/update_user_email.yaml
+++ b/docs/postgres/pipelines/update_user_email.yaml
@@ -1,7 +1,10 @@
+kind: pipeline
+
 metadata:
   name: "update_user_email"
   version: "1.0"
   description: "Update a user's email address by name"
 
-query: |
-  UPDATE users SET email = {new_email} WHERE name = {name}
+spec:
+  query: |
+    UPDATE users SET email = {new_email} WHERE name = {name}

--- a/docs/postgres/pipelines/vector_demo/vector_search_cosine.yaml
+++ b/docs/postgres/pipelines/vector_demo/vector_search_cosine.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "vector-search-cosine"
   version: "1.0.0"
@@ -11,10 +13,11 @@ metadata:
 #   {k}       - Number of candidates pg_knn fetches from the ANN index
 #   {limit}   - Maximum number of results to return (trims the final result set)
 
-query: |
-  SELECT id, content, metadata, _score
-  FROM pg_knn('documents', 'embedding',
-      (SELECT embedding FROM documents WHERE id = {seed_id}),
-      '<=>', {k})
-  ORDER BY _score
-  LIMIT {limit}
+spec:
+  query: |
+    SELECT id, content, metadata, _score
+    FROM pg_knn('documents', 'embedding',
+        (SELECT embedding FROM documents WHERE id = {seed_id}),
+        '<=>', {k})
+    ORDER BY _score
+    LIMIT {limit}

--- a/docs/postgres/pipelines/vector_demo/vector_search_inner_product.yaml
+++ b/docs/postgres/pipelines/vector_demo/vector_search_inner_product.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "vector-search-inner-product"
   version: "1.0.0"
@@ -11,10 +13,11 @@ metadata:
 #   {k}       - Number of candidates pg_knn fetches from the ANN index
 #   {limit}   - Maximum number of results to return (trims the final result set)
 
-query: |
-  SELECT id, content, metadata, _score
-  FROM pg_knn('documents', 'embedding',
-      (SELECT embedding FROM documents WHERE id = {seed_id}),
-      '<#>', {k})
-  ORDER BY _score
-  LIMIT {limit}
+spec:
+  query: |
+    SELECT id, content, metadata, _score
+    FROM pg_knn('documents', 'embedding',
+        (SELECT embedding FROM documents WHERE id = {seed_id}),
+        '<#>', {k})
+    ORDER BY _score
+    LIMIT {limit}

--- a/docs/postgres/pipelines/vector_demo/vector_search_l2.yaml
+++ b/docs/postgres/pipelines/vector_demo/vector_search_l2.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "vector-search-l2"
   version: "1.0.0"
@@ -11,10 +13,11 @@ metadata:
 #   {k}       - Number of candidates pg_knn fetches from the ANN index
 #   {limit}   - Maximum number of results to return (trims the final result set)
 
-query: |
-  SELECT id, content, metadata, _score
-  FROM pg_knn('documents', 'embedding',
-      (SELECT embedding FROM documents WHERE id = {seed_id}),
-      '<->', {k})
-  ORDER BY _score
-  LIMIT {limit}
+spec:
+  query: |
+    SELECT id, content, metadata, _score
+    FROM pg_knn('documents', 'embedding',
+        (SELECT embedding FROM documents WHERE id = {seed_id}),
+        '<->', {k})
+    ORDER BY _score
+    LIMIT {limit}

--- a/docs/postgres/pipelines_for_catalog_example/cross_schema_summary.yaml
+++ b/docs/postgres/pipelines_for_catalog_example/cross_schema_summary.yaml
@@ -1,14 +1,17 @@
+kind: pipeline
+
 metadata:
   name: "cross_schema_summary"
   version: "1.0"
   description: "Join public-schema users with analytics-schema monthly_revenue — both in the same catalog entry"
 
-query: |
-  SELECT
-    u.id AS user_id,
-    u.name AS user_name,
-    r.month,
-    r.revenue
-  FROM mydb.public.users u
-  INNER JOIN mydb.analytics.monthly_revenue r ON u.id = r.user_id
-  ORDER BY r.month, u.id
+spec:
+  query: |
+    SELECT
+      u.id AS user_id,
+      u.name AS user_name,
+      r.month,
+      r.revenue
+    FROM mydb.public.users u
+    INNER JOIN mydb.analytics.monthly_revenue r ON u.id = r.user_id
+    ORDER BY r.month, u.id

--- a/docs/postgres/pipelines_for_catalog_example/list_all_users_and_orders.yaml
+++ b/docs/postgres/pipelines_for_catalog_example/list_all_users_and_orders.yaml
@@ -1,16 +1,19 @@
+kind: pipeline
+
 metadata:
   name: "list_all_users_and_orders"
   version: "1.0"
   description: "List all users with their orders using fully qualified catalog.schema.table paths"
 
-query: |
-  SELECT
-    u.id AS user_id,
-    u.name AS user_name,
-    u.email,
-    o.id AS order_id,
-    o.product,
-    o.amount
-  FROM mydb.public.users u
-  LEFT JOIN mydb.public.orders o ON u.id = o.user_id
-  ORDER BY u.id, o.id
+spec:
+  query: |
+    SELECT
+      u.id AS user_id,
+      u.name AS user_name,
+      u.email,
+      o.id AS order_id,
+      o.product,
+      o.amount
+    FROM mydb.public.users u
+    LEFT JOIN mydb.public.orders o ON u.id = o.user_id
+    ORDER BY u.id, o.id

--- a/docs/postgres/pipelines_for_catalog_example/vector_search_catalog.yaml
+++ b/docs/postgres/pipelines_for_catalog_example/vector_search_catalog.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "vector-search-catalog"
   version: "1.0.0"
@@ -13,10 +15,11 @@ metadata:
 #   {k}            - Number of candidates pg_knn fetches from the ANN index
 #   {limit}        - Maximum number of results to return (trims the final result set)
 
-query: |
-  SELECT id, content, metadata, _score
-  FROM pg_knn('mydb.public.documents', 'embedding',
-      {query_vector},
-      '<=>', {k})
-  ORDER BY _score
-  LIMIT {limit}
+spec:
+  query: |
+    SELECT id, content, metadata, _score
+    FROM pg_knn('mydb.public.documents', 'embedding',
+        {query_vector},
+        '<=>', {k})
+    ORDER BY _score
+    LIMIT {limit}

--- a/docs/redis/README.md
+++ b/docs/redis/README.md
@@ -276,29 +276,43 @@ pkill -f skardi-server
 ### Basic Configuration
 
 ```yaml
-data_sources:
-  - name: "products"
-    type: "redis"
-    access_mode: "read_write"
-    connection_string: "redis://localhost:6379"
-    description: "Redis hash table for products"
-    options:
-      key_space: "mydb"           # Namespace prefix for Redis keys
-      table: "products"           # Table name (keys become {key_space}:{table}:{id})
-      key_column: "product_id"    # Column derived from the key suffix (optional)
+kind: context
+
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "products"
+      type: "redis"
+      access_mode: "read_write"
+      connection_string: "redis://localhost:6379"
+      description: "Redis hash table for products"
+      options:
+        key_space: "mydb"           # Namespace prefix for Redis keys
+        table: "products"           # Table name (keys become {key_space}:{table}:{id})
+        key_column: "product_id"    # Column derived from the key suffix (optional)
 ```
 
 ### Redis with Authentication
 
 ```yaml
-data_sources:
-  - name: "products"
-    type: "redis"
-    connection_string: "redis://:mypassword@localhost:6379"
-    options:
-      key_space: "mydb"
-      table: "products"
-      key_column: "product_id"
+kind: context
+
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "products"
+      type: "redis"
+      connection_string: "redis://:mypassword@localhost:6379"
+      options:
+        key_space: "mydb"
+        table: "products"
+        key_column: "product_id"
 ```
 
 ### Empty Tables with Declared Schema
@@ -306,16 +320,23 @@ data_sources:
 If a Redis table has no data yet, you can declare the columns upfront so that INSERT operations work immediately:
 
 ```yaml
-data_sources:
-  - name: "product_stats"
-    type: "redis"
-    access_mode: "read_write"
-    connection_string: "redis://localhost:6379"
-    options:
-      key_space: "mydb"
-      table: "product_stats"
-      key_column: "stat_id"
-      columns: "stat_id, category, total_products, total_value, avg_price"
+kind: context
+
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "product_stats"
+      type: "redis"
+      access_mode: "read_write"
+      connection_string: "redis://localhost:6379"
+      options:
+        key_space: "mydb"
+        table: "product_stats"
+        key_column: "stat_id"
+        columns: "stat_id, category, total_products, total_value, avg_price"
 ```
 
 The `columns` option is only used when the table is empty — once data exists in Redis, the schema is inferred from the data automatically.
@@ -323,19 +344,26 @@ The `columns` option is only used when the table is empty — once data exists i
 ### Multiple Redis Databases
 
 ```yaml
-data_sources:
-  - name: "cache_products"
-    type: "redis"
-    connection_string: "redis://localhost:6379/0"
-    options:
-      key_space: "app"
-      table: "products"
-      key_column: "product_id"
+kind: context
 
-  - name: "analytics"
-    type: "redis"
-    connection_string: "redis://localhost:6379/1"
-    options:
-      key_space: "analytics"
-      table: "events"
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "cache_products"
+      type: "redis"
+      connection_string: "redis://localhost:6379/0"
+      options:
+        key_space: "app"
+        table: "products"
+        key_column: "product_id"
+
+    - name: "analytics"
+      type: "redis"
+      connection_string: "redis://localhost:6379/1"
+      options:
+        key_space: "analytics"
+        table: "events"
 ```

--- a/docs/redis/ctx_redis_demo.yaml
+++ b/docs/redis/ctx_redis_demo.yaml
@@ -1,27 +1,34 @@
-data_sources:
-  - name: "products"
-    type: "redis"
-    access_mode: "read_write"
-    connection_string: "redis://localhost:6379"
-    description: "Redis hash table for products"
-    options:
-      key_space: "mydb"
-      table: "products"
-      key_column: "product_id"
+kind: context
 
-  - name: "product_stats"
-    type: "redis"
-    access_mode: "read_write"
-    connection_string: "redis://localhost:6379"
-    description: "Redis hash table for aggregated product statistics"
-    options:
-      key_space: "mydb"
-      table: "product_stats"
-      key_column: "stat_id"
-      columns: "stat_id, category, total_products, total_value, avg_price"
+metadata:
+  name: ctx_redis_demo
+  version: 1.0.0
 
-  # CSV data source (for federated query demo)
-  - name: "csv_inventory"
-    type: "csv"
-    path: "docs/sample_data/product_inventory.csv"
-    description: "CSV file containing product inventory data"
+spec:
+  data_sources:
+    - name: "products"
+      type: "redis"
+      access_mode: "read_write"
+      connection_string: "redis://localhost:6379"
+      description: "Redis hash table for products"
+      options:
+        key_space: "mydb"
+        table: "products"
+        key_column: "product_id"
+
+    - name: "product_stats"
+      type: "redis"
+      access_mode: "read_write"
+      connection_string: "redis://localhost:6379"
+      description: "Redis hash table for aggregated product statistics"
+      options:
+        key_space: "mydb"
+        table: "product_stats"
+        key_column: "stat_id"
+        columns: "stat_id, category, total_products, total_value, avg_price"
+
+    # CSV data source (for federated query demo)
+    - name: "csv_inventory"
+      type: "csv"
+      path: "docs/sample_data/product_inventory.csv"
+      description: "CSV file containing product inventory data"

--- a/docs/redis/pipelines/delete_product.yaml
+++ b/docs/redis/pipelines/delete_product.yaml
@@ -1,7 +1,10 @@
+kind: pipeline
+
 metadata:
   name: "delete_product"
   version: "1.0"
   description: "Delete a product by product ID"
 
-query: |
-  DELETE FROM products WHERE product_id = {product_id}
+spec:
+  query: |
+    DELETE FROM products WHERE product_id = {product_id}

--- a/docs/redis/pipelines/federated_join_and_insert.yaml
+++ b/docs/redis/pipelines/federated_join_and_insert.yaml
@@ -1,17 +1,20 @@
+kind: pipeline
+
 metadata:
   name: "federated_join_and_insert"
   version: "1.0"
   description: "Join CSV inventory with Redis products and write aggregated stats"
 
-query: |
-  INSERT INTO product_stats (stat_id, category, total_products, total_value, avg_price)
-  SELECT
-    {category} as stat_id,
-    p.category,
-    COUNT(DISTINCT p.product_id) as total_products,
-    SUM(i.quantity * CAST(p.price AS DOUBLE)) as total_value,
-    AVG(CAST(p.price AS DOUBLE)) as avg_price
-  FROM products p
-  INNER JOIN csv_inventory i ON p.product_id = i.product_id
-  WHERE p.category = {category}
-  GROUP BY p.category
+spec:
+  query: |
+    INSERT INTO product_stats (stat_id, category, total_products, total_value, avg_price)
+    SELECT
+      {category} as stat_id,
+      p.category,
+      COUNT(DISTINCT p.product_id) as total_products,
+      SUM(i.quantity * CAST(p.price AS DOUBLE)) as total_value,
+      AVG(CAST(p.price AS DOUBLE)) as avg_price
+    FROM products p
+    INNER JOIN csv_inventory i ON p.product_id = i.product_id
+    WHERE p.category = {category}
+    GROUP BY p.category

--- a/docs/redis/pipelines/insert_product.yaml
+++ b/docs/redis/pipelines/insert_product.yaml
@@ -1,8 +1,11 @@
+kind: pipeline
+
 metadata:
   name: "insert_product"
   version: "1.0"
   description: "Insert a single product"
 
-query: |
-  INSERT INTO products (product_id, name, category, price, in_stock)
-  VALUES ({product_id}, {name}, {category}, {price}, {in_stock})
+spec:
+  query: |
+    INSERT INTO products (product_id, name, category, price, in_stock)
+    VALUES ({product_id}, {name}, {category}, {price}, {in_stock})

--- a/docs/redis/pipelines/list_all_products.yaml
+++ b/docs/redis/pipelines/list_all_products.yaml
@@ -1,6 +1,9 @@
+kind: pipeline
+
 metadata:
   name: "list_all_products"
   version: "1.0"
   description: "List all products (full scan)"
 
-query: "SELECT product_id, name, category, price, in_stock FROM products ORDER BY name"
+spec:
+  query: "SELECT product_id, name, category, price, in_stock FROM products ORDER BY name"

--- a/docs/redis/pipelines/query_product_by_id.yaml
+++ b/docs/redis/pipelines/query_product_by_id.yaml
@@ -1,6 +1,9 @@
+kind: pipeline
+
 metadata:
   name: "query_product_by_id"
   version: "1.0"
   description: "Query a specific product by ID (point lookup)"
 
-query: "SELECT * FROM products WHERE product_id = {product_id}"
+spec:
+  query: "SELECT * FROM products WHERE product_id = {product_id}"

--- a/docs/redis/pipelines/query_products_by_category.yaml
+++ b/docs/redis/pipelines/query_products_by_category.yaml
@@ -1,6 +1,9 @@
+kind: pipeline
+
 metadata:
   name: "query_products_by_category"
   version: "1.0"
   description: "Query products by category (non-key column filter, full scan)"
 
-query: "SELECT * FROM products WHERE category = {category}"
+spec:
+  query: "SELECT * FROM products WHERE category = {category}"

--- a/docs/redis/pipelines/update_product_price.yaml
+++ b/docs/redis/pipelines/update_product_price.yaml
@@ -1,7 +1,10 @@
+kind: pipeline
+
 metadata:
   name: "update_product_price"
   version: "1.0"
   description: "Update a product's price by product ID"
 
-query: |
-  UPDATE products SET price = {price} WHERE product_id = {product_id}
+spec:
+  query: |
+    UPDATE products SET price = {price} WHERE product_id = {product_id}

--- a/docs/redis/pipelines/update_stock_by_category.yaml
+++ b/docs/redis/pipelines/update_stock_by_category.yaml
@@ -1,7 +1,10 @@
+kind: pipeline
+
 metadata:
   name: "update_stock_by_category"
   version: "1.0"
   description: "Update in_stock status for all products in a category"
 
-query: |
-  UPDATE products SET in_stock = {in_stock} WHERE category = {category}
+spec:
+  query: |
+    UPDATE products SET in_stock = {in_stock} WHERE category = {category}

--- a/docs/seekdb/ctx_seekdb_demo.yaml
+++ b/docs/seekdb/ctx_seekdb_demo.yaml
@@ -1,66 +1,73 @@
-data_sources:
-  # Relational tables
-  - name: "users"
-    type: "seekdb"
-    access_mode: "read_write"
-    connection_string: "mysql://127.0.0.1:2881/mydb"
-    description: "SeekDB users table"
-    options:
-      table: "users"
-      user_env: "SEEKDB_USER"
-      pass_env: "SEEKDB_PASSWORD"
-      ssl_mode: "disabled"
+kind: context
 
-  - name: "orders"
-    type: "seekdb"
-    access_mode: "read_write"
-    connection_string: "mysql://127.0.0.1:2881/mydb"
-    description: "SeekDB orders table"
-    options:
-      table: "orders"
-      user_env: "SEEKDB_USER"
-      pass_env: "SEEKDB_PASSWORD"
-      ssl_mode: "disabled"
+metadata:
+  name: ctx_seekdb_demo
+  version: 1.0.0
 
-  # FTS-enabled table (FULLTEXT index on body with the IK parser)
-  - name: "articles"
-    type: "seekdb"
-    access_mode: "read_write"
-    connection_string: "mysql://127.0.0.1:2881/mydb"
-    description: "Articles with a FULLTEXT index used by seekdb_fts"
-    options:
-      table: "articles"
-      user_env: "SEEKDB_USER"
-      pass_env: "SEEKDB_PASSWORD"
-      ssl_mode: "disabled"
+spec:
+  data_sources:
+    # Relational tables
+    - name: "users"
+      type: "seekdb"
+      access_mode: "read_write"
+      connection_string: "mysql://127.0.0.1:2881/mydb"
+      description: "SeekDB users table"
+      options:
+        table: "users"
+        user_env: "SEEKDB_USER"
+        pass_env: "SEEKDB_PASSWORD"
+        ssl_mode: "disabled"
 
-  # KNN-enabled table (VECTOR column with HNSW index)
-  - name: "docs"
-    type: "seekdb"
-    access_mode: "read_write"
-    connection_string: "mysql://127.0.0.1:2881/mydb"
-    description: "Docs with a VECTOR/HNSW column used by seekdb_knn"
-    options:
-      table: "docs"
-      user_env: "SEEKDB_USER"
-      pass_env: "SEEKDB_PASSWORD"
-      ssl_mode: "disabled"
+    - name: "orders"
+      type: "seekdb"
+      access_mode: "read_write"
+      connection_string: "mysql://127.0.0.1:2881/mydb"
+      description: "SeekDB orders table"
+      options:
+        table: "orders"
+        user_env: "SEEKDB_USER"
+        pass_env: "SEEKDB_PASSWORD"
+        ssl_mode: "disabled"
 
-  # 384-dim KNN table for the embedding-UDF demo (bge-small-en-v1.5 output).
-  - name: "docs_embed"
-    type: "seekdb"
-    access_mode: "read_write"
-    connection_string: "mysql://127.0.0.1:2881/mydb"
-    description: "Docs with a 384-dim VECTOR column, embedded by candle() at query/write time"
-    options:
-      table: "docs_embed"
-      user_env: "SEEKDB_USER"
-      pass_env: "SEEKDB_PASSWORD"
-      ssl_mode: "disabled"
+    # FTS-enabled table (FULLTEXT index on body with the IK parser)
+    - name: "articles"
+      type: "seekdb"
+      access_mode: "read_write"
+      connection_string: "mysql://127.0.0.1:2881/mydb"
+      description: "Articles with a FULLTEXT index used by seekdb_fts"
+      options:
+        table: "articles"
+        user_env: "SEEKDB_USER"
+        pass_env: "SEEKDB_PASSWORD"
+        ssl_mode: "disabled"
 
-  # A CSV source for the federated-join demo.
-  - name: "csv_orders"
-    type: "csv"
-    access_mode: "read_only"
-    path: "docs/sample_data/orders.csv"
-    description: "CSV file containing order data for federated queries"
+    # KNN-enabled table (VECTOR column with HNSW index)
+    - name: "docs"
+      type: "seekdb"
+      access_mode: "read_write"
+      connection_string: "mysql://127.0.0.1:2881/mydb"
+      description: "Docs with a VECTOR/HNSW column used by seekdb_knn"
+      options:
+        table: "docs"
+        user_env: "SEEKDB_USER"
+        pass_env: "SEEKDB_PASSWORD"
+        ssl_mode: "disabled"
+
+    # 384-dim KNN table for the embedding-UDF demo (bge-small-en-v1.5 output).
+    - name: "docs_embed"
+      type: "seekdb"
+      access_mode: "read_write"
+      connection_string: "mysql://127.0.0.1:2881/mydb"
+      description: "Docs with a 384-dim VECTOR column, embedded by candle() at query/write time"
+      options:
+        table: "docs_embed"
+        user_env: "SEEKDB_USER"
+        pass_env: "SEEKDB_PASSWORD"
+        ssl_mode: "disabled"
+
+    # A CSV source for the federated-join demo.
+    - name: "csv_orders"
+      type: "csv"
+      access_mode: "read_only"
+      path: "docs/sample_data/orders.csv"
+      description: "CSV file containing order data for federated queries"

--- a/docs/seekdb/pipelines/delete_user.yaml
+++ b/docs/seekdb/pipelines/delete_user.yaml
@@ -1,6 +1,9 @@
+kind: pipeline
+
 metadata:
   name: "seekdb-delete-user"
   version: "1.0"
   description: "Delete a user by name in SeekDB."
 
-query: "DELETE FROM users WHERE name = {name}"
+spec:
+  query: "DELETE FROM users WHERE name = {name}"

--- a/docs/seekdb/pipelines/federated_join_and_insert.yaml
+++ b/docs/seekdb/pipelines/federated_join_and_insert.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "seekdb-federated-join-and-insert"
   version: "1.0"
@@ -5,13 +7,14 @@ metadata:
     Federated join between a CSV file and SeekDB tables, with the aggregated
     result INSERT-ed into a SeekDB table (user_order_stats — create it first).
 
-query: |
-  INSERT INTO user_order_stats (user_id, user_name, total_orders, total_spent)
-  SELECT u.id,
-         u.name,
-         COUNT(c.order_id) AS total_orders,
-         SUM(c.amount)     AS total_spent
-  FROM users u
-  INNER JOIN csv_orders c ON u.id = c.user_id
-  WHERE u.id = {user_id}
-  GROUP BY u.id, u.name
+spec:
+  query: |
+    INSERT INTO user_order_stats (user_id, user_name, total_orders, total_spent)
+    SELECT u.id,
+           u.name,
+           COUNT(c.order_id) AS total_orders,
+           SUM(c.amount)     AS total_spent
+    FROM users u
+    INNER JOIN csv_orders c ON u.id = c.user_id
+    WHERE u.id = {user_id}
+    GROUP BY u.id, u.name

--- a/docs/seekdb/pipelines/fts_search.yaml
+++ b/docs/seekdb/pipelines/fts_search.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "seekdb-fts-search"
   version: "1.0.0"
@@ -10,7 +12,8 @@ metadata:
 #   {query} - Search terms (space-separated — passed straight to MATCH/AGAINST)
 #   {limit} - Maximum number of results to return
 
-query: |
-  SELECT title, body, category, _score
-  FROM seekdb_fts('articles', 'body', {query}, {limit})
-  ORDER BY _score DESC
+spec:
+  query: |
+    SELECT title, body, category, _score
+    FROM seekdb_fts('articles', 'body', {query}, {limit})
+    ORDER BY _score DESC

--- a/docs/seekdb/pipelines/fts_search_with_filter.yaml
+++ b/docs/seekdb/pipelines/fts_search_with_filter.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "seekdb-fts-search-with-filter"
   version: "1.0.0"
@@ -10,8 +12,9 @@ metadata:
 #   {category} - Category to filter by
 #   {limit}    - Maximum number of results to return
 
-query: |
-  SELECT title, body, category, _score
-  FROM seekdb_fts('articles', 'body', {query}, {limit})
-  WHERE category = {category}
-  ORDER BY _score DESC
+spec:
+  query: |
+    SELECT title, body, category, _score
+    FROM seekdb_fts('articles', 'body', {query}, {limit})
+    WHERE category = {category}
+    ORDER BY _score DESC

--- a/docs/seekdb/pipelines/insert_user.yaml
+++ b/docs/seekdb/pipelines/insert_user.yaml
@@ -1,6 +1,9 @@
+kind: pipeline
+
 metadata:
   name: "seekdb-insert-user"
   version: "1.0"
   description: "Insert a new row into SeekDB (read_write access mode required)."
 
-query: "INSERT INTO users (name, email) VALUES ({name}, {email})"
+spec:
+  query: "INSERT INTO users (name, email) VALUES ({name}, {email})"

--- a/docs/seekdb/pipelines/knn_search.yaml
+++ b/docs/seekdb/pipelines/knn_search.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "seekdb-knn-search"
   version: "1.0.0"
@@ -10,7 +12,8 @@ metadata:
 #   {query_vec} - Query embedding as a literal array (e.g. [1.0, 0.0, 0.0, 0.0])
 #   {k}         - Number of nearest neighbours to return
 
-query: |
-  SELECT id, title, category, _score
-  FROM seekdb_knn('docs', 'embedding', {query_vec}, 'l2', {k})
-  ORDER BY _score ASC
+spec:
+  query: |
+    SELECT id, title, category, _score
+    FROM seekdb_knn('docs', 'embedding', {query_vec}, 'l2', {k})
+    ORDER BY _score ASC

--- a/docs/seekdb/pipelines/knn_search_by_seed.yaml
+++ b/docs/seekdb/pipelines/knn_search_by_seed.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "seekdb-knn-search-by-seed"
   version: "1.0.0"
@@ -9,9 +11,10 @@ metadata:
 #   {seed_id} - id of the seed row in docs
 #   {k}       - Number of nearest neighbours to return
 
-query: |
-  SELECT id, title, category, _score
-  FROM seekdb_knn('docs', 'embedding',
-      (SELECT embedding FROM docs WHERE id = {seed_id}),
-      'cosine', {k})
-  ORDER BY _score ASC
+spec:
+  query: |
+    SELECT id, title, category, _score
+    FROM seekdb_knn('docs', 'embedding',
+        (SELECT embedding FROM docs WHERE id = {seed_id}),
+        'cosine', {k})
+    ORDER BY _score ASC

--- a/docs/seekdb/pipelines/knn_search_by_text.yaml
+++ b/docs/seekdb/pipelines/knn_search_by_text.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "seekdb-knn-search-by-text"
   version: "1.0.0"
@@ -11,9 +13,10 @@ metadata:
 #   {text} - free-text query; embedded inline
 #   {k}    - number of nearest neighbours to return
 
-query: |
-  SELECT id, title, category, _score
-  FROM seekdb_knn('docs_embed', 'embedding',
-      candle('models/generated/bge-small-en-v1.5', {text}),
-      'cosine', {k})
-  ORDER BY _score ASC
+spec:
+  query: |
+    SELECT id, title, category, _score
+    FROM seekdb_knn('docs_embed', 'embedding',
+        candle('models/generated/bge-small-en-v1.5', {text}),
+        'cosine', {k})
+    ORDER BY _score ASC

--- a/docs/seekdb/pipelines/query_user_by_id.yaml
+++ b/docs/seekdb/pipelines/query_user_by_id.yaml
@@ -1,6 +1,9 @@
+kind: pipeline
+
 metadata:
   name: "seekdb-query-user-by-id"
   version: "1.0"
   description: "Point lookup on the SeekDB users table."
 
-query: "SELECT id, name, email FROM users WHERE id = {user_id}"
+spec:
+  query: "SELECT id, name, email FROM users WHERE id = {user_id}"

--- a/docs/seekdb/pipelines/search_users_by_email.yaml
+++ b/docs/seekdb/pipelines/search_users_by_email.yaml
@@ -1,6 +1,9 @@
+kind: pipeline
+
 metadata:
   name: "seekdb-search-users-by-email"
   version: "1.0"
   description: "LIKE-based search on the users table, pushed down to SeekDB."
 
-query: "SELECT id, name, email FROM users WHERE email LIKE {email_pattern} ORDER BY id"
+spec:
+  query: "SELECT id, name, email FROM users WHERE email LIKE {email_pattern} ORDER BY id"

--- a/docs/seekdb/pipelines/seed_doc_embed.yaml
+++ b/docs/seekdb/pipelines/seed_doc_embed.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "seekdb-seed-doc-embed"
   version: "1.0.0"
@@ -12,11 +14,12 @@ metadata:
 #   {category} - coarse page category
 #   {content}  - free-text body; embedded inline
 
-query: |
-  INSERT INTO docs_embed (title, category, content, embedding)
-  SELECT {title},
-         {category},
-         {content},
-         '[' || array_to_string(
-                  candle('models/generated/bge-small-en-v1.5', {content}),
-                  ',') || ']'
+spec:
+  query: |
+    INSERT INTO docs_embed (title, category, content, embedding)
+    SELECT {title},
+           {category},
+           {content},
+           '[' || array_to_string(
+                    candle('models/generated/bge-small-en-v1.5', {content}),
+                    ',') || ']'

--- a/docs/seekdb/pipelines/update_user_email.yaml
+++ b/docs/seekdb/pipelines/update_user_email.yaml
@@ -1,6 +1,9 @@
+kind: pipeline
+
 metadata:
   name: "seekdb-update-user-email"
   version: "1.0"
   description: "Update a user's email address in SeekDB."
 
-query: "UPDATE users SET email = {email} WHERE name = {name}"
+spec:
+  query: "UPDATE users SET email = {email} WHERE name = {name}"

--- a/docs/seekdb/pipelines/user_orders_summary.yaml
+++ b/docs/seekdb/pipelines/user_orders_summary.yaml
@@ -1,15 +1,18 @@
+kind: pipeline
+
 metadata:
   name: "seekdb-user-orders-summary"
   version: "1.0"
   description: "Aggregate a user's orders, joined against the users table in SeekDB."
 
-query: |
-  SELECT u.id AS user_id,
-         u.name,
-         u.email,
-         COUNT(o.id)           AS total_orders,
-         COALESCE(SUM(o.amount), 0) AS total_spent
-  FROM users u
-  LEFT JOIN orders o ON u.id = o.user_id
-  WHERE u.id = {user_id}
-  GROUP BY u.id, u.name, u.email
+spec:
+  query: |
+    SELECT u.id AS user_id,
+           u.name,
+           u.email,
+           COUNT(o.id)           AS total_orders,
+           COALESCE(SUM(o.amount), 0) AS total_spent
+    FROM users u
+    LEFT JOIN orders o ON u.id = o.user_id
+    WHERE u.id = {user_id}
+    GROUP BY u.id, u.name, u.email

--- a/docs/server.md
+++ b/docs/server.md
@@ -46,36 +46,50 @@ No configuration required — the dashboard is built into `skardi-server` and up
 A context file (`ctx.yaml`) defines the data sources available to your pipelines. Each data source is registered as a table in the query engine.
 
 ```yaml
-data_sources:
-  - name: "products"          # Table name used in SQL queries
-    type: "csv"               # Data source type
-    path: "data/products.csv" # File path or connection string
-    options:                  # Type-specific options
-      has_header: true
-      delimiter: ","
-      schema_infer_max_records: 1000
-    description: "Product catalog"
+kind: context
+
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "products"          # Table name used in SQL queries
+      type: "csv"               # Data source type
+      path: "data/products.csv" # File path or connection string
+      options:                  # Type-specific options
+        has_header: true
+        delimiter: ","
+        schema_infer_max_records: 1000
+      description: "Product catalog"
 ```
 
 You can define multiple data sources of different types in a single context file:
 
 ```yaml
-data_sources:
-  - name: "users"
-    type: "postgres"
-    connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
-    options:
-      table: "users"
-      schema: "public"
-      user_env: "PG_USER"
-      pass_env: "PG_PASSWORD"
+kind: context
 
-  - name: "orders"
-    type: "csv"
-    path: "docs/sample_data/orders.csv"
-    options:
-      has_header: true
-      delimiter: ","
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "users"
+      type: "postgres"
+      connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
+      options:
+        table: "users"
+        schema: "public"
+        user_env: "PG_USER"
+        pass_env: "PG_PASSWORD"
+
+    - name: "orders"
+      type: "csv"
+      path: "docs/sample_data/orders.csv"
+      options:
+        has_header: true
+        delimiter: ","
 ```
 
 ## Access Mode
@@ -83,20 +97,27 @@ data_sources:
 By default, all data sources are **read-only** — only `SELECT` queries are allowed. To enable write operations (`INSERT`, `UPDATE`, `DELETE`), set `access_mode: read_write` on the data source. Only `postgres`, `mysql`, `sqlite`, `mongo`, and `redis` sources support `read_write` mode; setting it on other types will produce an error at startup.
 
 ```yaml
-data_sources:
-  - name: "users"
-    type: "postgres"
-    connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
-    access_mode: read_write    # Enable INSERT/UPDATE/DELETE
-    options:
-      table: "users"
-      user_env: "PG_USER"
-      pass_env: "PG_PASSWORD"
+kind: context
 
-  - name: "products"
-    type: "csv"
-    path: "data/products.csv"
-    # access_mode defaults to read_only (CSV doesn't support writes)
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "users"
+      type: "postgres"
+      connection_string: "postgresql://localhost:5432/mydb?sslmode=disable"
+      access_mode: read_write    # Enable INSERT/UPDATE/DELETE
+      options:
+        table: "users"
+        user_env: "PG_USER"
+        pass_env: "PG_PASSWORD"
+
+    - name: "products"
+      type: "csv"
+      path: "data/products.csv"
+      # access_mode defaults to read_only (CSV doesn't support writes)
 ```
 
 If a pipeline attempts a write operation on a `read_only` source, the server returns an error:
@@ -109,13 +130,20 @@ Write operation not allowed on data source 'products'. The data source is config
 For file-based sources (`csv`, `parquet`, `iceberg`), you can set `enable_cache: true` to load the entire dataset into memory at startup. This gives significantly faster query performance at the cost of memory usage.
 
 ```yaml
-data_sources:
-  - name: "products"
-    type: "csv"
-    path: "data/products.csv"
-    enable_cache: true          # Load into memory at startup
-    options:
-      has_header: true
+kind: context
+
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "products"
+      type: "csv"
+      path: "data/products.csv"
+      enable_cache: true          # Load into memory at startup
+      options:
+        has_header: true
 ```
 
 This is useful for datasets that are queried frequently and fit in memory. The cache is created once at startup and used for all subsequent queries.
@@ -125,21 +153,24 @@ This is useful for datasets that are queried frequently and fit in memory. The c
 A pipeline file defines a SQL query with parameter placeholders. Parameters are enclosed in `{braces}` and automatically extracted. Types and response schemas are inferred from the SQL and table schemas.
 
 ```yaml
+kind: pipeline
+
 metadata:
   name: product-search-demo
   version: 1.0.0
   description: "Product search and filtering"
 
-query: |
-  SELECT
-    "Name" as product_name,
-    "Brand" as brand,
-    "Price" as price
-  FROM products
-  WHERE ({brand} IS NULL OR "Brand" = {brand})
-    AND ({max_price} IS NULL OR "Price" < {max_price})
-  ORDER BY "Price" ASC
-  LIMIT {limit}
+spec:
+  query: |
+    SELECT
+      "Name" as product_name,
+      "Brand" as brand,
+      "Price" as price
+    FROM products
+    WHERE ({brand} IS NULL OR "Brand" = {brand})
+      AND ({max_price} IS NULL OR "Price" < {max_price})
+    ORDER BY "Price" ASC
+    LIMIT {limit}
 ```
 
 Execute with:

--- a/docs/sqlite/README.md
+++ b/docs/sqlite/README.md
@@ -259,12 +259,20 @@ is always `main`).
 
 ```yaml
 # docs/sqlite/ctx_sqlite_catalog_demo.yaml
-data_sources:
-  - name: "demo_catalog"
-    type: "sqlite"
-    hierarchy_level: "catalog"
-    path: "docs/sqlite/demo.db"
-    description: "Entire demo.db SQLite database registered as a DataFusion catalog"
+
+kind: context
+
+metadata:
+  name: example-context
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "demo_catalog"
+      type: "sqlite"
+      hierarchy_level: "catalog"
+      path: "docs/sqlite/demo.db"
+      description: "Entire demo.db SQLite database registered as a DataFusion catalog"
 ```
 
 ### Start the server

--- a/docs/sqlite/ctx_sqlite_catalog_demo.yaml
+++ b/docs/sqlite/ctx_sqlite_catalog_demo.yaml
@@ -1,13 +1,20 @@
-data_sources:
-  # Expose the entire demo.db SQLite database as a DataFusion catalog.
-  # Every non-system table and view is registered automatically.
-  # Query tables with the three-part reference: demo_catalog.main.<table>
-  - name: "demo_catalog"
-    type: "sqlite"
-    hierarchy_level: "catalog"
-    path: "docs/sqlite/demo.db"
-    description: "Entire demo.db SQLite database registered as a named DataFusion catalog"
-    # options:
-    #   Restrict to specific schemas (optional — SQLite schema is always "main"):
-    #   allowed_schemas: "main"
-    #   busy_timeout_ms: "5000"
+kind: context
+
+metadata:
+  name: ctx_sqlite_catalog_demo
+  version: 1.0.0
+
+spec:
+  data_sources:
+    # Expose the entire demo.db SQLite database as a DataFusion catalog.
+    # Every non-system table and view is registered automatically.
+    # Query tables with the three-part reference: demo_catalog.main.<table>
+    - name: "demo_catalog"
+      type: "sqlite"
+      hierarchy_level: "catalog"
+      path: "docs/sqlite/demo.db"
+      description: "Entire demo.db SQLite database registered as a named DataFusion catalog"
+      # options:
+      #   Restrict to specific schemas (optional — SQLite schema is always "main"):
+      #   allowed_schemas: "main"
+      #   busy_timeout_ms: "5000"

--- a/docs/sqlite/ctx_sqlite_demo.yaml
+++ b/docs/sqlite/ctx_sqlite_demo.yaml
@@ -1,31 +1,38 @@
-data_sources:
-  # SQLite data sources
-  - name: "users"
-    type: "sqlite"
-    access_mode: "read_write"
-    path: "docs/sqlite/demo.db"
-    description: "SQLite users table"
-    options:
-      table: "users"
+kind: context
 
-  - name: "orders"
-    type: "sqlite"
-    path: "docs/sqlite/demo.db"
-    description: "SQLite orders table"
-    options:
-      table: "orders"
+metadata:
+  name: ctx_sqlite_demo
+  version: 1.0.0
 
-  - name: "user_order_stats"
-    type: "sqlite"
-    access_mode: "read_write"
-    path: "docs/sqlite/demo.db"
-    description: "SQLite table for aggregated user order statistics"
-    options:
-      table: "user_order_stats"
+spec:
+  data_sources:
+    # SQLite data sources
+    - name: "users"
+      type: "sqlite"
+      access_mode: "read_write"
+      path: "docs/sqlite/demo.db"
+      description: "SQLite users table"
+      options:
+        table: "users"
 
-  # CSV data source (for federated query demo)
-  - name: "csv_orders"
-    type: "csv"
-    access_mode: "read_only"
-    path: "docs/sample_data/orders.csv"
-    description: "CSV file containing order data"
+    - name: "orders"
+      type: "sqlite"
+      path: "docs/sqlite/demo.db"
+      description: "SQLite orders table"
+      options:
+        table: "orders"
+
+    - name: "user_order_stats"
+      type: "sqlite"
+      access_mode: "read_write"
+      path: "docs/sqlite/demo.db"
+      description: "SQLite table for aggregated user order statistics"
+      options:
+        table: "user_order_stats"
+
+    # CSV data source (for federated query demo)
+    - name: "csv_orders"
+      type: "csv"
+      access_mode: "read_only"
+      path: "docs/sample_data/orders.csv"
+      description: "CSV file containing order data"

--- a/docs/sqlite/ctx_sqlite_fts_demo.yaml
+++ b/docs/sqlite/ctx_sqlite_fts_demo.yaml
@@ -1,8 +1,15 @@
-data_sources:
-  - name: "articles_fts"
-    type: "sqlite"
-    access_mode: "read_write"
-    path: "docs/sqlite/fts_demo.db"
-    description: "SQLite FTS5 virtual table for full-text search"
-    options:
-      table: "articles_fts"
+kind: context
+
+metadata:
+  name: ctx_sqlite_fts_demo
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "articles_fts"
+      type: "sqlite"
+      access_mode: "read_write"
+      path: "docs/sqlite/fts_demo.db"
+      description: "SQLite FTS5 virtual table for full-text search"
+      options:
+        table: "articles_fts"

--- a/docs/sqlite/ctx_sqlite_knn_demo.yaml
+++ b/docs/sqlite/ctx_sqlite_knn_demo.yaml
@@ -1,20 +1,27 @@
-data_sources:
-  - name: "vec_items"
-    type: "sqlite"
-    access_mode: "read_write"
-    path: "docs/sqlite/knn_demo.db"
-    description: "SQLite vec0 virtual table for vector similarity search"
-    options:
-      table: "vec_items"
-      # Path to the sqlite-vec shared library.
-      # Find it with: python -c "import sqlite_vec; print(sqlite_vec.loadable_path())"
-      extensions_env: "VEC0_PATH"
+kind: context
 
-  - name: "items"
-    type: "sqlite"
-    access_mode: "read_write"
-    path: "docs/sqlite/knn_demo.db"
-    description: "SQLite data table with item metadata"
-    options:
-      table: "items"
-      extensions_env: "VEC0_PATH"
+metadata:
+  name: ctx_sqlite_knn_demo
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "vec_items"
+      type: "sqlite"
+      access_mode: "read_write"
+      path: "docs/sqlite/knn_demo.db"
+      description: "SQLite vec0 virtual table for vector similarity search"
+      options:
+        table: "vec_items"
+        # Path to the sqlite-vec shared library.
+        # Find it with: python -c "import sqlite_vec; print(sqlite_vec.loadable_path())"
+        extensions_env: "VEC0_PATH"
+
+    - name: "items"
+      type: "sqlite"
+      access_mode: "read_write"
+      path: "docs/sqlite/knn_demo.db"
+      description: "SQLite data table with item metadata"
+      options:
+        table: "items"
+        extensions_env: "VEC0_PATH"

--- a/docs/sqlite/pipelines/catalog_demo/cross_table_join.yaml
+++ b/docs/sqlite/pipelines/catalog_demo/cross_table_join.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "sqlite-catalog-cross-table-join"
   version: "1.0.0"
@@ -9,13 +11,14 @@ metadata:
 # Parameters:
 #   {limit} - Maximum number of rows to return
 
-query: |
-  SELECT
-    u.name      AS user_name,
-    u.email     AS user_email,
-    o.product,
-    o.amount
-  FROM demo_catalog.main.users  u
-  INNER JOIN demo_catalog.main.orders o ON u.id = o.user_id
-  ORDER BY o.id
-  LIMIT {limit}
+spec:
+  query: |
+    SELECT
+      u.name      AS user_name,
+      u.email     AS user_email,
+      o.product,
+      o.amount
+    FROM demo_catalog.main.users  u
+    INNER JOIN demo_catalog.main.orders o ON u.id = o.user_id
+    ORDER BY o.id
+    LIMIT {limit}

--- a/docs/sqlite/pipelines/catalog_demo/list_users.yaml
+++ b/docs/sqlite/pipelines/catalog_demo/list_users.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "sqlite-catalog-list-users"
   version: "1.0.0"
@@ -8,8 +10,9 @@ metadata:
 # Parameters:
 #   {limit} - Maximum number of rows to return
 
-query: |
-  SELECT id, name, email
-  FROM demo_catalog.main.users
-  ORDER BY id
-  LIMIT {limit}
+spec:
+  query: |
+    SELECT id, name, email
+    FROM demo_catalog.main.users
+    ORDER BY id
+    LIMIT {limit}

--- a/docs/sqlite/pipelines/catalog_demo/user_order_summary.yaml
+++ b/docs/sqlite/pipelines/catalog_demo/user_order_summary.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "sqlite-catalog-user-order-summary"
   version: "1.0.0"
@@ -8,13 +10,14 @@ metadata:
 # Parameters:
 #   {min_orders} - Only return users with at least this many orders
 
-query: |
-  SELECT
-    u.name                  AS user_name,
-    COUNT(o.id)             AS total_orders,
-    SUM(o.amount)           AS total_spent
-  FROM demo_catalog.main.users  u
-  INNER JOIN demo_catalog.main.orders o ON u.id = o.user_id
-  GROUP BY u.id, u.name
-  HAVING COUNT(o.id) >= {min_orders}
-  ORDER BY total_spent DESC
+spec:
+  query: |
+    SELECT
+      u.name                  AS user_name,
+      COUNT(o.id)             AS total_orders,
+      SUM(o.amount)           AS total_spent
+    FROM demo_catalog.main.users  u
+    INNER JOIN demo_catalog.main.orders o ON u.id = o.user_id
+    GROUP BY u.id, u.name
+    HAVING COUNT(o.id) >= {min_orders}
+    ORDER BY total_spent DESC

--- a/docs/sqlite/pipelines/delete_user.yaml
+++ b/docs/sqlite/pipelines/delete_user.yaml
@@ -1,7 +1,10 @@
+kind: pipeline
+
 metadata:
   name: "delete_user"
   version: "1.0"
   description: "Delete a user from the SQLite users table by name"
 
-query: |
-  DELETE FROM users WHERE name = {name}
+spec:
+  query: |
+    DELETE FROM users WHERE name = {name}

--- a/docs/sqlite/pipelines/federated_join_and_insert.yaml
+++ b/docs/sqlite/pipelines/federated_join_and_insert.yaml
@@ -1,18 +1,21 @@
+kind: pipeline
+
 metadata:
   name: "federated_join_and_insert"
   version: "1.0"
   description: "Join CSV orders with SQLite users (filtered by name) and write aggregated results to SQLite"
 
-query: |
-  INSERT INTO user_order_stats (user_id, user_name, user_email, total_orders, total_spent, last_order_date)
-  SELECT
-    u.id as user_id,
-    u.name as user_name,
-    u.email as user_email,
-    COUNT(o.order_id) as total_orders,
-    SUM(o.amount) as total_spent,
-    MAX(o.order_date) as last_order_date
-  FROM users u
-  INNER JOIN csv_orders o ON u.id = o.user_id
-  WHERE u.name = {name}
-  GROUP BY u.id, u.name, u.email
+spec:
+  query: |
+    INSERT INTO user_order_stats (user_id, user_name, user_email, total_orders, total_spent, last_order_date)
+    SELECT
+      u.id as user_id,
+      u.name as user_name,
+      u.email as user_email,
+      COUNT(o.order_id) as total_orders,
+      SUM(o.amount) as total_spent,
+      MAX(o.order_date) as last_order_date
+    FROM users u
+    INNER JOIN csv_orders o ON u.id = o.user_id
+    WHERE u.name = {name}
+    GROUP BY u.id, u.name, u.email

--- a/docs/sqlite/pipelines/fts_demo/fts_delete_article.yaml
+++ b/docs/sqlite/pipelines/fts_demo/fts_delete_article.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "sqlite-fts-delete-article"
   version: "1.0.0"
@@ -8,5 +10,6 @@ metadata:
 # Parameters:
 #   {title} - Title of the article to delete
 
-query: |
-  DELETE FROM articles_fts WHERE title = {title}
+spec:
+  query: |
+    DELETE FROM articles_fts WHERE title = {title}

--- a/docs/sqlite/pipelines/fts_demo/fts_insert_article.yaml
+++ b/docs/sqlite/pipelines/fts_demo/fts_insert_article.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "sqlite-fts-insert-article"
   version: "1.0.0"
@@ -10,6 +12,7 @@ metadata:
 #   {body}     - Article body text (indexed for full-text search)
 #   {category} - Article category
 
-query: |
-  INSERT INTO articles_fts (title, body, category)
-  VALUES ({title}, {body}, {category})
+spec:
+  query: |
+    INSERT INTO articles_fts (title, body, category)
+    VALUES ({title}, {body}, {category})

--- a/docs/sqlite/pipelines/fts_demo/fts_search.yaml
+++ b/docs/sqlite/pipelines/fts_demo/fts_search.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "sqlite-fts-search"
   version: "1.0.0"
@@ -9,7 +11,8 @@ metadata:
 #   {query} - Search terms (space-separated, "quoted" for phrase, NOT for negation)
 #   {limit} - Maximum number of results to return
 
-query: |
-  SELECT title, body, category, _score
-  FROM sqlite_fts('articles_fts', 'body', {query}, {limit})
-  ORDER BY _score DESC
+spec:
+  query: |
+    SELECT title, body, category, _score
+    FROM sqlite_fts('articles_fts', 'body', {query}, {limit})
+    ORDER BY _score DESC

--- a/docs/sqlite/pipelines/fts_demo/fts_search_with_filter.yaml
+++ b/docs/sqlite/pipelines/fts_demo/fts_search_with_filter.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "sqlite-fts-search-with-filter"
   version: "1.0.0"
@@ -10,8 +12,9 @@ metadata:
 #   {category} - Category to filter by
 #   {limit}    - Maximum number of results to return
 
-query: |
-  SELECT title, body, category, _score
-  FROM sqlite_fts('articles_fts', 'body', {query}, {limit})
-  WHERE category = {category}
-  ORDER BY _score DESC
+spec:
+  query: |
+    SELECT title, body, category, _score
+    FROM sqlite_fts('articles_fts', 'body', {query}, {limit})
+    WHERE category = {category}
+    ORDER BY _score DESC

--- a/docs/sqlite/pipelines/insert_user.yaml
+++ b/docs/sqlite/pipelines/insert_user.yaml
@@ -1,6 +1,9 @@
+kind: pipeline
+
 metadata:
   name: "insert_user"
   version: "1.0"
   description: "Insert a new user"
 
-query: "INSERT INTO users (name, email) VALUES ({name}, {email})"
+spec:
+  query: "INSERT INTO users (name, email) VALUES ({name}, {email})"

--- a/docs/sqlite/pipelines/knn_demo/knn_delete_item.yaml
+++ b/docs/sqlite/pipelines/knn_demo/knn_delete_item.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "sqlite-knn-delete-item"
   version: "1.0.0"
@@ -8,5 +10,6 @@ metadata:
 # Parameters:
 #   {id} - Item ID to delete
 
-query: |
-  DELETE FROM items WHERE id = {id}
+spec:
+  query: |
+    DELETE FROM items WHERE id = {id}

--- a/docs/sqlite/pipelines/knn_demo/knn_delete_vector.yaml
+++ b/docs/sqlite/pipelines/knn_demo/knn_delete_vector.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "sqlite-knn-delete-vector"
   version: "1.0.0"
@@ -8,5 +10,6 @@ metadata:
 # Parameters:
 #   {id} - Item ID whose vector to delete
 
-query: |
-  DELETE FROM vec_items WHERE item_id = {id}
+spec:
+  query: |
+    DELETE FROM vec_items WHERE item_id = {id}

--- a/docs/sqlite/pipelines/knn_demo/knn_insert_item.yaml
+++ b/docs/sqlite/pipelines/knn_demo/knn_insert_item.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "sqlite-knn-insert-item"
   version: "1.0.0"
@@ -10,6 +12,7 @@ metadata:
 #   {name}     - Item name
 #   {category} - Item category
 
-query: |
-  INSERT INTO items (id, name, category)
-  VALUES ({id}, {name}, {category})
+spec:
+  query: |
+    INSERT INTO items (id, name, category)
+    VALUES ({id}, {name}, {category})

--- a/docs/sqlite/pipelines/knn_demo/knn_insert_vector.yaml
+++ b/docs/sqlite/pipelines/knn_demo/knn_insert_vector.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "sqlite-knn-insert-vector"
   version: "1.0.0"
@@ -12,6 +14,7 @@ metadata:
 
 # Requires: --features candle
 
-query: |
-  INSERT INTO vec_items (item_id, embedding)
-  SELECT {id}, vec_to_binary(candle('models/generated/bge-small-en-v1.5', {text}))
+spec:
+  query: |
+    INSERT INTO vec_items (item_id, embedding)
+    SELECT {id}, vec_to_binary(candle('models/generated/bge-small-en-v1.5', {text}))

--- a/docs/sqlite/pipelines/knn_demo/knn_search.yaml
+++ b/docs/sqlite/pipelines/knn_demo/knn_search.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "sqlite-knn-search"
   version: "1.0.0"
@@ -14,11 +16,12 @@ metadata:
 # Requires: --features candle
 # Model: BAAI/bge-small-en-v1.5 (384 dims) — download with setup.py
 
-query: |
-  SELECT item_id, _score
-  FROM sqlite_knn(
-    'vec_items',
-    'embedding',
-    candle('models/generated/bge-small-en-v1.5', {query}),
-    {k}
-  )
+spec:
+  query: |
+    SELECT item_id, _score
+    FROM sqlite_knn(
+      'vec_items',
+      'embedding',
+      candle('models/generated/bge-small-en-v1.5', {query}),
+      {k}
+    )

--- a/docs/sqlite/pipelines/knn_demo/knn_search_by_seed.yaml
+++ b/docs/sqlite/pipelines/knn_demo/knn_search_by_seed.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "sqlite-knn-search-by-seed"
   version: "1.0.0"
@@ -10,13 +12,14 @@ metadata:
 #   {seed_id} - ID of the item whose embedding is used as the query vector
 #   {k}       - Number of nearest neighbours to return
 
-query: |
-  SELECT i.id, i.name, i.category, knn._score
-  FROM sqlite_knn(
-    'vec_items',
-    'embedding',
-    (SELECT embedding FROM vec_items WHERE item_id = {seed_id}),
-    {k}
-  ) knn
-  JOIN items i ON i.id = knn.item_id
-  ORDER BY knn._score
+spec:
+  query: |
+    SELECT i.id, i.name, i.category, knn._score
+    FROM sqlite_knn(
+      'vec_items',
+      'embedding',
+      (SELECT embedding FROM vec_items WHERE item_id = {seed_id}),
+      {k}
+    ) knn
+    JOIN items i ON i.id = knn.item_id
+    ORDER BY knn._score

--- a/docs/sqlite/pipelines/knn_demo/knn_search_with_join.yaml
+++ b/docs/sqlite/pipelines/knn_demo/knn_search_with_join.yaml
@@ -1,3 +1,5 @@
+kind: pipeline
+
 metadata:
   name: "sqlite-knn-search-with-join"
   version: "1.0.0"
@@ -12,13 +14,14 @@ metadata:
 
 # Requires: --features candle
 
-query: |
-  SELECT i.id, i.name, i.category, knn._score
-  FROM sqlite_knn(
-    'vec_items',
-    'embedding',
-    candle('models/generated/bge-small-en-v1.5', {query}),
-    {k}
-  ) knn
-  JOIN items i ON i.id = knn.item_id
-  ORDER BY knn._score
+spec:
+  query: |
+    SELECT i.id, i.name, i.category, knn._score
+    FROM sqlite_knn(
+      'vec_items',
+      'embedding',
+      candle('models/generated/bge-small-en-v1.5', {query}),
+      {k}
+    ) knn
+    JOIN items i ON i.id = knn.item_id
+    ORDER BY knn._score

--- a/docs/sqlite/pipelines/query_user_by_id.yaml
+++ b/docs/sqlite/pipelines/query_user_by_id.yaml
@@ -1,6 +1,9 @@
+kind: pipeline
+
 metadata:
   name: "query_user_by_id"
   version: "1.0"
   description: "Query a specific user by ID"
 
-query: "SELECT id, name, email FROM users WHERE id = {user_id}"
+spec:
+  query: "SELECT id, name, email FROM users WHERE id = {user_id}"

--- a/docs/sqlite/pipelines/update_user_email.yaml
+++ b/docs/sqlite/pipelines/update_user_email.yaml
@@ -1,7 +1,10 @@
+kind: pipeline
+
 metadata:
   name: "update_user_email"
   version: "1.0"
   description: "Update a user's email address by name"
 
-query: |
-  UPDATE users SET email = {new_email} WHERE name = {name}
+spec:
+  query: |
+    UPDATE users SET email = {new_email} WHERE name = {name}


### PR DESCRIPTION
## Summary
- Every resource YAML (pipeline, job, context, aliases) now carries a `kind:` discriminator, a `metadata:` block, and a `spec:` body. Loaders enforce the kind strictly — no backcompat shim.
- Migrated all 138 bundled YAMLs under `docs/` and `demo/`, plus ~38 YAML code blocks across the markdown docs. Comment-preserving text migration was done via a one-off script (not committed).
- Added integration tests for the pipeline side to match the existing jobs coverage: `pipelines_http.rs` (8 tests through the full axum router) and `pipelines_e2e.rs` (5 tests through `StandardPipeline::load_from_file` into DataFusion).

Shapes:
```yaml
kind: pipeline
metadata: { name, version, description }
spec:
  query: |
    SELECT ...
```
```yaml
kind: job
metadata: { ... }
spec:
  query: | ...
  destination: { table, mode, create_if_missing }
  execution: { timeout_ms }
```
```yaml
kind: context
metadata: { ... }
spec:
  data_sources: [...]
```
```yaml
kind: aliases
metadata: { ... }
spec:
  grep: { pipeline: ..., positional: [query], defaults: {...} }
```

## Test plan
- [x] `cargo test --workspace --tests --bins` — 577 passing, 0 failing
- [x] `cargo test -p skardi-server --test pipelines_http` — 8/8
- [x] `cargo test -p skardi-server --test pipelines_e2e` — 5/5
- [x] `cargo test -p skardi-cli --bin skardi` — 41/41 (alias roundtrip + demo-alias regression)
- [x] End-to-end smoke test: `skardi alias show grep --ctx demo/llm_wiki/cli/ctx.yaml` against the migrated ctx + aliases + pipelines works

🤖 Generated with [Claude Code](https://claude.com/claude-code)