### PR TITLE
fix: register chunk UDF on runtime ctx; add libgomp1 to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install -y \
     libssl3t64 \
     libsqlite3-0 \
     zlib1g \
+    libgomp1 \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -17,6 +17,8 @@ use crate::auth::mode::AuthMode;
 use crate::config::ServerConfig;
 #[cfg(feature = "candle")]
 use crate::config::register_candle_udf;
+#[cfg(feature = "chunking")]
+use crate::config::register_chunk_udf;
 #[cfg(feature = "gguf")]
 use crate::config::register_gguf_udf;
 #[cfg(feature = "onnx")]
@@ -148,6 +150,9 @@ pub async fn setup_app_state(config: ServerConfig) -> Result<AppState> {
     // Register candle UDF (lazy — models loaded on first call from inline path)
     #[cfg(feature = "candle")]
     register_candle_udf(&mut session_ctx);
+    // Register chunk UDF (text-splitter wrapper for inline ingestion)
+    #[cfg(feature = "chunking")]
+    register_chunk_udf(&mut session_ctx);
 
     // Build auth layer and register auth.users / auth.sessions on the runtime SessionContext.
     let auth_layer = AuthLayer::build(&AuthMode::from_env()).await?;

--- a/crates/skardi/src/model/chunking/mod.rs
+++ b/crates/skardi/src/model/chunking/mod.rs
@@ -667,4 +667,8 @@ mod tests {
         assert!(slugs[0].starts_with("alice/chap1/p0"), "got {slugs:?}");
         assert!(slugs.iter().all(|s| s.starts_with("alice/chap1/p")));
     }
+
+    // Cross-UDF composition guards (chunk × candle/gguf/onnx/remote_embed)
+    // live in `crates/skardi/tests/cross_udf_composition.rs` so chunking
+    // module tests stay focused on chunk()'s own behaviour.
 }

--- a/crates/skardi/tests/cross_udf_composition.rs
+++ b/crates/skardi/tests/cross_udf_composition.rs
@@ -1,0 +1,127 @@
+//! Cross-UDF composition guards.
+//!
+//! Each test pairs `chunk()` with one embedding UDF and asserts both
+//! resolve and plan together on a single `SessionContext`. Tests stop at
+//! `ctx.sql(...)` (no `.collect()`) so the embedding UDF is never invoked
+//! and no real model needs to exist on disk.
+//!
+//! These guard the regression class fixed in #128 — a UDF registered on
+//! the planning context but missing from the runtime context would let
+//! pipeline SQL validate at startup but fail at request time. Catching
+//! that in unit tests would require simulating the server's two-context
+//! setup; this is the next-best thing: structural assertions that every
+//! shipping embedding UDF can coexist with `chunk()` on the same context.
+
+#![cfg(feature = "chunking")]
+
+use std::sync::Arc;
+
+use datafusion::execution::FunctionRegistry;
+use datafusion::prelude::SessionContext;
+use skardi::model::ChunkingRegistry;
+
+/// SQL fragment that all four tests reuse — chunks a literal markdown
+/// body and pipes the chunks through the paired embedding UDF.
+fn build_ctx() -> SessionContext {
+    let mut ctx = SessionContext::new();
+    Arc::new(ChunkingRegistry::new()).register_chunk_udf(&mut ctx);
+    ctx
+}
+
+#[cfg(feature = "candle")]
+#[tokio::test]
+async fn chunk_composes_with_candle() {
+    use skardi::model::CandleModelRegistry;
+
+    let mut ctx = build_ctx();
+    Arc::new(CandleModelRegistry::new()).register_candle_udf(&mut ctx);
+
+    assert!(ctx.udf("chunk").is_ok());
+    assert!(ctx.udf("candle").is_ok());
+
+    let sql = "WITH src AS (SELECT 'doc body for chunking' AS body) \
+               SELECT chunk_text, \
+                      candle('models/does/not/exist', chunk_text) AS embedding \
+               FROM ( \
+                 SELECT UNNEST(chunk('markdown', body, 50)) AS chunk_text \
+                 FROM src \
+               )";
+    ctx.sql(sql)
+        .await
+        .expect("chunk + candle composition should plan cleanly");
+}
+
+#[cfg(feature = "gguf")]
+#[tokio::test]
+async fn chunk_composes_with_gguf() {
+    use skardi::model::GgufModelRegistry;
+
+    let mut ctx = build_ctx();
+    Arc::new(GgufModelRegistry::new()).register_gguf_udf(&mut ctx);
+
+    assert!(ctx.udf("chunk").is_ok());
+    assert!(ctx.udf("gguf").is_ok());
+
+    let sql = "WITH src AS (SELECT 'doc body for chunking' AS body) \
+               SELECT chunk_text, \
+                      gguf('models/does/not/exist', chunk_text) AS embedding \
+               FROM ( \
+                 SELECT UNNEST(chunk('markdown', body, 50)) AS chunk_text \
+                 FROM src \
+               )";
+    ctx.sql(sql)
+        .await
+        .expect("chunk + gguf composition should plan cleanly");
+}
+
+#[cfg(feature = "onnx")]
+#[tokio::test]
+async fn chunk_composes_with_onnx_predict() {
+    use skardi::model::OnnxModelRegistry;
+
+    let mut ctx = build_ctx();
+    Arc::new(OnnxModelRegistry::new()).register_onnx_predict_udf(&mut ctx);
+
+    assert!(ctx.udf("chunk").is_ok());
+    assert!(ctx.udf("onnx_predict").is_ok());
+
+    // onnx_predict takes a model path + numeric inputs. Pair it with the
+    // chunk-text length so both UDFs land in the same query shape.
+    let sql = "WITH src AS (SELECT 'doc body for chunking' AS body) \
+               SELECT chunk_text, \
+                      onnx_predict('models/does/not/exist.onnx', \
+                                   CAST(LENGTH(chunk_text) AS BIGINT)) AS score \
+               FROM ( \
+                 SELECT UNNEST(chunk('markdown', body, 50)) AS chunk_text \
+                 FROM src \
+               )";
+    ctx.sql(sql)
+        .await
+        .expect("chunk + onnx_predict composition should plan cleanly");
+}
+
+#[cfg(feature = "remote-embed")]
+#[tokio::test]
+async fn chunk_composes_with_remote_embed() {
+    use skardi::model::RemoteEmbedRegistry;
+
+    let mut ctx = build_ctx();
+    Arc::new(RemoteEmbedRegistry::new()).register_remote_embed_udf(&mut ctx);
+
+    assert!(ctx.udf("chunk").is_ok());
+    assert!(ctx.udf("remote_embed").is_ok());
+
+    // We never `.collect()` — no API call fires, just a planner-level check
+    // that both UDFs name-resolve and compose.
+    let sql = "WITH src AS (SELECT 'doc body for chunking' AS body) \
+               SELECT chunk_text, \
+                      remote_embed('openai', 'text-embedding-3-small', chunk_text) \
+                        AS embedding \
+               FROM ( \
+                 SELECT UNNEST(chunk('markdown', body, 50)) AS chunk_text \
+                 FROM src \
+               )";
+    ctx.sql(sql)
+        .await
+        .expect("chunk + remote_embed composition should plan cleanly");
+}


