### PR TITLE
feat(server): add `kind: semantics` catalog overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Full reference:
 - **Server** — [docs/server.md](docs/server.md)
 - **Pipelines (online serving)** — [docs/pipelines.md](docs/pipelines.md)
 - **Jobs (offline batch)** — [docs/jobs.md](docs/jobs.md)
+- **Catalog semantics** — [docs/semantics.md](docs/semantics.md)
 - **Spark for Agents narrative** — [docs/spark_for_agents.md](docs/spark_for_agents.md)
 
 ---
@@ -167,6 +168,7 @@ The **[`auto_knowledge_base` skill](https://github.com/SkardiLabs/skardi-skills/
 ## Additional Features
 
 - **Federated queries** — JOIN across different source types. See [docs/federated-queries.md](docs/federated-queries.md).
+- **Catalog semantics** — NL descriptions on tables and columns, surfaced on the catalog endpoint so agents can pick the right tool from `GET /data_source`. See [docs/semantics.md](docs/semantics.md).
 - **Authentication** — session-based via better-auth + SQLite. See [docs/auth/](docs/auth/).
 - **ONNX inference** — inline model predictions in SQL. See [docs/onnx_predict.md](docs/onnx_predict.md).
 - **Embedding inference** — GGUF, Candle, or remote APIs. See [docs/embeddings/](docs/embeddings/).
@@ -277,7 +279,8 @@ We're **building in public**. `[x]` means shipped today, `[ ]` means open for co
    - [ ] MCP binding — same pipeline YAML projected to MCP tools for non-Claude hosts
 
 `6` Governance & lineage
-   - [ ] Catalog with semantics — NL `description` on catalog / table / column; an agent-callable `describe` pipeline
+   - [x] Catalog with semantics — `kind: semantics` YAML overlay attaching NL descriptions to tables / columns; surfaced on `GET /data_source` for agent-side discovery
+   - [ ] Agent-callable `describe` verb — CLI / pipeline form on top of the catalog endpoint
    - [ ] Lineage capture — `agent_id`, `session_id`, `tool_call_id`, `timestamp` on writes; queryable from metadata tables
    - [ ] Agent identity passthrough — any binding injects client identity into a SQL context var pipelines can read
    - [ ] Snapshot-as-branch / agent checkpoints — Iceberg / Lance-backed; `git checkout`-like semantics for destructive agent experiments

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ We're **building in public**. `[x]` means shipped today, `[ ]` means open for co
    - [ ] MCP binding — same pipeline YAML projected to MCP tools for non-Claude hosts
 
 `6` Governance & lineage
-   - [x] Catalog with semantics — `kind: semantics` YAML overlay attaching NL descriptions to tables / columns; surfaced on `GET /data_source` for agent-side discovery
+   - [x] Catalog with semantics — `kind: semantics` YAML overlay attaching NL descriptions to tables / columns; supports both bare source names and fully-qualified `catalog.schema.table` paths for per-table targeting on catalog-mode sources; surfaced on `GET /data_source` for agent-side discovery
    - [ ] Agent-callable `describe` verb — CLI / pipeline form on top of the catalog endpoint
    - [ ] Lineage capture — `agent_id`, `session_id`, `tool_call_id`, `timestamp` on writes; queryable from metadata tables
    - [ ] Agent identity passthrough — any binding injects client identity into a SQL context var pipelines can read

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -35,6 +35,7 @@ use skardi::model::GgufModelRegistry;
 use skardi::model::OnnxModelRegistry;
 #[cfg(feature = "remote-embed")]
 use skardi::model::RemoteEmbedRegistry;
+use skardi::semantics::{SemanticsRegistry, resolve_semantics_source};
 use skardi::sources::HierarchyLevel;
 use skardi::sources::providers::lance::fts_table_function::register_lance_fts_udtf;
 use skardi::sources::providers::lance::knn_table_function::register_lance_knn_udtf;
@@ -52,8 +53,9 @@ use skardi::sources::providers::{
     },
     sqlx::postgres::register_postgres_tables,
 };
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 use url::Url;
@@ -90,6 +92,13 @@ enum Commands {
         /// Path to .sql file to execute (takes precedence over --sql)
         #[arg(short = 'f', long = "file")]
         file: Option<PathBuf>,
+        /// Path to a `kind: semantics` YAML file or directory of them, used by
+        /// `--schema` to render natural-language descriptions next to tables
+        /// and columns. When omitted, the CLI auto-discovers
+        /// `<ctx_dir>/semantics/` (directory) or `<ctx_dir>/semantics.yaml`
+        /// (single file).
+        #[arg(long = "semantics", value_name = "FILE-OR-DIR")]
+        semantics: Option<PathBuf>,
     },
     /// Execute a pipeline YAML by name with named parameters
     #[command(name = "run")]
