### PR TITLE
feat(server): add chunk() UDF for inline text chunking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,14 +151,14 @@ jobs:
             suffix: ""
             platform: linux/arm64
             runner: ubuntu-24.04-arm
-          - variant: embedding
-            features: "embedding"
-            suffix: "-embedding"
+          - variant: rag
+            features: "rag"
+            suffix: "-rag"
             platform: linux/amd64
             runner: ubuntu-latest
-          - variant: embedding
-            features: "embedding"
-            suffix: "-embedding"
+          - variant: rag
+            features: "rag"
+            suffix: "-rag"
             platform: linux/arm64
             runner: ubuntu-24.04-arm
     steps:
@@ -221,8 +221,8 @@ jobs:
         include:
           - variant: default
             suffix: ""
-          - variant: embedding
-            suffix: "-embedding"
+          - variant: rag
+            suffix: "-rag"
     steps:
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,8 @@ cargo check --workspace --all-targets
 cargo build --release -p skardi-cli
 cargo build --release -p skardi-server
 
-# Optional embedding stack (ONNX, GGUF, Candle, remote embed)
-cargo build --release -p skardi-server --features embedding
+# Full RAG kit: embedding UDFs (ONNX, GGUF, Candle, remote embed) + chunk UDF
+cargo build --release -p skardi-server --features rag
 
 # Tests
 cargo test --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,6 +596,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto_enums"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65398a2893f41bce5c9259f6e1a4f03fbae40637c1bdc755b4f387f48c613b03"