### PR DESCRIPTION
## Summary

Two bugs surfaced when running the new \`-rag\` Docker variant end-to-end against a pgvector sidecar with \`demo/rag/server/\` pipelines:

- **Server runtime missing \`chunk\` UDF.** [\`config.rs::setup_context_for_pipelines\`](crates/server/src/config.rs) registers \`chunk()\` on the *planning* \`SessionContext\` (so pipeline SQL validates at startup), but [\`server.rs::setup_app_state\`](crates/server/src/server.rs) — which builds the *runtime* \`SessionContext\` used to execute requests — was missing the matching \`#[cfg(feature = \"chunking\")] register_chunk_udf(...)\` block. Result: \`/ingest-chunked/execute\` would fail at request time with \"function chunk not found.\" Same shape as #120.
- **Runtime image missing \`libgomp1\`.** \`candle-core\` links against OpenMP on the CPU path; \`debian:trixie-slim\` doesn't ship it, so \`skardi-server\` failed to load with \`libgomp.so.1: cannot open shared object file\`. Pre-existed this PR — the prior \`-embedding\` variant had the same loader error on first start.

## Test plan

Verified end-to-end against \`skardi-server-rag:local\` (built with \`FEATURES=rag\`) on a private docker network:

- [x] \`POST /ingest-chunked/execute\` with a 3-section markdown body landed 7 rows (\`100000..100006\`) in Postgres with valid pgvector embeddings
- [x] Server logs show \`Registered 'chunk' UDF\` on **both** planning and runtime SessionContexts
- [x] \`POST /search-hybrid/execute\` with query \"reciprocal rank fusion\" returned chunk \`100004\` (the RRF definition) first
- [x] \`cargo check -p skardi-server --features rag\` clean
- [x] Container boots cleanly with no \`libgomp\` loader error

🤖 Generated with [Claude Code](https://claude.com/claude-code)