@@ -220,6 +229,11 @@ struct LocalDataSource {
     /// "read" (default) or "read_write". Currently honored by the SQLite source.
     #[serde(default)]
     access_mode: Option<String>,
+    /// Optional natural-language description of the table this source
+    /// exposes. Used as a fallback by `--schema` when no `kind: semantics`
+    /// overlay supplies one.
+    #[serde(default)]
+    description: Option<String>,
 }
 
 impl LocalDataSource {
@@ -548,6 +562,7 @@ async fn main() -> Result<()> {
             table,
             sql,
             file,
+            semantics,
         } => {
             if schema {
                 if all && table.is_some() {
@@ -559,7 +574,8 @@ async fn main() -> Result<()> {
                 let ctx_path = resolve_ctx_path(ctx.as_deref())
                     .ok_or_else(|| anyhow::anyhow!("Could not resolve a ctx path (no --ctx, no SKARDICONFIG, no home directory)"))?;
                 let table_filter = if all { None } else { table.as_deref() };
-                show_schema(&ctx_path, table_filter).await
+                let mut stdout = std::io::stdout().lock();
+                show_schema(&ctx_path, semantics.as_deref(), table_filter, &mut stdout).await
             } else {
                 let sql_content = if let Some(path) = &file {
                     std::fs::read_to_string(path)
@@ -1098,9 +1114,34 @@ fn available_list(all: &[TableEntry], defaults: &CatalogDefaults) -> String {
         .join(", ")
 }
 
-async fn show_schema(ctx_path: &Path, table_filter: Option<&str>) -> Result<()> {
+async fn show_schema(
+    ctx_path: &Path,
+    semantics_override: Option<&Path>,
+    table_filter: Option<&str>,
+    out: &mut dyn Write,
+) -> Result<()> {
     let (mut session_ctx, dataset_registry) = new_session_context();
-    load_and_register_all(ctx_path, &mut session_ctx, &dataset_registry).await?;
+    let config = load_and_register_all(ctx_path, &mut session_ctx, &dataset_registry).await?;
+
+    // Build the semantics registry from the same inputs the server uses:
+    //   - the ctx-inline `description` field on each data source (fallback), and
+    //   - either an explicit --semantics path or whatever auto-discovery finds
+    //     next to the ctx (`semantics/` dir or `semantics.yaml` file).
+    let ctx_dir = ctx_path.parent();
+    let semantics_path = resolve_semantics_source(ctx_dir, semantics_override)
+        .with_context(|| "Failed to resolve semantics source")?;
+    let ctx_descriptions: Vec<(String, Option<String>)> = config
+        .data_sources
+        .iter()
+        .map(|ds| (ds.name.clone(), ds.description.clone()))
+        .collect();
+    let semantics = SemanticsRegistry::build(semantics_path.as_deref(), &ctx_descriptions)
+        .with_context(|| "Failed to load semantics")?;
+    let source_names: HashSet<String> = config
+        .data_sources
+        .iter()
+        .map(|ds| ds.name.clone())
+        .collect();
 
     let defaults = CatalogDefaults::from_ctx(&session_ctx);
     let all_tables = enumerate_tables(&session_ctx);
@@ -1110,7 +1151,7 @@ async fn show_schema(ctx_path: &Path, table_filter: Option<&str>) -> Result<()> 
     };
 
     if selected.is_empty() {
-        println!("No tables registered.");
+        writeln!(out, "No tables registered.")?;
         return Ok(());
     }
 
@@ -1136,13 +1177,61 @@ async fn show_schema(ctx_path: &Path, table_filter: Option<&str>) -> Result<()> 
                 )
             })?;
         let table_schema = provider.schema();
-        println!("table: {}", entry.display_name(&defaults));
-        for field in table_schema.fields() {
-            println!("  {}: {:?}", field.name(), field.data_type());
+        let source_name = source_name_for(entry, &defaults, &source_names);
+
+        let table_desc = source_name.and_then(|name| semantics.table_description(name));
+        match table_desc {
+            Some(desc) => writeln!(out, "table: {}  -- {}", entry.display_name(&defaults), desc)?,
+            None => writeln!(out, "table: {}", entry.display_name(&defaults))?,
         }
-        println!();
+
+        for field in table_schema.fields() {
+            let col_desc =
+                source_name.and_then(|name| semantics.column_description(name, field.name()));
+            match col_desc {
+                Some(desc) => writeln!(
+                    out,
+                    "  {}: {:?}  -- {}",
+                    field.name(),
+                    field.data_type(),
+                    desc
+                )?,
+                None => writeln!(out, "  {}: {:?}", field.name(), field.data_type())?,
+            }
+        }
+        writeln!(out)?;
     }
     Ok(())
+}
+
+/// Resolve a DataFusion `(catalog, schema, table)` triple back to the ctx
+/// `data_sources[].name` it came from, so we can look up the right
+/// semantics overlay entry.
+///
+/// - **Table-mode** sources register in the session's default
+///   `(catalog, schema)` under `source.name`. So if the entry sits in the
+///   defaults and `entry.table` is a known source name, that's it.
+/// - **Catalog-mode** sources (SQLite, etc.) register the *catalog* under
+///   `source.name`, with the underlying provider supplying inner schemas
+///   and tables. So if `entry.catalog` is a known source name, the source
+///   description applies to every inner table.
+/// - Anything else (ad-hoc URL-registered tables, `information_schema`)
+///   has no source-level description; return `None`.
+///
+/// Per-inner-table semantics for catalog-mode sources is a deferred
+/// feature — see `docs/semantics.md`.
+fn source_name_for<'a>(
+    entry: &TableEntry,
+    defaults: &CatalogDefaults,
+    source_names: &'a HashSet<String>,
+) -> Option<&'a str> {
+    if entry.catalog == defaults.catalog
+        && entry.schema == defaults.schema
+        && source_names.contains(&entry.table)
+    {
+        return source_names.get(&entry.table).map(String::as_str);
+    }
+    source_names.get(&entry.catalog).map(String::as_str)
 }
 
 /// Execute a SQL query. If a context file is provided (or found via defaults), register its
@@ -1515,8 +1604,7 @@ fn validate_alias_against_pipeline(
     positional: &[String],
     defaults: &BTreeMap<String, String>,
 ) -> Result<()> {
-    let known: std::collections::HashSet<&str> =
-        pipeline_params.iter().map(|s| s.as_str()).collect();
+    let known: HashSet<&str> = pipeline_params.iter().map(|s| s.as_str()).collect();
     for p in positional {
         if !known.contains(p.as_str()) {
             anyhow::bail!(
@@ -1544,10 +1632,8 @@ fn report_alias_coverage(
     positional: &[String],
     defaults: &BTreeMap<String, String>,
 ) {
-    let positional_set: std::collections::HashSet<&str> =
-        positional.iter().map(|s| s.as_str()).collect();
-    let default_set: std::collections::HashSet<&str> =
-        defaults.keys().map(|s| s.as_str()).collect();
+    let positional_set: HashSet<&str> = positional.iter().map(|s| s.as_str()).collect();
+    let default_set: HashSet<&str> = defaults.keys().map(|s| s.as_str()).collect();
     let unbound: Vec<&str> = pipeline_params
         .iter()
         .map(|s| s.as_str())
@@ -1732,6 +1818,7 @@ mod tests {
         CatalogProvider, MemoryCatalogProvider, MemorySchemaProvider, SchemaProvider,
     };
     use datafusion::datasource::MemTable;
+    use tempfile::TempDir;
 
     fn entry(catalog: &str, schema: &str, table: &str) -> TableEntry {
         TableEntry {
@@ -1942,6 +2029,318 @@ mod tests {
             got,
             vec![entry("wiki", "main", "wiki_pages")],
             "system schemas should be filtered out"
+        );
+    }
+
+    // ---------- semantics rendering ----------
+
+    fn source_set(names: &[&str]) -> HashSet<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn source_name_for_table_mode_resolves_via_default_catalog() {
+        let names = source_set(&["products", "events"]);
+        let got = source_name_for(
+            &entry("datafusion", "public", "products"),
+            &df_defaults(),
+            &names,
+        );
+        assert_eq!(got, Some("products"));
+    }
+
+    #[test]
+    fn source_name_for_catalog_mode_resolves_via_catalog_name() {
+        // SQLite-style: source.name == catalog name; inner schema/table come
+        // from the underlying provider.
+        let names = source_set(&["wiki"]);
+        let got = source_name_for(&entry("wiki", "main", "wiki_pages"), &df_defaults(), &names);
+        assert_eq!(got, Some("wiki"));
+    }
+
+    #[test]
+    fn source_name_for_returns_none_for_unknown_source() {
+        let names = source_set(&["products"]);
+        let got = source_name_for(
+            &entry("datafusion", "public", "ad_hoc_csv_url"),
+            &df_defaults(),
+            &names,
+        );
+        assert_eq!(got, None);
+    }
+
+    #[tokio::test]
+    async fn show_schema_renders_descriptions_via_auto_discovered_semantics_yaml() {
+        // Full pipeline: ctx + auto-discovered semantics.yaml next to it.
+        // No --semantics flag passed; the resolver should pick up the file
+        // by convention.
+        let tmp = TempDir::new().unwrap();
+
+        let csv_path = tmp.path().join("products.csv");
+        std::fs::write(&csv_path, "id,price\n1,9.99\n2,19.50\n").unwrap();
+
+        let ctx_path = tmp.path().join("ctx.yaml");
+        std::fs::write(
+            &ctx_path,
+            format!(
+                r#"kind: context
+metadata:
+  name: t
+  version: 1.0.0
+spec:
+  data_sources:
+    - name: products
+      type: csv
+      path: {}
+      options:
+        has_header: "true"
+      description: "Ctx-inline fallback"
+"#,
+                csv_path.display()
+            ),
+        )
+        .unwrap();
+
+        // Auto-discovered: semantics.yaml sits next to ctx.yaml. Description
+        // here should *override* the ctx-inline one.
+        std::fs::write(
+            tmp.path().join("semantics.yaml"),
+            r#"kind: semantics
+metadata: { name: t }
+spec:
+  sources:
+    - name: products
+      description: "Catalog of products"
+      columns:
+        - name: id
+          description: "Stable internal SKU"
+        - name: price
+          description: "Retail price in USD"
+"#,
+        )
+        .unwrap();
+
+        let mut out: Vec<u8> = Vec::new();
+        show_schema(&ctx_path, None, None, &mut out).await.unwrap();
+        let rendered = String::from_utf8(out).unwrap();
+
+        assert!(
+            rendered.contains("table: products  -- Catalog of products"),
+            "table-level overlay should win over ctx-inline. Got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("id: Int64  -- Stable internal SKU"),
+            "column overlay missing. Got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("price: Float64  -- Retail price in USD"),
+            "column overlay missing. Got:\n{rendered}"
+        );
+        // The ctx-inline description must not leak through once the file overrides it.
+        assert!(
+            !rendered.contains("Ctx-inline fallback"),
+            "ctx-inline description should have been overridden. Got:\n{rendered}"
+        );
+    }
+
+    #[tokio::test]
+    async fn show_schema_falls_back_to_ctx_inline_when_no_semantics_file() {
+        let tmp = TempDir::new().unwrap();
+
+        let csv_path = tmp.path().join("products.csv");
+        std::fs::write(&csv_path, "id\n1\n").unwrap();
+
+        let ctx_path = tmp.path().join("ctx.yaml");
+        std::fs::write(
+            &ctx_path,
+            format!(
+                r#"kind: context
+metadata: {{ name: t, version: 1.0.0 }}
+spec:
+  data_sources:
+    - name: products
+      type: csv
+      path: {}
+      options:
+        has_header: "true"
+      description: "From ctx"
+"#,
+                csv_path.display()
+            ),
+        )
+        .unwrap();
+
+        let mut out: Vec<u8> = Vec::new();
+        show_schema(&ctx_path, None, None, &mut out).await.unwrap();
+        let rendered = String::from_utf8(out).unwrap();
+
+        assert!(
+            rendered.contains("table: products  -- From ctx"),
+            "ctx-inline description should render when no semantics file present. Got:\n{rendered}"
+        );
+        // No column overlays defined → columns should render bare.
+        assert!(
+            rendered.contains("\n  id: Int64\n"),
+            "column with no overlay should render bare. Got:\n{rendered}"
+        );
+    }
+
+    #[tokio::test]
+    async fn show_schema_renders_bare_when_no_descriptions_anywhere() {
+        // No semantics file, no ctx-inline description → byte-for-byte the
+        // same shape as before semantics existed.
+        let tmp = TempDir::new().unwrap();
+
+        let csv_path = tmp.path().join("products.csv");
+        std::fs::write(&csv_path, "id\n1\n").unwrap();
+
+        let ctx_path = tmp.path().join("ctx.yaml");
+        std::fs::write(
+            &ctx_path,
+            format!(
+                r#"kind: context
+metadata: {{ name: t, version: 1.0.0 }}
+spec:
+  data_sources:
+    - name: products
+      type: csv
+      path: {}
+      options:
+        has_header: "true"
+"#,
+                csv_path.display()
+            ),
+        )
+        .unwrap();
+
+        let mut out: Vec<u8> = Vec::new();
+        show_schema(&ctx_path, None, None, &mut out).await.unwrap();
+        let rendered = String::from_utf8(out).unwrap();
+
+        assert!(
+            rendered.contains("table: products\n"),
+            "no description means no `--` suffix on the table line. Got:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains(" -- "),
+            "no `--` separators anywhere when nothing supplies descriptions. Got:\n{rendered}"
+        );
+    }
+
+    #[tokio::test]
+    async fn show_schema_explicit_semantics_path_overrides_auto_discovery() {
+        let tmp = TempDir::new().unwrap();
+
+        let csv_path = tmp.path().join("products.csv");
+        std::fs::write(&csv_path, "id\n1\n").unwrap();
+
+        let ctx_path = tmp.path().join("ctx.yaml");
+        std::fs::write(
+            &ctx_path,
+            format!(
+                r#"kind: context
+metadata: {{ name: t, version: 1.0.0 }}
+spec:
+  data_sources:
+    - name: products
+      type: csv
+      path: {}
+      options:
+        has_header: "true"
+"#,
+                csv_path.display()
+            ),
+        )
+        .unwrap();
+
+        // The auto-discovered file says "AUTO".
+        std::fs::write(
+            tmp.path().join("semantics.yaml"),
+            r#"kind: semantics
+metadata: { name: auto }
+spec:
+  sources:
+    - name: products
+      description: "AUTO"
+"#,
+        )
+        .unwrap();
+
+        // The explicit override says "OVERRIDE" and lives elsewhere.
+        let override_dir = tmp.path().join("custom");
+        std::fs::create_dir(&override_dir).unwrap();
+        let override_path = override_dir.join("custom.yaml");
+        std::fs::write(
+            &override_path,
+            r#"kind: semantics
+metadata: { name: override }
+spec:
+  sources:
+    - name: products
+      description: "OVERRIDE"
+"#,
+        )
+        .unwrap();
+
+        let mut out: Vec<u8> = Vec::new();
+        show_schema(&ctx_path, Some(&override_path), None, &mut out)
+            .await
+            .unwrap();
+        let rendered = String::from_utf8(out).unwrap();
+
+        assert!(
+            rendered.contains("OVERRIDE"),
+            "explicit --semantics should win. Got:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("AUTO"),
+            "auto-discovery must not be merged on top of override. Got:\n{rendered}"
+        );
+    }
+
+    #[tokio::test]
+    async fn show_schema_hard_errors_when_dir_and_file_collide() {
+        let tmp = TempDir::new().unwrap();
+
+        let csv_path = tmp.path().join("products.csv");
+        std::fs::write(&csv_path, "id\n1\n").unwrap();
+
+        let ctx_path = tmp.path().join("ctx.yaml");
+        std::fs::write(
+            &ctx_path,
+            format!(
+                r#"kind: context
+metadata: {{ name: t, version: 1.0.0 }}
+spec:
+  data_sources:
+    - name: products
+      type: csv
+      path: {}
+      options:
+        has_header: "true"
+"#,
+                csv_path.display()
+            ),
+        )
+        .unwrap();
+
+        // Both a `semantics/` dir and a `semantics.yaml` next to the ctx →
+        // hard error so we don't silently shadow one with the other.
+        std::fs::create_dir(tmp.path().join("semantics")).unwrap();
+        std::fs::write(
+            tmp.path().join("semantics.yaml"),
+            "kind: semantics\nspec: {}\n",
+        )
+        .unwrap();
+
+        let mut out: Vec<u8> = Vec::new();
+        let err = show_schema(&ctx_path, None, None, &mut out)
+            .await
+            .unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("Ambiguous semantics auto-discovery"),
+            "should bubble up the resolver's collision error: {msg}"
         );
     }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1143,8 +1143,23 @@ async fn show_schema(
         .map(|ds| ds.name.clone())
         .collect();
 
-    let defaults = CatalogDefaults::from_ctx(&session_ctx);
-    let all_tables = enumerate_tables(&session_ctx);
+    render_schema(&session_ctx, &semantics, &source_names, table_filter, out).await
+}
+
+/// Render the schema view (table + columns, with overlay descriptions)
+/// for whatever is registered in `session_ctx`. Split out from
+/// [`show_schema`] so tests can drive it with a hand-built session that
+/// exercises rare paths (catalog-mode sources, custom defaults, etc.)
+/// without going through `load_and_register_all`.
+async fn render_schema(
+    session_ctx: &SessionContext,
+    semantics: &SemanticsRegistry,
+    source_names: &HashSet<String>,
+    table_filter: Option<&str>,
+    out: &mut dyn Write,
+) -> Result<()> {
+    let defaults = CatalogDefaults::from_ctx(session_ctx);
+    let all_tables = enumerate_tables(session_ctx);
     let selected = match table_filter {
         Some(t) => select_tables(&all_tables, t, &defaults)?,
         None => all_tables,
@@ -1177,17 +1192,30 @@ async fn show_schema(
                 )
             })?;
         let table_schema = provider.schema();
-        let source_name = source_name_for(entry, &defaults, &source_names);
+        let source_name = source_name_for(entry, &defaults, source_names);
 
-        let table_desc = source_name.and_then(|name| semantics.table_description(name));
+        // Most-specific overlay wins: a fully-qualified `name:
+        // catalog.schema.table` entry beats the bare `name: <source>`
+        // fallback. Both ultimately resolve through the same registry.
+        let table_desc = semantics.resolve_table_description(
+            &entry.catalog,
+            &entry.schema,
+            &entry.table,
+            source_name,
+        );
         match table_desc {
             Some(desc) => writeln!(out, "table: {}  -- {}", entry.display_name(&defaults), desc)?,
             None => writeln!(out, "table: {}", entry.display_name(&defaults))?,
         }
 
         for field in table_schema.fields() {
-            let col_desc =
-                source_name.and_then(|name| semantics.column_description(name, field.name()));
+            let col_desc = semantics.resolve_column_description(
+                &entry.catalog,
+                &entry.schema,
+                &entry.table,
+                source_name,
+                field.name(),
+            );
             match col_desc {
                 Some(desc) => writeln!(
                     out,
@@ -1227,9 +1255,9 @@ fn source_name_for<'a>(
 ) -> Option<&'a str> {
     if entry.catalog == defaults.catalog
         && entry.schema == defaults.schema
-        && source_names.contains(&entry.table)
+        && let Some(name) = source_names.get(&entry.table)
     {
-        return source_names.get(&entry.table).map(String::as_str);
+        return Some(name.as_str());
     }
     source_names.get(&entry.catalog).map(String::as_str)
 }
@@ -2341,6 +2369,207 @@ spec:
         assert!(
             msg.contains("Ambiguous semantics auto-discovery"),
             "should bubble up the resolver's collision error: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn render_schema_attaches_catalog_mode_description_to_every_inner_table() {
+        // Catalog-mode sources (e.g. SQLite registered with `type: sqlite`)
+        // present as a *catalog* whose name == the source name, with
+        // multiple inner tables underneath. With a bare `name: <source>`
+        // entry (the broad form), the source-level description attaches
+        // to every inner table and column overlays match against the
+        // live Arrow column names regardless of which inner table holds
+        // them. (Per-table targeting is exercised by the qualified-path
+        // test below.)
+        //
+        // This test fakes the registration with an in-memory catalog so we
+        // don't need a real SQLite source — the rendering path is what we
+        // care about pinning.
+        let ctx = SessionContext::new();
+        let inner_schema = Arc::new(MemorySchemaProvider::new());
+        let pages = Arc::new(
+            MemTable::try_new(
+                Arc::new(ArrowSchema::new(vec![
+                    Field::new("title", DataType::Utf8, false),
+                    Field::new("body", DataType::Utf8, true),
+                ])),
+                vec![vec![]],
+            )
+            .unwrap(),
+        );
+        let revisions = Arc::new(
+            MemTable::try_new(
+                Arc::new(ArrowSchema::new(vec![
+                    Field::new("title", DataType::Utf8, false),
+                    Field::new("revised_at", DataType::Int64, false),
+                ])),
+                vec![vec![]],
+            )
+            .unwrap(),
+        );
+        inner_schema
+            .register_table("pages".to_string(), pages)
+            .unwrap();
+        inner_schema
+            .register_table("revisions".to_string(), revisions)
+            .unwrap();
+        let catalog = Arc::new(MemoryCatalogProvider::new());
+        catalog
+            .register_schema("main", inner_schema as Arc<dyn SchemaProvider>)
+            .unwrap();
+        ctx.register_catalog("wiki", catalog as Arc<dyn CatalogProvider>);
+
+        let ctx_descriptions = vec![("wiki".to_string(), None)];
+        let tmp = TempDir::new().unwrap();
+        let sem_path = tmp.path().join("sem.yaml");
+        std::fs::write(
+            &sem_path,
+            r#"kind: semantics
+metadata: { name: t }
+spec:
+  sources:
+    - name: wiki
+      description: "Wiki content store"
+      columns:
+        - name: title
+          description: "Page title"
+        - name: revised_at
+          description: "Last edit (epoch seconds)"
+"#,
+        )
+        .unwrap();
+        let semantics = SemanticsRegistry::build(Some(&sem_path), &ctx_descriptions).unwrap();
+        let source_names: HashSet<String> = ["wiki".to_string()].into_iter().collect();
+
+        let mut out: Vec<u8> = Vec::new();
+        render_schema(&ctx, &semantics, &source_names, None, &mut out)
+            .await
+            .unwrap();
+        let rendered = String::from_utf8(out).unwrap();
+
+        // Source-level description must attach to *both* inner tables.
+        assert!(
+            rendered.contains("table: wiki.main.pages  -- Wiki content store"),
+            "pages row missing source-level description. Got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("table: wiki.main.revisions  -- Wiki content store"),
+            "revisions row missing source-level description. Got:\n{rendered}"
+        );
+        // Column overlays match by name across inner tables (no
+        // per-inner-table targeting yet), so `title` shows up annotated
+        // in *both* rows.
+        let title_hits = rendered.matches("title: Utf8  -- Page title").count();
+        assert_eq!(
+            title_hits, 2,
+            "the `title` overlay should attach in both pages and revisions. Got:\n{rendered}"
+        );
+        // A column unique to one inner table picks up its own overlay.
+        assert!(
+            rendered.contains("revised_at: Int64  -- Last edit (epoch seconds)"),
+            "revised_at column overlay missing. Got:\n{rendered}"
+        );
+        // A column with no overlay renders bare.
+        assert!(
+            rendered.contains("\n  body: Utf8\n"),
+            "body column should render bare. Got:\n{rendered}"
+        );
+    }
+
+    #[tokio::test]
+    async fn render_schema_uses_qualified_path_for_specific_inner_table() {
+        // Same catalog-mode setup as above, but the semantics file uses
+        // a fully-qualified `name: wiki.main.pages` to target *only*
+        // the pages table. The other inner table (revisions) should
+        // fall through to the bare `wiki` source-level fallback.
+        let ctx = SessionContext::new();
+        let inner_schema = Arc::new(MemorySchemaProvider::new());
+        let pages = Arc::new(
+            MemTable::try_new(
+                Arc::new(ArrowSchema::new(vec![
+                    Field::new("title", DataType::Utf8, false),
+                    Field::new("body", DataType::Utf8, true),
+                ])),
+                vec![vec![]],
+            )
+            .unwrap(),
+        );
+        let revisions = Arc::new(
+            MemTable::try_new(
+                Arc::new(ArrowSchema::new(vec![
+                    Field::new("title", DataType::Utf8, false),
+                    Field::new("revised_at", DataType::Int64, false),
+                ])),
+                vec![vec![]],
+            )
+            .unwrap(),
+        );
+        inner_schema
+            .register_table("pages".to_string(), pages)
+            .unwrap();
+        inner_schema
+            .register_table("revisions".to_string(), revisions)
+            .unwrap();
+        let catalog = Arc::new(MemoryCatalogProvider::new());
+        catalog
+            .register_schema("main", inner_schema as Arc<dyn SchemaProvider>)
+            .unwrap();
+        ctx.register_catalog("wiki", catalog as Arc<dyn CatalogProvider>);
+
+        let ctx_descriptions = vec![("wiki".to_string(), None)];
+        let tmp = TempDir::new().unwrap();
+        let sem_path = tmp.path().join("sem.yaml");
+        std::fs::write(
+            &sem_path,
+            r#"kind: semantics
+metadata: { name: t }
+spec:
+  sources:
+    - name: wiki
+      description: "Wiki content store (broad)"
+    - name: wiki.main.pages
+      description: "Page contents only"
+      columns:
+        - name: title
+          description: "Page heading"
+"#,
+        )
+        .unwrap();
+        let semantics = SemanticsRegistry::build(Some(&sem_path), &ctx_descriptions).unwrap();
+        let source_names: HashSet<String> = ["wiki".to_string()].into_iter().collect();
+
+        let mut out: Vec<u8> = Vec::new();
+        render_schema(&ctx, &semantics, &source_names, None, &mut out)
+            .await
+            .unwrap();
+        let rendered = String::from_utf8(out).unwrap();
+
+        // The qualified entry wins for `pages`...
+        assert!(
+            rendered.contains("table: wiki.main.pages  -- Page contents only"),
+            "pages should pick the qualified description. Got:\n{rendered}"
+        );
+        // ...and the broad fallback covers the other inner table.
+        assert!(
+            rendered.contains("table: wiki.main.revisions  -- Wiki content store (broad)"),
+            "revisions should fall back to the bare `wiki` description. Got:\n{rendered}"
+        );
+        // The qualified column overlay applies on `pages.title`.
+        // (The line for pages comes right after `table: wiki.main.pages`.)
+        assert!(
+            rendered.contains("title: Utf8  -- Page heading"),
+            "qualified column overlay missing on pages.title. Got:\n{rendered}"
+        );
+        // `revisions.title` has no overlay (the qualified entry only
+        // covers pages, and the bare `wiki` entry has no `columns:`).
+        let revisions_block = rendered
+            .split("table: wiki.main.revisions")
+            .nth(1)
+            .expect("revisions block should be present");
+        assert!(
+            revisions_block.contains("\n  title: Utf8\n"),
+            "revisions.title should render bare. Got revisions block:\n{revisions_block}"
         );
     }
 

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -341,6 +341,7 @@ mod tests {
         use crate::auth::layer::AuthLayer;
         use crate::config::{CliArgs, ServerConfig};
         use crate::metrics::PipelineMetrics;
+        use crate::semantics::SemanticsRegistry;
         use crate::server::AppState;
         use datafusion::prelude::SessionContext;
         use skardi::engine::datafusion::DataFusionEngine;
@@ -351,11 +352,13 @@ mod tests {
             pipelines: Default::default(),
             jobs: Default::default(),
             data_sources: vec![],
+            semantics: SemanticsRegistry::default(),
             args: CliArgs {
                 pipeline_path: Some(PathBuf::from("p.yaml")),
                 jobs_path: None,
                 jobs_db_path: None,
                 ctx_file: None,
+                semantics_path: None,
                 port: 8080,
             },
         };
@@ -382,6 +385,7 @@ mod tests {
         use crate::auth::layer::AuthLayer;
         use crate::config::{CliArgs, ServerConfig};
         use crate::metrics::PipelineMetrics;
+        use crate::semantics::SemanticsRegistry;
         use crate::server::AppState;
         use datafusion::prelude::SessionContext;
         use skardi::engine::datafusion::DataFusionEngine;
@@ -402,11 +406,13 @@ mod tests {
             pipelines: Default::default(),
             jobs: Default::default(),
             data_sources: vec![],
+            semantics: SemanticsRegistry::default(),
             args: CliArgs {
                 pipeline_path: Some(PathBuf::from("p.yaml")),
                 jobs_path: None,
                 jobs_db_path: None,
                 ctx_file: None,
+                semantics_path: None,
                 port: 8080,
             },
         };

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -21,6 +21,7 @@ use thiserror::Error;
 
 use crate::OptimizerRegistry;
 use crate::remote_storage::{RemoteStorage, S3Storage};
+use crate::semantics::SemanticsRegistry;
 pub use skardi::sources::AccessMode;
 pub use skardi::sources::DataSourceType;
 pub use skardi::sources::HierarchyLevel;
@@ -63,6 +64,15 @@ pub struct CliArgs {
     )]
     pub ctx_file: Option<PathBuf>,
 
+    /// Path to a `kind: semantics` YAML file or directory of them.
+    /// Files in a directory whose root `kind:` is not `semantics` are
+    /// silently skipped, mirroring `--jobs`.
+    #[arg(
+        long = "semantics",
+        help = "Path to semantics YAML file or directory containing semantics overlays"
+    )]
+    pub semantics_path: Option<PathBuf>,
+
     /// Server port number
     #[arg(long, default_value = "8080", help = "Server port number")]
     pub port: u16,
@@ -78,6 +88,10 @@ pub struct ServerConfig {
     pub jobs: HashMap<String, JobDefinition>,
     /// Data sources to register with DataFusion
     pub data_sources: Vec<DataSource>,
+    /// Natural-language descriptions overlaid on top of the catalog,
+    /// merged from all `kind: semantics` files plus any inline `description`
+    /// fields on `data_sources[]` in the ctx (the latter is the fallback).
+    pub semantics: SemanticsRegistry,
     /// CLI arguments
     pub args: CliArgs,
 }
@@ -108,6 +122,11 @@ pub struct DataSource {
     /// If true, load the entire table into memory at startup (only for Csv, Parquet, Iceberg)
     #[serde(default)]
     pub enable_cache: bool,
+    /// Optional natural-language description of the table this data source exposes.
+    /// Used as a fallback table-level description on the catalog endpoint when no
+    /// matching entry is present in a loaded `kind: semantics` file.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 }
 
 /// Top-level envelope for context YAML files:
@@ -472,6 +491,11 @@ pub async fn load_server_config(args: CliArgs) -> Result<ServerConfig> {
         );
     }
 
+    // Load semantics overlays (if --semantics was passed) and seed the
+    // registry with the ctx-inline descriptions as a fallback.
+    let semantics = SemanticsRegistry::build(args.semantics_path.as_deref(), &data_sources)
+        .with_context(|| "Failed to load semantics")?;
+
     tracing::info!(
         "Configuration loaded successfully: pipelines={}, jobs={}, data_sources={}",
         pipelines.len(),
@@ -483,6 +507,7 @@ pub async fn load_server_config(args: CliArgs) -> Result<ServerConfig> {
         pipelines,
         jobs,
         data_sources,
+        semantics,
         args,
     })
 }
@@ -1566,6 +1591,7 @@ spec:
             jobs_path: None,
             jobs_db_path: None,
             ctx_file: Some(context_path),
+            semantics_path: None,
             port: 8080,
         };
 
@@ -1590,6 +1616,7 @@ spec:
             jobs_path: None,
             jobs_db_path: None,
             ctx_file: None,
+            semantics_path: None,
             port: 3000,
         };
 
@@ -1643,6 +1670,7 @@ spec:
             jobs_path: None,
             jobs_db_path: None,
             ctx_file: None,
+            semantics_path: None,
             port: 3000,
         };
 
@@ -1670,6 +1698,7 @@ spec:
             jobs_path: None,
             jobs_db_path: None,
             ctx_file: None,
+            semantics_path: None,
             port: 8080,
         };
 
@@ -1693,6 +1722,7 @@ spec:
             jobs_path: None,
             jobs_db_path: None,
             ctx_file: None,
+            semantics_path: None,
             port: 8080,
         };
 

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -21,7 +21,7 @@ use thiserror::Error;
 
 use crate::OptimizerRegistry;
 use crate::remote_storage::{RemoteStorage, S3Storage};
-use crate::semantics::SemanticsRegistry;
+use crate::semantics::{SemanticsRegistry, resolve_semantics_source};
 pub use skardi::sources::AccessMode;
 pub use skardi::sources::DataSourceType;
 pub use skardi::sources::HierarchyLevel;