+dependencies = [
+ "derive_utils",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,6 +1520,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -2730,6 +2751,17 @@ dependencies = [
  "rustc_version",
  "syn 2.0.117",
  "unicode-xid",
+]
+
+[[package]]
+name = "derive_utils"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "362f47930db19fe7735f527e6595e4900316b893ebf6d48ad3d31be928d57dd6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4258,6 +4290,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_locale"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
 name = "icu_locale_core"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4265,10 +4312,17 @@ checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
+ "serde",
  "tinystr",
  "writeable",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_locale_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
 
 [[package]]
 name = "icu_normalizer"
@@ -4318,12 +4372,36 @@ checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
  "writeable",
  "yoke 0.8.2",
  "zerofrom",
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_segmenter"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0794db0b1a86193ac9c48768d0e6c52c54448e0870ad87907d456ee0dac964"
+dependencies = [
+ "core_maths",
+ "icu_collections",
+ "icu_locale",
+ "icu_provider",
+ "icu_segmenter_data",
+ "potential_utf",
+ "utf8_iter",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_segmenter_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a2c462a4d927d512f5f882a033ddd62f33a05bb9f230d98f736ac3dc85938f"
 
 [[package]]
 name = "id-arena"
@@ -6611,6 +6689,8 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
+ "serde_core",
+ "writeable",
  "zerovec",
 ]
 
@@ -6781,6 +6861,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+dependencies = [
+ "bitflags 2.11.0",
+ "memchr",
+ "unicase",
 ]
 
 [[package]]
@@ -8044,6 +8135,7 @@ dependencies = [
  "sqlparser 0.53.0",
  "sqlx",
  "tempfile",
+ "text-splitter",
  "thiserror 2.0.18",
  "tokenizers",
  "tokio",
@@ -8458,6 +8550,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8475,6 +8576,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -8766,6 +8879,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "text-splitter"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1c090dcb5a7e4da833fcd8bdaf7fd5a9596c8fe9fe5c5355960243eaa4b5716"
+dependencies = [
+ "ahash 0.8.12",
+ "auto_enums",
+ "either",
+ "icu_provider",
+ "icu_segmenter",
+ "itertools 0.14.0",
+ "memchr",
+ "pulldown-cmark",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8881,6 +9012,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -10522,6 +10654,7 @@ dependencies = [
  "displaydoc",
  "yoke 0.8.2",
  "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
@@ -10530,6 +10663,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
+ "serde",
  "yoke 0.8.2",
  "zerofrom",
  "zerovec-derive",

--- a/README.md
+++ b/README.md
@@ -197,10 +197,11 @@ The **[`auto_knowledge_base` skill](https://github.com/SkardiLabs/skardi-skills/
 ```bash
 # Build
 docker build -t skardi .
-docker build -t skardi --build-arg FEATURES=embedding .
+docker build -t skardi --build-arg FEATURES=rag .   # adds embedding + chunk UDFs
 
 # Or pull pre-built
 docker pull ghcr.io/skardilabs/skardi/skardi-server:latest
+docker pull ghcr.io/skardilabs/skardi/skardi-server-rag:latest   # embedding + chunk UDFs
 
 # Run
 docker run --rm \
@@ -226,7 +227,10 @@ cd skardi
 cargo build --release -p skardi-cli
 cargo build --release -p skardi-server
 
-# With embedding support (ONNX, GGUF, Candle, remote embed)
+# With the full RAG kit (embedding UDFs + chunk UDF)
+cargo build --release -p skardi-server --features rag
+
+# Or just the embedding UDFs (ONNX, GGUF, Candle, remote embed) without chunking
 cargo build --release -p skardi-server --features embedding
 ```
 

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ We're **building in public**. `[x]` means shipped today, `[ ]` means open for co
    - [x] Hybrid search — RRF merge of FTS + KNN in plain SQL
    - [x] Inline embeddings — `candle()` UDF (GGUF / Candle / remote embed APIs) runs directly inside SQL; content + vector stay on the same row atomically
    - [x] ONNX inference — `onnx_predict` UDF for inline model predictions in SQL
-   - [ ] Chunking UDF — character / token / markdown / code splitters (via [`text-splitter`](https://crates.io/crates/text-splitter)) so ingestion can chunk inline in SQL
+   - [x] Chunking UDF — `chunk()` with character / markdown splitters (via [`text-splitter`](https://crates.io/crates/text-splitter)) so ingestion can chunk inline in SQL ([docs](docs/chunk.md)); token / code splitters next
    - [ ] Memory primitive — hybrid access + TTL + provenance + consolidation collapsed into one declarative macro
 
 `3` Online serving (pipelines)
@@ -303,6 +303,7 @@ We're **building in public**. `[x]` means shipped today, `[ ]` means open for co
 - **Vector search** — native KNN via Lance, `pg_knn` (pgvector), `sqlite_knn` (sqlite-vec), SeekDB HNSW.
 - **Full-text search** — Lance BM25 inverted indexes, `pg_fts`, `sqlite_fts`, SeekDB native FULLTEXT.
 - **Inline embeddings** — `candle()` UDF (GGUF / Candle / remote embed APIs) directly inside SQL, so content + vector stay on the same row atomically.
+- **Inline chunking** — `chunk()` UDF (character / markdown splitters via [`text-splitter`](https://crates.io/crates/text-splitter)) so RAG ingest stays a single SQL statement: chunk → embed → write ([docs](docs/chunk.md)).
 - **ONNX inference** — `onnx_predict` UDF for inline model predictions in SQL.
 - **Hybrid search** — RRF merge of FTS + KNN in plain SQL (see [llm_wiki demo](demo/llm_wiki/)).
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -13,12 +13,15 @@ name = "skardi"
 path = "src/main.rs"
 
 [features]
-default = ["candle", "gguf", "onnx", "remote-embed"]
+default = ["candle", "gguf", "onnx", "remote-embed", "chunking"]
 candle = ["skardi/candle"]
 gguf = ["skardi/gguf"]
 onnx = ["skardi/onnx"]
 remote-embed = ["skardi/remote-embed"]
 embedding = ["skardi/embedding"]
+chunking = ["skardi/chunking"]
+# RAG umbrella: chunk → embed → write loop in one feature.
+rag = ["skardi/rag"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -29,6 +29,8 @@ use pipeline::{
 use serde::Deserialize;
 #[cfg(feature = "candle")]
 use skardi::model::CandleModelRegistry;
+#[cfg(feature = "chunking")]
+use skardi::model::ChunkingRegistry;
 #[cfg(feature = "gguf")]
 use skardi::model::GgufModelRegistry;
 #[cfg(feature = "onnx")]
@@ -527,6 +529,11 @@ fn new_session_context() -> (SessionContext, DatasetRegistry) {
     {
         let registry = Arc::new(CandleModelRegistry::new());
         registry.register_candle_udf(&mut ctx);
+    }
+    #[cfg(feature = "chunking")]
+    {
+        let registry = Arc::new(ChunkingRegistry::new());
+        registry.register_chunk_udf(&mut ctx);
     }
 
     (ctx, dataset_registry)

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -19,6 +19,7 @@ onnx = ["skardi/onnx"]
 embedding = ["candle", "gguf", "onnx", "remote-embed"]
 remote-embed = ["skardi/remote-embed"]
 gguf = ["skardi/gguf"]
+chunking = ["skardi/chunking"]
 
 [dependencies]
 better-auth = { workspace = true }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -20,6 +20,8 @@ embedding = ["candle", "gguf", "onnx", "remote-embed"]
 remote-embed = ["skardi/remote-embed"]
 gguf = ["skardi/gguf"]
 chunking = ["skardi/chunking"]
+# RAG umbrella: chunk → embed → write loop in one feature.
+rag = ["embedding", "chunking"]
 
 [dependencies]
 better-auth = { workspace = true }

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -378,6 +378,9 @@ pub async fn load_server_config(args: CliArgs) -> Result<ServerConfig> {
     // Register candle UDF (lazy — models loaded on first call from inline path)
     #[cfg(feature = "candle")]
     register_candle_udf(&mut session_ctx);
+    // Register chunk UDF (text-splitter wrapper for inline ingestion)
+    #[cfg(feature = "chunking")]
+    register_chunk_udf(&mut session_ctx);
 
     // This auth layer is used only for SQL planning and is discarded after current function returns.
     // The live auth layer is built separately in setup_app_state.
@@ -615,6 +618,20 @@ pub fn register_gguf_udf(ctx: &mut SessionContext) {
 pub fn register_candle_udf(ctx: &mut SessionContext) {
     let registry = Arc::new(skardi::model::CandleModelRegistry::new());
     registry.register_candle_udf(ctx);
+}
+
+/// Register the `chunk` UDF for inline text chunking.
+///
+/// SQL:
+///   chunk('character', text_col, 1000)
+///   chunk('character', text_col, 1000, 200)
+///   chunk('markdown',  text_col, 1000, 200)
+///
+/// Returns `List<Utf8>`; combine with `UNNEST(...)` to expand into rows.
+#[cfg(feature = "chunking")]
+pub fn register_chunk_udf(ctx: &mut SessionContext) {
+    let registry = Arc::new(skardi::model::ChunkingRegistry::new());
+    registry.register_chunk_udf(ctx);
 }
 
 /// Load context configuration from YAML file

--- a/crates/skardi/Cargo.toml
+++ b/crates/skardi/Cargo.toml
@@ -21,6 +21,8 @@ remote-embed = ["dep:reqwest"]
 gguf = ["dep:llama-cpp-4"]
 candle = ["dep:candle-core", "dep:candle-nn", "dep:candle-transformers", "dep:tokenizers"]
 chunking = ["dep:text-splitter"]
+# RAG umbrella: chunk → embed → write loop in one feature.
+rag = ["embedding", "chunking"]
 
 [dependencies]
 # engine

--- a/crates/skardi/Cargo.toml
+++ b/crates/skardi/Cargo.toml
@@ -20,6 +20,7 @@ embedding = ["onnx", "candle", "gguf", "remote-embed"]
 remote-embed = ["dep:reqwest"]
 gguf = ["dep:llama-cpp-4"]
 candle = ["dep:candle-core", "dep:candle-nn", "dep:candle-transformers", "dep:tokenizers"]
+chunking = ["dep:text-splitter"]
 
 [dependencies]
 # engine
@@ -47,6 +48,7 @@ candle-core = { version = "0.8", optional = true }
 candle-nn = { version = "0.8", optional = true }
 candle-transformers = { version = "0.8", optional = true }
 tokenizers = { version = "0.21", default-features = false, features = ["onig"], optional = true }
+text-splitter = { version = "0.30", features = ["markdown"], optional = true }
 # sources
 datafusion-federation = { workspace = true }
 datafusion-table-providers = { workspace = true }

--- a/crates/skardi/src/model/chunking/mod.rs
+++ b/crates/skardi/src/model/chunking/mod.rs
@@ -1,0 +1,584 @@
+//! `chunk` UDF — split text into chunks for inline ingestion.
+//!
+//! Returns `List<Utf8>` so callers can keep chunks as a list column or expand
+//! them into rows with `UNNEST(chunk(...))`.
+//!
+//! Usage:
+//! ```text
+//! chunk('character', text_col, 1000)         -- size only
+//! chunk('character', text_col, 1000, 200)    -- size + overlap
+//! chunk('markdown',  text_col, 1000, 200)
+//! ```
+//!
+//! Backed by the [`text-splitter`](https://crates.io/crates/text-splitter) crate.
+
+use std::sync::Arc;
+
+use arrow::array::{Array, ArrayRef, ListBuilder, StringArray, StringBuilder};
+use arrow::datatypes::{DataType, Field};
+use datafusion::common::Result as DfResult;
+use datafusion::error::DataFusionError;
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+};
+use datafusion::prelude::SessionContext;
+use datafusion::scalar::ScalarValue;
+use text_splitter::{ChunkConfig, MarkdownSplitter, TextSplitter};
+
+// =============================================================================
+// ChunkingRegistry — handle for the `chunk` UDF
+// =============================================================================
+
+/// Registry for the `chunk` UDF.
+///
+/// The character / markdown splitters are stateless and cheap to construct, so
+/// no caching is needed today. The registry exists for parity with other UDF
+/// registries (`CandleModelRegistry`, etc.) and as a hook for future modes that
+/// need cached state (e.g. tokenizer-based or code-language splitters).
+#[derive(Debug, Default)]
+pub struct ChunkingRegistry;
+
+impl ChunkingRegistry {
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Register the `chunk` UDF with a DataFusion `SessionContext`.
+    ///
+    /// SQL signature:
+    /// ```text
+    /// chunk(mode, text, size [, overlap]) -> List<Utf8>
+    /// ```
+    /// - `mode`: `'character'` or `'markdown'`
+    /// - `text`: `Utf8` literal, scalar subquery, or column
+    /// - `size`: target max chunk length (characters), positive integer literal
+    /// - `overlap`: optional characters of overlap between adjacent chunks; must be `< size`
+    pub fn register_chunk_udf(self: &Arc<Self>, ctx: &mut SessionContext) {
+        let udf = ScalarUDF::new_from_impl(ChunkingUDF::new(Arc::clone(self)));
+        ctx.register_udf(udf);
+        tracing::info!("Registered 'chunk' UDF");
+    }
+}
+
+// =============================================================================
+// ChunkingUDF — ScalarUDFImpl
+// =============================================================================
+
+#[derive(Debug)]
+struct ChunkingUDF {
+    registry: Arc<ChunkingRegistry>,
+    signature: Signature,
+}
+
+impl PartialEq for ChunkingUDF {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.registry, &other.registry)
+    }
+}
+
+impl Eq for ChunkingUDF {}
+
+impl std::hash::Hash for ChunkingUDF {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        Arc::as_ptr(&self.registry).hash(state);
+    }
+}
+
+impl ChunkingUDF {
+    fn new(registry: Arc<ChunkingRegistry>) -> Self {
+        Self {
+            registry,
+            // mode + text + size [+ overlap]
+            signature: Signature::variadic_any(Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for ChunkingUDF {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "chunk"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> DfResult<DataType> {
+        Ok(DataType::List(Arc::new(Field::new(
+            "item",
+            DataType::Utf8,
+            true,
+        ))))
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> DfResult<ColumnarValue> {
+        let args = args.args;
+
+        if args.len() < 3 || args.len() > 4 {
+            return Err(DataFusionError::Execution(format!(
+                "chunk expects 3 or 4 arguments (mode, text, size [, overlap]); got {}",
+                args.len()
+            )));
+        }
+
+        let mode = read_scalar_string(&args[0], "mode")?;
+        let size = read_scalar_usize(&args[2], "size")?;
+        if size == 0 {
+            return Err(DataFusionError::Execution(
+                "chunk: 'size' must be > 0".to_string(),
+            ));
+        }
+        let overlap = if args.len() == 4 {
+            read_scalar_usize(&args[3], "overlap")?
+        } else {
+            0
+        };
+        if overlap >= size {
+            return Err(DataFusionError::Execution(format!(
+                "chunk: 'overlap' ({overlap}) must be strictly less than 'size' ({size})"
+            )));
+        }
+
+        let texts = read_text_column(&args[1], "text")?;
+
+        let array: ArrayRef = match mode.as_str() {
+            "character" => {
+                let cfg = build_config(size, overlap)?;
+                let splitter = TextSplitter::new(cfg);
+                build_list_array(&texts, |t| splitter.chunks(t))
+            }
+            "markdown" => {
+                let cfg = build_config(size, overlap)?;
+                let splitter = MarkdownSplitter::new(cfg);
+                build_list_array(&texts, |t| splitter.chunks(t))
+            }
+            other => {
+                return Err(DataFusionError::Execution(format!(
+                    "chunk: unsupported mode '{other}'; supported modes: 'character', 'markdown'"
+                )));
+            }
+        };
+
+        Ok(ColumnarValue::Array(array))
+    }
+}
+
+// =============================================================================
+// Argument decoding helpers
+// =============================================================================
+
+fn read_scalar_string(arg: &ColumnarValue, name: &str) -> DfResult<String> {
+    match arg {
+        ColumnarValue::Scalar(ScalarValue::Utf8(Some(s)))
+        | ColumnarValue::Scalar(ScalarValue::LargeUtf8(Some(s))) => Ok(s.clone()),
+        ColumnarValue::Scalar(ScalarValue::Utf8(None) | ScalarValue::LargeUtf8(None)) => Err(
+            DataFusionError::Execution(format!("chunk: '{name}' argument must not be null")),
+        ),
+        ColumnarValue::Array(arr) => {
+            let str_arr = arr.as_any().downcast_ref::<StringArray>().ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "chunk: '{name}' argument must be a Utf8 literal"
+                ))
+            })?;
+            if str_arr.is_empty() || str_arr.is_null(0) {
+                return Err(DataFusionError::Execution(format!(
+                    "chunk: '{name}' argument must not be null"
+                )));
+            }
+            Ok(str_arr.value(0).to_string())
+        }
+        _ => Err(DataFusionError::Execution(format!(
+            "chunk: '{name}' argument must be a Utf8 literal"
+        ))),
+    }
+}
+
+fn read_scalar_usize(arg: &ColumnarValue, name: &str) -> DfResult<usize> {
+    let n: i64 = match arg {
+        ColumnarValue::Scalar(ScalarValue::Int64(Some(n))) => *n,
+        ColumnarValue::Scalar(ScalarValue::Int32(Some(n))) => i64::from(*n),
+        ColumnarValue::Scalar(ScalarValue::Int16(Some(n))) => i64::from(*n),
+        ColumnarValue::Scalar(ScalarValue::Int8(Some(n))) => i64::from(*n),
+        ColumnarValue::Scalar(ScalarValue::UInt64(Some(n))) => i64::try_from(*n).map_err(|_| {
+            DataFusionError::Execution(format!("chunk: '{name}' value {n} overflows i64"))
+        })?,
+        ColumnarValue::Scalar(ScalarValue::UInt32(Some(n))) => i64::from(*n),
+        ColumnarValue::Scalar(ScalarValue::UInt16(Some(n))) => i64::from(*n),
+        ColumnarValue::Scalar(ScalarValue::UInt8(Some(n))) => i64::from(*n),
+        _ => {
+            return Err(DataFusionError::Execution(format!(
+                "chunk: '{name}' argument must be an integer literal"
+            )));
+        }
+    };
+    if n < 0 {
+        return Err(DataFusionError::Execution(format!(
+            "chunk: '{name}' must be non-negative (got {n})"
+        )));
+    }
+    Ok(n as usize)
+}
+
+fn read_text_column(arg: &ColumnarValue, name: &str) -> DfResult<Vec<Option<String>>> {
+    match arg {
+        ColumnarValue::Array(arr) => {
+            let str_arr = arr.as_any().downcast_ref::<StringArray>().ok_or_else(|| {
+                DataFusionError::Execution(format!("chunk: '{name}' must be a Utf8 column"))
+            })?;
+            Ok((0..str_arr.len())
+                .map(|i| {
+                    if str_arr.is_null(i) {
+                        None
+                    } else {
+                        Some(str_arr.value(i).to_string())
+                    }
+                })
+                .collect())
+        }
+        ColumnarValue::Scalar(ScalarValue::Utf8(Some(s)))
+        | ColumnarValue::Scalar(ScalarValue::LargeUtf8(Some(s))) => Ok(vec![Some(s.clone())]),
+        ColumnarValue::Scalar(ScalarValue::Utf8(None) | ScalarValue::LargeUtf8(None)) => {
+            Ok(vec![None])
+        }
+        _ => Err(DataFusionError::Execution(format!(
+            "chunk: '{name}' must be Utf8"
+        ))),
+    }
+}
+
+// =============================================================================
+// Splitter helpers
+// =============================================================================
+
+fn build_config(size: usize, overlap: usize) -> DfResult<ChunkConfig<text_splitter::Characters>> {
+    ChunkConfig::new(size)
+        .with_overlap(overlap)
+        .map_err(|e| DataFusionError::Execution(format!("chunk: invalid chunk config: {e}")))
+}
+
+/// Build a `ListArray<Utf8>` by applying `split` to each non-null row.
+fn build_list_array<'a, F, I>(texts: &'a [Option<String>], mut split: F) -> ArrayRef
+where
+    F: FnMut(&'a str) -> I,
+    I: Iterator<Item = &'a str>,
+{
+    let mut builder = ListBuilder::new(StringBuilder::new());
+    for maybe_text in texts {
+        match maybe_text {
+            Some(text) => {
+                for chunk in split(text.as_str()) {
+                    builder.values().append_value(chunk);
+                }
+                builder.append(true);
+            }
+            None => builder.append(false),
+        }
+    }
+    Arc::new(builder.finish())
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Array, ListArray, StringArray};
+    use arrow::datatypes::Field;
+    use datafusion::config::ConfigOptions;
+    use datafusion::logical_expr::ScalarFunctionArgs;
+
+    fn make_args(args: Vec<ColumnarValue>) -> ScalarFunctionArgs {
+        let number_rows = args
+            .iter()
+            .map(|a| match a {
+                ColumnarValue::Array(arr) => arr.len(),
+                ColumnarValue::Scalar(_) => 1,
+            })
+            .max()
+            .unwrap_or(1);
+        let arg_fields = args
+            .iter()
+            .map(|a| Arc::new(Field::new("_", a.data_type(), true)))
+            .collect();
+        let return_type = DataType::List(Arc::new(Field::new("item", DataType::Utf8, true)));
+        ScalarFunctionArgs {
+            args,
+            arg_fields,
+            number_rows,
+            return_field: Arc::new(Field::new("chunks", return_type, true)),
+            config_options: Arc::new(ConfigOptions::default()),
+        }
+    }
+
+    fn udf() -> ChunkingUDF {
+        ChunkingUDF::new(Arc::new(ChunkingRegistry::new()))
+    }
+
+    fn list_at(arr: &ListArray, row: usize) -> Vec<String> {
+        let inner = arr.value(row);
+        let s = inner.as_any().downcast_ref::<StringArray>().unwrap();
+        (0..s.len()).map(|i| s.value(i).to_string()).collect()
+    }
+
+    #[test]
+    fn character_mode_splits_long_literal() {
+        let text = "a".repeat(2500);
+        let result = udf()
+            .invoke_with_args(make_args(vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("character".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some(text.clone()))),
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(1000))),
+            ]))
+            .unwrap();
+        let arr = match result {
+            ColumnarValue::Array(a) => a,
+            _ => panic!("expected array result"),
+        };
+        let list = arr.as_any().downcast_ref::<ListArray>().unwrap();
+        assert_eq!(list.len(), 1);
+        let chunks = list_at(list, 0);
+        assert!(
+            chunks.len() >= 3,
+            "expected ≥3 chunks, got {}",
+            chunks.len()
+        );
+        assert!(chunks.iter().all(|c| c.len() <= 1000));
+        assert_eq!(chunks.concat(), text);
+    }
+
+    #[test]
+    fn character_mode_with_overlap() {
+        let text = "a".repeat(500);
+        let result = udf()
+            .invoke_with_args(make_args(vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("character".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some(text))),
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(100))),
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(20))),
+            ]))
+            .unwrap();
+        let arr = match result {
+            ColumnarValue::Array(a) => a,
+            _ => panic!("expected array"),
+        };
+        let list = arr.as_any().downcast_ref::<ListArray>().unwrap();
+        let chunks = list_at(list, 0);
+        // Without overlap: 500/100 = 5 chunks. With 20 overlap, expect ≥5.
+        assert!(chunks.len() >= 5);
+        assert!(chunks.iter().all(|c| c.len() <= 100));
+    }
+
+    #[test]
+    fn markdown_mode_respects_headings() {
+        let text = "# Heading One\n\nBody one.\n\n# Heading Two\n\nBody two.";
+        let result = udf()
+            .invoke_with_args(make_args(vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("markdown".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some(text.to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(30))),
+            ]))
+            .unwrap();
+        let arr = match result {
+            ColumnarValue::Array(a) => a,
+            _ => panic!("expected array"),
+        };
+        let list = arr.as_any().downcast_ref::<ListArray>().unwrap();
+        let chunks = list_at(list, 0);
+        assert!(chunks.len() >= 2);
+        assert!(
+            chunks.iter().any(|c| c.contains("# Heading")),
+            "expected at least one chunk to keep a heading: {chunks:?}"
+        );
+    }
+
+    #[test]
+    fn array_input_chunks_per_row() {
+        let texts = StringArray::from(vec![Some("a".repeat(250)), Some("b".repeat(50)), None]);
+        let result = udf()
+            .invoke_with_args(make_args(vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("character".to_string()))),
+                ColumnarValue::Array(Arc::new(texts)),
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(100))),
+            ]))
+            .unwrap();
+        let arr = match result {
+            ColumnarValue::Array(a) => a,
+            _ => panic!("expected array"),
+        };
+        let list = arr.as_any().downcast_ref::<ListArray>().unwrap();
+        assert_eq!(list.len(), 3);
+        assert!(list_at(list, 0).len() >= 3); // 250 chars / 100 → ≥3
+        assert_eq!(list_at(list, 1).len(), 1); // 50 chars fits in one
+        assert!(list.is_null(2)); // null in → null out
+    }
+
+    #[test]
+    fn unknown_mode_errors() {
+        let err = udf()
+            .invoke_with_args(make_args(vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("token".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("hello".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(100))),
+            ]))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("unsupported mode"), "got: {err}");
+    }
+
+    #[test]
+    fn overlap_must_be_less_than_size() {
+        let err = udf()
+            .invoke_with_args(make_args(vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("character".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("hello".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(100))),
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(100))),
+            ]))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("strictly less than"), "got: {err}");
+    }
+
+    #[test]
+    fn wrong_arity_errors() {
+        let err = udf()
+            .invoke_with_args(make_args(vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("character".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("hi".to_string()))),
+            ]))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("3 or 4 arguments"), "got: {err}");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // SQL-level integration tests — exercise the full DataFusion path
+    // ─────────────────────────────────────────────────────────────────────────
+
+    use arrow::array::Int64Array;
+    use arrow::datatypes::Schema;
+    use arrow::record_batch::RecordBatch;
+    use datafusion::execution::FunctionRegistry;
+    use datafusion::prelude::SessionContext;
+
+    fn build_ctx() -> SessionContext {
+        let mut ctx = SessionContext::new();
+        Arc::new(ChunkingRegistry::new()).register_chunk_udf(&mut ctx);
+        ctx
+    }
+
+    #[tokio::test]
+    async fn sql_registers_and_returns_list_column() {
+        let ctx = build_ctx();
+        assert!(ctx.udf("chunk").is_ok(), "chunk UDF should be registered");
+
+        let body = "a".repeat(250);
+        let sql = format!("SELECT chunk('character', '{body}', 100) AS chunks");
+        let batches = ctx.sql(&sql).await.unwrap().collect().await.unwrap();
+
+        assert_eq!(batches.len(), 1);
+        let batch = &batches[0];
+        assert_eq!(batch.num_rows(), 1);
+
+        let list = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("chunk should return a ListArray");
+        let inner = list.value(0);
+        let strings = inner.as_any().downcast_ref::<StringArray>().unwrap();
+        assert!(
+            strings.len() >= 3,
+            "expected ≥3 chunks, got {}",
+            strings.len()
+        );
+        let joined: String = (0..strings.len())
+            .map(|i| strings.value(i).to_string())
+            .collect();
+        assert_eq!(joined, body);
+    }
+
+    #[tokio::test]
+    async fn sql_unnest_expands_chunks_into_rows() {
+        let ctx = build_ctx();
+        let body = "x".repeat(220);
+        let sql = format!("SELECT UNNEST(chunk('character', '{body}', 100)) AS chunk_text");
+        let batches = ctx.sql(&sql).await.unwrap().collect().await.unwrap();
+
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert!(total >= 3, "expected ≥3 rows from UNNEST, got {total}");
+
+        for batch in &batches {
+            let strings = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("UNNEST'd column should be Utf8");
+            for i in 0..strings.len() {
+                assert!(strings.value(i).len() <= 100);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn sql_chunks_per_row_over_registered_table() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("body", DataType::Utf8, false),
+        ]));
+        let body0 = String::from("# Header\n\n") + &"para one. ".repeat(20);
+        let body1 = String::from("short doc");
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1i64, 2])),
+                Arc::new(StringArray::from(vec![body0, body1])),
+            ],
+        )
+        .unwrap();
+
+        let ctx = build_ctx();
+        ctx.register_batch("docs", batch).unwrap();
+
+        let batches = ctx
+            .sql(
+                "SELECT id, UNNEST(chunk('markdown', body, 50)) AS chunk_text \
+                 FROM docs ORDER BY id",
+            )
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert!(
+            total_rows >= 2,
+            "expected ≥2 expanded rows, got {total_rows}"
+        );
+
+        let mut ids_seen = std::collections::BTreeSet::new();
+        for b in &batches {
+            let id_arr = b.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+            let text_arr = b.column(1).as_any().downcast_ref::<StringArray>().unwrap();
+            for i in 0..b.num_rows() {
+                ids_seen.insert(id_arr.value(i));
+                assert!(
+                    !text_arr.value(i).is_empty(),
+                    "chunk text should be non-empty"
+                );
+            }
+        }
+        assert_eq!(
+            ids_seen,
+            [1i64, 2].iter().copied().collect(),
+            "both source rows should appear in the expanded output"
+        );
+    }
+}

