### PR TITLE
ci: pass CODECOV_TOKEN to upload step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,7 +372,7 @@ jobs:
           EOF
 
       - name: Execute Integration tests
-        run: cargo llvm-cov --no-report --no-clean nextest --all-features -- --ignored
+        run: cargo llvm-cov --no-report nextest --all-features -- --ignored
 
       - name: Generate coverage report (lcov)
         run: cargo llvm-cov report --lcov --output-path lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Check the package for errors
         run: cargo check --all
       - name: Execute rust tests
-        run: cargo nextest run --all-features
+        run: cargo llvm-cov --no-report nextest --all-features
 
       - name: Install integration test dependencies
         run: |
@@ -372,4 +372,13 @@ jobs:
           EOF
 
       - name: Execute Integration tests
-        run: cargo nextest run --all-features -- --ignored
+        run: cargo llvm-cov --no-report --no-clean nextest --all-features -- --ignored
+
+      - name: Generate coverage report (lcov)
+        run: cargo llvm-cov report --lcov --output-path lcov.info
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,3 +382,4 @@ jobs:
         with:
           files: lcov.info
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 [License Badge]: https://img.shields.io/badge/License-Apache%202.0-orange.svg
 [CI]: https://github.com/SkardiLabs/skardi/actions/workflows/ci.yml
 [CI Badge]: https://github.com/SkardiLabs/skardi/actions/workflows/ci.yml/badge.svg
+[Codecov]: https://codecov.io/gh/SkardiLabs/skardi
+[Codecov Badge]: https://codecov.io/gh/SkardiLabs/skardi/branch/main/graph/badge.svg
 [crates.io]: https://crates.io/crates/skardi
 [crates.io Badge]: https://img.shields.io/crates/v/skardi.svg
 [Docs]: https://docs.rs/skardi
@@ -22,6 +24,7 @@
 
 [![License Badge]][License]
 [![CI Badge]][CI]
+[![Codecov Badge]][Codecov]
 [![crates.io Badge]][crates.io]
 [![Docs Badge]][Docs]
 [![Discord Badge]][Discord]


### PR DESCRIPTION
## Summary
- The previous Codecov upload was failing with `Token required - not valid tokenless upload`. Codecov's tokenless flow only covers PRs from external forks — pushes to the upstream repo's own branches/main always require a token, so the README badge stayed `unknown` after #115 merged.
- Wires the `CODECOV_TOKEN` repo secret (added manually) into the upload step.

## Test plan
- [ ] CI run on this PR shows the Codecov upload step succeeding (no "Token required" error).
- [ ] Codecov page for the repo populates with a coverage report.
- [ ] After merge to `main`, the README badge resolves to a real coverage percentage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)