@@ -491,9 +491,20 @@ pub async fn load_server_config(args: CliArgs) -> Result<ServerConfig> {
         );
     }
 
-    // Load semantics overlays (if --semantics was passed) and seed the
-    // registry with the ctx-inline descriptions as a fallback.
-    let semantics = SemanticsRegistry::build(args.semantics_path.as_deref(), &data_sources)
+    // Load semantics overlays. The path is either:
+    //   1. `--semantics <path>` (explicit override), or
+    //   2. auto-discovered next to the ctx file (`<ctx_dir>/semantics/`
+    //      directory or `<ctx_dir>/semantics.yaml` single file).
+    // The registry is then seeded with the ctx-inline `description` fields
+    // as a fallback for any source not covered by the overlay.
+    let ctx_dir = args.ctx_file.as_deref().and_then(Path::parent);
+    let semantics_path = resolve_semantics_source(ctx_dir, args.semantics_path.as_deref())
+        .with_context(|| "Failed to resolve semantics source")?;
+    let ctx_descriptions: Vec<(String, Option<String>)> = data_sources
+        .iter()
+        .map(|ds| (ds.name.clone(), ds.description.clone()))
+        .collect();
+    let semantics = SemanticsRegistry::build(semantics_path.as_deref(), &ctx_descriptions)
         .with_context(|| "Failed to load semantics")?;
 
     tracing::info!(

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -9,9 +9,7 @@ pub mod remote_storage;
 pub mod server;
 pub mod telemetry;
 
-// Re-export the relocated semantics module under its old path so existing
-// `crate::semantics::...` imports keep working without churning every
-// caller. The implementation lives in `crates/skardi`.
+// Re-export `skardi::semantics` so server code can use `crate::semantics::...`.
 pub use skardi::semantics;
 
 // Re-export public types for easy access

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -6,6 +6,7 @@ pub mod metrics;
 pub mod optimizer_registry;
 pub mod pipeline_handlers;
 pub mod remote_storage;
+pub mod semantics;
 pub mod server;
 pub mod telemetry;
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -6,9 +6,13 @@ pub mod metrics;
 pub mod optimizer_registry;
 pub mod pipeline_handlers;
 pub mod remote_storage;
-pub mod semantics;
 pub mod server;
 pub mod telemetry;
+
+// Re-export the relocated semantics module under its old path so existing
+// `crate::semantics::...` imports keep working without churning every
+// caller. The implementation lives in `crates/skardi`.
+pub use skardi::semantics;
 
 // Re-export public types for easy access
 pub use config::{

--- a/crates/server/src/optimizer_registry.rs
+++ b/crates/server/src/optimizer_registry.rs
@@ -273,6 +273,7 @@ mod tests {
             access_mode: crate::config::AccessMode::default(),
             enable_cache: false,
             hierarchy_level: Default::default(),
+            description: None,
         }];
 
         // Should not register Lance functions for CSV-only data sources

--- a/crates/server/src/pipeline_handlers.rs
+++ b/crates/server/src/pipeline_handlers.rs
@@ -26,6 +26,7 @@ use std::collections::HashMap;
 use std::time::Instant;
 
 use crate::config::DataSourceType;
+use crate::semantics::SemanticsRegistry;
 use crate::server::AppState;
 
 /// Request structure for pipeline execution
@@ -71,6 +72,10 @@ pub struct FieldInfo {
     pub r#type: String,
     /// Whether the field is nullable
     pub nullable: bool,
+    /// Natural-language description sourced from the loaded `kind: semantics`
+    /// overlay, if any. Omitted from the JSON response when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 }
 
 /// Table information with schema
@@ -78,6 +83,10 @@ pub struct FieldInfo {
 pub struct TableInfo {
     /// Table name (same as data source name)
     pub name: String,
+    /// Natural-language description for the table (semantics overlay first,
+    /// ctx-inline `description` second). Omitted when neither supplies one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     /// Table schema fields
     pub schema: Vec<FieldInfo>,
 }
@@ -136,7 +145,11 @@ fn create_success_response(data: Vec<Value>, rows: usize, execution_time_ms: u64
 ///
 /// Returns a vector of FieldInfo containing column name, type, and nullability.
 /// Returns an error if the table is not found or schema retrieval fails.
-async fn get_table_schema(ctx: &SessionContext, table_name: &str) -> Result<Vec<FieldInfo>> {
+async fn get_table_schema(
+    ctx: &SessionContext,
+    table_name: &str,
+    semantics: &SemanticsRegistry,
+) -> Result<Vec<FieldInfo>> {
     // Get the default catalog
     let catalog = ctx
         .catalog("datafusion")
@@ -157,7 +170,8 @@ async fn get_table_schema(ctx: &SessionContext, table_name: &str) -> Result<Vec<
     // Get the table schema
     let table_schema = table.schema();
 
-    // Convert Arrow fields to FieldInfo
+    // Convert Arrow fields to FieldInfo, attaching any column-level
+    // semantics overlay registered for this (table, column) pair.
     let fields: Vec<FieldInfo> = table_schema
         .fields()
         .iter()
@@ -165,6 +179,9 @@ async fn get_table_schema(ctx: &SessionContext, table_name: &str) -> Result<Vec<
             name: field.name().clone(),
             r#type: format!("{:?}", field.data_type()),
             nullable: field.is_nullable(),
+            description: semantics
+                .column_description(table_name, field.name())
+                .map(str::to_string),
         })
         .collect();
 
@@ -360,8 +377,9 @@ pub async fn get_pipelines_info(
 pub async fn get_data_sources(
     State(app_state): State<AppState>,
 ) -> Result<Json<Value>, (StatusCode, Json<ErrorResponse>)> {
-    // Acquire lock and extract data sources, then drop lock before async operations
-    let data_sources = {
+    // Acquire lock and extract data sources + semantics, then drop lock
+    // before async operations.
+    let (data_sources, semantics) = {
         let config = app_state.config.read().map_err(|_| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -372,7 +390,7 @@ pub async fn get_data_sources(
                 ),
             )
         })?;
-        config.data_sources.clone()
+        (config.data_sources.clone(), config.semantics.clone())
     };
 
     let session_ctx = app_state.engine.session_context();
@@ -420,8 +438,10 @@ pub async fn get_data_sources(
             _ => None,
         };
 
-        // Get table schema from SessionContext
-        let table_schema = match get_table_schema(session_ctx, &data_source.name).await {
+        // Get table schema from SessionContext, with column descriptions
+        // merged in from the semantics registry.
+        let table_schema = match get_table_schema(session_ctx, &data_source.name, &semantics).await
+        {
             Ok(fields) => fields,
             Err(e) => {
                 tracing::warn!(
@@ -434,9 +454,16 @@ pub async fn get_data_sources(
             }
         };
 
-        // Build table info (data source name is the table name)
+        // Build table info (data source name is the table name). The table
+        // description is the merged view: a `kind: semantics` overlay wins
+        // when present, falling back to the ctx-inline `description` field
+        // (this fallback is seeded into the registry at boot, so the
+        // single lookup here covers both cases).
         let tables = vec![TableInfo {
             name: data_source.name.clone(),
+            description: semantics
+                .table_description(&data_source.name)
+                .map(str::to_string),
             schema: table_schema,
         }];
 
@@ -774,6 +801,7 @@ spec:
             jobs_path: None,
             jobs_db_path: None,
             ctx_file: None,
+            semantics_path: None,
             port: 8080,
         };
 
@@ -781,6 +809,7 @@ spec:
             pipelines,
             jobs: HashMap::new(),
             data_sources,
+            semantics: SemanticsRegistry::default(),
             args,
         };
 
@@ -842,6 +871,7 @@ spec:
             access_mode: AccessMode::default(),
             enable_cache: false,
             hierarchy_level: Default::default(),
+            description: None,
         };
 
         // Create pipeline that queries the registered data source
@@ -855,6 +885,7 @@ spec:
             jobs_path: None,
             jobs_db_path: None,
             ctx_file: None,
+            semantics_path: None,
             port: 8080,
         };
 
@@ -862,6 +893,7 @@ spec:
             pipelines,
             jobs: HashMap::new(),
             data_sources: vec![data_source],
+            semantics: SemanticsRegistry::default(),
             args,
         };
 

--- a/crates/server/src/semantics.rs
+++ b/crates/server/src/semantics.rs
@@ -1,0 +1,656 @@
+//! Natural-language semantics overlays for the catalog.
+//!
+//! Semantics files are a separate Kubernetes-style YAML kind (`kind: semantics`)
+//! that attach human-readable descriptions to tables and columns already
+//! registered through a `kind: context` file. They are loaded at server
+//! startup alongside pipelines, jobs, and the context, and the catalog
+//! endpoint (`GET /data_source`) emits the descriptions on its response so
+//! agents can read them when picking a tool.
+//!
+//! ```yaml
+//! kind: semantics
+//! metadata:
+//!   name: basic-semantics
+//!   version: 1.0.0
+//! spec:
+//!   sources:
+//!     - name: products              # must match data_sources[].name in the ctx
+//!       description: "Product catalog with pricing/inventory"
+//!       columns:
+//!         - name: price_usd
+//!           description: "Retail price in USD; nullable for unlisted SKUs"
+//! ```
+//!
+//! Composition rules:
+//! - Multiple files may be loaded by pointing `--semantics` at a directory.
+//!   Files in that directory whose root `kind:` is not `semantics` are
+//!   silently skipped, mirroring how `--jobs` tolerates plain pipelines.
+//! - Two entries (across all files) for the same source — or two column
+//!   entries on the same source/column — are a hard error. Auto-generated
+//!   overlays must produce non-overlapping files.
+//! - References to sources or columns that do not exist on the loaded ctx
+//!   are warned about (not failed) so a stale overlay does not brick a
+//!   server boot.
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+use crate::config::DataSource;
+
+/// Required value of the root `kind:` discriminator.
+pub const SEMANTICS_KIND: &str = "semantics";
+
+/// Top-level envelope for a semantics YAML file. Mirrors the
+/// `kind / metadata / spec` shape used by context, pipelines, jobs, and
+/// aliases.
+///
+/// `kind` is `Option<String>` so the loader can distinguish "no kind"
+/// (legitimate, treat as not-a-semantics file when scanning a mixed dir)
+/// from "wrong kind" (only relevant when the file was named explicitly).
+/// `metadata` is opaque — nothing at runtime reads inside it, but the
+/// field is kept so a typo (`metdata:`) surfaces at parse time.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SemanticsFile {
+    #[serde(default)]
+    pub kind: Option<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub metadata: serde_yaml::Value,
+    #[serde(default)]
+    pub spec: SemanticsSpec,
+}
+
+/// `spec:` block — a flat list of per-source overlays.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct SemanticsSpec {
+    #[serde(default)]
+    pub sources: Vec<SourceSemantics>,
+}
+
+/// Per-source overlay. `name` matches a `data_sources[].name` from the
+/// loaded context. `description` overrides the ctx-inline description on
+/// the catalog response. `columns` is optional — supply only the columns
+/// that need a description.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SourceSemantics {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub columns: Vec<ColumnSemantics>,
+}
+
+/// Per-column overlay. `name` must match the column name as it appears in
+/// the registered Arrow schema (case-sensitive).
+#[derive(Debug, Clone, Deserialize)]
+pub struct ColumnSemantics {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+#[derive(Error, Debug)]
+pub enum SemanticsError {
+    #[error("Semantics path not found: {path:?}")]
+    PathNotFound { path: PathBuf },
+
+    #[error("Semantics file {path:?} has unexpected kind {found:?}; expected `kind: semantics`")]
+    WrongKind { path: PathBuf, found: String },
+
+    #[error("Semantics file {path:?} is missing the root `kind:` field")]
+    MissingKind { path: PathBuf },
+
+    #[error("Failed to parse semantics file {path:?}: {error}")]
+    ParseError { path: PathBuf, error: String },
+
+    #[error(
+        "Duplicate semantics entry for source `{source_name}` (already defined in {first:?}, redefined in {second:?})"
+    )]
+    DuplicateSource {
+        source_name: String,
+        first: PathBuf,
+        second: PathBuf,
+    },
+
+    #[error(
+        "Duplicate semantics entry for column `{source_name}.{column}` (already defined in {first:?}, redefined in {second:?})"
+    )]
+    DuplicateColumn {
+        source_name: String,
+        column: String,
+        first: PathBuf,
+        second: PathBuf,
+    },
+}
+
+/// In-memory lookup attached to `ServerConfig` and consumed by the catalog
+/// HTTP handler. Indexed by source name; per-column descriptions live in a
+/// nested map.
+///
+/// The registry merges *all* semantics files passed to `--semantics`, plus
+/// the ctx-inline `description` field, into a single view. Lookups in the
+/// HTTP handler should read from this struct only, not from the raw
+/// `DataSource` list, so that auto-generated overlays and hand-written
+/// ones flow through the same path.
+#[derive(Debug, Clone, Default)]
+pub struct SemanticsRegistry {
+    sources: HashMap<String, SourceEntry>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct SourceEntry {
+    description: Option<String>,
+    /// `column name → description`. Only columns with a non-empty description live here.
+    columns: HashMap<String, String>,
+    /// Origin file for the source-level description, used to render a
+    /// helpful "redefined here" error if a second file collides.
+    description_origin: Option<PathBuf>,
+    /// Origin file per column, same purpose.
+    column_origins: HashMap<String, PathBuf>,
+}
+
+impl SemanticsRegistry {
+    /// Build the registry for the running server.
+    ///
+    /// `semantics_path` may be a single file, a directory, or `None`.
+    /// `data_sources` is the ctx-loaded data source list — used both for
+    /// the inline-description fallback and for the dangling-reference
+    /// validation pass at the end.
+    pub fn build(semantics_path: Option<&Path>, data_sources: &[DataSource]) -> Result<Self> {
+        let mut registry = Self::default();
+
+        // Seed with ctx-inline descriptions. Semantics-file entries can
+        // overwrite these (with their own collision-tracking origin), so
+        // load order is: ctx first, files second.
+        for ds in data_sources {
+            if let Some(desc) = &ds.description
+                && !desc.is_empty()
+            {
+                registry
+                    .sources
+                    .entry(ds.name.clone())
+                    .or_default()
+                    .description = Some(desc.clone());
+            }
+        }
+
+        // Now walk semantics files (if any) and merge.
+        if let Some(path) = semantics_path {
+            let files = resolve_semantics_files(path)?;
+            for file_path in &files {
+                let Some(loaded) = load_semantics_file(file_path)? else {
+                    tracing::debug!("Skipping {:?}: no `kind: semantics` at root", file_path);
+                    continue;
+                };
+                registry.merge(loaded.spec, file_path)?;
+            }
+        }
+
+        // Warn (not fail) on dangling references — auto-generated overlays
+        // shouldn't brick a partially-rebooted ctx.
+        registry.warn_on_dangling_refs(data_sources);
+
+        Ok(registry)
+    }
+
+    /// Merge a parsed semantics spec into the registry, hard-erroring on
+    /// duplicate source or column entries.
+    fn merge(&mut self, spec: SemanticsSpec, origin: &Path) -> Result<()> {
+        for source in spec.sources {
+            let entry = self.sources.entry(source.name.clone()).or_default();
+
+            if let Some(desc) = source.description {
+                if let Some(prior) = &entry.description_origin {
+                    return Err(SemanticsError::DuplicateSource {
+                        source_name: source.name.clone(),
+                        first: prior.clone(),
+                        second: origin.to_path_buf(),
+                    }
+                    .into());
+                }
+                entry.description = Some(desc);
+                entry.description_origin = Some(origin.to_path_buf());
+            }
+
+            for col in source.columns {
+                if let Some(desc) = col.description {
+                    if let Some(prior) = entry.column_origins.get(&col.name) {
+                        return Err(SemanticsError::DuplicateColumn {
+                            source_name: source.name.clone(),
+                            column: col.name.clone(),
+                            first: prior.clone(),
+                            second: origin.to_path_buf(),
+                        }
+                        .into());
+                    }
+                    entry.columns.insert(col.name.clone(), desc);
+                    entry.column_origins.insert(col.name, origin.to_path_buf());
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn warn_on_dangling_refs(&self, data_sources: &[DataSource]) {
+        let known: HashSet<&str> = data_sources.iter().map(|ds| ds.name.as_str()).collect();
+        for name in self.sources.keys() {
+            if !known.contains(name.as_str()) {
+                tracing::warn!(
+                    "Semantics references unknown data source `{name}`; entry will be ignored \
+                     until a matching source is added to the context"
+                );
+            }
+        }
+    }
+
+    /// Table-level description for a data source (semantics override > ctx-inline).
+    pub fn table_description(&self, source: &str) -> Option<&str> {
+        self.sources
+            .get(source)
+            .and_then(|e| e.description.as_deref())
+    }
+
+    /// Column-level description for `(source, column)`. Returns `None` when
+    /// no overlay exists.
+    pub fn column_description(&self, source: &str, column: &str) -> Option<&str> {
+        self.sources
+            .get(source)
+            .and_then(|e| e.columns.get(column).map(String::as_str))
+    }
+}
+
+/// Walk a path that may be either a single yaml file or a directory of yaml
+/// files. Mirrors `resolve_pipeline_files` semantics: a directory yields
+/// every `*.yaml` / `*.yml` at one level, sorted alphabetically; a missing
+/// path is a hard error.
+fn resolve_semantics_files(path: &Path) -> Result<Vec<PathBuf>> {
+    if !path.exists() {
+        return Err(SemanticsError::PathNotFound {
+            path: path.to_path_buf(),
+        }
+        .into());
+    }
+
+    if path.is_file() {
+        return Ok(vec![path.to_path_buf()]);
+    }
+
+    if path.is_dir() {
+        let mut out = Vec::new();
+        for entry in std::fs::read_dir(path)
+            .with_context(|| format!("Failed to read semantics directory: {:?}", path))?
+        {
+            let entry = entry.with_context(|| "Failed to read directory entry")?;
+            let p = entry.path();
+            if p.is_file()
+                && let Some(ext) = p.extension()
+            {
+                let ext = ext.to_string_lossy().to_lowercase();
+                if ext == "yaml" || ext == "yml" {
+                    out.push(p);
+                }
+            }
+        }
+        out.sort();
+        return Ok(out);
+    }
+
+    Err(SemanticsError::PathNotFound {
+        path: path.to_path_buf(),
+    }
+    .into())
+}
+
+/// Load a single yaml file. Returns `Ok(None)` when the file's root `kind`
+/// is missing or set to something other than `semantics` — that is a soft
+/// skip during directory scans, mirroring the jobs loader. A malformed
+/// yaml or a `kind: semantics` file with broken structure is a hard error.
+fn load_semantics_file(path: &Path) -> Result<Option<SemanticsFile>> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read semantics file: {:?}", path))?;
+
+    // Peek at the kind first so non-semantics files in a mixed dir parse
+    // cheaply and don't trip the strict struct deserialization below.
+    #[derive(Deserialize)]
+    struct KindOnly {
+        #[serde(default)]
+        kind: Option<String>,
+    }
+    let peek: KindOnly = serde_yaml::from_str(&raw).map_err(|e| SemanticsError::ParseError {
+        path: path.to_path_buf(),
+        error: e.to_string(),
+    })?;
+
+    match peek.kind.as_deref() {
+        Some(SEMANTICS_KIND) => {}
+        Some(_) | None => return Ok(None),
+    }
+
+    let parsed: SemanticsFile =
+        serde_yaml::from_str(&raw).map_err(|e| SemanticsError::ParseError {
+            path: path.to_path_buf(),
+            error: e.to_string(),
+        })?;
+
+    Ok(Some(parsed))
+}
+
+/// Load a single yaml file that the caller already knows is supposed to be
+/// a semantics file (for example, because `--semantics path/to/file.yaml`
+/// was passed explicitly). Unlike [`load_semantics_file`], a missing or
+/// wrong `kind:` is a hard error here.
+#[allow(dead_code)]
+pub fn load_required_semantics_file(path: &Path) -> Result<SemanticsFile> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read semantics file: {:?}", path))?;
+
+    let parsed: SemanticsFile =
+        serde_yaml::from_str(&raw).map_err(|e| SemanticsError::ParseError {
+            path: path.to_path_buf(),
+            error: e.to_string(),
+        })?;
+
+    match parsed.kind.as_deref() {
+        Some(SEMANTICS_KIND) => Ok(parsed),
+        Some(other) => Err(SemanticsError::WrongKind {
+            path: path.to_path_buf(),
+            found: other.to_string(),
+        }
+        .into()),
+        None => Err(SemanticsError::MissingKind {
+            path: path.to_path_buf(),
+        }
+        .into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{DataSource, DataSourceType};
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn ds(name: &str, description: Option<&str>) -> DataSource {
+        DataSource {
+            name: name.to_string(),
+            source_type: DataSourceType::Csv,
+            path: PathBuf::new(),
+            connection_string: None,
+            schema: None,
+            options: None,
+            hierarchy_level: Default::default(),
+            access_mode: Default::default(),
+            enable_cache: false,
+            description: description.map(str::to_string),
+        }
+    }
+
+    fn write_yaml(dir: &Path, name: &str, content: &str) -> PathBuf {
+        let p = dir.join(name);
+        let mut f = std::fs::File::create(&p).unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        p
+    }
+
+    #[test]
+    fn loads_single_semantics_file() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_yaml(
+            tmp.path(),
+            "sem.yaml",
+            r#"
+kind: semantics
+metadata:
+  name: t
+  version: 1.0.0
+spec:
+  sources:
+    - name: products
+      description: "Product catalog"
+      columns:
+        - name: price_usd
+          description: "Retail price in USD"
+"#,
+        );
+
+        let sources = vec![ds("products", None)];
+        let reg = SemanticsRegistry::build(Some(&path), &sources).unwrap();
+        assert_eq!(reg.table_description("products"), Some("Product catalog"));
+        assert_eq!(
+            reg.column_description("products", "price_usd"),
+            Some("Retail price in USD")
+        );
+        assert_eq!(reg.column_description("products", "missing"), None);
+    }
+
+    #[test]
+    fn ctx_inline_description_used_as_fallback() {
+        let sources = vec![ds("products", Some("From ctx"))];
+        let reg = SemanticsRegistry::build(None, &sources).unwrap();
+        assert_eq!(reg.table_description("products"), Some("From ctx"));
+    }
+
+    #[test]
+    fn semantics_file_overrides_ctx_inline() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_yaml(
+            tmp.path(),
+            "sem.yaml",
+            r#"
+kind: semantics
+metadata:
+  name: t
+spec:
+  sources:
+    - name: products
+      description: "Override"
+"#,
+        );
+
+        let sources = vec![ds("products", Some("From ctx"))];
+        let reg = SemanticsRegistry::build(Some(&path), &sources).unwrap();
+        assert_eq!(reg.table_description("products"), Some("Override"));
+    }
+
+    #[test]
+    fn directory_skips_non_semantics_yamls() {
+        let tmp = TempDir::new().unwrap();
+        write_yaml(
+            tmp.path(),
+            "sem.yaml",
+            r#"
+kind: semantics
+metadata: { name: t }
+spec:
+  sources:
+    - name: products
+      description: "Product catalog"
+"#,
+        );
+        write_yaml(
+            tmp.path(),
+            "pipeline.yaml",
+            r#"
+kind: pipeline
+metadata: { name: p, version: 1.0.0 }
+spec:
+  query: SELECT 1
+"#,
+        );
+
+        let sources = vec![ds("products", None)];
+        let reg = SemanticsRegistry::build(Some(tmp.path()), &sources).unwrap();
+        assert_eq!(reg.table_description("products"), Some("Product catalog"));
+    }
+
+    #[test]
+    fn duplicate_source_description_is_hard_error() {
+        let tmp = TempDir::new().unwrap();
+        write_yaml(
+            tmp.path(),
+            "a.yaml",
+            r#"
+kind: semantics
+metadata: { name: a }
+spec:
+  sources:
+    - name: products
+      description: "first"
+"#,
+        );
+        write_yaml(
+            tmp.path(),
+            "b.yaml",
+            r#"
+kind: semantics
+metadata: { name: b }
+spec:
+  sources:
+    - name: products
+      description: "second"
+"#,
+        );
+
+        let sources = vec![ds("products", None)];
+        let err = SemanticsRegistry::build(Some(tmp.path()), &sources).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("Duplicate semantics entry for source `products`"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn duplicate_column_description_is_hard_error() {
+        let tmp = TempDir::new().unwrap();
+        write_yaml(
+            tmp.path(),
+            "a.yaml",
+            r#"
+kind: semantics
+metadata: { name: a }
+spec:
+  sources:
+    - name: products
+      columns:
+        - name: price_usd
+          description: "first"
+"#,
+        );
+        write_yaml(
+            tmp.path(),
+            "b.yaml",
+            r#"
+kind: semantics
+metadata: { name: b }
+spec:
+  sources:
+    - name: products
+      columns:
+        - name: price_usd
+          description: "second"
+"#,
+        );
+
+        let sources = vec![ds("products", None)];
+        let err = SemanticsRegistry::build(Some(tmp.path()), &sources).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("Duplicate semantics entry for column `products.price_usd`"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn dangling_reference_warns_but_does_not_fail() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_yaml(
+            tmp.path(),
+            "sem.yaml",
+            r#"
+kind: semantics
+metadata: { name: t }
+spec:
+  sources:
+    - name: orphan
+      description: "no matching source"
+"#,
+        );
+
+        let sources = vec![ds("products", None)];
+        let reg = SemanticsRegistry::build(Some(&path), &sources).unwrap();
+        // The orphan entry is still in the registry — it just gets a warning at load time.
+        assert_eq!(reg.table_description("orphan"), Some("no matching source"));
+        assert_eq!(reg.table_description("products"), None);
+    }
+
+    #[test]
+    fn missing_kind_in_explicit_file_is_treated_as_skip_for_directory_scan() {
+        // Single-file mode through `build()` goes through `load_semantics_file`
+        // (the soft-skip variant) — a yaml without `kind: semantics` is
+        // silently ignored even when passed explicitly. This matches the
+        // behavior of `--jobs path/to/single.yaml` for non-job files.
+        let tmp = TempDir::new().unwrap();
+        let path = write_yaml(
+            tmp.path(),
+            "stray.yaml",
+            r#"
+metadata: { name: not-a-semantics }
+spec:
+  sources:
+    - name: products
+      description: "ignored"
+"#,
+        );
+
+        let sources = vec![ds("products", None)];
+        let reg = SemanticsRegistry::build(Some(&path), &sources).unwrap();
+        assert_eq!(reg.table_description("products"), None);
+    }
+
+    #[test]
+    fn required_loader_rejects_missing_kind() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_yaml(
+            tmp.path(),
+            "stray.yaml",
+            r#"
+metadata: { name: x }
+spec:
+  sources: []
+"#,
+        );
+
+        let err = load_required_semantics_file(&path).unwrap_err();
+        assert!(format!("{err}").contains("missing the root `kind:` field"));
+    }
+
+    #[test]
+    fn required_loader_rejects_wrong_kind() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_yaml(
+            tmp.path(),
+            "stray.yaml",
+            r#"
+kind: pipeline
+metadata: { name: x, version: 1.0.0 }
+spec:
+  query: SELECT 1
+"#,
+        );
+
+        let err = load_required_semantics_file(&path).unwrap_err();
+        assert!(format!("{err}").contains("unexpected kind"));
+    }
+
+    #[test]
+    fn empty_path_input_returns_empty_registry() {
+        let sources: Vec<DataSource> = Vec::new();
+        let reg = SemanticsRegistry::build(None, &sources).unwrap();
+        assert_eq!(reg.table_description("anything"), None);
+    }
+}

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -30,6 +30,8 @@ use crate::pipeline_handlers::{
     execute_pipeline_by_name, get_data_sources, get_pipelines_info, list_pipelines,
     pipeline_health_check,
 };
+#[cfg(test)]
+use crate::semantics::SemanticsRegistry;
 use crate::{OptimizerRegistry, auth::layer::AuthLayer};
 
 /// Shared application state containing pipeline and engine
@@ -365,6 +367,7 @@ spec:
             access_mode: AccessMode::default(),
             enable_cache: false,
             hierarchy_level: Default::default(),
+            description: None,
         }];
 
         let pipeline = create_test_pipeline().await;
@@ -375,11 +378,13 @@ spec:
             pipelines,
             jobs: std::collections::HashMap::new(),
             data_sources,
+            semantics: SemanticsRegistry::default(),
             args: CliArgs {
                 pipeline_path: Some(PathBuf::from("test-pipeline.yaml")),
                 jobs_path: None,
                 jobs_db_path: None,
                 ctx_file: None,
+                semantics_path: None,
                 port: 8080,
             },
         };
@@ -396,11 +401,13 @@ spec:
             pipelines,
             jobs: std::collections::HashMap::new(),
             data_sources: vec![],
+            semantics: SemanticsRegistry::default(),
             args: CliArgs {
                 pipeline_path: Some(PathBuf::from("test-pipeline.yaml")),
                 jobs_path: None,
                 jobs_db_path: None,
                 ctx_file: None,
+                semantics_path: None,
                 port: 8080,
             },
         }

