### PR TITLE
chore(cli): remove dead `load_pipeline_from_path`

### DIFF
--- a/crates/cli/src/pipeline.rs
+++ b/crates/cli/src/pipeline.rs
@@ -47,22 +47,8 @@ pub struct PipelineFile {
     pub query: String,
 }
 
-/// Load a single pipeline YAML from disk.
-///
-/// Returns an error if the file is not a `kind: pipeline` document —
-/// `kind: job` files have their own loader path (`JobDefinition`), and
-/// any other kind is unsupported here.
-pub fn load_pipeline_from_path(path: &Path) -> Result<PipelineFile> {
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Failed to read pipeline file: {}", path.display()))?;
-    let value: serde_yaml::Value = serde_yaml::from_str(&content)
-        .with_context(|| format!("Failed to parse pipeline YAML: {}", path.display()))?;
-    pipeline_from_value(path, value)
-}
-
 /// Build a `PipelineFile` from an already-parsed YAML root, enforcing the
-/// `kind: pipeline` discriminator. Shared between the single-file loader
-/// and directory discovery so each file is read and parsed only once.
+/// `kind: pipeline` discriminator.
 fn pipeline_from_value(path: &Path, value: serde_yaml::Value) -> Result<PipelineFile> {
     let env: PipelineEnvelope = serde_yaml::from_value(value)
         .with_context(|| format!("Failed to parse pipeline YAML: {}", path.display()))?;


### PR DESCRIPTION
## Summary
- Removes the orphaned `load_pipeline_from_path` function in [crates/cli/src/pipeline.rs](crates/cli/src/pipeline.rs), which became dead code in the envelope refactor (#103) when `discover_pipelines` was rewritten to read + parse YAML inline and call `pipeline_from_value` directly.
- The CLI is a binary crate, so `pub` did not expose it to external consumers — nothing reachable was calling it. Clears the `dead_code` CI warning.
- Also trims the now-stale "shared between the single-file loader and directory discovery" sentence on `pipeline_from_value`'s docstring, since there is only one caller now.

## Test plan
- [x] `cargo check -p skardi-cli` — clean, no warnings
- [ ] CI passes (the original `dead_code` warning should no longer appear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)