### PR TITLE
fix(server): activate UDF cfg gates under embedding feature

### DIFF
--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 default = []
 candle = ["skardi/candle"]
 onnx = ["skardi/onnx"]
-embedding = ["skardi/embedding"]
+embedding = ["candle", "gguf", "onnx", "remote-embed"]
 remote-embed = ["skardi/remote-embed"]
 gguf = ["skardi/gguf"]
 


### PR DESCRIPTION
## Summary
- Chains the server crate's `embedding` feature to its local `candle`, `gguf`, `onnx`, and `remote-embed` features so the `#[cfg(feature = ...)]` gates around UDF registration in `server.rs` actually compile in.
- Fixes the `-embedding` docker image shipping without the `candle` / `gguf` / `onnx_predict` / `remote_embed` UDFs registered.
- Mirrors the working pattern used by the CLI crate (`default = ["candle", "gguf", "onnx", "remote-embed"]`).

Fixes #119

## Test plan
- [x] `cargo check -p skardi-server --features embedding` succeeds
- [ ] Build the `skardi-server-embedding` image from this branch and confirm startup logs show `Registered 'candle' UDF` / `'gguf' UDF` / `'remote_embed' UDF` / `'onnx_predict' UDF`
- [ ] Run a planning-only pipeline that calls `candle(...)` against the rebuilt image and confirm config load no longer fails with `Invalid function 'candle'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)