--- a/crates/server/tests/jobs_http.rs
+++ b/crates/server/tests/jobs_http.rs
@@ -23,6 +23,7 @@ use tower::ServiceExt;
 use skardi_server::auth::layer::AuthLayer;
 use skardi_server::config::{CliArgs, ServerConfig};
 use skardi_server::metrics::PipelineMetrics;
+use skardi_server::semantics::SemanticsRegistry;
 use skardi_server::server::{AppState, configure_routes};
 
 fn write_yaml(path: &std::path::Path, content: &str) {
@@ -95,11 +96,13 @@ spec:
         pipelines: HashMap::new(),
         jobs: jobs_map,
         data_sources: vec![],
+        semantics: SemanticsRegistry::default(),
         args: CliArgs {
             pipeline_path: None,
             jobs_path: None,
             jobs_db_path: None,
             ctx_file: None,
+            semantics_path: None,
             port: 0,
         },
     };

--- a/crates/server/tests/pipelines_http.rs
+++ b/crates/server/tests/pipelines_http.rs
@@ -22,6 +22,7 @@ use tower::ServiceExt;
 use skardi_server::auth::layer::AuthLayer;
 use skardi_server::config::{CliArgs, ServerConfig};
 use skardi_server::metrics::PipelineMetrics;
+use skardi_server::semantics::SemanticsRegistry;
 use skardi_server::server::{AppState, configure_routes};
 
 fn write_yaml(path: &std::path::Path, content: &str) {
@@ -99,11 +100,13 @@ spec:
         pipelines,
         jobs: HashMap::new(),
         data_sources: vec![],
+        semantics: SemanticsRegistry::default(),
         args: CliArgs {
             pipeline_path: None,
             jobs_path: None,
             jobs_db_path: None,
             ctx_file: None,
+            semantics_path: None,
             port: 0,
         },
     };