--- a/crates/skardi/src/model/chunking/mod.rs
+++ b/crates/skardi/src/model/chunking/mod.rs
@@ -137,6 +137,8 @@ impl ScalarUDFImpl for ChunkingUDF {
         } else {
             0
         };
+        // text-splitter's ChunkConfig::with_overlap also rejects this; the explicit
+        // check exists so the error names both values instead of a generic message.
         if overlap >= size {
             return Err(DataFusionError::Execution(format!(
                 "chunk: 'overlap' ({overlap}) must be strictly less than 'size' ({size})"
@@ -178,19 +180,9 @@ fn read_scalar_string(arg: &ColumnarValue, name: &str) -> DfResult<String> {
         ColumnarValue::Scalar(ScalarValue::Utf8(None) | ScalarValue::LargeUtf8(None)) => Err(
             DataFusionError::Execution(format!("chunk: '{name}' argument must not be null")),
         ),
-        ColumnarValue::Array(arr) => {
-            let str_arr = arr.as_any().downcast_ref::<StringArray>().ok_or_else(|| {
-                DataFusionError::Execution(format!(
-                    "chunk: '{name}' argument must be a Utf8 literal"
-                ))
-            })?;
-            if str_arr.is_empty() || str_arr.is_null(0) {
-                return Err(DataFusionError::Execution(format!(
-                    "chunk: '{name}' argument must not be null"
-                )));
-            }
-            Ok(str_arr.value(0).to_string())
-        }
+        ColumnarValue::Array(_) => Err(DataFusionError::Execution(format!(
+            "chunk: '{name}' must be a literal, not a column"
+        ))),
         _ => Err(DataFusionError::Execution(format!(
             "chunk: '{name}' argument must be a Utf8 literal"
         ))),
@@ -223,7 +215,7 @@ fn read_scalar_usize(arg: &ColumnarValue, name: &str) -> DfResult<usize> {
     Ok(n as usize)
 }
 
-fn read_text_column(arg: &ColumnarValue, name: &str) -> DfResult<Vec<Option<String>>> {
+fn read_text_column<'a>(arg: &'a ColumnarValue, name: &str) -> DfResult<Vec<Option<&'a str>>> {
     match arg {
         ColumnarValue::Array(arr) => {
             let str_arr = arr.as_any().downcast_ref::<StringArray>().ok_or_else(|| {
@@ -234,13 +226,13 @@ fn read_text_column(arg: &ColumnarValue, name: &str) -> DfResult<Vec<Option<Stri
                     if str_arr.is_null(i) {
                         None
                     } else {
-                        Some(str_arr.value(i).to_string())
+                        Some(str_arr.value(i))
                     }
                 })
                 .collect())
         }
         ColumnarValue::Scalar(ScalarValue::Utf8(Some(s)))
-        | ColumnarValue::Scalar(ScalarValue::LargeUtf8(Some(s))) => Ok(vec![Some(s.clone())]),
+        | ColumnarValue::Scalar(ScalarValue::LargeUtf8(Some(s))) => Ok(vec![Some(s.as_str())]),
         ColumnarValue::Scalar(ScalarValue::Utf8(None) | ScalarValue::LargeUtf8(None)) => {
             Ok(vec![None])
         }
@@ -261,16 +253,16 @@ fn build_config(size: usize, overlap: usize) -> DfResult<ChunkConfig<text_splitt
 }
 
 /// Build a `ListArray<Utf8>` by applying `split` to each non-null row.
-fn build_list_array<'a, F, I>(texts: &'a [Option<String>], mut split: F) -> ArrayRef
+fn build_list_array<'t, F, I>(texts: &[Option<&'t str>], mut split: F) -> ArrayRef
 where
-    F: FnMut(&'a str) -> I,
-    I: Iterator<Item = &'a str>,
+    F: FnMut(&'t str) -> I,
+    I: Iterator<Item = &'t str>,
 {
     let mut builder = ListBuilder::new(StringBuilder::new());
     for maybe_text in texts {
         match maybe_text {
             Some(text) => {
-                for chunk in split(text.as_str()) {
+                for chunk in split(text) {
                     builder.values().append_value(chunk);
                 }
                 builder.append(true);
@@ -398,6 +390,35 @@ mod tests {
     }
 
     #[test]
+    fn character_mode_counts_chars_not_bytes() {
+        // Each "日" is 3 bytes but 1 char. Size=20 chars must hold for char count,
+        // not byte count — a byte-based splitter would emit chunks well under 20 chars.
+        let text = "日本語段落。".repeat(50);
+        let result = udf()
+            .invoke_with_args(make_args(vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("character".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some(text.clone()))),
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(20))),
+            ]))
+            .unwrap();
+        let arr = match result {
+            ColumnarValue::Array(a) => a,
+            _ => panic!("expected array"),
+        };
+        let list = arr.as_any().downcast_ref::<ListArray>().unwrap();
+        let chunks = list_at(list, 0);
+        assert!(!chunks.is_empty());
+        for c in &chunks {
+            assert!(
+                c.chars().count() <= 20,
+                "chunk exceeds 20 chars: {} chars in {c:?}",
+                c.chars().count()
+            );
+        }
+        assert_eq!(chunks.concat(), text, "chunks should reconstruct input");
+    }
+
+    #[test]
     fn array_input_chunks_per_row() {
         let texts = StringArray::from(vec![Some("a".repeat(250)), Some("b".repeat(50)), None]);
         let result = udf()
@@ -446,6 +467,25 @@ mod tests {
     }
 
     #[test]
+    fn array_mode_argument_rejected() {
+        // `mode` must be a literal — passing a column (Array) should error,
+        // not silently use row 0.
+        let modes = StringArray::from(vec!["character", "markdown"]);
+        let err = udf()
+            .invoke_with_args(make_args(vec![
+                ColumnarValue::Array(Arc::new(modes)),
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("hello".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(100))),
+            ]))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("must be a literal, not a column"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
     fn wrong_arity_errors() {
         let err = udf()
             .invoke_with_args(make_args(vec![
@@ -465,7 +505,6 @@ mod tests {
     use arrow::datatypes::Schema;
     use arrow::record_batch::RecordBatch;
     use datafusion::execution::FunctionRegistry;
-    use datafusion::prelude::SessionContext;
 
     fn build_ctx() -> SessionContext {
         let mut ctx = SessionContext::new();

--- a/crates/skardi/src/model/chunking/mod.rs
+++ b/crates/skardi/src/model/chunking/mod.rs
@@ -581,4 +581,51 @@ mod tests {
             "both source rows should appear in the expanded output"
         );
     }
+
+    /// Smoke-tests the exact SQL pattern the demo pipelines emit:
+    /// `ROW_NUMBER() OVER (ORDER BY 1)` over `UNNEST(chunk(...))`.
+    /// If this stops working, the demos break too — fail loudly here first.
+    #[tokio::test]
+    async fn sql_row_number_over_unnest_chunk() {
+        let ctx = build_ctx();
+        let body = "a".repeat(250);
+        let sql = format!(
+            "SELECT ROW_NUMBER() OVER (ORDER BY 1) AS rn, chunk_text \
+             FROM (SELECT UNNEST(chunk('character', '{body}', 100)) AS chunk_text)"
+        );
+        let batches = ctx.sql(&sql).await.unwrap().collect().await.unwrap();
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert!(total >= 3, "expected ≥3 rows, got {total}");
+    }
+
+    /// Smoke-tests slug synthesis used by the LLM Wiki bulk-create demo:
+    /// `prefix || '/p' || lpad(CAST(rn AS VARCHAR), 3, '0')`.
+    #[tokio::test]
+    async fn sql_slug_synthesis_over_chunked_text() {
+        let ctx = build_ctx();
+        let body = "a".repeat(220);
+        let sql = format!(
+            "SELECT \
+               'alice/chap1' || '/p' || lpad(CAST(rn AS VARCHAR), 3, '0') AS slug, \
+               chunk_text \
+             FROM ( \
+               SELECT chunk_text, ROW_NUMBER() OVER (ORDER BY 1) AS rn \
+               FROM (SELECT UNNEST(chunk('character', '{body}', 100)) AS chunk_text) \
+             )"
+        );
+        let batches = ctx.sql(&sql).await.unwrap().collect().await.unwrap();
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert!(total >= 3, "expected ≥3 rows, got {total}");
+
+        let mut slugs: Vec<String> = vec![];
+        for b in &batches {
+            let s = b.column(0).as_any().downcast_ref::<StringArray>().unwrap();
+            for i in 0..s.len() {
+                slugs.push(s.value(i).to_string());
+            }
+        }
+        slugs.sort();
+        assert!(slugs[0].starts_with("alice/chap1/p0"), "got {slugs:?}");
+        assert!(slugs.iter().all(|s| s.starts_with("alice/chap1/p")));
+    }
 }

--- a/crates/skardi/src/model/mod.rs
+++ b/crates/skardi/src/model/mod.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "candle")]
 pub mod candle;
+#[cfg(feature = "chunking")]
+pub mod chunking;
 #[cfg(feature = "onnx")]
 pub mod converter;
 #[cfg(feature = "gguf")]
@@ -13,6 +15,8 @@ pub mod remote_embed;
 // Re-export for convenience
 #[cfg(feature = "candle")]
 pub use candle::CandleModelRegistry;
+#[cfg(feature = "chunking")]
+pub use chunking::ChunkingRegistry;
 #[cfg(feature = "gguf")]
 pub use gguf::GgufModelRegistry;
 #[cfg(feature = "onnx")]

--- a/demo/llm_wiki/README.md
+++ b/demo/llm_wiki/README.md
@@ -253,6 +253,37 @@ create and update are separate endpoints. The agent pattern is: try
 `wiki-update` first; if it reports zero rows affected, fall back to
 `wiki-create`.
 
+### Bulk-create from a long document — `wiki-bulk-create`
+
+`wiki-create` keeps one page = one row, which is the wiki's editing model.
+But for **seeding** the wiki — turning a long markdown doc into many pages
+in one shot — `wiki-bulk-create` chunks the body inline with
+[`chunk('markdown', …)`](../../docs/chunk.md), embeds each chunk with
+`candle()`, and writes one page per chunk:
+
+```bash
+curl -X POST http://localhost:8080/wiki-bulk-create/execute \
+  -H "Content-Type: application/json" \
+  -d '{
+    "slug_prefix": "rfc/9110",
+    "title": "RFC 9110: HTTP Semantics",
+    "page_type": "rfc",
+    "content": "<the full RFC body in markdown>",
+    "chunk_size": 800,
+    "overlap": 150
+  }' | jq .
+```
+
+Synthesised slugs follow `{slug_prefix}/p<NNN>` (`rfc/9110/p001`,
+`/p002`, …) and titles get a `#N` suffix so each chunk is a distinct page
+visible to `wiki-list`, `wiki-search-hybrid`, etc. Pages later edited
+via `wiki-update` keep their slug — the bulk-create path is a
+one-way seeder, not a re-runnable upsert.
+
+Requires `--features rag` on `skardi-server` (the umbrella that bundles
+`embedding` + `chunking`). See
+[server/pipelines/bulk_create.yaml](server/pipelines/bulk_create.yaml).
+
 ---
 
 ## Read Path: Agent Retrieval Loop
@@ -334,6 +365,7 @@ curl -X POST http://localhost:8080/wiki-log-append/execute \
 |---|---|---|
 | [server/pipelines/create.yaml](server/pipelines/create.yaml) | `/wiki-create/execute` | INSERT a new page; re-embeds with `candle()` inline |
 | [server/pipelines/update.yaml](server/pipelines/update.yaml) | `/wiki-update/execute` | UPDATE an existing page by slug; re-embeds with `candle()` inline |
+| [server/pipelines/bulk_create.yaml](server/pipelines/bulk_create.yaml) | `/wiki-bulk-create/execute` | Chunk a long doc with `chunk('markdown', …)`, embed each chunk with `candle()`, write one page per chunk |
 | [server/pipelines/get.yaml](server/pipelines/get.yaml) | `/wiki-get/execute` | Fetch one page by slug |
 | [server/pipelines/search_hybrid.yaml](server/pipelines/search_hybrid.yaml) | `/wiki-search-hybrid/execute` | RRF hybrid search over `pg_knn` + `pg_fts` |
 | [server/pipelines/list.yaml](server/pipelines/list.yaml) | `/wiki-list/execute` | Filter pages by `page_type` + slug prefix, newest first |
@@ -551,6 +583,53 @@ mirrors the row to `wiki_pages_fts` and `wiki_pages_vec` atomically.
 > width against it, ignoring the intermediate projection that adds
 > `vec_to_binary(candle(...))`. The SELECT-wrapper keeps the subquery's own
 > schema in scope so the projection lands the row at full width.
+
+### 7b. `bulk-write` — seed many pages from one long markdown doc
+
+`write` is for hand-curated pages. To seed a long document — a chapter,
+an RFC, a transcript — `bulk-write` chunks the body inline with
+[`chunk('markdown', …)`](../../docs/chunk.md), embeds each chunk with
+`candle()`, and inserts one page per chunk. Each call goes through the
+same `AFTER INSERT` trigger as `write`, so the resulting pages are
+immediately searchable via `skardi grep`.
+
+```bash
+skardi bulk-write \
+  --slug_prefix=rfc/9110 \
+  --title="RFC 9110: HTTP Semantics" \
+  --page_type=rfc \
+  --content="$(cat rfc9110.md)"
+```
+
+Override the chunk shape on the same line:
+
+```bash
+skardi bulk-write \
+  --slug_prefix=alice/ch1 \
+  --title="Alice in Wonderland — Chapter 1" \
+  --page_type=alice \
+  --content="$(cat data/test_corpus/alice_sample.md)" \
+  --chunk_size=400 --overlap=80
+```
+
+Synthesised slugs follow `{slug_prefix}/p<NNN>` (`rfc/9110/p001`,
+`/p002`, …) and titles get a `#N` suffix so each chunk is a distinct
+page visible to `skardi ls` and `skardi grep`. Per-page edits stay on
+`rm` + `write` (or direct UPDATE against SQLite) — `bulk-write` is a
+one-shot seeder, not a re-runnable upsert. Re-running it on the same
+slug prefix will fail on the `UNIQUE(slug)` constraint.
+
+This is the same flow [seed.py](seed.py) implements in Python today,
+but in pure SQL: `chunk('markdown', body, ...)` replaces the manual
+paragraph splitter and `candle()` replaces the Python embedding step.
+Seeding a fresh corpus needs only `setup.py` + `bulk-write` calls —
+no Python embedding loop.
+
+Install the CLI with the RAG umbrella (bundles embedding UDFs + `chunk`):
+
+```bash
+cargo install --locked --path crates/cli --features rag
+```
 
 ### 8. Edit an existing page (`rm` + `write`)
 

--- a/demo/llm_wiki/cli/aliases.yaml
+++ b/demo/llm_wiki/cli/aliases.yaml
@@ -49,3 +49,10 @@ spec:
     defaults:
       page_type: entity
     description: Create a new wiki page (re-embeds content inline); use --slug --title --content
+  bulk-write:
+    pipeline: wiki-bulk-create
+    defaults:
+      chunk_size: '800'
+      overlap: '150'
+      page_type: entity
+    description: Chunk a long markdown doc into many pages (slug_prefix/pNNN); use --slug_prefix --title --content [--page_type --chunk_size --overlap]

--- a/demo/llm_wiki/cli/pipelines/bulk_create.yaml
+++ b/demo/llm_wiki/cli/pipelines/bulk_create.yaml
@@ -1,0 +1,50 @@
+kind: pipeline
+
+metadata:
+  name: "wiki-bulk-create"
+  version: "1.0.0"
+  description: >
+    Create many wiki pages from one long markdown document by chunking it
+    inline. Each chunk becomes its own page: slug = '{slug_prefix}/p<NNN>',
+    title = '{title} #<N>', page_type = {page_type}, content = the chunk
+    body, embedding = vec_to_binary(candle(chunk_body)). The AFTER INSERT
+    trigger fans every row out to wiki_pages_fts and wiki_pages_vec, so an
+    N-chunk doc yields N searchable pages in one statement.
+
+    Per-page edits remain the responsibility of `skardi write` /
+    `skardi rm` (i.e. wiki-create / wiki-delete). Bulk-create is for the
+    seeding / long-document path — same flow seed.py uses today, but in
+    SQL with no Python.
+
+    The synthesized projection is wrapped in `SELECT ... FROM (...) AS t`
+    so DataFusion's INSERT planner does not validate row width against
+    the inner subquery and drop vec_to_binary(candle(...)).
+
+# Parameters:
+#   {slug_prefix} - Slug prefix, e.g. 'alice/chap-1' (chunks become .../p001, /p002, ...)
+#   {title}       - Title prefix; chunk index suffixed as ' #N'
+#   {page_type}   - Page-type tag for the bulk run (e.g. 'alice', 'rfc', 'summary')
+#   {content}     - Markdown body to chunk
+#   {chunk_size}  - Target max chunk length in characters
+#   {overlap}     - Characters of overlap between adjacent chunks
+
+spec:
+  query: |
+    INSERT INTO wiki.main.wiki_pages (slug, title, page_type, content, embedding, updated_at)
+    SELECT
+      slug, title, page_type, content,
+      vec_to_binary(candle('models/generated/bge-small-en-v1.5', content)),
+      CAST(now() AS VARCHAR)
+    FROM (
+      SELECT
+        {slug_prefix} || '/p' || lpad(CAST(rn AS VARCHAR), 3, '0') AS slug,
+        {title} || ' #' || CAST(rn AS VARCHAR)                    AS title,
+        {page_type}                                                AS page_type,
+        chunk_text                                                 AS content
+      FROM (
+        SELECT chunk_text, ROW_NUMBER() OVER (ORDER BY 1) AS rn
+        FROM (
+          SELECT UNNEST(chunk('markdown', {content}, {chunk_size}, {overlap})) AS chunk_text
+        ) c
+      ) r
+    ) AS t

--- a/demo/llm_wiki/server/pipelines/bulk_create.yaml
+++ b/demo/llm_wiki/server/pipelines/bulk_create.yaml
@@ -1,0 +1,39 @@
+kind: pipeline
+
+metadata:
+  name: "wiki-bulk-create"
+  version: "1.0.0"
+  description: >
+    Create many wiki pages from one long markdown document by chunking it
+    inline. Each chunk becomes its own page: slug = '{slug_prefix}/p<NNN>',
+    title = '{title} #<N>', page_type = {page_type}, content = the chunk
+    body, embedding = candle(chunk_body). One INSERT writes N rows; pg_fts
+    and pg_knn are populated atomically by the same row.
+
+    Per-page edits remain the responsibility of the wiki-create / wiki-update
+    endpoints. Bulk-create is for the seeding / long-document path.
+
+# Parameters:
+#   {slug_prefix} - Prefix for synthesized slugs, e.g. "alice/chap-1"
+#   {title}       - Title prefix; chunk index suffixed as " #N"
+#   {page_type}   - One of entity | concept | summary | index | schema | <book-tag>
+#   {content}     - Markdown body to chunk
+#   {chunk_size}  - Target max chunk length in characters
+#   {overlap}     - Characters of overlap between adjacent chunks
+
+spec:
+  query: |
+    INSERT INTO wikidb.public.wiki_pages (slug, title, page_type, content, embedding, updated_at)
+    SELECT
+      {slug_prefix} || '/p' || lpad(CAST(rn AS VARCHAR), 3, '0') AS slug,
+      {title} || ' #' || CAST(rn AS VARCHAR)                    AS title,
+      {page_type}                                                AS page_type,
+      chunk_text                                                 AS content,
+      candle('models/generated/bge-small-en-v1.5', chunk_text)   AS embedding,
+      now()                                                      AS updated_at
+    FROM (
+      SELECT chunk_text, ROW_NUMBER() OVER (ORDER BY 1) AS rn
+      FROM (
+        SELECT UNNEST(chunk('markdown', {content}, {chunk_size}, {overlap})) AS chunk_text
+      ) c
+    ) t

--- a/demo/rag/README.md
+++ b/demo/rag/README.md
@@ -153,6 +153,45 @@ VALUES (
 
 One row, one write — immediately searchable by both `pg_fts` and `pg_knn`.
 
+### Long-form ingestion: chunk → embed → write
+
+`/ingest` above expects each `content` to already be chunk-sized. For real
+documents (a wiki page, a chapter, a long support thread) Skardi can do the
+chunking inline — `chunk('markdown', ...)` splits the body, `UNNEST` expands
+each chunk into its own row, and `candle()` embeds every chunk. One request,
+N rows, all atomically searchable.
+
+```bash
+curl -X POST http://localhost:8080/ingest-chunked/execute \
+  -H "Content-Type: application/json" \
+  -d '{
+    "doc_id": 100,
+    "content": "# Vector Search\n\nVector databases index high-dimensional embeddings. They use approximate nearest-neighbour algorithms — HNSW, IVF, and product quantisation are common — to keep recall high while bounding latency.\n\n# Hybrid Search\n\nHybrid search merges semantic similarity with keyword relevance. Reciprocal Rank Fusion (RRF) is a common merge: each candidate gets a score of `weight / (60 + rank)` from each ranker, and the sums are sorted.\n\n# Practical Notes\n\nChunk size and overlap matter. Too small and chunks lose context; too large and precision drops. Markdown splitters preserve heading boundaries so each chunk stays semantically coherent.",
+    "chunk_size": 250,
+    "overlap": 50
+  }' | jq .
+```
+
+Server SQL (see [server/pipelines/ingest_chunked.yaml](server/pipelines/ingest_chunked.yaml)):
+
+```sql
+INSERT INTO documents (id, content, embedding)
+SELECT
+  {doc_id} * 1000 + (ROW_NUMBER() OVER (ORDER BY 1) - 1) AS id,
+  chunk_text                                              AS content,
+  candle('models/generated/bge-small-en-v1.5', chunk_text) AS embedding
+FROM (
+  SELECT UNNEST(chunk('markdown', {content}, {chunk_size}, {overlap})) AS chunk_text
+) c
+```
+
+Synthesised ids are `doc_id * 1000 + chunk_idx` (0-based), so doc 100
+above becomes rows `100000, 100001, 100002 …`. Pick `doc_id`s that don't
+collide with the single-row `/ingest` path.
+
+Requires `--features rag` on `skardi-server` (the umbrella that bundles
+`embedding` + `chunking`).
+
 ---
 
 ## Read Path: Searching
@@ -246,6 +285,7 @@ lookup, no id-type conversion.
 | Pipeline | Endpoint | Description |
 |---|---|---|
 | [server/pipelines/ingest.yaml](server/pipelines/ingest.yaml) | `/ingest/execute` | Single INSERT writes content + candle embedding into `documents` |
+| [server/pipelines/ingest_chunked.yaml](server/pipelines/ingest_chunked.yaml) | `/ingest-chunked/execute` | Inline `chunk('markdown', …)` + `candle(…)` per chunk; one row per chunk |
 | [server/pipelines/search_vector.yaml](server/pipelines/search_vector.yaml) | `/search-vector/execute` | Semantic search via `pg_knn` |
 | [server/pipelines/search_fulltext.yaml](server/pipelines/search_fulltext.yaml) | `/search-fulltext/execute` | Keyword search via `pg_fts` over `documents.content` |
 | [server/pipelines/search_hybrid.yaml](server/pipelines/search_hybrid.yaml) | `/search-hybrid/execute` | RRF hybrid search combining `pg_knn` + `pg_fts` |
@@ -394,6 +434,48 @@ document searchable by both `sqlite_fts` and `sqlite_knn`.
 > ignoring the intermediate projection that adds
 > `vec_to_binary(candle(...))`. The SELECT-wrapper keeps the subquery's own
 > schema in scope so the projection lands the row at full width.
+
+### 6b. `ingest-doc` — write one *long* document, chunked inline
+
+`ingest` above expects content that's already chunk-sized. For a real
+document, `ingest-doc` chunks it inline with the markdown splitter,
+embeds each chunk with `candle()`, and writes one row per chunk — all in
+one statement, all going through the same `AFTER INSERT` trigger:
+
+```bash
+skardi ingest-doc 100 "# Vector Search
+
+Vector databases index high-dimensional embeddings. They use approximate
+nearest-neighbour algorithms — HNSW, IVF, and product quantisation are
+common.
+
+# Hybrid Search
+
+Hybrid search merges semantic similarity with keyword relevance.
+Reciprocal Rank Fusion (RRF) is a common merge.
+
+# Practical Notes
+
+Chunk size and overlap matter. Too small and chunks lose context; too
+large and precision drops."
+```
+
+Override the chunk shape on the same line:
+
+```bash
+skardi ingest-doc 101 "$(cat my-long-doc.md)" \
+  --chunk_size=400 --overlap=80
+```
+
+Synthesised ids are `doc_id * 1000 + chunk_idx` (0-based), so the
+example above becomes ids `100000, 100001, 100002, …`. Pick `doc_id`s
+that don't collide with single-row `ingest` calls.
+
+Install the CLI with the RAG umbrella (bundles embedding UDFs + `chunk`):
+
+```bash
+cargo install --locked --path crates/cli --features rag
+```
 
 ### 7. `grep` — hybrid search (RRF over FTS + vector)
 

--- a/demo/rag/cli/aliases.yaml
+++ b/demo/rag/cli/aliases.yaml
@@ -12,6 +12,15 @@ spec:
       - doc_id
       - content
     description: Insert one document (id, content) — computes embedding inline
+  ingest-doc:
+    pipeline: ingest-chunked
+    positional:
+      - doc_id
+      - content
+    defaults:
+      chunk_size: "500"
+      overlap: "100"
+    description: Chunk a long document inline (markdown splitter), embed each chunk, insert one row per chunk
   grep:
     pipeline: search-hybrid
     positional:

--- a/demo/rag/cli/pipelines/ingest_chunked.yaml
+++ b/demo/rag/cli/pipelines/ingest_chunked.yaml
@@ -1,0 +1,43 @@
+kind: pipeline
+
+metadata:
+  name: "ingest-chunked"
+  version: "1.0.0"
+  description: >
+    Ingest one long document by splitting it into chunks inline with
+    chunk('markdown', ...), embedding each chunk with candle, and writing
+    one row per chunk into rag.main.documents. The AFTER INSERT trigger
+    fans every new row out to documents_fts and documents_vec, so an
+    N-chunk document yields N rows that are immediately searchable via
+    sqlite_fts and sqlite_knn.
+
+    Synthesized chunk ids: `id = doc_id * 1000 + chunk_idx` (0-based), so
+    pick `doc_id` values that don't collide with the single-row `ingest`
+    pipeline. ROW_NUMBER drives the chunk_idx; chunk order matches
+    text-splitter's emission order.
+
+    The synthesized projection is wrapped in `SELECT ... FROM (...) AS t`
+    rather than going straight into INSERT — same reason as the simple
+    ingest path: DataFusion's INSERT planner otherwise validates row
+    width against the inner subquery and drops the
+    vec_to_binary(candle(...)) column from the projection.
+
+# Parameters:
+#   {doc_id}     - Source-doc id, used as a prefix for synthesized chunk ids
+#   {content}    - Full document text (any length); chunked inline
+#   {chunk_size} - Target max chunk length in characters
+#   {overlap}    - Characters of overlap between adjacent chunks
+
+spec:
+  query: |
+    INSERT INTO rag.main.documents (id, content, embedding)
+    SELECT id, content,
+           vec_to_binary(candle('models/generated/bge-small-en-v1.5', content))
+    FROM (
+      SELECT
+        {doc_id} * 1000 + (ROW_NUMBER() OVER (ORDER BY 1) - 1) AS id,
+        chunk_text                                              AS content
+      FROM (
+        SELECT UNNEST(chunk('markdown', {content}, {chunk_size}, {overlap})) AS chunk_text
+      ) c
+    ) AS t

--- a/demo/rag/server/pipelines/ingest_chunked.yaml
+++ b/demo/rag/server/pipelines/ingest_chunked.yaml
@@ -1,0 +1,33 @@
+kind: pipeline
+
+metadata:
+  name: "ingest-chunked"
+  version: "1.0.0"
+  description: >
+    Ingest one long document by splitting it into chunks inline with
+    chunk('markdown', ...), embedding each chunk with candle, and writing
+    one row per chunk. The whole loop — chunk → embed → write — happens in
+    a single SQL statement, so an N-chunk document is N rows, all
+    immediately searchable via pg_fts and pg_knn.
+
+    Synthesized chunk ids: `id = doc_id * 1000 + chunk_idx` (0-based), so
+    pick `doc_id` values that don't collide if you also use the single-row
+    `ingest` pipeline. ROW_NUMBER drives the chunk_idx; chunk order
+    matches text-splitter's emission order.
+
+# Parameters:
+#   {doc_id}     - Source-doc id, used as a prefix for synthesized chunk ids
+#   {content}    - Full document text (any length); chunked inline
+#   {chunk_size} - Target max chunk length in characters (default 500)
+#   {overlap}    - Characters of overlap between adjacent chunks (default 100)
+
+spec:
+  query: |
+    INSERT INTO documents (id, content, embedding)
+    SELECT
+      {doc_id} * 1000 + (ROW_NUMBER() OVER (ORDER BY 1) - 1) AS id,
+      chunk_text                                              AS content,
+      candle('models/generated/bge-small-en-v1.5', chunk_text) AS embedding
+    FROM (
+      SELECT UNNEST(chunk('markdown', {content}, {chunk_size}, {overlap})) AS chunk_text
+    ) c

--- a/docs/chunk.md
+++ b/docs/chunk.md
@@ -1,14 +1,14 @@
 # Text Chunking (`chunk`)
 
-> **Requires `--features chunking`** — build with:
+> **Build flags:**
 > ```bash
-> cargo build --release -p skardi-server --features chunking
+> cargo build --release -p skardi-server --features chunking   # just chunk()
+> cargo build --release -p skardi-server --features rag        # chunk() + embedding UDFs
 > ```
 >
-> To chain chunking with inline embeddings in a single pipeline, combine features:
-> ```bash
-> cargo build --release -p skardi-server --features "chunking,embedding"
-> ```
+> The `rag` umbrella feature bundles `embedding` and `chunking` so the
+> chunk → embed → write loop ships in one flag. The pre-built Docker image
+> `ghcr.io/skardilabs/skardi/skardi-server-rag:<tag>` includes both.
 
 `chunk` is a DataFusion scalar UDF that splits text into smaller pieces directly inside SQL, so document ingestion can chunk inline alongside embedding and writing — no out-of-band Python step. It wraps the [`text-splitter`](https://crates.io/crates/text-splitter) crate.
 
@@ -75,7 +75,7 @@ FROM (
 );
 ```
 
-Requires the `chunking` and `embedding` (or `candle`) features.
+Requires `--features rag` (or `--features "chunking,candle"` if you want to pick à la carte).
 
 ### Keep chunks as a list column
 

--- a/docs/chunk.md
+++ b/docs/chunk.md
@@ -1,0 +1,125 @@
+# Text Chunking (`chunk`)
+
+> **Requires `--features chunking`** — build with:
+> ```bash
+> cargo build --release -p skardi-server --features chunking
+> ```
+>
+> To chain chunking with inline embeddings in a single pipeline, combine features:
+> ```bash
+> cargo build --release -p skardi-server --features "chunking,embedding"
+> ```
+
+`chunk` is a DataFusion scalar UDF that splits text into smaller pieces directly inside SQL, so document ingestion can chunk inline alongside embedding and writing — no out-of-band Python step. It wraps the [`text-splitter`](https://crates.io/crates/text-splitter) crate.
+
+## Function Signature
+
+```sql
+chunk(mode, text, size [, overlap]) -> List<Utf8>
+```
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `mode` | string literal | Splitter to use. Supported: `'character'`, `'markdown'`. |
+| `text` | `Utf8` | The text to split. May be a literal, a scalar subquery, or a column reference. `NULL` rows pass through unchanged. |
+| `size` | integer literal | Target maximum chunk length in characters. Must be `> 0`. |
+| `overlap` | integer literal | Optional. Characters of overlap between adjacent chunks. Must be strictly less than `size`. Defaults to `0`. |
+
+**Returns:** `List<Utf8>` — one element per chunk. A `NULL` input row produces a `NULL` list element.
+
+Use `UNNEST(chunk(...))` to expand the list into one row per chunk.
+
+## Modes
+
+| Mode | Behavior |
+|------|----------|
+| `'character'` | Generic recursive splitter: tries paragraph → sentence → word → grapheme boundaries before falling back to character splits. Use for arbitrary plain text. |
+| `'markdown'` | Markdown-aware: prefers heading / paragraph / code-block boundaries so chunks stay semantically coherent. Use when the input is Markdown (READMEs, wiki pages, knowledge bases). |
+
+Both modes count length in characters (Unicode scalar values), not bytes or tokens.
+
+> Token-based and code-aware splitters are planned follow-ups. See the [roadmap](../README.md#roadmap).
+
+## Examples
+
+### Split a literal
+
+```sql
+SELECT UNNEST(chunk('character', 'a long document body...', 1000)) AS piece;
+```
+
+### Per-row chunking over a table
+
+```sql
+SELECT id, UNNEST(chunk('markdown', body, 1000, 200)) AS chunk_text
+FROM docs;
+```
+
+Each row in `docs` produces one row per chunk. `id` repeats; `chunk_text` carries the split.
+
+### Inline ingestion: chunk → embed → write
+
+The motivating use case — RAG ingest expressed as one SQL statement, no application code in between:
+
+```sql
+INSERT INTO doc_chunks
+SELECT
+  doc_id,
+  chunk_text,
+  candle('models/bge-small-en-v1.5', chunk_text) AS embedding
+FROM (
+  SELECT
+    doc_id,
+    UNNEST(chunk('markdown', body, 1000, 200)) AS chunk_text
+  FROM raw_docs
+);
+```
+
+Requires the `chunking` and `embedding` (or `candle`) features.
+
+### Keep chunks as a list column
+
+Skip the `UNNEST` to keep all chunks for a document together:
+
+```sql
+SELECT id, chunk('character', body, 500) AS chunks
+FROM articles;
+```
+
+`chunks` is a `List<Utf8>` you can index, count with `array_length`, or expand later.
+
+### As a pipeline
+
+```yaml
+params:
+  source_table: { type: string }
+  chunk_size:   { type: integer, default: 1000 }
+  overlap:      { type: integer, default: 200 }
+  model:        { type: string,  default: "models/bge-small-en-v1.5" }
+sql: |
+  WITH split AS (
+    SELECT id,
+           UNNEST(chunk('markdown', body, ${chunk_size}, ${overlap})) AS text
+    FROM ${source_table}
+  )
+  SELECT id, text, candle('${model}', text) AS embedding
+  FROM split
+```
+
+## Key Behaviors
+
+- **Splitter is built once per batch.** Per-row construction would be wasteful; the underlying `TextSplitter` / `MarkdownSplitter` is constructed once and reused for every row in the batch.
+- **`NULL` text → `NULL` list element.** Null inputs do not error and do not produce empty lists.
+- **`size` and `overlap` must be literal integers.** They are read once per call, not per row.
+- **`overlap < size` is enforced.** Equal or greater overlap returns an execution error rather than looping.
+- **Subqueries work transparently.** Because `chunk` is a scalar UDF, scalar subqueries collapse to a single value before invocation, and relational subqueries simply feed rows into the parent scan — no special syntax needed.
+
+## Troubleshooting
+
+**"chunk: unsupported mode '<x>'"** — only `'character'` and `'markdown'` are supported today.
+
+**"chunk: 'overlap' (N) must be strictly less than 'size' (M)"** — pick `overlap < size`. Setting `overlap = 0` is always valid.
+
+**"chunk expects 3 or 4 arguments"** — the call shape is `chunk(mode, text, size [, overlap])`.
+
+**Long literal embedded into SQL fails to parse** — large text passed as a SQL string literal must escape single quotes. Pass via a parameter / scalar subquery / column reference for anything beyond toy examples.

--- a/docs/embeddings/README.md
+++ b/docs/embeddings/README.md
@@ -56,7 +56,7 @@ FROM (
 );
 ```
 
-Build with both features enabled: `--features "chunking,embedding"`. See [docs/chunk.md](../chunk.md) for full `chunk()` semantics, supported modes, and overlap behaviour.
+Build with `--features rag` to get embedding UDFs plus the `chunk` UDF in one flag. See [docs/chunk.md](../chunk.md) for full `chunk()` semantics, supported modes, and overlap behaviour.
 
 ## Pipeline Shape
 

--- a/docs/embeddings/README.md
+++ b/docs/embeddings/README.md
@@ -40,6 +40,24 @@ Quick rule of thumb:
 
 The shared corpus means you can run all three demos against the same source data and compare results side by side.
 
+## Inline Ingestion: Chunk → Embed → Write
+
+The demos above pre-embed documents via Python because the source corpus is small and pre-chunked. For real ingest where each document is too large to embed as a single vector, combine [`chunk()`](../chunk.md) with the embedding UDF and skip Python entirely:
+
+```sql
+INSERT INTO doc_chunks
+SELECT
+  doc_id,
+  chunk_text,
+  candle('models/bge-small-en-v1.5', chunk_text) AS embedding
+FROM (
+  SELECT doc_id, UNNEST(chunk('markdown', body, 1000, 200)) AS chunk_text
+  FROM raw_docs
+);
+```
+
+Build with both features enabled: `--features "chunking,embedding"`. See [docs/chunk.md](../chunk.md) for full `chunk()` semantics, supported modes, and overlap behaviour.
+
 ## Pipeline Shape
 
 Every backend uses the same parameter shape so pipelines are interchangeable:


### PR DESCRIPTION
Wraps the `text-splitter` crate as a DataFusion scalar UDF returning List<Utf8>, so RAG ingest can express chunk → embed → write as a single SQL statement (no out-of-band Python step). v1 ships character and markdown splitters; token / code modes are deferred follow-ups.

Gated behind a new `chunking` feature on both `skardi` and `skardi-server`, following the same pattern as the embedding UDFs. Includes 7 unit tests plus 3 SQL-level integration tests that exercise registration, UNNEST expansion, and per-row chunking over a registered table.