--- a/crates/server/tests/semantics_endpoint.rs
+++ b/crates/server/tests/semantics_endpoint.rs
@@ -1,0 +1,227 @@
+//! Integration test for the `kind: semantics` overlay:
+//! boot the same `configure_routes` axum router the binary does, register
+//! a MemTable, attach a semantics overlay, and verify the descriptions
+//! flow out through `GET /data_source`.
+//!
+//! Companion to `pipelines_http.rs` and `jobs_http.rs`.
+
+use arrow::array::{Float64Array, Int64Array, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use datafusion::prelude::SessionContext;
+use http_body_util::BodyExt;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::{Arc, RwLock};
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+use skardi::sources::DataSourceType;
+use skardi_server::auth::layer::AuthLayer;
+use skardi_server::config::{CliArgs, DataSource, ServerConfig};
+use skardi_server::metrics::PipelineMetrics;
+use skardi_server::semantics::SemanticsRegistry;
+use skardi_server::server::{AppState, configure_routes};
+
+fn write_yaml(path: &std::path::Path, content: &str) {
+    let mut f = std::fs::File::create(path).unwrap();
+    f.write_all(content.as_bytes()).unwrap();
+}
+
+fn products_batch() -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("brand", DataType::Utf8, false),
+        Field::new("price", DataType::Float64, false),
+    ]));
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(vec![1i64, 2, 3])),
+            Arc::new(StringArray::from(vec!["Apple", "Sony", "Apple"])),
+            Arc::new(Float64Array::from(vec![1299.0, 199.0, 999.0])),
+        ],
+    )
+    .unwrap()
+}
+
+fn products_data_source(description: Option<&str>) -> DataSource {
+    DataSource {
+        name: "products".to_string(),
+        source_type: DataSourceType::Csv,
+        path: PathBuf::from("unused.csv"),
+        connection_string: None,
+        schema: None,
+        options: None,
+        access_mode: Default::default(),
+        enable_cache: false,
+        hierarchy_level: Default::default(),
+        description: description.map(str::to_string),
+    }
+}
+
+async fn make_state(data_sources: Vec<DataSource>, semantics: SemanticsRegistry) -> AppState {
+    let ctx = Arc::new(SessionContext::new());
+    ctx.register_batch("products", products_batch()).unwrap();
+
+    let engine = Arc::new(skardi::engine::datafusion::DataFusionEngine::new_with_arc(
+        Arc::clone(&ctx),
+    ));
+    let config = ServerConfig {
+        pipelines: HashMap::new(),
+        jobs: HashMap::new(),
+        data_sources,
+        semantics,
+        args: CliArgs {
+            pipeline_path: None,
+            jobs_path: None,
+            jobs_db_path: None,
+            ctx_file: None,
+            semantics_path: None,
+            port: 0,
+        },
+    };
+    AppState {
+        config: Arc::new(RwLock::new(config)),
+        engine,
+        session_ctx: Arc::clone(&ctx),
+        metrics: PipelineMetrics::new(),
+        auth_layer: AuthLayer::None,
+        jobs: None,
+    }
+}
+
+async fn body_to_json(resp: axum::response::Response) -> Value {
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+async fn fetch_data_source(state: AppState) -> Value {
+    let app = configure_routes(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/data_source")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    body_to_json(resp).await
+}
+
+// ---------------------------------------------------------------------------
+// Semantics file overlays surface on the catalog endpoint.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn semantics_file_descriptions_appear_in_data_source_response() {
+    let tmp = TempDir::new().unwrap();
+    let sem_path = tmp.path().join("sem.yaml");
+    write_yaml(
+        &sem_path,
+        r#"
+kind: semantics
+metadata:
+  name: products-semantics
+  version: 1.0.0
+spec:
+  sources:
+    - name: products
+      description: "Five-row product fixture (semantics-overridden)"
+      columns:
+        - name: id
+          description: "Stable internal SKU"
+        - name: price
+          description: "Retail price in USD"
+"#,
+    );
+
+    let data_sources = vec![products_data_source(None)];
+    let semantics = SemanticsRegistry::build(Some(&sem_path), &data_sources).unwrap();
+    let state = make_state(data_sources, semantics).await;
+
+    let body = fetch_data_source(state).await;
+    let table = &body["data"][0]["tables"][0];
+
+    assert_eq!(
+        table["description"].as_str(),
+        Some("Five-row product fixture (semantics-overridden)"),
+        "table description missing/wrong: {body}"
+    );
+
+    let cols = table["schema"].as_array().unwrap();
+    let col_desc = |name: &str| -> Option<&str> {
+        cols.iter()
+            .find(|c| c["name"].as_str() == Some(name))
+            .and_then(|c| c["description"].as_str())
+    };
+    assert_eq!(col_desc("id"), Some("Stable internal SKU"));
+    assert_eq!(col_desc("price"), Some("Retail price in USD"));
+    // `brand` has no overlay — the field is omitted from the JSON entirely.
+    let brand = cols
+        .iter()
+        .find(|c| c["name"].as_str() == Some("brand"))
+        .unwrap();
+    assert!(
+        brand.get("description").is_none(),
+        "brand should not have a description key, got: {brand}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ctx-inline `description` is the fallback when no semantics file is loaded.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn ctx_inline_description_used_when_no_semantics_file() {
+    let data_sources = vec![products_data_source(Some("From ctx.yaml"))];
+    let semantics = SemanticsRegistry::build(None, &data_sources).unwrap();
+    let state = make_state(data_sources, semantics).await;
+
+    let body = fetch_data_source(state).await;
+    let table = &body["data"][0]["tables"][0];
+    assert_eq!(table["description"].as_str(), Some("From ctx.yaml"));
+    // No column overlays exist, so no schema entry should carry one.
+    for col in table["schema"].as_array().unwrap() {
+        assert!(
+            col.get("description").is_none(),
+            "no column should have a description, got: {col}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Semantics file wins over the ctx-inline description on the same source.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn semantics_file_overrides_ctx_inline_description() {
+    let tmp = TempDir::new().unwrap();
+    let sem_path = tmp.path().join("sem.yaml");
+    write_yaml(
+        &sem_path,
+        r#"
+kind: semantics
+metadata: { name: t }
+spec:
+  sources:
+    - name: products
+      description: "Override"
+"#,
+    );
+
+    let data_sources = vec![products_data_source(Some("Original from ctx"))];
+    let semantics = SemanticsRegistry::build(Some(&sem_path), &data_sources).unwrap();
+    let state = make_state(data_sources, semantics).await;
+
+    let body = fetch_data_source(state).await;
+    let table = &body["data"][0]["tables"][0];
+    assert_eq!(table["description"].as_str(), Some("Override"));
+}

--- a/crates/server/tests/semantics_endpoint.rs
+++ b/crates/server/tests/semantics_endpoint.rs
@@ -49,6 +49,13 @@ fn products_batch() -> RecordBatch {
     .unwrap()
 }
 
+fn ctx_descriptions(sources: &[DataSource]) -> Vec<(String, Option<String>)> {
+    sources
+        .iter()
+        .map(|ds| (ds.name.clone(), ds.description.clone()))
+        .collect()
+}
+
 fn products_data_source(description: Option<&str>) -> DataSource {
     DataSource {
         name: "products".to_string(),
@@ -144,7 +151,8 @@ spec:
     );
 
     let data_sources = vec![products_data_source(None)];
-    let semantics = SemanticsRegistry::build(Some(&sem_path), &data_sources).unwrap();
+    let semantics =
+        SemanticsRegistry::build(Some(&sem_path), &ctx_descriptions(&data_sources)).unwrap();
     let state = make_state(data_sources, semantics).await;
 
     let body = fetch_data_source(state).await;
@@ -182,7 +190,7 @@ spec:
 #[tokio::test]
 async fn ctx_inline_description_used_when_no_semantics_file() {
     let data_sources = vec![products_data_source(Some("From ctx.yaml"))];
-    let semantics = SemanticsRegistry::build(None, &data_sources).unwrap();
+    let semantics = SemanticsRegistry::build(None, &ctx_descriptions(&data_sources)).unwrap();
     let state = make_state(data_sources, semantics).await;
 
     let body = fetch_data_source(state).await;
@@ -218,7 +226,8 @@ spec:
     );
 
     let data_sources = vec![products_data_source(Some("Original from ctx"))];
-    let semantics = SemanticsRegistry::build(Some(&sem_path), &data_sources).unwrap();
+    let semantics =
+        SemanticsRegistry::build(Some(&sem_path), &ctx_descriptions(&data_sources)).unwrap();
     let state = make_state(data_sources, semantics).await;
 
     let body = fetch_data_source(state).await;

--- a/crates/skardi/src/lib.rs
+++ b/crates/skardi/src/lib.rs
@@ -2,4 +2,5 @@ pub mod engine;
 pub mod jobs;
 pub mod model;
 pub mod pipeline;
+pub mod semantics;
 pub mod sources;

--- a/crates/skardi/src/semantics.rs
+++ b/crates/skardi/src/semantics.rs
@@ -1,11 +1,14 @@
 //! Natural-language semantics overlays for the catalog.
 //!
-//! Semantics files are a separate Kubernetes-style YAML kind (`kind: semantics`)
-//! that attach human-readable descriptions to tables and columns already
-//! registered through a `kind: context` file. They are loaded at server
-//! startup alongside pipelines, jobs, and the context, and the catalog
-//! endpoint (`GET /data_source`) emits the descriptions on its response so
-//! agents can read them when picking a tool.
+//! Semantics files are a Kubernetes-style YAML kind (`kind: semantics`) that
+//! attach human-readable descriptions to tables and columns already
+//! registered through a `kind: context` file. They are loaded at startup
+//! alongside pipelines, jobs, and the context, and consumed by:
+//!
+//! * `skardi-server`'s `GET /data_source` response, so agents can read the
+//!   descriptions when picking a tool.
+//! * `skardi query --schema`, which renders the descriptions inline next to
+//!   each table and column.
 //!
 //! ```yaml
 //! kind: semantics
@@ -22,23 +25,28 @@
 //! ```
 //!
 //! Composition rules:
-//! - Multiple files may be loaded by pointing `--semantics` at a directory.
-//!   Files in that directory whose root `kind:` is not `semantics` are
-//!   silently skipped, mirroring how `--jobs` tolerates plain pipelines.
+//! - Multiple files may be loaded by pointing at a directory. Files in that
+//!   directory whose root `kind:` is not `semantics` are silently skipped,
+//!   mirroring how `--jobs` tolerates plain pipelines.
 //! - Two entries (across all files) for the same source — or two column
 //!   entries on the same source/column — are a hard error. Auto-generated
 //!   overlays must produce non-overlapping files.
 //! - References to sources or columns that do not exist on the loaded ctx
 //!   are warned about (not failed) so a stale overlay does not brick a
 //!   server boot.
+//!
+//! Auto-discovery (see [`resolve_semantics_source`]):
+//! - Both `skardi-server` and `skardi query --schema` look for an overlay
+//!   next to the ctx file when no explicit path is supplied:
+//!   `<ctx_dir>/semantics/` (directory) or `<ctx_dir>/semantics.yaml`
+//!   (single file). Defining both is a hard error to prevent silent
+//!   shadowing.
 
 use anyhow::{Context, Result};
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use thiserror::Error;
-
-use crate::config::DataSource;
 
 /// Required value of the root `kind:` discriminator.
 pub const SEMANTICS_KIND: &str = "semantics";
@@ -124,17 +132,23 @@ pub enum SemanticsError {
         first: PathBuf,
         second: PathBuf,
     },
+
+    #[error(
+        "Ambiguous semantics auto-discovery: both {dir:?} and {file:?} exist next to the ctx file. \
+         Remove one (or pass --semantics explicitly) so the loader knows which to use."
+    )]
+    AmbiguousAutoDiscovery { dir: PathBuf, file: PathBuf },
 }
 
-/// In-memory lookup attached to `ServerConfig` and consumed by the catalog
-/// HTTP handler. Indexed by source name; per-column descriptions live in a
-/// nested map.
+/// In-memory lookup attached to `ServerConfig` (server side) or built
+/// on-demand by `skardi query --schema` (CLI side). Indexed by source
+/// name; per-column descriptions live in a nested map.
 ///
-/// The registry merges *all* semantics files passed to `--semantics`, plus
-/// the ctx-inline `description` field, into a single view. Lookups in the
-/// HTTP handler should read from this struct only, not from the raw
-/// `DataSource` list, so that auto-generated overlays and hand-written
-/// ones flow through the same path.
+/// The registry merges *all* semantics files passed in, plus the
+/// ctx-inline `description` field, into a single view. Lookups should
+/// read from this struct only, not from the raw data source list, so
+/// that auto-generated overlays and hand-written ones flow through the
+/// same path.
 #[derive(Debug, Clone, Default)]
 pub struct SemanticsRegistry {
     sources: HashMap<String, SourceEntry>,
@@ -146,34 +160,39 @@ struct SourceEntry {
     /// `column name → description`. Only columns with a non-empty description live here.
     columns: HashMap<String, String>,
     /// Origin file for the source-level description, used to render a
-    /// helpful "redefined here" error if a second file collides.
+    /// helpful "redefined here" error if a second file collides. `None`
+    /// when the description came from the ctx-inline seed (which is
+    /// always allowed to be overwritten by a semantics file).
     description_origin: Option<PathBuf>,
     /// Origin file per column, same purpose.
     column_origins: HashMap<String, PathBuf>,
 }
 
 impl SemanticsRegistry {
-    /// Build the registry for the running server.
+    /// Build the registry.
     ///
     /// `semantics_path` may be a single file, a directory, or `None`.
-    /// `data_sources` is the ctx-loaded data source list — used both for
-    /// the inline-description fallback and for the dangling-reference
-    /// validation pass at the end.
-    pub fn build(semantics_path: Option<&Path>, data_sources: &[DataSource]) -> Result<Self> {
+    /// `ctx_descriptions` is the ctx-loaded list of `(source_name,
+    /// inline_description)` pairs — used both for the inline-description
+    /// fallback and for the dangling-reference validation pass at the end.
+    pub fn build(
+        semantics_path: Option<&Path>,
+        ctx_descriptions: &[(String, Option<String>)],
+    ) -> Result<Self> {
         let mut registry = Self::default();
 
         // Seed with ctx-inline descriptions. Semantics-file entries can
         // overwrite these (with their own collision-tracking origin), so
         // load order is: ctx first, files second.
-        for ds in data_sources {
-            if let Some(desc) = &ds.description
-                && !desc.is_empty()
+        for (name, desc) in ctx_descriptions {
+            if let Some(d) = desc.as_deref()
+                && !d.is_empty()
             {
                 registry
                     .sources
-                    .entry(ds.name.clone())
+                    .entry(name.clone())
                     .or_default()
-                    .description = Some(desc.clone());
+                    .description = Some(d.to_string());
             }
         }
 
@@ -191,7 +210,7 @@ impl SemanticsRegistry {
 
         // Warn (not fail) on dangling references — auto-generated overlays
         // shouldn't brick a partially-rebooted ctx.
-        registry.warn_on_dangling_refs(data_sources);
+        registry.warn_on_dangling_refs(ctx_descriptions);
 
         Ok(registry)
     }
@@ -234,8 +253,8 @@ impl SemanticsRegistry {
         Ok(())
     }
 
-    fn warn_on_dangling_refs(&self, data_sources: &[DataSource]) {
-        let known: HashSet<&str> = data_sources.iter().map(|ds| ds.name.as_str()).collect();
+    fn warn_on_dangling_refs(&self, ctx_descriptions: &[(String, Option<String>)]) {
+        let known: HashSet<&str> = ctx_descriptions.iter().map(|(n, _)| n.as_str()).collect();
         for name in self.sources.keys() {
             if !known.contains(name.as_str()) {
                 tracing::warn!(
@@ -259,6 +278,63 @@ impl SemanticsRegistry {
         self.sources
             .get(source)
             .and_then(|e| e.columns.get(column).map(String::as_str))
+    }
+
+    /// True when no overlay (file or ctx-inline) registered any
+    /// description. Used by `skardi query --schema` to skip the rendering
+    /// path entirely when there is nothing to show.
+    pub fn is_empty(&self) -> bool {
+        self.sources.is_empty()
+    }
+}
+
+/// Resolve which semantics path the loader should use, given an explicit
+/// override and/or a ctx directory to auto-discover from.
+///
+/// Resolution order:
+/// 1. `override_path` (e.g. `--semantics <path>`) — used directly if
+///    `Some`. No existence check here; the downstream loader will report
+///    a missing path with a clearer message.
+/// 2. `<ctx_dir>/semantics/` if it exists as a directory.
+/// 3. `<ctx_dir>/semantics.yaml` (or `.yml`) if it exists as a file.
+/// 4. `None` — no overlay configured.
+///
+/// Defining both `<ctx_dir>/semantics/` and `<ctx_dir>/semantics.yaml`
+/// is a hard error: silent shadowing of overlays that drive an agent's
+/// catalog view is exactly the sort of bug we want loud.
+pub fn resolve_semantics_source(
+    ctx_dir: Option<&Path>,
+    override_path: Option<&Path>,
+) -> Result<Option<PathBuf>> {
+    if let Some(p) = override_path {
+        return Ok(Some(p.to_path_buf()));
+    }
+    let Some(dir) = ctx_dir else {
+        return Ok(None);
+    };
+
+    let dir_path = dir.join("semantics");
+    let yaml_path = dir.join("semantics.yaml");
+    let yml_path = dir.join("semantics.yml");
+
+    let dir_exists = dir_path.is_dir();
+    let single_file = if yaml_path.is_file() {
+        Some(yaml_path)
+    } else if yml_path.is_file() {
+        Some(yml_path)
+    } else {
+        None
+    };
+
+    match (dir_exists, single_file) {
+        (true, Some(file)) => Err(SemanticsError::AmbiguousAutoDiscovery {
+            dir: dir_path,
+            file,
+        }
+        .into()),
+        (true, None) => Ok(Some(dir_path)),
+        (false, Some(file)) => Ok(Some(file)),
+        (false, None) => Ok(None),
     }
 }
 
@@ -370,23 +446,11 @@ pub fn load_required_semantics_file(path: &Path) -> Result<SemanticsFile> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{DataSource, DataSourceType};
     use std::io::Write;
     use tempfile::TempDir;
 
-    fn ds(name: &str, description: Option<&str>) -> DataSource {
-        DataSource {
-            name: name.to_string(),
-            source_type: DataSourceType::Csv,
-            path: PathBuf::new(),
-            connection_string: None,
-            schema: None,
-            options: None,
-            hierarchy_level: Default::default(),
-            access_mode: Default::default(),
-            enable_cache: false,
-            description: description.map(str::to_string),
-        }
+    fn ctx(name: &str, description: Option<&str>) -> (String, Option<String>) {
+        (name.to_string(), description.map(str::to_string))
     }
 
     fn write_yaml(dir: &Path, name: &str, content: &str) -> PathBuf {
@@ -417,7 +481,7 @@ spec:
 "#,
         );
 
-        let sources = vec![ds("products", None)];
+        let sources = vec![ctx("products", None)];
         let reg = SemanticsRegistry::build(Some(&path), &sources).unwrap();
         assert_eq!(reg.table_description("products"), Some("Product catalog"));
         assert_eq!(
@@ -429,7 +493,7 @@ spec:
 
     #[test]
     fn ctx_inline_description_used_as_fallback() {
-        let sources = vec![ds("products", Some("From ctx"))];
+        let sources = vec![ctx("products", Some("From ctx"))];
         let reg = SemanticsRegistry::build(None, &sources).unwrap();
         assert_eq!(reg.table_description("products"), Some("From ctx"));
     }
@@ -451,7 +515,7 @@ spec:
 "#,
         );
 
-        let sources = vec![ds("products", Some("From ctx"))];
+        let sources = vec![ctx("products", Some("From ctx"))];
         let reg = SemanticsRegistry::build(Some(&path), &sources).unwrap();
         assert_eq!(reg.table_description("products"), Some("Override"));
     }
@@ -482,7 +546,7 @@ spec:
 "#,
         );
 
-        let sources = vec![ds("products", None)];
+        let sources = vec![ctx("products", None)];
         let reg = SemanticsRegistry::build(Some(tmp.path()), &sources).unwrap();
         assert_eq!(reg.table_description("products"), Some("Product catalog"));
     }
@@ -515,7 +579,7 @@ spec:
 "#,
         );
 
-        let sources = vec![ds("products", None)];
+        let sources = vec![ctx("products", None)];
         let err = SemanticsRegistry::build(Some(tmp.path()), &sources).unwrap_err();
         let msg = format!("{err}");
         assert!(
@@ -556,7 +620,7 @@ spec:
 "#,
         );
 
-        let sources = vec![ds("products", None)];
+        let sources = vec![ctx("products", None)];
         let err = SemanticsRegistry::build(Some(tmp.path()), &sources).unwrap_err();
         let msg = format!("{err}");
         assert!(
@@ -581,7 +645,7 @@ spec:
 "#,
         );
 
-        let sources = vec![ds("products", None)];
+        let sources = vec![ctx("products", None)];
         let reg = SemanticsRegistry::build(Some(&path), &sources).unwrap();
         // The orphan entry is still in the registry — it just gets a warning at load time.
         assert_eq!(reg.table_description("orphan"), Some("no matching source"));
@@ -607,7 +671,7 @@ spec:
 "#,
         );
 
-        let sources = vec![ds("products", None)];
+        let sources = vec![ctx("products", None)];
         let reg = SemanticsRegistry::build(Some(&path), &sources).unwrap();
         assert_eq!(reg.table_description("products"), None);
     }
@@ -649,8 +713,91 @@ spec:
 
     #[test]
     fn empty_path_input_returns_empty_registry() {
-        let sources: Vec<DataSource> = Vec::new();
+        let sources: Vec<(String, Option<String>)> = Vec::new();
         let reg = SemanticsRegistry::build(None, &sources).unwrap();
         assert_eq!(reg.table_description("anything"), None);
+        assert!(reg.is_empty());
+    }
+
+    // ---------- resolve_semantics_source ----------
+
+    #[test]
+    fn resolver_returns_override_when_provided() {
+        let tmp = TempDir::new().unwrap();
+        let explicit = tmp.path().join("custom.yaml");
+        let resolved = resolve_semantics_source(Some(tmp.path()), Some(&explicit)).unwrap();
+        assert_eq!(resolved.as_deref(), Some(explicit.as_path()));
+    }
+
+    #[test]
+    fn resolver_returns_none_when_no_ctx_dir_and_no_override() {
+        let resolved = resolve_semantics_source(None, None).unwrap();
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn resolver_picks_directory_when_present() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir(tmp.path().join("semantics")).unwrap();
+        let resolved = resolve_semantics_source(Some(tmp.path()), None)
+            .unwrap()
+            .unwrap();
+        assert_eq!(resolved, tmp.path().join("semantics"));
+    }
+
+    #[test]
+    fn resolver_picks_yaml_file_when_present() {
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("semantics.yaml");
+        std::fs::File::create(&file).unwrap();
+        let resolved = resolve_semantics_source(Some(tmp.path()), None)
+            .unwrap()
+            .unwrap();
+        assert_eq!(resolved, file);
+    }
+
+    #[test]
+    fn resolver_picks_yml_file_when_yaml_missing() {
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("semantics.yml");
+        std::fs::File::create(&file).unwrap();
+        let resolved = resolve_semantics_source(Some(tmp.path()), None)
+            .unwrap()
+            .unwrap();
+        assert_eq!(resolved, file);
+    }
+
+    #[test]
+    fn resolver_returns_none_when_neither_present() {
+        let tmp = TempDir::new().unwrap();
+        let resolved = resolve_semantics_source(Some(tmp.path()), None).unwrap();
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn resolver_hard_errors_when_dir_and_file_both_present() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir(tmp.path().join("semantics")).unwrap();
+        std::fs::File::create(tmp.path().join("semantics.yaml")).unwrap();
+        let err = resolve_semantics_source(Some(tmp.path()), None).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("Ambiguous semantics auto-discovery"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn resolver_override_skips_collision_check() {
+        // If the user passes an explicit path, we don't even look at the
+        // ctx dir — collisions there don't matter.
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir(tmp.path().join("semantics")).unwrap();
+        std::fs::File::create(tmp.path().join("semantics.yaml")).unwrap();
+        let explicit = tmp.path().join("custom.yaml");
+        let resolved = resolve_semantics_source(Some(tmp.path()), Some(&explicit))
+            .unwrap()
+            .unwrap();
+        assert_eq!(resolved, explicit);
     }
 }

--- a/crates/skardi/src/semantics.rs
+++ b/crates/skardi/src/semantics.rs
@@ -17,19 +17,39 @@
 //!   version: 1.0.0
 //! spec:
 //!   sources:
-//!     - name: products              # must match data_sources[].name in the ctx
+//!     # Bare name: matches a `data_sources[].name` from the ctx. For
+//!     # table-mode sources, this *is* the table description. For
+//!     # catalog-mode sources, this is the broad fallback applied to
+//!     # every inner table that isn't covered by a qualified entry.
+//!     - name: products
 //!       description: "Product catalog with pricing/inventory"
 //!       columns:
 //!         - name: price_usd
 //!           description: "Retail price in USD; nullable for unlisted SKUs"
+//!
+//!     # Qualified `catalog.schema.table`: targets one specific physical
+//!     # table inside a catalog-mode source.
+//!     - name: mydb.public.users
+//!       description: "Auth + profile data, one row per registered account"
+//!       columns:
+//!         - name: id
+//!           description: "Auth UUID"
 //! ```
 //!
 //! Composition rules:
 //! - Multiple files may be loaded by pointing at a directory. Files in that
 //!   directory whose root `kind:` is not `semantics` are silently skipped,
 //!   mirroring how `--jobs` tolerates plain pipelines.
-//! - Two entries (across all files) for the same source — or two column
-//!   entries on the same source/column — are a hard error. Auto-generated
+//! - The `name:` field is parsed into a [`SemanticsKey`]: a bare segment
+//!   becomes [`SemanticsKey::Source`], three dot-separated segments become
+//!   [`SemanticsKey::Qualified`]. Anything else (0, 2, 4+ segments, empty
+//!   segments) is a hard error.
+//! - Bare and qualified entries live in separate addressing spaces — one
+//!   bare and one qualified entry can coexist for the same physical
+//!   table, and the qualified entry wins through
+//!   [`SemanticsRegistry::resolve_table_description`].
+//! - Two entries with the same key (same bare name, or same qualified
+//!   triple) at table or column level are a hard error. Auto-generated
 //!   overlays must produce non-overlapping files.
 //! - References to sources or columns that do not exist on the loaded ctx
 //!   are warned about (not failed) so a stale overlay does not brick a
@@ -42,10 +62,11 @@
 //!   (single file). Defining both is a hard error to prevent silent
 //!   shadowing.
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use thiserror::Error;
 
 /// Required value of the root `kind:` discriminator.
@@ -78,10 +99,15 @@ pub struct SemanticsSpec {
     pub sources: Vec<SourceSemantics>,
 }
 
-/// Per-source overlay. `name` matches a `data_sources[].name` from the
-/// loaded context. `description` overrides the ctx-inline description on
-/// the catalog response. `columns` is optional — supply only the columns
-/// that need a description.
+/// Per-source overlay. `name` is either a bare source name (matching a
+/// `data_sources[].name` from the loaded context) or a fully-qualified
+/// DataFusion path `catalog.schema.table` that targets one specific
+/// physical table — useful for catalog-mode sources that expose many
+/// inner tables under a single registration.
+///
+/// `description` overrides the ctx-inline description on the catalog
+/// response. `columns` is optional — supply only the columns that need
+/// a description.
 #[derive(Debug, Clone, Deserialize)]
 pub struct SourceSemantics {
     pub name: String,
@@ -89,6 +115,76 @@ pub struct SourceSemantics {
     pub description: Option<String>,
     #[serde(default)]
     pub columns: Vec<ColumnSemantics>,
+}
+
+/// Parsed form of `SourceSemantics::name`. Either a bare source name
+/// (matches table-mode sources directly and serves as the broad fallback
+/// for catalog-mode sources) or a fully-qualified `catalog.schema.table`
+/// triple that targets one specific inner table.
+///
+/// Used as the `HashMap` key inside [`SemanticsRegistry`] so lookups can
+/// pick the most specific entry without needing to walk the whole
+/// registry.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+enum SemanticsKey {
+    /// Bare source name. Matches `data_sources[].name` from the ctx.
+    Source(String),
+    /// Fully-qualified DataFusion path. Matches a specific physical
+    /// table.
+    Qualified {
+        catalog: String,
+        schema: String,
+        table: String,
+    },
+}
+
+impl SemanticsKey {
+    /// Parse a user-supplied `name:` string. Accepts either a single
+    /// segment (bare source name) or three dot-separated segments
+    /// (qualified path). Anything else is a hard error.
+    fn parse(name: &str) -> Result<Self> {
+        let parts: Vec<&str> = name.split('.').collect();
+        match parts.as_slice() {
+            [single] if !single.is_empty() => Ok(Self::Source((*single).to_string())),
+            [catalog, schema, table]
+                if !catalog.is_empty() && !schema.is_empty() && !table.is_empty() =>
+            {
+                Ok(Self::Qualified {
+                    catalog: (*catalog).to_string(),
+                    schema: (*schema).to_string(),
+                    table: (*table).to_string(),
+                })
+            }
+            _ => bail!(
+                "semantics source name `{name}` must be either a bare \
+                 source name (e.g. `products`) or a fully-qualified \
+                 `catalog.schema.table` path (e.g. `mydb.public.users`)"
+            ),
+        }
+    }
+
+    /// Source name this key references — for bare keys, the name itself;
+    /// for qualified keys, the catalog segment (which equals the
+    /// catalog-mode source name). Used for dangling-reference checks
+    /// against the loaded ctx.
+    fn referenced_source(&self) -> &str {
+        match self {
+            Self::Source(name) => name,
+            Self::Qualified { catalog, .. } => catalog,
+        }
+    }
+
+    /// Human-readable form for error messages, matching the user's input.
+    fn display(&self) -> String {
+        match self {
+            Self::Source(name) => name.clone(),
+            Self::Qualified {
+                catalog,
+                schema,
+                table,
+            } => format!("{catalog}.{schema}.{table}"),
+        }
+    }
 }
 
 /// Per-column overlay. `name` must match the column name as it appears in
@@ -104,12 +200,6 @@ pub struct ColumnSemantics {
 pub enum SemanticsError {
     #[error("Semantics path not found: {path:?}")]
     PathNotFound { path: PathBuf },
-
-    #[error("Semantics file {path:?} has unexpected kind {found:?}; expected `kind: semantics`")]
-    WrongKind { path: PathBuf, found: String },
-
-    #[error("Semantics file {path:?} is missing the root `kind:` field")]
-    MissingKind { path: PathBuf },
 
     #[error("Failed to parse semantics file {path:?}: {error}")]
     ParseError { path: PathBuf, error: String },
@@ -141,17 +231,23 @@ pub enum SemanticsError {
 }
 
 /// In-memory lookup attached to `ServerConfig` (server side) or built
-/// on-demand by `skardi query --schema` (CLI side). Indexed by source
-/// name; per-column descriptions live in a nested map.
+/// on-demand by `skardi query --schema` (CLI side). Indexed by
+/// [`SemanticsKey`] so a single registry can hold both bare source-name
+/// entries and fully-qualified `catalog.schema.table` entries; per-column
+/// descriptions live in a nested map.
 ///
 /// The registry merges *all* semantics files passed in, plus the
 /// ctx-inline `description` field, into a single view. Lookups should
 /// read from this struct only, not from the raw data source list, so
 /// that auto-generated overlays and hand-written ones flow through the
 /// same path.
+///
+/// The inner map is `Arc`-wrapped so cloning the registry (e.g. once per
+/// `GET /data_source` request to release the config lock before async
+/// work) is O(1).
 #[derive(Debug, Clone, Default)]
 pub struct SemanticsRegistry {
-    sources: HashMap<String, SourceEntry>,
+    entries: Arc<HashMap<SemanticsKey, SourceEntry>>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -179,18 +275,19 @@ impl SemanticsRegistry {
         semantics_path: Option<&Path>,
         ctx_descriptions: &[(String, Option<String>)],
     ) -> Result<Self> {
-        let mut registry = Self::default();
+        let mut entries: HashMap<SemanticsKey, SourceEntry> = HashMap::new();
 
         // Seed with ctx-inline descriptions. Semantics-file entries can
         // overwrite these (with their own collision-tracking origin), so
         // load order is: ctx first, files second.
+        // Ctx-inline descriptions are always source-level (bare name),
+        // since `data_sources[]` only addresses sources, not inner tables.
         for (name, desc) in ctx_descriptions {
             if let Some(d) = desc.as_deref()
                 && !d.is_empty()
             {
-                registry
-                    .sources
-                    .entry(name.clone())
+                entries
+                    .entry(SemanticsKey::Source(name.clone()))
                     .or_default()
                     .description = Some(d.to_string());
             }
@@ -204,87 +301,194 @@ impl SemanticsRegistry {
                     tracing::debug!("Skipping {:?}: no `kind: semantics` at root", file_path);
                     continue;
                 };
-                registry.merge(loaded.spec, file_path)?;
+                merge_into(&mut entries, loaded.spec, file_path)?;
             }
         }
 
         // Warn (not fail) on dangling references — auto-generated overlays
         // shouldn't brick a partially-rebooted ctx.
-        registry.warn_on_dangling_refs(ctx_descriptions);
+        warn_on_dangling_refs(&entries, ctx_descriptions);
 
-        Ok(registry)
+        Ok(Self {
+            entries: Arc::new(entries),
+        })
     }
 
-    /// Merge a parsed semantics spec into the registry, hard-erroring on
-    /// duplicate source or column entries.
-    fn merge(&mut self, spec: SemanticsSpec, origin: &Path) -> Result<()> {
-        for source in spec.sources {
-            let entry = self.sources.entry(source.name.clone()).or_default();
-
-            if let Some(desc) = source.description {
-                if let Some(prior) = &entry.description_origin {
-                    return Err(SemanticsError::DuplicateSource {
-                        source_name: source.name.clone(),
-                        first: prior.clone(),
-                        second: origin.to_path_buf(),
-                    }
-                    .into());
-                }
-                entry.description = Some(desc);
-                entry.description_origin = Some(origin.to_path_buf());
-            }
-
-            for col in source.columns {
-                if let Some(desc) = col.description {
-                    if let Some(prior) = entry.column_origins.get(&col.name) {
-                        return Err(SemanticsError::DuplicateColumn {
-                            source_name: source.name.clone(),
-                            column: col.name.clone(),
-                            first: prior.clone(),
-                            second: origin.to_path_buf(),
-                        }
-                        .into());
-                    }
-                    entry.columns.insert(col.name.clone(), desc);
-                    entry.column_origins.insert(col.name, origin.to_path_buf());
-                }
-            }
-        }
-        Ok(())
-    }
-
-    fn warn_on_dangling_refs(&self, ctx_descriptions: &[(String, Option<String>)]) {
-        let known: HashSet<&str> = ctx_descriptions.iter().map(|(n, _)| n.as_str()).collect();
-        for name in self.sources.keys() {
-            if !known.contains(name.as_str()) {
-                tracing::warn!(
-                    "Semantics references unknown data source `{name}`; entry will be ignored \
-                     until a matching source is added to the context"
-                );
-            }
-        }
-    }
-
-    /// Table-level description for a data source (semantics override > ctx-inline).
+    /// Bare source-name lookup. Matches the `name: foo` form in a
+    /// semantics file (or the ctx-inline `data_sources[].description`
+    /// fallback). For table-mode sources where the source name *is* the
+    /// physical table name, this is the only form that resolves.
     pub fn table_description(&self, source: &str) -> Option<&str> {
-        self.sources
-            .get(source)
+        self.entries
+            .get(&SemanticsKey::Source(source.to_string()))
             .and_then(|e| e.description.as_deref())
     }
 
-    /// Column-level description for `(source, column)`. Returns `None` when
-    /// no overlay exists.
+    /// Bare-source column lookup. See [`Self::table_description`] for the
+    /// addressing model.
     pub fn column_description(&self, source: &str, column: &str) -> Option<&str> {
-        self.sources
-            .get(source)
+        self.entries
+            .get(&SemanticsKey::Source(source.to_string()))
             .and_then(|e| e.columns.get(column).map(String::as_str))
+    }
+
+    /// Fully-qualified table lookup — matches the `name:
+    /// catalog.schema.table` form. Used to address a specific inner
+    /// table of a catalog-mode source.
+    pub fn qualified_table_description(
+        &self,
+        catalog: &str,
+        schema: &str,
+        table: &str,
+    ) -> Option<&str> {
+        self.entries
+            .get(&SemanticsKey::Qualified {
+                catalog: catalog.to_string(),
+                schema: schema.to_string(),
+                table: table.to_string(),
+            })
+            .and_then(|e| e.description.as_deref())
+    }
+
+    /// Fully-qualified column lookup. See
+    /// [`Self::qualified_table_description`] for the addressing model.
+    pub fn qualified_column_description(
+        &self,
+        catalog: &str,
+        schema: &str,
+        table: &str,
+        column: &str,
+    ) -> Option<&str> {
+        self.entries
+            .get(&SemanticsKey::Qualified {
+                catalog: catalog.to_string(),
+                schema: schema.to_string(),
+                table: table.to_string(),
+            })
+            .and_then(|e| e.columns.get(column).map(String::as_str))
+    }
+
+    /// Resolve a description for a physical `(catalog, schema, table)`
+    /// triple, with fallback through the bare source name. Most-specific
+    /// match wins:
+    ///
+    /// 1. Qualified `name: catalog.schema.table` entry, or
+    /// 2. Bare `name: <source>` entry (for table-mode sources, or the
+    ///    catalog-mode broad fallback), or
+    /// 3. `None`.
+    ///
+    /// Pass `source = None` if the caller can't resolve a bare source
+    /// name (e.g. ad-hoc URL-registered tables); that path will skip
+    /// step 2.
+    pub fn resolve_table_description(
+        &self,
+        catalog: &str,
+        schema: &str,
+        table: &str,
+        source: Option<&str>,
+    ) -> Option<&str> {
+        self.qualified_table_description(catalog, schema, table)
+            .or_else(|| source.and_then(|s| self.table_description(s)))
+    }
+
+    /// Same fall-through as [`Self::resolve_table_description`], but
+    /// for one column inside the physical table.
+    pub fn resolve_column_description(
+        &self,
+        catalog: &str,
+        schema: &str,
+        table: &str,
+        source: Option<&str>,
+        column: &str,
+    ) -> Option<&str> {
+        self.qualified_column_description(catalog, schema, table, column)
+            .or_else(|| source.and_then(|s| self.column_description(s, column)))
     }
 
     /// True when no overlay (file or ctx-inline) registered any
     /// description. Used by `skardi query --schema` to skip the rendering
     /// path entirely when there is nothing to show.
     pub fn is_empty(&self) -> bool {
-        self.sources.is_empty()
+        self.entries.is_empty()
+    }
+}
+
+/// Merge a parsed semantics spec into the in-progress entry map,
+/// hard-erroring on duplicate entries (same key, same column).
+///
+/// Each `name:` is parsed into a [`SemanticsKey`]: a bare segment becomes
+/// `Source(name)`, three dot-separated segments become a `Qualified`
+/// triple. A 1-part entry and a 3-part entry are different keys — both
+/// can coexist; lookup precedence is handled at the registry level.
+///
+/// Empty-string descriptions (`description: ""`) are treated as absent —
+/// same policy as the ctx-inline seed pass — so they never overwrite a
+/// non-empty fallback nor count toward the duplicate-detection.
+fn merge_into(
+    entries: &mut HashMap<SemanticsKey, SourceEntry>,
+    spec: SemanticsSpec,
+    origin: &Path,
+) -> Result<()> {
+    for source in spec.sources {
+        let key = SemanticsKey::parse(&source.name)
+            .with_context(|| format!("In semantics file {origin:?}"))?;
+        let key_display = key.display();
+        let entry = entries.entry(key.clone()).or_default();
+
+        if let Some(desc) = source.description.filter(|d| !d.is_empty()) {
+            if let Some(prior) = &entry.description_origin {
+                return Err(SemanticsError::DuplicateSource {
+                    source_name: key_display.clone(),
+                    first: prior.clone(),
+                    second: origin.to_path_buf(),
+                }
+                .into());
+            }
+            entry.description = Some(desc);
+            entry.description_origin = Some(origin.to_path_buf());
+        }
+
+        for col in source.columns {
+            if let Some(desc) = col.description.filter(|d| !d.is_empty()) {
+                if let Some(prior) = entry.column_origins.get(&col.name) {
+                    return Err(SemanticsError::DuplicateColumn {
+                        source_name: key_display.clone(),
+                        column: col.name.clone(),
+                        first: prior.clone(),
+                        second: origin.to_path_buf(),
+                    }
+                    .into());
+                }
+                entry.columns.insert(col.name.clone(), desc);
+                entry.column_origins.insert(col.name, origin.to_path_buf());
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Warn for entries that don't reference a known ctx source.
+///
+/// For a bare `Source(name)` key, "known" means `name` appears in
+/// `data_sources[].name`. For a `Qualified { catalog, .. }` key, we check
+/// the catalog segment, since for catalog-mode sources the catalog name
+/// equals the ctx source name. (Unknown inner schemas/tables aren't
+/// validated here — they're resolved against the live Arrow schema at
+/// render time.)
+fn warn_on_dangling_refs(
+    entries: &HashMap<SemanticsKey, SourceEntry>,
+    ctx_descriptions: &[(String, Option<String>)],
+) {
+    let known: HashSet<&str> = ctx_descriptions.iter().map(|(n, _)| n.as_str()).collect();
+    for key in entries.keys() {
+        let referenced = key.referenced_source();
+        if !known.contains(referenced) {
+            let key_str = key.display();
+            tracing::warn!(
+                "Semantics references unknown data source `{key_str}`; entry will be ignored \
+                 until a matching source is added to the context"
+            );
+        }
     }
 }
 
@@ -414,35 +618,6 @@ fn load_semantics_file(path: &Path) -> Result<Option<SemanticsFile>> {
     Ok(Some(parsed))
 }
 
-/// Load a single yaml file that the caller already knows is supposed to be
-/// a semantics file (for example, because `--semantics path/to/file.yaml`
-/// was passed explicitly). Unlike [`load_semantics_file`], a missing or
-/// wrong `kind:` is a hard error here.
-#[allow(dead_code)]
-pub fn load_required_semantics_file(path: &Path) -> Result<SemanticsFile> {
-    let raw = std::fs::read_to_string(path)
-        .with_context(|| format!("Failed to read semantics file: {:?}", path))?;
-
-    let parsed: SemanticsFile =
-        serde_yaml::from_str(&raw).map_err(|e| SemanticsError::ParseError {
-            path: path.to_path_buf(),
-            error: e.to_string(),
-        })?;
-
-    match parsed.kind.as_deref() {
-        Some(SEMANTICS_KIND) => Ok(parsed),
-        Some(other) => Err(SemanticsError::WrongKind {
-            path: path.to_path_buf(),
-            found: other.to_string(),
-        }
-        .into()),
-        None => Err(SemanticsError::MissingKind {
-            path: path.to_path_buf(),
-        }
-        .into()),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -518,6 +693,357 @@ spec:
         let sources = vec![ctx("products", Some("From ctx"))];
         let reg = SemanticsRegistry::build(Some(&path), &sources).unwrap();
         assert_eq!(reg.table_description("products"), Some("Override"));
+    }
+
+    #[test]
+    fn empty_string_description_in_file_does_not_override_ctx_fallback() {
+        // `description: ""` in a semantics file is treated as "no
+        // description" — same policy as the ctx-inline seed pass — so it
+        // must not overwrite a non-empty ctx fallback. Empty column
+        // descriptions are likewise absent.
+        let tmp = TempDir::new().unwrap();
+        let path = write_yaml(
+            tmp.path(),
+            "sem.yaml",
+            r#"
+kind: semantics
+metadata: { name: t }
+spec:
+  sources:
+    - name: products
+      description: ""
+      columns:
+        - name: id
+          description: ""
+"#,
+        );
+
+        let sources = vec![ctx("products", Some("From ctx"))];
+        let reg = SemanticsRegistry::build(Some(&path), &sources).unwrap();
+        assert_eq!(
+            reg.table_description("products"),
+            Some("From ctx"),
+            "empty file description must not stomp the ctx fallback"
+        );
+        assert_eq!(reg.column_description("products", "id"), None);
+    }
+
+    #[test]
+    fn empty_string_description_does_not_trigger_duplicate_error() {
+        // First file sets a real description; second file has `description: ""`
+        // for the same source. Since empty is treated as absent, this is
+        // *not* a collision and the original description survives.
+        let tmp = TempDir::new().unwrap();
+        write_yaml(
+            tmp.path(),
+            "a.yaml",
+            r#"
+kind: semantics
+metadata: { name: a }
+spec:
+  sources:
+    - name: products
+      description: "first"
+      columns:
+        - name: price
+          description: "real price"
+"#,
+        );
+        write_yaml(
+            tmp.path(),
+            "b.yaml",
+            r#"
+kind: semantics
+metadata: { name: b }
+spec:
+  sources:
+    - name: products
+      description: ""
+      columns:
+        - name: price
+          description: ""
+"#,
+        );
+
+        let sources = vec![ctx("products", None)];
+        let reg = SemanticsRegistry::build(Some(tmp.path()), &sources).unwrap();
+        assert_eq!(reg.table_description("products"), Some("first"));
+        assert_eq!(
+            reg.column_description("products", "price"),
+            Some("real price")
+        );
+    }
+
+    // ---------- qualified-path keys (catalog.schema.table) ----------
+
+    #[test]
+    fn semantics_key_parse_accepts_bare_and_qualified() {
+        assert!(matches!(
+            SemanticsKey::parse("products").unwrap(),
+            SemanticsKey::Source(s) if s == "products"
+        ));
+        let qualified = SemanticsKey::parse("mydb.public.users").unwrap();
+        match qualified {
+            SemanticsKey::Qualified {
+                catalog,
+                schema,
+                table,
+            } => {
+                assert_eq!(catalog, "mydb");
+                assert_eq!(schema, "public");
+                assert_eq!(table, "users");
+            }
+            _ => panic!("expected Qualified, got {qualified:?}"),
+        }
+    }
+
+    #[test]
+    fn semantics_key_parse_rejects_two_part_path() {
+        // Two parts is ambiguous (schema.table? source.table?). We
+        // require either 1 segment or all 3, never something in
+        // between.
+        let err = SemanticsKey::parse("schema.table").unwrap_err();
+        assert!(
+            format!("{err}").contains("must be either a bare"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn semantics_key_parse_rejects_too_many_parts() {
+        let err = SemanticsKey::parse("a.b.c.d").unwrap_err();
+        assert!(format!("{err}").contains("must be either a bare"));
+    }
+
+    #[test]
+    fn semantics_key_parse_rejects_empty_segments() {
+        // Leading / trailing / interior empty segment ("a..b") is invalid.
+        assert!(SemanticsKey::parse("").is_err());
+        assert!(SemanticsKey::parse("..").is_err());
+        assert!(SemanticsKey::parse("mydb..users").is_err());
+        assert!(SemanticsKey::parse(".mydb.public.users").is_err());
+    }
+
+    #[test]
+    fn malformed_name_in_semantics_file_is_hard_error() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_yaml(
+            tmp.path(),
+            "sem.yaml",
+            r#"
+kind: semantics
+metadata: { name: t }
+spec:
+  sources:
+    - name: schema.table        # 2-part is invalid
+      description: "x"
+"#,
+        );
+        let sources = vec![ctx("anything", None)];
+        let err = SemanticsRegistry::build(Some(&path), &sources).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("must be either a bare"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn qualified_path_resolves_specific_inner_table() {
+        // A `name: catalog.schema.table` entry is reachable via the
+        // qualified-lookup helpers and is *separate* from any bare
+        // `name: catalog` entry.
+        let tmp = TempDir::new().unwrap();
+        let path = write_yaml(
+            tmp.path(),
+            "sem.yaml",
+            r#"
+kind: semantics
+metadata: { name: t }
+spec:
+  sources:
+    - name: wiki.main.pages
+      description: "Wiki page contents"
+      columns:
+        - name: title
+          description: "Page title"
+"#,
+        );
+
+        let sources = vec![ctx("wiki", None)];
+        let reg = SemanticsRegistry::build(Some(&path), &sources).unwrap();
+        assert_eq!(
+            reg.qualified_table_description("wiki", "main", "pages"),
+            Some("Wiki page contents")
+        );
+        assert_eq!(
+            reg.qualified_column_description("wiki", "main", "pages", "title"),
+            Some("Page title")
+        );
+        // The bare lookup must NOT pick up the qualified entry — it's a
+        // different addressing space.
+        assert_eq!(reg.table_description("wiki"), None);
+        assert_eq!(reg.column_description("wiki", "title"), None);
+    }
+
+    #[test]
+    fn resolve_table_description_prefers_qualified_over_bare() {
+        // Both `wiki` and `wiki.main.pages` describe the same physical
+        // table. The qualified form is more specific, so it wins through
+        // resolve_table_description.
+        let tmp = TempDir::new().unwrap();
+        let path = write_yaml(
+            tmp.path(),
+            "sem.yaml",
+            r#"
+kind: semantics
+metadata: { name: t }
+spec:
+  sources:
+    - name: wiki
+      description: "broad fallback"
+      columns:
+        - name: title
+          description: "broad title"
+    - name: wiki.main.pages
+      description: "specific to pages"
+      columns:
+        - name: title
+          description: "specific title"
+"#,
+        );
+
+        let sources = vec![ctx("wiki", None)];
+        let reg = SemanticsRegistry::build(Some(&path), &sources).unwrap();
+        assert_eq!(
+            reg.resolve_table_description("wiki", "main", "pages", Some("wiki")),
+            Some("specific to pages")
+        );
+        assert_eq!(
+            reg.resolve_column_description("wiki", "main", "pages", Some("wiki"), "title"),
+            Some("specific title")
+        );
+        // For an inner table that has no qualified overlay, the bare
+        // `wiki` fallback still applies.
+        assert_eq!(
+            reg.resolve_table_description("wiki", "main", "revisions", Some("wiki")),
+            Some("broad fallback")
+        );
+        assert_eq!(
+            reg.resolve_column_description("wiki", "main", "revisions", Some("wiki"), "title"),
+            Some("broad title")
+        );
+    }
+
+    #[test]
+    fn resolve_falls_back_to_none_when_neither_form_present() {
+        let sources = vec![ctx("wiki", None)];
+        let reg = SemanticsRegistry::build(None, &sources).unwrap();
+        assert_eq!(
+            reg.resolve_table_description("wiki", "main", "pages", Some("wiki")),
+            None
+        );
+        // No source name passed at all — still fine, just returns None.
+        assert_eq!(
+            reg.resolve_table_description("wiki", "main", "pages", None),
+            None
+        );
+    }
+
+    #[test]
+    fn duplicate_qualified_entry_is_hard_error() {
+        // Same `(catalog, schema, table)` defined in two files: still
+        // a collision because the keys are equal.
+        let tmp = TempDir::new().unwrap();
+        write_yaml(
+            tmp.path(),
+            "a.yaml",
+            r#"
+kind: semantics
+metadata: { name: a }
+spec:
+  sources:
+    - name: wiki.main.pages
+      description: "first"
+"#,
+        );
+        write_yaml(
+            tmp.path(),
+            "b.yaml",
+            r#"
+kind: semantics
+metadata: { name: b }
+spec:
+  sources:
+    - name: wiki.main.pages
+      description: "second"
+"#,
+        );
+        let sources = vec![ctx("wiki", None)];
+        let err = SemanticsRegistry::build(Some(tmp.path()), &sources).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("Duplicate semantics entry for source `wiki.main.pages`"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn bare_and_qualified_for_same_source_coexist() {
+        // A source-level entry and a qualified entry are *not*
+        // duplicates of each other — they're addressed at different
+        // levels and resolve_table_description handles precedence.
+        let tmp = TempDir::new().unwrap();
+        let path = write_yaml(
+            tmp.path(),
+            "sem.yaml",
+            r#"
+kind: semantics
+metadata: { name: t }
+spec:
+  sources:
+    - name: wiki
+      description: "broad"
+    - name: wiki.main.pages
+      description: "specific"
+"#,
+        );
+        let sources = vec![ctx("wiki", None)];
+        // Should NOT error.
+        let reg = SemanticsRegistry::build(Some(&path), &sources).unwrap();
+        assert_eq!(reg.table_description("wiki"), Some("broad"));
+        assert_eq!(
+            reg.qualified_table_description("wiki", "main", "pages"),
+            Some("specific")
+        );
+    }
+
+    #[test]
+    fn qualified_dangling_reference_warns_via_catalog_segment() {
+        // When the catalog segment of a qualified entry doesn't match
+        // any ctx source, we warn (just like with bare-name dangling
+        // refs). The entry is still loaded and reachable — we just
+        // surface the mismatch in logs.
+        let tmp = TempDir::new().unwrap();
+        let path = write_yaml(
+            tmp.path(),
+            "sem.yaml",
+            r#"
+kind: semantics
+metadata: { name: t }
+spec:
+  sources:
+    - name: nope.public.users
+      description: "stale"
+"#,
+        );
+        let sources = vec![ctx("wiki", None)];
+        let reg = SemanticsRegistry::build(Some(&path), &sources).unwrap();
+        // Entry is still queryable — only logged as a warning.
+        assert_eq!(
+            reg.qualified_table_description("nope", "public", "users"),
+            Some("stale")
+        );
     }
 
     #[test]
@@ -674,41 +1200,6 @@ spec:
         let sources = vec![ctx("products", None)];
         let reg = SemanticsRegistry::build(Some(&path), &sources).unwrap();
         assert_eq!(reg.table_description("products"), None);
-    }
-
-    #[test]
-    fn required_loader_rejects_missing_kind() {
-        let tmp = TempDir::new().unwrap();
-        let path = write_yaml(
-            tmp.path(),
-            "stray.yaml",
-            r#"
-metadata: { name: x }
-spec:
-  sources: []
-"#,
-        );
-
-        let err = load_required_semantics_file(&path).unwrap_err();
-        assert!(format!("{err}").contains("missing the root `kind:` field"));
-    }
-
-    #[test]
-    fn required_loader_rejects_wrong_kind() {
-        let tmp = TempDir::new().unwrap();
-        let path = write_yaml(
-            tmp.path(),
-            "stray.yaml",
-            r#"
-kind: pipeline
-metadata: { name: x, version: 1.0.0 }
-spec:
-  query: SELECT 1
-"#,
-        );
-
-        let err = load_required_semantics_file(&path).unwrap_err();
-        assert!(format!("{err}").contains("unexpected kind"));
     }
 
     #[test]

--- a/crates/skardi/src/semantics.rs
+++ b/crates/skardi/src/semantics.rs
@@ -40,10 +40,10 @@
 //! - Multiple files may be loaded by pointing at a directory. Files in that
 //!   directory whose root `kind:` is not `semantics` are silently skipped,
 //!   mirroring how `--jobs` tolerates plain pipelines.
-//! - The `name:` field is parsed into a [`SemanticsKey`]: a bare segment
-//!   becomes [`SemanticsKey::Source`], three dot-separated segments become
-//!   [`SemanticsKey::Qualified`]. Anything else (0, 2, 4+ segments, empty
-//!   segments) is a hard error.
+//! - The `name:` field is parsed into one of two key shapes: a bare
+//!   segment is treated as a source name; three dot-separated segments
+//!   are treated as a fully-qualified `catalog.schema.table` triple.
+//!   Anything else (0, 2, 4+ segments, empty segments) is a hard error.
 //! - Bare and qualified entries live in separate addressing spaces — one
 //!   bare and one qualified entry can coexist for the same physical
 //!   table, and the qualified entry wins through
@@ -231,10 +231,10 @@ pub enum SemanticsError {
 }
 
 /// In-memory lookup attached to `ServerConfig` (server side) or built
-/// on-demand by `skardi query --schema` (CLI side). Indexed by
-/// [`SemanticsKey`] so a single registry can hold both bare source-name
-/// entries and fully-qualified `catalog.schema.table` entries; per-column
-/// descriptions live in a nested map.
+/// on-demand by `skardi query --schema` (CLI side). Holds both bare
+/// source-name entries and fully-qualified `catalog.schema.table`
+/// entries in a single keyed map; per-column descriptions live in a
+/// nested map.
 ///
 /// The registry merges *all* semantics files passed in, plus the
 /// ctx-inline `description` field, into a single view. Lookups should

--- a/docs/basic/semantics.yaml
+++ b/docs/basic/semantics.yaml
@@ -1,0 +1,19 @@
+kind: semantics
+
+metadata:
+  name: basic-semantics
+  version: 1.0.0
+
+spec:
+  sources:
+    - name: products
+      description: "Product catalog dataset with comprehensive product information including pricing, inventory, and categorization. One row per SKU."
+      columns:
+        - name: id
+          description: "Stable internal SKU; primary key."
+        - name: brand
+          description: "Manufacturer / brand name as it appears on product packaging."
+        - name: price
+          description: "Retail price in USD."
+        - name: category
+          description: "Top-level product category (e.g. Electronics, Audio)."

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -102,8 +102,31 @@ Use `--schema` with either `--all` (all tables) or `-t TABLE` (one table):
 ```bash
 skardi query --ctx ./demo/ctx.yaml --schema --all
 skardi query --ctx ./demo/ctx.yaml --schema -t products
-
 ```
+
+**Semantics overlay** — if a `kind: semantics` YAML is discovered (or
+`data_sources[].description` is set), `--schema` renders the
+descriptions inline next to each table and column with a `--`
+separator. No flag is needed to opt in.
+
+```text
+table: products  -- Product catalog with pricing/inventory. One row per SKU.
+  id: Int64  -- Stable internal SKU; primary key.
+  brand: Utf8
+  price: Float64  -- Retail price in USD.
+```
+
+The overlay is resolved in this order:
+
+1. `--semantics <FILE-OR-DIR>` (explicit override).
+2. Auto-discovered `<ctx_dir>/semantics/` directory.
+3. Auto-discovered `<ctx_dir>/semantics.yaml` (or `.yml`) file.
+4. None — descriptions fall back to `data_sources[].description` from
+   the ctx, or render bare if neither is set.
+
+Defining both `<ctx_dir>/semantics/` and `<ctx_dir>/semantics.yaml` is
+a hard error to prevent silent shadowing. See [semantics.md](semantics.md)
+for the file format and composition rules.
 
 #### Context file format
 

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -1,14 +1,16 @@
 # Catalog Semantics
 
 A **semantics overlay** attaches natural-language descriptions to the
-tables and columns already registered through a context file. The server
-loads them at startup alongside pipelines, jobs, and the context, and
-the catalog endpoint (`GET /data_source`) emits the descriptions on its
-response so an agent can read them when picking a tool.
+tables and columns already registered through a context file. Both
+binaries consume it:
 
-This page documents the YAML shape, how the server loads it, the
-override / fallback rules, and the resulting JSON shape on the catalog
-endpoint.
+- `skardi-server` loads it at startup and emits the descriptions on
+  `GET /data_source` so an agent can read them when picking a tool.
+- `skardi query --schema` renders the descriptions inline next to each
+  table and column, for human inspection.
+
+This page documents the YAML shape, how the loader finds it, the
+override / fallback rules, and where the descriptions surface.
 
 ---
 
@@ -67,25 +69,38 @@ existing [`docs/basic/ctx.yaml`](basic/ctx.yaml).
 ## Loading
 
 ```bash
+# server
 skardi-server \
   --ctx ctx.yaml \
   --pipeline pipelines/ \
-  --semantics semantics/ \    # file or directory
+  --semantics semantics/ \    # optional; auto-discovered next to ctx if omitted
   --port 8080
+
+# CLI
+skardi query --ctx ctx.yaml --schema --all
+skardi query --ctx ctx.yaml --schema --all --semantics ./custom/semantics.yaml
 ```
 
-`--semantics` accepts either a single yaml file or a directory:
+Both binaries follow the same resolution order:
 
-- **Single file** — must be `kind: semantics`. A wrong or missing kind
-  is treated the same as for `--jobs`: the file is silently skipped.
-- **Directory** — every `*.yaml` / `*.yml` at one level is scanned, in
-  alphabetical order. Files whose root `kind:` is not `semantics` are
-  silently skipped, so a single shared config directory can mix pipeline
-  / job / context / semantics yamls.
+1. **Explicit `--semantics <path>`** — used directly. Accepts either a
+   single yaml file or a directory.
+2. **Auto-discovered `<ctx_dir>/semantics/`** (directory) — every
+   `*.yaml` / `*.yml` at one level is scanned, in alphabetical order.
+3. **Auto-discovered `<ctx_dir>/semantics.yaml`** (single file).
+4. None — the catalog falls back to `data_sources[].description` only
+   (see *Fallback* below).
 
-When no `--semantics` flag is passed, the server starts normally and
-the catalog endpoint falls back to `data_sources[].description` only
-(see *Fallback* below).
+When `--semantics` points at a directory, files whose root `kind:` is
+not `semantics` are silently skipped, so a single shared config
+directory can mix pipeline / job / context / semantics yamls. A single
+file passed explicitly with the wrong or missing kind is also a soft
+skip — same behavior as `--jobs`.
+
+> **Auto-discovery collision**: defining both
+> `<ctx_dir>/semantics/` and `<ctx_dir>/semantics.yaml` is a hard error
+> at startup. Pick one. Silent shadowing of overlays that drive an
+> agent's catalog view is exactly the bug worth being loud about.
 
 ---
 
@@ -135,7 +150,28 @@ The merge precedence:
 
 ## Where it shows up
 
-The catalog endpoint `GET /data_source` returns the merged view:
+### `skardi query --schema`
+
+The CLI renders the merged view inline next to each table and column.
+A `--` separator carries the description; lines without an overlay or
+fallback render bare, so existing scripts that parse the output keep
+working.
+
+```bash
+$ skardi query --ctx ./ctx.yaml --schema --all
+table: products  -- Product catalog with pricing/inventory. One row per SKU.
+  id: Int64  -- Stable internal SKU; primary key.
+  brand: Utf8
+  price: Float64  -- Retail price in USD.
+```
+
+No flag is needed to opt in: if a `kind: semantics` overlay is
+discovered (or `data_sources[].description` is set), the descriptions
+appear automatically.
+
+### `GET /data_source` (server)
+
+The catalog endpoint returns the merged view:
 
 ```bash
 curl http://localhost:8080/data_source
@@ -179,9 +215,13 @@ present, so the wire shape stays clean for sources that opt out.
   expose many tables under a single registration, but only the
   source-level description bubbles through today. Per-table semantics
   for catalog-mode sources is on the roadmap.
+- The same limitation applies to `skardi query --schema`: catalog-mode
+  sources (e.g. SQLite registered as a catalog) get the source-level
+  description attached to *every* inner table, since there is no
+  per-inner-table semantics yet.
 - There is no agent-callable `describe` verb yet. Agents reach the
-  semantics through the HTTP endpoint above; a CLI / pipeline form is
-  a separate task on the roadmap.
+  semantics through the HTTP endpoint above; a pipeline form is a
+  separate task on the roadmap.
 
 ---
 

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -1,0 +1,192 @@
+# Catalog Semantics
+
+A **semantics overlay** attaches natural-language descriptions to the
+tables and columns already registered through a context file. The server
+loads them at startup alongside pipelines, jobs, and the context, and
+the catalog endpoint (`GET /data_source`) emits the descriptions on its
+response so an agent can read them when picking a tool.
+
+This page documents the YAML shape, how the server loads it, the
+override / fallback rules, and the resulting JSON shape on the catalog
+endpoint.
+
+---
+
+## Why
+
+Raw `column: Utf8` schemas are not enough for an agent to pick the right
+tool. The model needs to know *what* the column holds — `price_usd` is
+"retail price in USD", `slug` is the "URL-stable identifier", and so
+on. Stuffing those descriptions inline in `ctx.yaml` works for a single
+table but does not scale: catalog-mode sources have many tables, and
+auto-generated descriptions (e.g. from the
+[`auto_knowledge_base`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_knowledge_base)
+skill) want their own file so they don't pollute hand-curated config.
+
+A separate `kind: semantics` resource is the answer: same envelope as
+context / pipelines / jobs, hot-pluggable at startup, freely composable
+across multiple files.
+
+---
+
+## File shape
+
+```yaml
+kind: semantics
+
+metadata:
+  name: basic-semantics
+  version: 1.0.0
+
+spec:
+  sources:
+    - name: products              # must match a data_sources[].name in the ctx
+      description: "Product catalog with pricing/inventory. One row per SKU."
+      columns:
+        - name: id
+          description: "Stable internal SKU; primary key."
+        - name: price
+          description: "Retail price in USD."
+```
+
+`spec.sources[]` is a flat list of overlays. The `name` field
+cross-references `data_sources[].name` from the ctx; semantics for an
+unknown source are warned about (not failed) at load time so a stale
+overlay does not brick a partially-rebooted server.
+
+`description` and `columns` are both optional — supply only what you
+have. Unknown columns are not reported (the merge runs at request time
+against the live Arrow schema).
+
+A complete worked example lives at
+[`docs/basic/semantics.yaml`](basic/semantics.yaml), paired with the
+existing [`docs/basic/ctx.yaml`](basic/ctx.yaml).
+
+---
+
+## Loading
+
+```bash
+skardi-server \
+  --ctx ctx.yaml \
+  --pipeline pipelines/ \
+  --semantics semantics/ \    # file or directory
+  --port 8080
+```
+
+`--semantics` accepts either a single yaml file or a directory:
+
+- **Single file** — must be `kind: semantics`. A wrong or missing kind
+  is treated the same as for `--jobs`: the file is silently skipped.
+- **Directory** — every `*.yaml` / `*.yml` at one level is scanned, in
+  alphabetical order. Files whose root `kind:` is not `semantics` are
+  silently skipped, so a single shared config directory can mix pipeline
+  / job / context / semantics yamls.
+
+When no `--semantics` flag is passed, the server starts normally and
+the catalog endpoint falls back to `data_sources[].description` only
+(see *Fallback* below).
+
+---
+
+## Composition rules
+
+Multiple semantics files may be merged into one registry. The rules:
+
+| Situation | Behavior |
+|-----------|----------|
+| Two files describe the same `(source)` table | **Hard error** at startup. Both file paths are reported. |
+| Two files describe the same `(source, column)` | **Hard error** at startup. Both file paths are reported. |
+| A file references an unknown source | **Warning**. The entry is kept in the registry but never matches. |
+| A file is named explicitly (`--semantics file.yaml`) and is missing `kind: semantics` | Soft skip — same as a non-semantics file in a directory scan. |
+
+The duplicate-is-error rule keeps auto-generated overlays composable:
+each file owns its own slice of the catalog and never silently overwrites
+a sibling.
+
+---
+
+## Fallback to ctx-inline `description`
+
+`data_sources[]` in `ctx.yaml` already accepts a free-text `description`
+field:
+
+```yaml
+spec:
+  data_sources:
+    - name: products
+      type: csv
+      path: data/products.csv
+      description: "Product catalog dataset"
+```
+
+That value is **the table-level fallback** — used when no semantics
+overlay supplies one. A semantics file's `description` always wins over
+the ctx-inline value when both are present. Column-level descriptions
+have no ctx fallback; they live only in semantics files.
+
+The merge precedence:
+
+1. `kind: semantics` overlay (table or column)
+2. `data_sources[].description` (table-level only)
+3. None — the field is omitted from the JSON response.
+
+---
+
+## Where it shows up
+
+The catalog endpoint `GET /data_source` returns the merged view:
+
+```bash
+curl http://localhost:8080/data_source
+```
+
+```json
+{
+  "success": true,
+  "count": 1,
+  "data": [
+    {
+      "name": "products",
+      "type": "csv",
+      "path": "data/products.csv",
+      "tables": [
+        {
+          "name": "products",
+          "description": "Product catalog with pricing/inventory. One row per SKU.",
+          "schema": [
+            { "name": "id",     "type": "Int64",   "nullable": false, "description": "Stable internal SKU; primary key." },
+            { "name": "brand",  "type": "Utf8",    "nullable": false },
+            { "name": "price",  "type": "Float64", "nullable": false, "description": "Retail price in USD." }
+          ]
+        }
+      ]
+    }
+  ],
+  "timestamp": "..."
+}
+```
+
+`description` is omitted from the JSON when no overlay or fallback is
+present, so the wire shape stays clean for sources that opt out.
+
+---
+
+## Limitations
+
+- The current `GET /data_source` response emits **one table per data
+  source** (the source name *is* the table name). Catalog-mode sources
+  expose many tables under a single registration, but only the
+  source-level description bubbles through today. Per-table semantics
+  for catalog-mode sources is on the roadmap.
+- There is no agent-callable `describe` verb yet. Agents reach the
+  semantics through the HTTP endpoint above; a CLI / pipeline form is
+  a separate task on the roadmap.
+
+---
+
+## Next
+
+- **[Server](server.md)** — full flag reference and lifecycle.
+- **[Catalog mode](catalog.md)** — registering an entire database as a DataFusion catalog.
+- **[Spark for Agents](spark_for_agents.md)** — why this primitive exists.

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -51,10 +51,46 @@ spec:
           description: "Retail price in USD."
 ```
 
-`spec.sources[]` is a flat list of overlays. The `name` field
-cross-references `data_sources[].name` from the ctx; semantics for an
-unknown source are warned about (not failed) at load time so a stale
-overlay does not brick a partially-rebooted server.
+`spec.sources[]` is a flat list of overlays. The `name` field is either:
+
+- **A bare source name** — cross-references `data_sources[].name` from
+  the ctx. For table-mode sources (CSV, Parquet, Lance, Iceberg…) where
+  the source name *is* the physical table name, this is the only form
+  you need. For [catalog-mode sources](catalog.md) (Postgres / MySQL /
+  SQLite registered with `hierarchy_level: catalog`), the bare entry
+  applies as a *broad fallback* to every inner table.
+- **A fully-qualified DataFusion path** `catalog.schema.table` —
+  targets one specific physical table. Useful for catalog-mode sources
+  where a single ctx registration spawns many inner tables and you
+  want per-inner-table descriptions.
+
+```yaml
+spec:
+  sources:
+    # 1-part: broad fallback for the whole `mydb` catalog.
+    - name: mydb
+      description: "Internal application DB"
+
+    # 3-part: targets a specific inner table. Wins over the bare entry
+    # above for `mydb.public.users` only.
+    - name: mydb.public.users
+      description: "Auth + profile data, one row per registered account"
+      columns:
+        - name: id
+          description: "User ID (auth.users.id)"
+
+    - name: mydb.public.orders
+      description: "Submitted orders"
+      columns:
+        - name: id
+          description: "Order number, monotonic"
+```
+
+Names with anything other than 1 or 3 dot-separated segments are a
+hard error (e.g. `schema.table`, `a.b.c.d`, or empty segments like
+`mydb..users`). Semantics for an unknown source / catalog are warned
+about (not failed) at load time so a stale overlay does not brick a
+partially-rebooted server.
 
 `description` and `columns` are both optional — supply only what you
 have. Unknown columns are not reported (the merge runs at request time
@@ -106,13 +142,17 @@ skip — same behavior as `--jobs`.
 
 ## Composition rules
 
-Multiple semantics files may be merged into one registry. The rules:
+Multiple semantics files may be merged into one registry. Bare and
+qualified entries live in different addressing spaces — they're not
+duplicates of each other even when they describe the same physical
+table. The rules:
 
 | Situation | Behavior |
 |-----------|----------|
-| Two files describe the same `(source)` table | **Hard error** at startup. Both file paths are reported. |
-| Two files describe the same `(source, column)` | **Hard error** at startup. Both file paths are reported. |
-| A file references an unknown source | **Warning**. The entry is kept in the registry but never matches. |
+| Two files share the same key (same bare `name:`, **or** same `catalog.schema.table`) at table or column level | **Hard error** at startup. Both file paths are reported. |
+| One file has `name: mydb`, another has `name: mydb.public.users` | **Both kept**. The qualified entry wins for `mydb.public.users`; the bare entry covers every other inner table. |
+| `name:` has 0, 2, or 4+ dot-separated segments (or any empty segment) | **Hard error** at startup. |
+| A file references an unknown source / catalog | **Warning**. The entry is kept in the registry but never matches. |
 | A file is named explicitly (`--semantics file.yaml`) and is missing `kind: semantics` | Soft skip — same as a non-semantics file in a directory scan. |
 
 The duplicate-is-error rule keeps auto-generated overlays composable:
@@ -121,7 +161,7 @@ a sibling.
 
 ---
 
-## Fallback to ctx-inline `description`
+## Fallback / precedence
 
 `data_sources[]` in `ctx.yaml` already accepts a free-text `description`
 field:
@@ -135,16 +175,23 @@ spec:
       description: "Product catalog dataset"
 ```
 
-That value is **the table-level fallback** — used when no semantics
-overlay supplies one. A semantics file's `description` always wins over
-the ctx-inline value when both are present. Column-level descriptions
-have no ctx fallback; they live only in semantics files.
+That value is the table-level **ctx-inline fallback** — used when no
+semantics overlay supplies one. Column-level descriptions have no ctx
+fallback; they live only in semantics files.
 
-The merge precedence:
+The merge precedence (most-specific wins):
 
-1. `kind: semantics` overlay (table or column)
-2. `data_sources[].description` (table-level only)
-3. None — the field is omitted from the JSON response.
+1. **Qualified semantics overlay** — `name: catalog.schema.table` (table
+   or column).
+2. **Bare semantics overlay** — `name: <source>` (table or column).
+3. **`data_sources[].description`** (table-level only).
+4. None — the field is omitted from the JSON response.
+
+Steps 1 and 2 cooperate: a qualified entry only covers what it
+addresses; the bare entry continues to apply to anything the qualified
+entry didn't touch. So writing both forms is the normal path for
+catalog-mode sources where most inner tables share a description but a
+few want their own.
 
 ---
 
@@ -210,15 +257,13 @@ present, so the wire shape stays clean for sources that opt out.
 
 ## Limitations
 
-- The current `GET /data_source` response emits **one table per data
-  source** (the source name *is* the table name). Catalog-mode sources
-  expose many tables under a single registration, but only the
-  source-level description bubbles through today. Per-table semantics
-  for catalog-mode sources is on the roadmap.
-- The same limitation applies to `skardi query --schema`: catalog-mode
-  sources (e.g. SQLite registered as a catalog) get the source-level
-  description attached to *every* inner table, since there is no
-  per-inner-table semantics yet.
+- `GET /data_source` still emits **one table per data source** (the
+  source name *is* the table name in the JSON response). Catalog-mode
+  sources expose many inner tables, but the HTTP endpoint doesn't
+  enumerate them yet — so qualified `catalog.schema.table` overlays
+  defined for inner tables won't surface on the endpoint until the
+  endpoint is extended. The CLI (`skardi query --schema --all`) does
+  enumerate inner tables and renders qualified overlays correctly today.
 - There is no agent-callable `describe` verb yet. Agents reach the
   semantics through the HTTP endpoint above; a pipeline form is a
   separate task on the roadmap.

--- a/docs/server.md
+++ b/docs/server.md
@@ -35,7 +35,7 @@ cargo run --bin skardi-server -- \
 | `--pipeline` | Pipeline YAML file or directory of pipeline files. When omitted, `POST /:name/execute` and `/pipelines` return empty. |
 | `--jobs` | Job YAML file or directory. When omitted, every `/jobs/*` endpoint returns `503` with `error_type: jobs_disabled`. |
 | `--jobs-db` | SQLite run ledger for jobs. Default: `~/.skardi/jobs.db` (parent dirs created on first use). |
-| `--semantics` | `kind: semantics` YAML file or directory. Attaches NL descriptions to tables / columns on `GET /data_source`. See [semantics.md](semantics.md). |
+| `--semantics` | `kind: semantics` YAML file or directory. Attaches NL descriptions to tables / columns on `GET /data_source`. **Auto-discovered** from `<ctx_dir>/semantics/` or `<ctx_dir>/semantics.yaml` when omitted. See [semantics.md](semantics.md). |
 | `--port` | Port to listen on. Default: `8080`. |
 
 On startup the server:

--- a/docs/server.md
+++ b/docs/server.md
@@ -25,6 +25,7 @@ cargo run --bin skardi-server -- \
   --pipeline <pipeline-file-or-directory> \
   --jobs <job-file-or-directory> \
   --jobs-db <path-to-jobs.db> \
+  --semantics <semantics-file-or-directory> \
   --port 8080
 ```
 
@@ -34,6 +35,7 @@ cargo run --bin skardi-server -- \
 | `--pipeline` | Pipeline YAML file or directory of pipeline files. When omitted, `POST /:name/execute` and `/pipelines` return empty. |
 | `--jobs` | Job YAML file or directory. When omitted, every `/jobs/*` endpoint returns `503` with `error_type: jobs_disabled`. |
 | `--jobs-db` | SQLite run ledger for jobs. Default: `~/.skardi/jobs.db` (parent dirs created on first use). |
+| `--semantics` | `kind: semantics` YAML file or directory. Attaches NL descriptions to tables / columns on `GET /data_source`. See [semantics.md](semantics.md). |
 | `--port` | Port to listen on. Default: `8080`. |
 
 On startup the server:
@@ -206,5 +208,6 @@ on that source, from pipelines and jobs alike.
 
 - **[Pipelines](pipelines.md)** — YAML shape, parameters, invocation, and response format for the online-serving side.
 - **[Jobs](jobs.md)** — YAML shape, destinations, run ledger, and cancellation for the offline-batch side.
+- **[Semantics](semantics.md)** — natural-language descriptions on tables and columns; the agent-facing catalog overlay.
 - **[CLI](cli.md)** — `skardi run`, aliases, federated SQL from the shell.
 - **[Spark for Agents](spark_for_agents.md)** — why the platform is shaped this way.


### PR DESCRIPTION
## Summary

- New `kind: semantics` YAML resource attaches natural-language descriptions to tables and columns. Server loads it via a new `--semantics <file-or-dir>` flag (mirrors `--jobs`); descriptions are emitted on `GET /data_source` so agents can pick the right tool.
- Existing `data_sources[].description` in `ctx.yaml` is now used as the table-level fallback (it was being silently dropped). Semantics-file overlays always win over the ctx-inline value.
- Pairs with the auto-knowledge-base skill so generated descriptions get their own file instead of polluting the hand-curated ctx.

## What's in the box

- New module [`crates/server/src/semantics.rs`](https://github.com/SkardiLabs/skardi/blob/BtXin/feature/semantic_catalog/crates/server/src/semantics.rs) with `SemanticsFile` / `SemanticsSpec` / `SourceSemantics` / `ColumnSemantics` types and a `SemanticsRegistry` that merges every loaded file plus the ctx-inline fallback at boot.
- `--semantics` CLI flag on `skardi-server`. Directory scans skip non-`kind: semantics` yamls (same behavior as `--jobs`).
- `TableInfo.description` and `FieldInfo.description` added to the `GET /data_source` JSON response (`#[serde(skip_serializing_if = "Option::is_none")]` so the wire shape stays clean when no overlay exists).
- Composition rules: duplicate `(source)` or `(source, column)` entries across files are a hard error at load time; references to unknown sources warn but don't fail (a stale overlay shouldn't brick a partially-rebooted server).

## Out of scope (deferred)

- Agent-callable `describe` verb on top of the catalog endpoint — separate task.
- Per-table semantics for catalog-mode sources — today `GET /data_source` emits one table per source, so the source-level description is what bubbles through. Limitation noted in [`docs/semantics.md`](https://github.com/SkardiLabs/skardi/blob/BtXin/feature/semantic_catalog/docs/semantics.md#limitations).

## Tests

- 11 unit tests in `semantics.rs`: single file, directory, mixed yamls, duplicate hard-errors (source + column), ctx fallback, override, dangling refs, missing/wrong kind on the strict loader.
- 3 HTTP integration tests in [`crates/server/tests/semantics_endpoint.rs`](https://github.com/SkardiLabs/skardi/blob/BtXin/feature/semantic_catalog/crates/server/tests/semantics_endpoint.rs) exercising the full path through `configure_routes` → `GET /data_source`.
- Workspace `cargo build` clean. Clippy clean on the new code.

## Test plan

- [ ] CI green (build, clippy, tests on Linux + macOS)
- [ ] Manual: `skardi-server --ctx docs/basic/ctx.yaml --semantics docs/basic/semantics.yaml --port 8080`, then `curl localhost:8080/data_source` shows the table + column descriptions
- [ ] Manual: same command without `--semantics` falls back to the ctx-inline `description` field
- [ ] Manual: pointing `--semantics` at a directory containing two files that both describe the same source fails at startup with both file paths in the error