### PR TITLE
docs: rewrite README intro for agent builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 
 <img src="asset/logo.png" alt="Skardi Logo" width="700">
 
-**Skardi is an agent data plane that gives AI agents data autonomy.**
+**Skardi is an open-source agent data plane** — the single layer every data call your agent makes flows through. RAG retrieval, table lookups, vector search, audit writes: declare each one as parameterized SQL in a YAML pipeline, and Skardi serves it as both a REST endpoint and a shell verb your agent can call as a tool, federated across Postgres, SQLite, MongoDB, S3, data lakes, and vector stores in a single query.
+
+**Federated** · one engine over every source &nbsp;·&nbsp; **Declarative** · YAML pipelines &nbsp;·&nbsp; **Agent-native** · REST + shell + MCP-soon
 
 <a href="https://skardilabs.github.io/skardi-docs/">Documentation</a> •
 <a href="#roadmap">Roadmap</a> •
@@ -36,22 +38,60 @@
 
 <hr />
 
-## What is Skardi?
+## What is an "agent data plane"?
 
-Skardi is an open-source **data plane for AI agents** — every tool call your agent makes hits a Skardi pipeline: declarative SQL, served over REST or shell, with retrieval primitives built in. Build RAG, hybrid search, memory, and data APIs across databases, files, data lakes, and vector stores.
+Borrowing the phrase from cloud infra: your AI agent has two layers. The **control plane** is the reasoning loop — prompts, tool selection, your orchestration code, your YAML configs. The **data plane** is where every byte of context actually comes from and goes to: vector DB hits, SQL queries, file reads, writes back, audit trails. The control plane is mostly fine these days (LLMs are smart, agent SDKs are mature). The data plane is the bottleneck — most agents today have a tangled one: a Pinecone client here, a Postgres query there, a hand-rolled RRF merge in Python, an HTTP wrapper around an internal API, glue code on top of glue code.
 
-Borrowing Spark's shape — one engine over every data source — but tilted for online serving, not analytics. Your agent and your pipeline YAMLs are the *control plane*; Skardi is the *data plane* every tool call traverses, designed for how agents actually use data: schemas they can *read*, outputs they can *parse*, tools they can *discover*, writes they can *trust*.
+**Skardi *is* the data plane.** A single open-source server (and CLI) where every one of your agent's data calls goes, declared once as parameterized SQL in YAML, then served as both a REST endpoint and a shell verb. Federated, so one query can JOIN across Postgres, SQLite, MongoDB, S3, data lakes, and vector stores. Fast enough to sit in your agent's request path — typically tens of milliseconds for a parameterized Postgres / SQLite query, dominated by your data source's own latency.
 
-- **`skardi` CLI** — federated SQL + parameterized pipelines as shell commands. Drop it into any agent that has a Bash tool (Claude Code, Cursor, custom loops) and it's wired.
-- **`skardi-server`** — two peer surfaces on one engine: **online serving** (declarative SQL pipelines as parameterized REST endpoints) and **offline jobs** (async batch writes into Lance or any read-write DB, with atomic commit + run ledger).
-- **Soon** — skills generation for auto-discovery, MCP binding for non-Claude hosts, a first-class **memory primitive** (structured + vector + FTS + provenance + TTL), lineage, and agent-scoped governance.
+**Concretely, you're replacing this:**
+
+```python
+# What an agent retrieval tool usually looks like today:
+def search_wiki(query: str, limit: int = 10):
+    embedding = openai.embeddings.create(input=query, model="...").data[0].embedding
+    vec_hits  = pg.execute("SELECT id FROM pages ORDER BY emb <=> %s LIMIT 80", [embedding])
+    fts_hits  = pg.execute("SELECT id FROM pages WHERE tsv @@ plainto_tsquery(%s) LIMIT 60", [query])
+    fused     = rrf_merge(vec_hits, fts_hits)            # hand-rolled
+    return pg.execute("SELECT slug,title FROM pages WHERE id = ANY(%s)", [fused[:limit]])
+# + a Flask/FastAPI route exposing it, + auth, + logging, + a schema for the LLM...
+```
+
+**…with a 20-line YAML pipeline** (full version in [Quick Start](#quick-start) below). Skardi handles the embedding call, the hybrid-search merge, the HTTP route, the parameter parsing, and the JSON response shape. Your agent calls it as `POST /wiki-search-hybrid/execute` over REST or `skardi grep "..."` from any shell — every retrieval flows through one engine instead of N hand-rolled tools.
+
+Build RAG, hybrid search, agent-callable APIs, and async batch writes across databases, files, data lakes, and vector stores — all behind the same SQL surface.
+
+```text
+   your agent  ──▶  skardi-server  ──┬─▶  Postgres / MySQL / SQLite / MongoDB / Redis
+   (Claude / GPT /     │              ├─▶  S3 / GCS / Azure (CSV, Parquet, Lance)
+    Cursor / your      │              ├─▶  Apache Iceberg, Lance datasets
+    own loop)          │              └─▶  pgvector, sqlite-vec, Lance KNN, SeekDB HNSW
+                       │
+                  parameterized SQL  ──▶  one JOIN can span all of the above
+                  (YAML pipelines)
+```
+
+- **`skardi` CLI** — run federated SQL or any pipeline directly from a shell. Drop it into Claude Code, Cursor, or any agent with a Bash tool and it's wired with no MCP config.
+- **`skardi-server`** — same engine over HTTP, with two surfaces: **online serving** (a YAML pipeline becomes a parameterized REST endpoint with an inferred request/response schema) and **offline jobs** (async batch writes into Lance or any read-write DB; if a job fails halfway you don't get a corrupted dataset, and every run is logged in a SQLite ledger you can list and inspect).
+- **Skardi-server is stateful but lightweight** — a single Rust process, plus a small SQLite file for the run ledger and (optional) auth. One server can serve many agents; deploy it next to your data, behind your usual auth.
+
+> **Glossary (for terms used below).**
+> **Pipeline** — a YAML file with a parameterized SQL query; becomes one REST endpoint + one CLI verb.
+> **Job** — a YAML file like a pipeline, but runs asynchronously and writes its result rows to a destination table.
+> **`ctx.yaml`** — the config that lists your data sources (a Postgres URL, a SQLite path, an S3 bucket, etc.) and gives each one a name you can reference in SQL.
+> **DataFusion** — an in-process Rust SQL engine ([Apache project](https://datafusion.apache.org/)). Runs inside `skardi-server`, so there is no separate cluster to manage. "Single-node" means the engine itself is in-process; the data sources it queries can be remote.
+> **Lance** — an open columnar file format with built-in vector and full-text indexes ([lancedb.github.io/lance](https://lancedb.github.io/lance/)). Useful as a job destination when you want a self-contained queryable dataset on disk or S3.
+> **Hybrid search / RRF** — combining keyword (full-text, "FTS") and semantic (vector, "KNN") results into one ranking. RRF (Reciprocal Rank Fusion) is the standard merge formula. Skardi does it in a single SQL query so there is no Python re-ranking layer.
+> **Catalog mode** — point Skardi at a database connection and let it auto-discover every table, instead of registering tables one at a time. Catalog-registered tables are addressed in SQL with the 3-part `catalog.schema.table` name (e.g. `wiki.main.wiki_pages_vec` below: `wiki` is the source name, `main` is the SQLite schema, `wiki_pages_vec` is the table).
+> **`sqlite_knn` / `sqlite_fts`** — Skardi UDFs that wrap [sqlite-vec](https://github.com/asg017/sqlite-vec) KNN and SQLite FTS5 inside SQL; analogous `pg_knn` / `pg_fts` exist for Postgres + pgvector. Full UDF reference in [docs/sqlite/](docs/sqlite/) and [docs/postgres/](docs/postgres/).
+> **SeekDB** — a MySQL-wire-compatible store with native HNSW vector indexes and FULLTEXT FTS, usable as a single-source replacement for "Postgres + pgvector + tsvector" (see [docs/seekdb/](docs/seekdb/)).
 
 > **Beta.** Skardi is under active development. APIs may move. Hit us on [Discord](https://discord.gg/S5YQQPEV2m) if you want to co-design a POC.
 
 <p align="center">
   <a href="https://htmlpreview.github.io/?https://github.com/SkardiLabs/skardi/blob/main/asset/architecture-open-source.html">
     <picture>
-      <img src="asset/architecture-open-source.svg" alt="Skardi open source architecture — agent data plane between any AI agent and your data sources" width="100%"/>
+      <img src="asset/architecture-open-source.svg" alt="Skardi open source architecture — between any AI agent and your data sources" width="100%"/>
     </picture>
   </a>
   <br>
@@ -60,17 +100,30 @@ Borrowing Spark's shape — one engine over every data source — but tilted for
 
 ---
 
-## Why an agent data plane?
+## Drop-in skills — go from zero to grounded retrieval in 60 seconds
 
-Agents don't lack intelligence — they lack **data autonomy**. Hand an LLM a raw schema dump and it hallucinates; hand it a bag of bespoke REST endpoints and it gets lost; hand it a vector store and it still can't JOIN. The gap isn't the model. The gap is that today's data stack was designed for humans writing queries, not agents calling tools.
+Don't want to hand-write YAML to see what Skardi does for your agent? The fastest path is to install one of our ready-made skills from **[skardi-skills](https://github.com/SkardiLabs/skardi-skills)**. Each skill renders the `ctx.yaml` + pipelines for you and exposes them as agent-callable verbs — zero config to write yourself, your agent can start retrieving immediately.
 
-Skardi closes that gap with three deliberate choices:
+- **[`auto_knowledge_base`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_knowledge_base)** — point it at a directory of documents and you have a queryable local RAG one command later. Chunking, embedding, indexing, and hybrid search are exposed to your agent as a `skardi grep` verb. Zero infra by default (SQLite + local embeddings), so any Claude Code / Cursor session gets a grounded, citable knowledge base over your files.
+- **[`auto_rag`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_rag)** — server-backed hybrid-search RAG via `skardi-server` on top of a datastore you already control (Postgres + pgvector, MongoDB, or Lance). The skill renders the config, starts the server, and drives ingestion and queries through REST — for when retrieval needs to be shared across multiple agents or processes.
 
-1. **One engine over every source.** DataFusion-based single-node federation. An agent can `JOIN` a CSV against Postgres against a Lance dataset in one query.
-2. **Online serving.** Parameterized SQL served synchronously as REST endpoints; the low-latency path every agent tool call hits.
-3. **Offline jobs.** The same SQL shape run asynchronously into a durable destination, with a run ledger, atomic commit, and submit / poll / cancel.
+Drop either skill into Claude Code or Cursor and your agent's data plane is wired in one prompt. Want to see what's happening under the hood, or build pipelines of your own? Read on.
 
-Read the full narrative in [docs/agent_data_plane.md](docs/agent_data_plane.md).
+---
+
+## Why not just write a Python function that wraps SQL?
+
+Fair question — that is the alternative, and for one tool it's fine. Skardi earns its keep when an agent needs more than one of these at once:
+
+1. **One engine over every source.** Skardi runs SQL across Postgres, MySQL, SQLite, MongoDB, Redis, S3 / GCS / Azure files, Iceberg, Lance, and SeekDB — and `JOIN`s across them in one query. A handrolled Python wrapper hits one source per function; cross-source JOINs become application code.
+2. **Same query, two surfaces.** The same pipeline YAML is callable both as a REST endpoint (for hosted agents, multi-process setups) and as a `skardi` CLI verb (for Claude Code, Cursor, any Bash-tool agent) with no extra glue.
+3. **Retrieval primitives in SQL.** Vector KNN, full-text search, hybrid (RRF) merge, inline embedding, inline chunking — all UDFs you can compose in plain SQL instead of stitching together Python libraries. So a RAG pipeline (chunk → embed → write → search) is one file, not a service.
+4. **Async writes you can trust.** A job that writes 100k rows to Lance commits atomically; if the process dies mid-write, the dataset is not corrupted, and every run is logged with `submitted/running/succeeded/failed` plus parameters in a SQLite ledger you can list and inspect.
+5. **A discovery surface for the agent.** `GET /data_source` returns each table's schema plus the natural-language description you wrote in YAML, so the agent picks the right pipeline before querying — instead of discovering it by trial and error.
+
+If your agent only ever needs one parameterized Postgres query, a Python function is simpler. If it needs five, plus a vector store, plus a CSV in S3, plus an audit log — that is what Skardi is for.
+
+For a deeper read on the agent-data-plane idea — what it borrows from cloud infra, why agents need their own, how it differs from a normal data warehouse — see [docs/agent_data_plane.md](docs/agent_data_plane.md).
 
 ---
 
@@ -113,17 +166,93 @@ sudo mv skardi /usr/local/bin/
 
 ### First-time agent loop (two minutes)
 
+**Step 1 — ad-hoc SQL, no server, no pre-registration.** The CLI prints results as a pretty-printed table to stdout — see [docs/cli.md](docs/cli.md).
+
 ```bash
-# 1. Ad-hoc SQL across local + remote data — no server, no pre-registration
 skardi query --sql "SELECT * FROM './data/products.csv' LIMIT 10"
 skardi query --sql "SELECT * FROM 's3://mybucket/events.parquet' LIMIT 10"
+```
 
-# 2. Register named sources in a ctx, query them by name
+**Step 2 — register named sources in a `ctx.yaml`.** Five example lines:
+
+```yaml
+# ctx.yaml — describes where your data lives. Each entry gets a name you use in SQL.
+kind: context
+spec:
+  data_sources:
+    - name: products            # referenceable as `products` in SQL
+      type: sqlite
+      path: ./shop.db
+      access_mode: read_write
+      options: { table: products }       # register one specific table…
+    - name: warehouse
+      type: postgres
+      connection_string: "postgresql://localhost:5432/warehouse"
+      hierarchy_level: catalog           # …or auto-discover every table in the DB.
+                                         # Reference catalog tables in SQL as
+                                         # `warehouse.<schema>.<table>` (3-part name).
+```
+
+```bash
 skardi query --ctx ./ctx.yaml --sql "SELECT * FROM products LIMIT 10"
+```
 
-# 3. Turn a parameterized SQL into an agent-callable verb (alias + pipeline)
-#    — now any agent with a shell can call it:
+**Step 3 — turn a parameterized SQL into an agent-callable verb.** Two YAMLs from [`demo/llm_wiki/cli/`](demo/llm_wiki/cli/) — the actual files, not pseudo-code:
+
+```yaml
+# pipelines/search_hybrid.yaml — declares the SQL once; Skardi infers the params
+kind: pipeline
+metadata: { name: wiki-search-hybrid }
+spec:
+  query: |
+    WITH vec AS (
+      SELECT id, ROW_NUMBER() OVER (ORDER BY _score ASC) AS rk
+      FROM sqlite_knn('wiki.main.wiki_pages_vec', 'embedding',
+           (SELECT candle('models/bge-small-en-v1.5', {query})), 80)
+    ),
+    fts AS (
+      SELECT id, slug, title, ROW_NUMBER() OVER (ORDER BY _score DESC) AS rk
+      FROM sqlite_fts('wiki.main.wiki_pages_fts', 'content', {text_query}, 60)
+    )
+    SELECT COALESCE(f.slug, p.slug) AS slug, COALESCE(f.title, p.title) AS title,
+           COALESCE({vector_weight}/(60.0 + v.rk), 0)
+         + COALESCE({text_weight} /(60.0 + f.rk), 0) AS rrf_score
+    FROM vec v FULL OUTER JOIN fts f USING (id)
+    LEFT JOIN wiki.main.wiki_pages p ON p.id = COALESCE(v.id, f.id)
+    ORDER BY rrf_score DESC LIMIT {limit}
+```
+
+```yaml
+# aliases.yaml — gives the pipeline a short shell verb, with positional + default args
+kind: aliases
+spec:
+  grep:
+    pipeline: wiki-search-hybrid
+    positional: [query]
+    defaults: { text_query: "{query}", text_weight: "0.5", vector_weight: "0.5", limit: "10" }
+    description: Hybrid search over the wiki (RRF of sqlite_knn + sqlite_fts)
+```
+
+Now any agent with a shell can call it:
+
+```bash
 skardi grep "turing machine computation" --limit=10
+```
+
+The output your agent sees is the standard Arrow-pretty table on stdout (`+----+--------+ ...`). Over the server (next section), the same pipeline is mounted at `POST /wiki-search-hybrid/execute` — the request body is a JSON object whose keys match the `{...}` placeholders in the SQL (Skardi infers this schema and serves it on `GET /data_source` so the agent can read it). One full cycle:
+
+```bash
+curl -X POST http://localhost:8080/wiki-search-hybrid/execute \
+  -H "Content-Type: application/json" \
+  -d '{"query": "turing machine computation",
+       "text_query": "turing machine computation",
+       "vector_weight": 0.5, "text_weight": 0.5, "limit": 10}'
+```
+
+```json
+{ "success": true,
+  "data": [ { "slug": "concept/turing-machine", "title": "Turing machine", "rrf_score": 0.0312 }, ... ],
+  "rows": 10, "execution_time_ms": 23 }
 ```
 
 Drop `skardi` into a Claude Code or Cursor session and the agent can already use any pipeline you've declared as a tool via its Bash integration. No MCP config, no separate server — that's the MVP design intent.
@@ -154,23 +283,14 @@ Full reference:
 - **Server** — [docs/server.md](docs/server.md)
 - **Pipelines (online serving)** — [docs/pipelines.md](docs/pipelines.md)
 - **Jobs (offline batch)** — [docs/jobs.md](docs/jobs.md)
-- **Catalog semantics** — [docs/semantics.md](docs/semantics.md)
-- **Why an agent data plane** — [docs/agent_data_plane.md](docs/agent_data_plane.md)
+- **Table descriptions for agent discovery** — [docs/semantics.md](docs/semantics.md)
+- **Background — design intent** — [docs/agent_data_plane.md](docs/agent_data_plane.md)
 
 ---
 
 ## Worked examples
 
 For end-to-end walkthroughs — RAG, recommendations, an agent-native wiki, a simple REST backend — see the [`demo/`](demo/) directory. Each demo ships as a self-contained `ctx.yaml` plus pipelines (and sometimes jobs), so reading the YAML shows the Skardi shape in practice. Full list in [Demo & Examples](#demo--examples) below.
-
----
-
-## RAG skills for agents
-
-Two ready-to-use skills from **[skardi-skills](https://github.com/SkardiLabs/skardi-skills)** you can drop into Claude Code or Cursor:
-
-- **[`auto_knowledge_base`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_knowledge_base)** — turn a directory of documents into a queryable local RAG with one command. Chunking, embedding, indexing, and hybrid search exposed as a `skardi grep` verb. Zero infra by default (SQLite + local embeddings), so any agent session gets a grounded, citable local knowledge base.
-- **[`auto_rag`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_rag)** — stand up server-backed hybrid-search RAG via `skardi-server` on top of a datastore you already control (Postgres + pgvector, MongoDB, or Lance). The skill renders the `ctx.yaml` + pipelines, starts the server, and drives ingestion and queries through REST — for when retrieval needs to be shared across multiple agents or processes.
 
 ---
 
@@ -195,12 +315,12 @@ Two ready-to-use skills from **[skardi-skills](https://github.com/SkardiLabs/ska
 
 ## Additional Features
 
-- **Federated queries** — JOIN across different source types. See [docs/federated-queries.md](docs/federated-queries.md).
-- **Catalog semantics** — NL descriptions on tables and columns, surfaced on the catalog endpoint so agents can pick the right tool from `GET /data_source`. See [docs/semantics.md](docs/semantics.md).
+- **Federated queries** — JOIN across different source types in one SQL query (CSV vs Postgres vs Lance, etc). See [docs/federated-queries.md](docs/federated-queries.md).
+- **Table descriptions for agents** — write natural-language descriptions of each table and column in YAML; Skardi serves them on `GET /data_source` so the agent can read what each table is for before it queries. See [docs/semantics.md](docs/semantics.md).
 - **Authentication** — session-based via better-auth + SQLite. See [docs/auth/](docs/auth/).
-- **ONNX inference** — inline model predictions in SQL. See [docs/onnx_predict.md](docs/onnx_predict.md).
-- **Embedding inference** — GGUF, Candle, or remote APIs. See [docs/embeddings/](docs/embeddings/).
-- **Observability** — OTel traces / metrics / logs with Grafana. See [docs/observability.md](docs/observability.md).
+- **ONNX inference** — inline model predictions in SQL via an `onnx_predict` UDF. See [docs/onnx_predict.md](docs/onnx_predict.md).
+- **Embedding inference** — call embedding models from inside SQL via the `candle()` UDF (local GGUF / Candle models, or remote OpenAI-style APIs). See [docs/embeddings/](docs/embeddings/).
+- **Observability** — OpenTelemetry traces / metrics / logs with a pre-configured Grafana stack. See [docs/observability.md](docs/observability.md).
 
 ---
 
@@ -276,21 +396,23 @@ For data-source-specific demos, see the entries in [Supported Data Sources](#sup
 
 ## Roadmap
 
+**Coming soon (not yet shipped)**: a skills generator that emits Claude Code skill files per pipeline, an MCP binding for non-Claude hosts, a first-class memory primitive (one YAML block giving an agent a memory store with keyword + semantic recall, automatic expiration, and per-session provenance), lineage capture, and snapshot-as-branch checkpoints (roll back a destructive agent write — e.g. an agent that updated 1,000 rows you don't like — in one call).
+
 We're **building in public**. `[x]` means shipped today, `[ ]` means open for contribution. Open an issue or hop into [Discord](https://discord.gg/S5YQQPEV2m) on anything unchecked.
 
 `1` Federated SQL engine
-   - [x] DataFusion single-node federation across CSV, Parquet, JSON, S3 / GCS / Azure, Postgres, MySQL, SQLite, MongoDB, Redis, Iceberg, Lance, SeekDB — all joinable in one query
-   - [x] Register by table, or load an entire DB (Postgres / MySQL / SQLite) as a DataFusion catalog — one config line either way
-   - [ ] Graph database sources (Neo4j / Kuzu) — native federation to unlock graphRAG patterns alongside vector / FTS retrieval
+   - [x] One SQL engine ([DataFusion](https://datafusion.apache.org/), in-process) over CSV, Parquet, JSON, S3 / GCS / Azure, Postgres, MySQL, SQLite, MongoDB, Redis, Iceberg, Lance, SeekDB — all joinable in one query
+   - [x] Register either one specific table, or point Skardi at a database (Postgres / MySQL / SQLite) and let it auto-discover all tables — one config line either way
+   - [ ] Graph database sources (Neo4j / Kuzu) — to unlock graphRAG patterns alongside vector / full-text retrieval
 
 `2` Retrieval primitives
-   - [x] Vector search — `pg_knn` (pgvector), `sqlite_knn` (sqlite-vec), Lance KNN, SeekDB HNSW
-   - [x] Full-text search — `pg_fts`, `sqlite_fts`, Lance BM25 inverted indexes, SeekDB FULLTEXT
-   - [x] Hybrid search — RRF merge of FTS + KNN in plain SQL
-   - [x] Inline embeddings — `candle()` UDF (GGUF / Candle / remote embed APIs) runs directly inside SQL; content + vector stay on the same row atomically
+   - [x] Vector search (KNN) — `pg_knn` (pgvector), `sqlite_knn` (sqlite-vec), Lance KNN, SeekDB HNSW
+   - [x] Full-text search (FTS) — `pg_fts`, `sqlite_fts`, Lance BM25 inverted indexes, SeekDB FULLTEXT
+   - [x] Hybrid search — combine keyword and semantic search results in one SQL query (RRF merge), no Python re-ranking layer
+   - [x] Inline embeddings — `candle()` UDF (local GGUF / Candle models, or remote embedding APIs) called inside SQL, so content + vector stay on the same row atomically
    - [x] ONNX inference — `onnx_predict` UDF for inline model predictions in SQL
    - [x] Chunking UDF — `chunk()` with character / markdown splitters (via [`text-splitter`](https://crates.io/crates/text-splitter)) so ingestion can chunk inline in SQL ([docs](docs/chunk.md)); token / code splitters next
-   - [ ] Memory primitive — hybrid access + TTL + provenance + consolidation collapsed into one declarative macro
+   - [ ] Memory primitive — give your agent a memory store (keyword + semantic recall, TTL/expiration, per-session provenance) defined in one YAML block
 
 `3` Online serving (pipelines)
    - [x] Declarative YAML → parameterized REST endpoint with inferred request / response schema
@@ -311,41 +433,16 @@ We're **building in public**. `[x]` means shipped today, `[ ]` means open for co
    - [ ] MCP binding — same pipeline YAML projected to MCP tools for non-Claude hosts
 
 `6` Governance & lineage
-   - [x] Catalog with semantics — `kind: semantics` YAML overlay attaching NL descriptions to tables / columns; supports both bare source names and fully-qualified `catalog.schema.table` paths for per-table targeting on catalog-mode sources; surfaced on `GET /data_source` for agent-side discovery
-   - [ ] Agent-callable `describe` verb — CLI / pipeline form on top of the catalog endpoint
+   - [x] Plain-English table descriptions — a `kind: semantics` YAML overlay attaching natural-language descriptions to tables / columns (supports both bare source names and fully-qualified `catalog.schema.table` paths); served on `GET /data_source` so agents can discover what each table is for before querying
+   - [ ] Agent-callable `describe` verb — CLI / pipeline form on top of the discovery endpoint
    - [ ] Lineage capture — `agent_id`, `session_id`, `tool_call_id`, `timestamp` on writes; queryable from metadata tables
    - [ ] Agent identity passthrough — any binding injects client identity into a SQL context var pipelines can read
-   - [ ] Snapshot-as-branch / agent checkpoints — Iceberg / Lance-backed; `git checkout`-like semantics for destructive agent experiments
+   - [ ] Snapshot-as-branch / agent checkpoints — Iceberg / Lance-backed `git checkout`-like semantics: if your agent updates 1,000 rows and you don't like the result, roll back in one call
 
 `7` Ops
    - [x] Session auth — drop-in user auth via [better-auth](https://www.better-auth.com/) backed by SQLite
    - [x] Observability — OpenTelemetry traces / metrics / logs with a pre-configured Grafana stack
    - [x] Docker + pre-built binaries — Linux x86_64 / ARM64, macOS ARM64
-
----
-
-## What's already in the box
-
-### Engine
-- **Federated SQL across every major source** — CSV, Parquet, JSON, S3 / GCS / Azure, Postgres, MySQL, SQLite, MongoDB, Redis, Iceberg, Lance, SeekDB — all joinable in one query.
-- **Register by table or by catalog** — pick per source: expose a single named table, or load an entire Postgres / MySQL / SQLite database as a DataFusion catalog. One config line either way.
-- **Vector search** — native KNN via Lance, `pg_knn` (pgvector), `sqlite_knn` (sqlite-vec), SeekDB HNSW.
-- **Full-text search** — Lance BM25 inverted indexes, `pg_fts`, `sqlite_fts`, SeekDB native FULLTEXT.
-- **Inline embeddings** — `candle()` UDF (GGUF / Candle / remote embed APIs) directly inside SQL, so content + vector stay on the same row atomically.
-- **Inline chunking** — `chunk()` UDF (character / markdown splitters via [`text-splitter`](https://crates.io/crates/text-splitter)) so RAG ingest stays a single SQL statement: chunk → embed → write ([docs](docs/chunk.md)).
-- **ONNX inference** — `onnx_predict` UDF for inline model predictions in SQL.
-- **Hybrid search** — RRF merge of FTS + KNN in plain SQL (see [llm_wiki demo](demo/llm_wiki/)).
-
-### Agent-facing surfaces
-- **CLI `skardi run <pipeline>`** — parameterized pipeline invocation from any shell; works in Claude Code / Cursor / any agent with a Bash tool.
-- **User-defined aliases** — `skardi grep "…"` → `run wiki-search-hybrid`. Collapses multi-line SQL into agent-ergonomic verbs.
-- **Online serving** — YAML → parameterized HTTP endpoint, with an inferred request / response schema and a built-in dashboard.
-- **Offline jobs** — async pipeline that commits to Lance or a DB destination, with a SQLite run ledger and submit / poll / cancel. ([#98](https://github.com/SkardiLabs/skardi/pull/98))
-
-### Ops
-- **Session auth** — drop-in user auth via [better-auth](https://www.better-auth.com/) backed by SQLite.
-- **Observability** — OpenTelemetry traces / metrics / logs with a pre-configured Grafana stack.
-- **Docker + pre-built binaries** — Linux x86_64 / ARM64, macOS ARM64.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,10 @@ That uniformity is also what makes the *durable* reason to put a plane in front 
 
 Without these, "let the agent touch the database" is reckless and the right answer is "don't"; with them, *data autonomy* — letting the agent decide what to query and write — becomes a default you can actually grant. Federation, declarative SQL pipelines, REST + shell bindings — those are how the plane is built. Governance is what the plane is *for*.
 
+For the longer technical read — each primitive's shipped vs. in-progress status, the run-ledger schema, the chokepoint argument unpacked — see [docs/agent_data_plane.md](docs/agent_data_plane.md).
+
 ```text
-   your agent  ──▶  skardi-server  ──┬─▶  Postgres / MySQL / SQLite / MongoDB / Redis
+   your agent  ──▶  skardi  ──┬─▶  Postgres / MySQL / SQLite / MongoDB / Redis
    (Claude / GPT /     │              ├─▶  S3 / GCS / Azure (CSV, Parquet, Lance)
     Cursor / your      │              ├─▶  Apache Iceberg, Lance datasets
     own loop)          │              └─▶  pgvector, sqlite-vec, Lance KNN, SeekDB HNSW
@@ -129,7 +131,7 @@ Direct SDKs work fine for a single read-only RAG bot — you can wire one to Pos
 
 If your agent only ever reads from one source, direct SDKs are simpler. If it reads from many, or writes back, or you want to govern what it does — the plane is what makes data autonomy a responsible default rather than a gamble.
 
-For a deeper read on the agent-data-plane idea — what it borrows from cloud infra, why agents need their own, how it differs from a normal data warehouse — see [docs/agent_data_plane.md](docs/agent_data_plane.md).
+Full breakdown of the three primitives — semantic-overlay YAML, the verbatim run-ledger schema, and why each primitive requires a chokepoint — in [docs/agent_data_plane.md](docs/agent_data_plane.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -83,17 +83,6 @@ For the longer technical read — each primitive's shipped vs. in-progress statu
 - **`skardi-server`** — same engine over HTTP, with two surfaces: **online serving** (a YAML pipeline becomes a parameterized REST endpoint with an inferred request/response schema) and **offline jobs** (async batch writes into Lance or any read-write DB; if a job fails halfway you don't get a corrupted dataset, and every run is logged in a SQLite ledger you can list and inspect).
 - **Skardi-server is stateful but lightweight** — a single Rust process, plus a small SQLite file for the run ledger and (optional) auth. One server can serve many agents; deploy it next to your data, behind your usual auth.
 
-> **Glossary (for terms used below).**
-> **Pipeline** — a YAML file with a parameterized SQL query; becomes one REST endpoint + one CLI verb.
-> **Job** — a YAML file like a pipeline, but runs asynchronously and writes its result rows to a destination table.
-> **`ctx.yaml`** — the config that lists your data sources (a Postgres URL, a SQLite path, an S3 bucket, etc.) and gives each one a name you can reference in SQL.
-> **DataFusion** — an in-process Rust SQL engine ([Apache project](https://datafusion.apache.org/)). Runs inside `skardi-server`, so there is no separate cluster to manage. "Single-node" means the engine itself is in-process; the data sources it queries can be remote.
-> **Lance** — an open columnar file format with built-in vector and full-text indexes ([lancedb.github.io/lance](https://lancedb.github.io/lance/)). Useful as a job destination when you want a self-contained queryable dataset on disk or S3.
-> **Hybrid search / RRF** — combining keyword (full-text, "FTS") and semantic (vector, "KNN") results into one ranking. RRF (Reciprocal Rank Fusion) is the standard merge formula. Skardi does it in a single SQL query so there is no Python re-ranking layer.
-> **Catalog mode** — point Skardi at a database connection and let it auto-discover every table, instead of registering tables one at a time. Catalog-registered tables are addressed in SQL with the 3-part `catalog.schema.table` name (e.g. `wiki.main.wiki_pages_vec` below: `wiki` is the source name, `main` is the SQLite schema, `wiki_pages_vec` is the table).
-> **`sqlite_knn` / `sqlite_fts`** — Skardi UDFs that wrap [sqlite-vec](https://github.com/asg017/sqlite-vec) KNN and SQLite FTS5 inside SQL; analogous `pg_knn` / `pg_fts` exist for Postgres + pgvector. Full UDF reference in [docs/sqlite/](docs/sqlite/) and [docs/postgres/](docs/postgres/).
-> **SeekDB** — a MySQL-wire-compatible store with native HNSW vector indexes and FULLTEXT FTS, usable as a single-source replacement for "Postgres + pgvector + tsvector" (see [docs/seekdb/](docs/seekdb/)).
-
 > **Beta.** Skardi is under active development. APIs may move. Hit us on [Discord](https://discord.gg/S5YQQPEV2m) if you want to co-design a POC.
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 <img src="asset/logo.png" alt="Skardi Logo" width="700">
 
-**Skardi is an open-source agent data plane** — the single layer every data call your agent makes flows through. RAG retrieval, table lookups, vector search, audit writes: declare each one as parameterized SQL in a YAML pipeline, and Skardi serves it as both a REST endpoint and a shell verb your agent can call as a tool, federated across Postgres, SQLite, MongoDB, S3, data lakes, and vector stores in a single query.
+**Skardi is an open-source agent data plane** — every read and write your agent makes flows through one uniform layer of parameterized SQL pipelines, served as REST endpoints and shell verbs your agent calls as tools. Putting reads and writes behind the same plane is what makes the durable thing possible: semantic discovery, audit, and rollback compose across your whole stack instead of fragmenting across SDKs — turning *data autonomy* (letting the agent decide what to query and write) from a gamble into a default you can actually govern.
 
-**Federated** · one engine over every source &nbsp;·&nbsp; **Declarative** · YAML pipelines &nbsp;·&nbsp; **Agent-native** · REST + shell + MCP-soon
+**Federated** · one engine over every source &nbsp;·&nbsp; **Governed** · semantic overlay, lineage, branching &nbsp;·&nbsp; **Agent-native** · REST + shell + MCP-soon
 
 <a href="https://skardilabs.github.io/skardi-docs/">Documentation</a> •
 <a href="#roadmap">Roadmap</a> •
@@ -40,26 +40,32 @@
 
 ## What is an "agent data plane"?
 
-Borrowing the phrase from cloud infra: your AI agent has two layers. The **control plane** is the reasoning loop — prompts, tool selection, your orchestration code, your YAML configs. The **data plane** is where every byte of context actually comes from and goes to: vector DB hits, SQL queries, file reads, writes back, audit trails. The control plane is mostly fine these days (LLMs are smart, agent SDKs are mature). The data plane is the bottleneck — most agents today have a tangled one: a Pinecone client here, a Postgres query there, a hand-rolled RRF merge in Python, an HTTP wrapper around an internal API, glue code on top of glue code.
+Borrowing the phrase from cloud infra: your AI agent has two layers. The **control plane** is the reasoning loop — prompts, tool selection, your orchestration code. The **data plane** is where every byte of context comes from and goes to: vector DB hits, SQL queries, file reads, writes back, audit trails.
 
-**Skardi *is* the data plane.** A single open-source server (and CLI) where every one of your agent's data calls goes, declared once as parameterized SQL in YAML, then served as both a REST endpoint and a shell verb. Federated, so one query can JOIN across Postgres, SQLite, MongoDB, S3, data lakes, and vector stores. Fast enough to sit in your agent's request path — typically tens of milliseconds for a parameterized Postgres / SQLite query, dominated by your data source's own latency.
+Skardi is a uniform plane for that data layer. A single open-source server (and CLI) that exposes your data — Postgres, SQLite, MongoDB, S3 files, data lakes, vector stores — as parameterized SQL pipelines declared in YAML. Each pipeline is callable as both a REST endpoint and a `skardi` shell verb, so the same definition works in Claude Code, Cursor, your own agent loop, or any HTTP-aware host. One JOIN can span every registered source. Latency typically sits in tens of milliseconds, dominated by your data source's own.
 
-**Concretely, you're replacing this:**
-
-```python
-# What an agent retrieval tool usually looks like today:
-def search_wiki(query: str, limit: int = 10):
-    embedding = openai.embeddings.create(input=query, model="...").data[0].embedding
-    vec_hits  = pg.execute("SELECT id FROM pages ORDER BY emb <=> %s LIMIT 80", [embedding])
-    fts_hits  = pg.execute("SELECT id FROM pages WHERE tsv @@ plainto_tsquery(%s) LIMIT 60", [query])
-    fused     = rrf_merge(vec_hits, fts_hits)            # hand-rolled
-    return pg.execute("SELECT slug,title FROM pages WHERE id = ANY(%s)", [fused[:limit]])
-# + a Flask/FastAPI route exposing it, + auth, + logging, + a schema for the LLM...
+```yaml
+# pipelines/wiki-search-hybrid.yaml — your agent's hybrid-search tool, declared once
+kind: pipeline
+metadata: { name: wiki-search-hybrid }
+spec:
+  query: |
+    SELECT slug, title FROM sqlite_knn('wiki', candle('bge-small', {query}), {limit})
+    -- (full vector + FTS + RRF version in Quick Start below)
 ```
 
-**…with a 20-line YAML pipeline** (full version in [Quick Start](#quick-start) below). Skardi handles the embedding call, the hybrid-search merge, the HTTP route, the parameter parsing, and the JSON response shape. Your agent calls it as `POST /wiki-search-hybrid/execute` over REST or `skardi grep "..."` from any shell — every retrieval flows through one engine instead of N hand-rolled tools.
+```bash
+$ skardi grep "turing machines" --limit=10                # shell tool, any Bash-tool agent
+$ curl -X POST :8080/wiki-search-hybrid/execute -d '{...}' # same pipeline, served as REST
+```
 
-Build RAG, hybrid search, agent-callable APIs, and async batch writes across databases, files, data lakes, and vector stores — all behind the same SQL surface.
+That uniformity is also what makes the *durable* reason to put a plane in front possible: **governance**. Once every read and write goes through one engine, three primitives compose on top of it instead of fragmenting across N SDKs:
+
+1. **Semantic overlay.** Plain-English descriptions of every table, column, and pipeline, served on `GET /data_source` as the agent's discovery surface. The agent reads *what each table is for* before querying, instead of guessing from a schema dump. Reading agents already cash this win — the catalog endpoint *is* the agent's prompt. ([docs/semantics.md](docs/semantics.md), shipped today)
+2. **Lineage.** Every write tagged with `agent_id`, `session_id`, `tool_call_id`, and `timestamp`, queryable from metadata. The async-job ledger already records every batch write today (parameters, status, run id); inline-write lineage on the synchronous path is in progress — see [Roadmap](#roadmap).
+3. **Snapshot-as-branch.** Iceberg / Lance-backed branches with `git checkout`-like semantics — an agent writes into a branch, you review, you merge or roll back. If the agent updated 1,000 rows you don't like, undoing it is one call, not an incident. (in progress — see [Roadmap](#roadmap))
+
+Without these, "let the agent touch the database" is reckless and the right answer is "don't"; with them, *data autonomy* — letting the agent decide what to query and write — becomes a default you can actually grant. Federation, declarative SQL pipelines, REST + shell bindings — those are how the plane is built. Governance is what the plane is *for*.
 
 ```text
    your agent  ──▶  skardi-server  ──┬─▶  Postgres / MySQL / SQLite / MongoDB / Redis
@@ -102,26 +108,26 @@ Build RAG, hybrid search, agent-callable APIs, and async batch writes across dat
 
 ## Drop-in skills — go from zero to grounded retrieval in 60 seconds
 
-Don't want to hand-write YAML to see what Skardi does for your agent? The fastest path is to install one of our ready-made skills from **[skardi-skills](https://github.com/SkardiLabs/skardi-skills)**. Each skill renders the `ctx.yaml` + pipelines for you and exposes them as agent-callable verbs — zero config to write yourself, your agent can start retrieving immediately.
+The fastest path to put Skardi in front of your agent is to install one of our ready-made skills from **[skardi-skills](https://github.com/SkardiLabs/skardi-skills)**. Each skill renders the `ctx.yaml` + pipelines for you and wires them up as agent-callable verbs — zero config to write yourself.
 
 - **[`auto_knowledge_base`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_knowledge_base)** — point it at a directory of documents and you have a queryable local RAG one command later. Chunking, embedding, indexing, and hybrid search are exposed to your agent as a `skardi grep` verb. Zero infra by default (SQLite + local embeddings), so any Claude Code / Cursor session gets a grounded, citable knowledge base over your files.
 - **[`auto_rag`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_rag)** — server-backed hybrid-search RAG via `skardi-server` on top of a datastore you already control (Postgres + pgvector, MongoDB, or Lance). The skill renders the config, starts the server, and drives ingestion and queries through REST — for when retrieval needs to be shared across multiple agents or processes.
 
-Drop either skill into Claude Code or Cursor and your agent's data plane is wired in one prompt. Want to see what's happening under the hood, or build pipelines of your own? Read on.
+Read-only RAG is a perfectly good first use case for the plane: you get the semantic overlay (the agent reads what your tables are for), one engine that can later JOIN against your operational data, and a swappable backend (move from SQLite-on-disk to Postgres + pgvector to Lance without touching the agent). The same plane keeps earning as the agent starts to *write* — that's where lineage and branching kick in. Drop a skill in to see the shape; read on if you want to build pipelines of your own.
 
 ---
 
-## Why not just write a Python function that wraps SQL?
+## When does a uniform data plane earn its keep?
 
-Fair question — that is the alternative, and for one tool it's fine. Skardi earns its keep when an agent needs more than one of these at once:
+Direct SDKs work fine for a single read-only RAG bot — you can wire one to Postgres + a vector DB and ship in an afternoon. The plane earns its keep cumulatively: every property below is true on day one for the simplest agent, and the last three become load-bearing once the agent starts writing, you add a second agent, or "what did the agent do yesterday?" stops being a rhetorical question.
 
-1. **One engine over every source.** Skardi runs SQL across Postgres, MySQL, SQLite, MongoDB, Redis, S3 / GCS / Azure files, Iceberg, Lance, and SeekDB — and `JOIN`s across them in one query. A handrolled Python wrapper hits one source per function; cross-source JOINs become application code.
-2. **Same query, two surfaces.** The same pipeline YAML is callable both as a REST endpoint (for hosted agents, multi-process setups) and as a `skardi` CLI verb (for Claude Code, Cursor, any Bash-tool agent) with no extra glue.
-3. **Retrieval primitives in SQL.** Vector KNN, full-text search, hybrid (RRF) merge, inline embedding, inline chunking — all UDFs you can compose in plain SQL instead of stitching together Python libraries. So a RAG pipeline (chunk → embed → write → search) is one file, not a service.
-4. **Async writes you can trust.** A job that writes 100k rows to Lance commits atomically; if the process dies mid-write, the dataset is not corrupted, and every run is logged with `submitted/running/succeeded/failed` plus parameters in a SQLite ledger you can list and inspect.
-5. **A discovery surface for the agent.** `GET /data_source` returns each table's schema plus the natural-language description you wrote in YAML, so the agent picks the right pipeline before querying — instead of discovering it by trial and error.
+1. **Discovery — the agent reads what data *means*, not just shapes.** A semantic overlay attaches plain-English descriptions to every table, column, and pipeline; the catalog endpoint serves them so the agent picks the right verb before querying instead of guessing from a schema dump. (shipped — [docs/semantics.md](docs/semantics.md))
+2. **Federation — one JOIN over every source.** Federated SQL across Postgres / SQLite / MongoDB / S3 / Iceberg / Lance / vector stores, so the agent's "give me X about Y" doesn't need application-side joins.
+3. **Bindings — one pipeline, every host.** The same YAML serves as REST endpoint, `skardi` shell verb, and (soon) MCP tool — works in Claude Code, Cursor, your own loop, or a hosted agent with no extra glue.
+4. **Audit — one trail across every write.** Every write tagged with `agent_id` / `session_id` / `tool_call_id` / `timestamp`, queryable from one place. With direct SDKs you get distributed log files; through a plane you get one ledger. (the existing async-job ledger already records every batch write today; inline-write lineage in progress)
+5. **Rollback — branch the data, not your incident channel.** Iceberg / Lance-backed branches with `git checkout`-like semantics: agent writes into a branch, you review, you merge or revert. With direct DB writes a bad agent run is an incident; through the plane it's one call. (in progress)
 
-If your agent only ever needs one parameterized Postgres query, a Python function is simpler. If it needs five, plus a vector store, plus a CSV in S3, plus an audit log — that is what Skardi is for.
+If your agent only ever reads from one source, direct SDKs are simpler. If it reads from many, or writes back, or you want to govern what it does — the plane is what makes data autonomy a responsible default rather than a gamble.
 
 For a deeper read on the agent-data-plane idea — what it borrows from cloud infra, why agents need their own, how it differs from a normal data warehouse — see [docs/agent_data_plane.md](docs/agent_data_plane.md).
 

--- a/docs/agent_data_plane.md
+++ b/docs/agent_data_plane.md
@@ -1,24 +1,32 @@
-# Why an Agent Data Plane
+# Why an agent data plane
 
-> Skardi is an agent data plane that gives AI agents data autonomy. One execution engine over every data source — build RAG, hybrid search, memory, and data APIs in plain SQL.
+> Data autonomy is the point of an agent loop. Three primitives — semantics, lineage, snapshot-as-branch — are what keep autonomy from being reckless. They only compose at a chokepoint, and a uniform data plane is that chokepoint.
 
 ## The thesis in one page
 
-Agents are not bottlenecked by intelligence. They're bottlenecked by **data autonomy** — the ability to pick the right data, query it, join across it, write to it, remember from it, and do all of that without a human hand-wiring each step.
+The whole point of an agent loop is that the agent picks the call. That includes which table to read, what query to run, whether to write back, and what rows to write. Take that away and the loop is just a routing layer in front of hand-written application code; the model is doing nothing the developer hasn't already done. **Data autonomy** — letting the agent decide what to query and what to write — is the thing the loop is actually for.
 
-Today's data stack was built for humans writing queries and ops teams maintaining pipelines. Hand an LLM a raw schema dump and it hallucinates column names. Hand it a bag of bespoke REST endpoints and it can't compose them. Hand it a vector store and it still can't `JOIN` the result against a Postgres table. Every agent framework patches around this with brittle, app-specific glue.
+Autonomy is reckless without governance. An agent that picks its own SQL also picks the wrong table sometimes; misreads a column whose name is `status` but whose meaning is "Stripe webhook delivery state, not order state"; updates 1,000 rows you'd rather it hadn't. The naive response is to gate every action on a human, but that defeats autonomy and collapses the loop back into application code with extra latency. The right response is the same one databases reached for transactions and source control reached for branches: **bound the action without removing it.**
 
-The fix isn't another agent framework. It's an **agent data plane** — the request path every agent tool call traverses. Your agent and your pipeline YAMLs are the *control plane*: they decide what to ask for. Skardi is the *data plane* that serves it: federated SQL over every source you already have, exposed as REST and shell, with retrieval primitives built in.
+Skardi's bet is that three primitives are enough to bound it:
+
+1. **Semantic overlay** — the agent reads what data *means*, not just its shape, before it writes any SQL.
+2. **Lineage** — every action is attributable to who, what, when, and against which source, queryable from one ledger.
+3. **Snapshot-as-branch** — destructive actions land in a branch the human reviews, with `git checkout`-like semantics for revert.
+
+These primitives only compose at a chokepoint. With direct SDKs the agent talks to N stores through N libraries, and there is no single layer at which any one of these can be implemented — the semantic catalog fragments, the audit trail scatters across log files, and atomic snapshots across sources are unreachable. With a uniform data plane there is one place to instrument all three.
+
+That is what Skardi is. Federation, declarative SQL pipelines, REST + shell + (soon) MCP bindings — those are how the plane is *built*. Governance is what the plane is *for*.
 
 ```mermaid
 flowchart TB
     subgraph cp["Control plane"]
         agent["Agent (LLM)<br/>decides what to call"]
-        yaml["Pipeline YAMLs<br/>declare what's callable"]
+        yaml["Pipeline / job YAMLs<br/>declare what's callable"]
     end
 
     subgraph dp["Data plane — Skardi"]
-        skardi["Federated SQL engine<br/>+ retrieval primitives<br/>(DataFusion)"]
+        skardi["Federated SQL engine (DataFusion)<br/>+ semantics overlay<br/>+ lineage (run ledger)<br/>+ snapshot-as-branch"]
     end
 
     subgraph sources["Sources (federated, joinable in one query)"]
@@ -32,79 +40,179 @@ flowchart TB
     skardi --> sources
 ```
 
-Or, by analogy:
+---
 
-- **Spark** gave data teams a single execution engine that worked over every storage format — HDFS, Parquet, Hive, JDBC, Iceberg — with one DataFrame API. Before Spark, every source had its own SDK and every join was a multi-day project.
-- **Skardi** gives agents the same shape, but tuned for the request path: one DataFusion-based engine that federates CSV, Parquet, S3, Postgres, MySQL, SQLite, MongoDB, Redis, Iceberg, Lance, and SeekDB; one declarative YAML format covering both online serving and offline jobs, projecting out to REST, shell, skills, and MCP; one set of SQL primitives (`candle()`, `pg_knn`, `pg_fts`) agents actually need.
+## 1. Semantic overlay — the agent reads what data *means*
 
-That's what we mean by "Spark for Agents" — borrowing the *shape* (one engine over every source) but not the workload. Spark targets large-scale analytics; Skardi targets the request path of agent tool calls.
+**Status: shipped.** YAML overlay loaded by the server and CLI; merged response served on `GET /data_source`. See [docs/semantics.md](semantics.md).
+
+The failure mode this primitive addresses is concrete. Hand an LLM a `CREATE TABLE` schema dump and it hallucinates column names that aren't there, picks the wrong one of two tables with similar shapes, treats `status` as if it were an order status when it's actually a webhook-delivery status. Schema is shape; the agent needs *meaning*. Stuffing meaning into prompt-engineered system messages doesn't scale across many tables and doesn't survive schema drift — it has to live next to the data, version-controlled with the source registration.
+
+The overlay is a `kind: semantics` resource, parallel in shape to `kind: pipeline` and `kind: context`, with one entry per source:
+
+```yaml
+kind: semantics
+
+metadata:
+  name: basic-semantics
+  version: 1.0.0
+
+spec:
+  sources:
+    - name: products              # cross-references data_sources[].name
+      description: "Product catalog with pricing/inventory. One row per SKU."
+      columns:
+        - name: id
+          description: "Stable internal SKU; primary key."
+        - name: price
+          description: "Retail price in USD."
+```
+
+For [catalog-mode sources](catalog.md) — where one Postgres / MySQL / SQLite registration auto-discovers many inner tables — the `name` field also accepts a fully-qualified `catalog.schema.table` path, addressing one specific inner table:
+
+```yaml
+spec:
+  sources:
+    # 1-part: broad fallback for the whole `mydb` catalog.
+    - name: mydb
+      description: "Internal application DB"
+
+    # 3-part: targets one specific inner table. Wins for mydb.public.users only;
+    # the bare entry above continues to apply to every other inner table.
+    - name: mydb.public.users
+      description: "Auth + profile data, one row per registered account"
+      columns:
+        - name: id
+          description: "User ID (auth.users.id)"
+```
+
+Names with anything other than 1 or 3 dot-separated segments are a hard error at startup; duplicate keys across files are a hard error too, so multiple semantics files can be auto-generated by separate skills without silently overwriting each other. Full rule table in [docs/semantics.md](semantics.md#composition-rules).
+
+The merged view is what the agent actually consumes. It surfaces in two places:
+
+- **`GET /data_source`** — the catalog endpoint that any agent client hits at startup. Each table includes its description and per-column descriptions inline next to the Arrow type. The shape:
+
+  ```json
+  {
+    "name": "products", "type": "csv", "path": "data/products.csv",
+    "tables": [{
+      "name": "products",
+      "description": "Product catalog with pricing/inventory. One row per SKU.",
+      "schema": [
+        { "name": "id",    "type": "Int64",   "description": "Stable internal SKU; primary key." },
+        { "name": "price", "type": "Float64", "description": "Retail price in USD." }
+      ]
+    }]
+  }
+  ```
+
+- **`skardi query --schema`** — the same merged view rendered inline for human inspection during context authoring.
+
+This is *the agent's prompt*. The catalog endpoint is the first thing a well-built reading agent calls in a session, and the descriptions there are what it reads before it decides which pipeline to invoke. The overlay is shipped today; an agent-callable `describe` verb (so the agent can pull a single table's overlay through a pipeline call rather than the catalog endpoint) is open on the roadmap (`6` — *agent-callable describe verb*).
+
+One known limitation: the HTTP `/data_source` endpoint emits one table per source today, so qualified `catalog.schema.table` overlays for inner tables of a catalog-mode source don't yet surface there (they do surface in the CLI). Tracked in the same doc.
 
 ---
 
-## Why an agent data plane is the right primitive, not "another agent framework"
+## 2. Lineage — every write attributable, every change debuggable
 
-Agent frameworks sit above the model and below the UX. They orchestrate tool calls. That's valuable, but it's not where the hard problem is — every framework has the same "how do I give my agent real data" chapter, and they all handle it by gluing together a vector DB, a SQL DB, and a pile of REST wrappers.
+**Status: partial.** Async-job ledger shipped; sync-pipeline-write lineage and agent identity passthrough are open on the roadmap (`6` — *lineage capture*, *agent identity passthrough*).
 
-The hard problem lives underneath. It's the data layer.
+The failure mode: an agent did something surprising last week. You want to know which agent, which session, which tool call, with which parameters, against which source, and what the result was. With direct SDKs that information lives in a different log file per integration — process logs in one place, ORM query logs in another, vector DB request logs in a third — and joining them across a single agent action is a forensic exercise. With one chokepoint, every action goes into one ledger.
 
-- **An agent cannot be autonomous if every new dataset requires a human to wire up an embedding pipeline, an index, and a query API.** Skardi's embedding UDF puts embedding inference directly inside SQL; `pg_knn` / `sqlite_knn` / Lance vector columns put retrieval in the same plan. One statement embeds, stores, and indexes.
-- **An agent cannot reason across data if every source has its own dialect and SDK.** Skardi is one SQL over eleven source types, with real `JOIN`s across them. That includes joining a Lance vector table against a Postgres reference table against a CSV of new inputs — in one query, in one process.
-- **An agent cannot discover tools if every endpoint is a hand-crafted one-off.** Skardi's pipeline YAML is the single source of truth — one file becomes a REST endpoint today, a `skardi run` shell command today, a Claude skill tomorrow, and an MCP tool shortly after. All surfaces stay in lockstep because they derive from the same spec.
-- **An agent cannot do durable work if every write is a fire-and-forget HTTP call.** Skardi's offline jobs primitive commits async writes to Lance or a DB with a run ledger, submit / poll / cancel, crash recovery, and atomic failure semantics.
+### What's recorded today: the async-job ledger
 
-None of the above is a model-level capability. All of it is data-plane plumbing. It's what Databricks built for humans and what nobody has built for agents yet. That's the gap.
+Every async job submission creates one row in a SQLite ledger (default `~/.skardi/jobs.db`). The schema is fixed by [`crates/skardi/src/jobs/store.rs`](../crates/skardi/src/jobs/store.rs) — the `INIT_SCHEMA_SQL` constant:
 
----
+```sql
+CREATE TABLE IF NOT EXISTS job_runs (
+    id            TEXT PRIMARY KEY,    -- UUIDv4, hex-only
+    job_name      TEXT NOT NULL,       -- metadata.name from the job YAML
+    parameters    TEXT NOT NULL,       -- JSON of bound submit-time values
+    status        TEXT NOT NULL,       -- pending → running → succeeded|failed|cancelled
+    created_at    TEXT NOT NULL,
+    started_at    TEXT,
+    finished_at   TEXT,
+    rows_written  INTEGER,             -- set on succeeded; also on post-commit cancels
+    snapshot_id   TEXT,                -- Lance: the version the commit landed on
+    error         TEXT                 -- non-null on failed/cancelled
+);
+```
 
-## Design principles
+Every submit appends a row; every lifecycle transition updates it. The submit-time pre-flight (parameter presence, type check, **destination schema diff** against the planned SELECT) runs *before* the row is inserted, so a malformed submit cannot pollute the ledger. On startup the server reconciles orphans — any row left in `pending` or `running` by a crashed previous process is rewritten to `failed` with `"server restarted before run completed"`, so the ledger never lies about what's still in flight.
 
-Every decision in the repo traces back to one of these.
+That gives you, today, for any async write Skardi committed:
 
-### 1. Online serving and offline jobs, one declarative shape
+- the exact rendered query parameters (replayable by reading `parameters` and rerunning the YAML);
+- the resulting Lance dataset version (`snapshot_id`) — the substrate for the snapshot-as-branch primitive below;
+- a pre-write schema-diff guarantee (the destination's columns and types matched what the query produced, or the row was rejected before it ran);
+- the row count and the error message on failure.
 
-Agents need both sides of the online/offline split: low-latency reads at tool-call time, and durable writes that commit somewhere queryable later. Skardi covers both with the same parameterized-SQL shape — **pipelines** serve SQL synchronously (the online-serving side), **jobs** run the same SQL asynchronously into a durable destination (Lance or a read-write DB) with a run ledger, atomic commit, submit/poll/cancel, and crash recovery (the offline-batch side).
+Full schema and lifecycle diagrams in [docs/jobs.md § Run ledger](jobs.md#the-run-ledger) and [§ Atomicity and failure modes](jobs.md#atomicity-and-failure-modes).
 
-Both project to the same agent-facing bindings — HTTP today, shell today, Claude skills in v0.1, MCP in v1.1 — so an agent reading live data via a skill and running a backfill via `skardi job run` is using the same machinery both times. Adding a new surface is one codegen over both primitives, never two separate integrations.
+### What's not yet there
 
-### 2. Primitives shaped for agents, not humans
+The async-job path is one of two write paths, and the ledger covers it only. Three gaps stand:
 
-Humans tolerate 20-line RRF queries; they write them once and reuse them. Agents don't — every token of SQL they generate is a token they can get wrong, and every extra step is a place the tool loop can derail.
+- **Sync-pipeline-write lineage.** Pipelines that issue `INSERT` / `UPDATE` / `DELETE` synchronously over `POST /<name>/execute` — the same shape as a read pipeline, but with a write SQL body — do not currently capture a ledger row. The pipeline handler in `crates/server/src/pipeline_handlers.rs` does not touch `JobStore`. Closing this means sync writes write a row with the same column shape (likely a unified `actions` ledger that subsumes `job_runs`).
+- **Agent identity passthrough.** The ledger's `parameters` column captures *what* was bound, but no binding currently injects *who*. A first-class agent identity — `agent_id`, `session_id`, `tool_call_id`, `timestamp` exposed as SQL context vars pipelines can read and the runtime stamps onto every ledger row — is open on the roadmap. The target shape (per roadmap item `6` — "any binding injects client identity into a SQL context var pipelines can read") is that each binding pulls identity from its own native carrier and lifts it into the same context var: HTTP headers for REST, environment variables or CLI flags for shell, the MCP context object for MCP — though the per-binding details (header names, env var names, MCP context fields) are open design decisions. Until it lands, attributing an action to a specific agent run requires the caller to include that information as an explicit parameter.
+- **Agent-callable lineage surface.** The ledger is queryable through `GET /jobs/runs` and the `skardi job list` CLI today, but those are operator surfaces, not agent verbs. The natural extension of roadmap item `6`'s *agent-callable `describe` verb* is a `skardi describe runs --since=… --by-agent=… --against=<source>` form, backed by a pipeline that joins the ledger against the semantic overlay so an agent can ask "which jobs touched `products` this week and what did they write" in one call rather than scraping `/jobs/runs` JSON.
 
-So we ship shape-shifting primitives:
-
-- **embedding UDFs** — embedding inference inline in SQL. Agents don't wire an embedding service; they write something like `gguf('model-path', content)` and move on.
-- **`pg_knn` / `sqlite_knn` / `pg_fts` / `sqlite_fts`** — vector and text retrieval as SQL functions, joinable like any other relation. Hybrid search (RRF) is a JOIN, not a separate system.
-- **Online serving and offline jobs, one YAML shape** — the same parameterized SQL either answers synchronously over REST or commits asynchronously to a durable destination. Durable agent writes are a YAML declaration, not an orchestration framework.
-- **Memory primitive** (roadmap, v1.1) — hybrid access + TTL + provenance + consolidation collapsed into one declarative macro that expands to the right tables and pipelines.
-
-The test for "should this be a primitive" is: *would an agent need to hand-assemble three-to-five SQL statements to do this?* If yes, it's a primitive candidate. If no, it's application code.
-
-### 3. Ship where agents already are
-
-The MVP deliberately doesn't require MCP, Claude Desktop, or a hosted service. The fastest path to "agent using skardi" is:
-
-1. Install the CLI.
-2. Drop it into a Claude Code / Cursor / custom-agent session that already has a Bash tool.
-3. Agent runs `skardi run pipeline --param=…` or `skardi grep "…"`.
-
-That works today, end to end. MCP, skills generation, and auto-discovery are layering on top of that foundation — they strictly add reach, not enable it. This is also why the MVP audience is *developers building agents*, not end-users of chat apps. Developers are exactly the audience Spark's first wave landed with.
-
-### 4. Trust the agent, but make writes safe
-
-Agent autonomy cuts both ways. An agent that can write to the lake can also corrupt it. Our answer is not to gate writes on human approval — that defeats autonomy — but to make the write path **atomic and recoverable** so mistakes don't cause damage:
-
-- **Lake destinations (Lance, Iceberg-roadmap)** commit atomically at end of batch. A crashed or cancelled run leaves the previous version visible.
-- **Submit-time pre-flight** diffs the query's output schema against the destination before creating a run row. Agents can't silently drift the schema.
-- **Run ledger** records every run in SQLite with parameters, status, rows_written, snapshot_id. Every agent-caused write is auditable by construction.
-- **Branching** (roadmap, v1.2) turns agent experiments into cheap `git checkout`-equivalents via Iceberg/Lance snapshots.
-
-The OSS primitives are designed so governance is *additive*, not a retrofit — governance (row/column grants, quotas, per-agent audit) lives on top of the metadata capture and snapshot primitives, rather than replacing them.
+The shape of the ledger we already have is the shape these gaps fill in against, not an extension of it — which is why this primitive is *partial* rather than *open*. Add the missing write path, add the missing identity columns, and the same row tells the same story for every action the agent took.
 
 ---
 
-## Roadmap — see the README
+## 3. Snapshot-as-branch — destructive autonomy is reversible
 
-The full public roadmap, with live checkboxes for what's shipped vs in flight vs open, lives in the [main README](../README.md#public-roadmap). We keep it there so anyone who lands on the repo sees exactly where the project is.
+**Status: in progress.** Lance dataset versions and atomic-commit semantics are shipped; branch-and-merge semantics on top of those versions are the next step. Roadmap item `6` — *snapshot-as-branch / agent checkpoints*.
+
+The failure mode is the most concrete of the three. The agent updated 1,000 rows you don't like. Without something better, this is an incident — restore from backup, page the on-call, write a postmortem. With a branch, it's a `revert` call. Source control solved this exact problem for code thirty years ago; the answer for agent writes against a lake is the same primitive applied one layer down.
+
+### What's true today
+
+- **Lance destinations commit atomically per run.** A job streams its query output through the destination in batches, but the Lance manifest commit is the last step and runs only after the stream drains successfully. A crashed server, a SIGKILL'd process, a query error mid-stream, or a `skardi job cancel` that arrives before commit all leave the destination at its previous version, with no partial rows visible. Lance manifests handle the on-disk equivalent of `BEGIN…COMMIT` for free.
+- **Lance dataset versions are the substrate.** Every successful job's `snapshot_id` is the Lance version the commit landed on. Lance keeps every version queryable until garbage-collected, so a "before / after" diff against a specific run is already mechanically possible — you have the version it landed on (from the ledger) and the version before that (Lance's parent pointer). The branch primitive is layered on top of this versioning, not built from scratch.
+- **Submit-time pre-flight prevents schema drift on async writes.** Every job submit runs the destination schema diff before creating a ledger row, so an agent that produces a column the destination doesn't have can't even start a run.
+
+This means even without explicit branches, the worst outcome of a bad async write today is "a Lance version you don't want, queryable side-by-side with the one you do, until the next commit replaces it." That is already a meaningfully better failure mode than corrupted Postgres tables, but it is not yet a workflow.
+
+### Branch-as-checkpoint, the next step
+
+The destination of this primitive: every agent write lands in a *branch*, the human reviews the diff against the trunk version, and merges or reverts. Borrowing the README's analogy directly, the workflow looks like:
+
+```bash
+# Agent submits a job that writes to a branch instead of trunk
+skardi job run wiki-rewrite --param prefix='entity/turing-%' --branch=experiment/turing-rewrite
+
+# Human reviews the diff between the branch and trunk
+skardi branch diff experiment/turing-rewrite
+
+# Either merge it in, or throw it away
+skardi branch merge  experiment/turing-rewrite
+skardi branch revert experiment/turing-rewrite
+```
+
+The pieces that remain to land for this to work: branches (named pointers above Lance versions), a branch-aware destination (so a job's `destination.table` resolves against a branch), a diff verb, and merge / revert. Iceberg destinations are also planned for the same primitive — Iceberg is read-only today on the source side; write support and its native branch / tag semantics are roadmap (`1` — Iceberg writes; `6` — snapshot-as-branch).
+
+Be honest about where this sits: of the three primitives, this is the most aspirational. Lance versions are real today, but the workflow above does not exist yet. The rest of the doc treats it accordingly.
+
+---
+
+## Why a uniform plane is the architectural prerequisite
+
+Each of the three primitives above has the same property: it works at *one* layer or it doesn't work. That is not aesthetic — it is what makes a uniform data plane the architectural prerequisite, not just one of several reasonable shapes.
+
+**Semantic overlay needs a single discovery surface.** N SDKs means N catalogs the agent has to learn about, each in its own dialect (SQL `INFORMATION_SCHEMA`, MongoDB collection lists, vector store index metadata, REST endpoint documentation). The agent has no place to find "the description of every table I can touch" because there is no "every." With one plane, `GET /data_source` is the single answer.
+
+**Lineage needs a single write path.** N SDKs means N log conventions and no joinable trail — the Postgres slow-query log, the MongoDB profiler, the vector store request log, and the application-level wrapper log are all separate streams with separate keys. Joining them around a single agent action is forensic work, not a query. With one plane, every write is one row in one ledger; "show me everything that agent did between 2pm and 3pm" is a `WHERE` clause.
+
+**Branching needs a single transactional layer.** N SDKs means no atomic cross-source snapshot — there is no "before this agent run" you can roll back to, because no SDK was watching all the SDKs. The unit a branch can wrap is the unit the chokepoint sees. With one plane, that unit is the agent's tool call; without one, it doesn't exist.
+
+The Spark analogy is a one-paragraph note here, not the headline: Spark gave data teams one engine over every storage format with one query language, and that shape is what made the Databricks governance layer (Unity Catalog, lineage, Delta time-travel) possible at all. Skardi borrows that half of Spark's shape — one engine, one SQL, every source — and adds the governance layer the analytics workload Spark targets never needed (because nightly Airflow DAGs do not pick their own queries; agents do). The workload is different; the shape is the same.
+
+[DataFusion](https://datafusion.apache.org/) is the in-process Rust SQL engine that makes this possible without a cluster. The plane is one Rust process plus a small SQLite file for the run ledger; deployment is "next to your data, behind your usual auth," not a multi-node spin-up.
+
+On the "behind your usual auth" half: Skardi ships drop-in session auth via [better-auth](https://www.better-auth.com/) backed by SQLite (roadmap `7` — *session auth*), so every `/<pipeline>/execute` call is gated on a logged-in session and `auth.users` / `auth.sessions` are available as virtual tables a pipeline can `JOIN` against — see [docs/auth/](auth/). What's *not* there yet is governance one layer in: per-pipeline grants, per-agent-identity grants, row-level policies. Today auth is at the server level — logged in or not — and finer-grained access (which agent identity is allowed to call which pipeline) is the natural next step on top of the lineage / identity-passthrough work in section 2, but is not yet a concrete roadmap item.
 
 ---
 
@@ -112,10 +220,10 @@ The full public roadmap, with live checkboxes for what's shipped vs in flight vs
 
 A few comparisons that sound similar but are deliberately off-mission:
 
-- **Not "MCP server framework."** MCP is a binding we ship (v1.1); it is not the product. Pipeline YAML is the product. If MCP gets replaced by a better protocol tomorrow, our YAMLs still describe the right tools.
-- **Not "another vector DB."** We integrate with pgvector, sqlite-vec, Lance, SeekDB HNSW — we don't ship a new vector store. The primitive is "hybrid retrieval in SQL," not "yet another ANN index."
-- **Not "an agent framework."** We have zero opinions about tool loops, planners, or routers. Bring your own agent. We just make the data layer work.
-- **Not "an LLM gateway."** `llm()` as a UDF is on the v1.2 roadmap, but the MVP deliberately stays out of provider / key / cost / caching decisions.
+- **Not "MCP server framework."** MCP is one binding among several (REST and shell are shipped; MCP is roadmap `5`). The product is the parameterized-SQL pipeline plus the three governance primitives above. If MCP gets replaced by a better protocol, the YAMLs still describe the right tools.
+- **Not "another vector DB."** Skardi integrates pgvector, sqlite-vec, Lance KNN, and SeekDB HNSW — it does not ship a new ANN index. The primitive is "hybrid retrieval as SQL," joinable like any other relation, not yet another store.
+- **Not "an agent framework."** No tool loop, no planner, no router. Bring your own agent. The plane only handles the data layer the agent's tool calls traverse.
+- **Not "an LLM gateway."** Provider keys, cost accounting, and model routing live above the plane. An `llm()` UDF for inline model calls is on the longer-horizon roadmap, but the MVP deliberately stays out of the gateway business.
 
 ---
 
@@ -127,10 +235,11 @@ We're building in public. If the thesis above resonates — or if it doesn't —
 - **[GitHub issues](https://github.com/SkardiLabs/skardi/issues)** — file against any unchecked roadmap item; we'll pair on design and review.
 - **[skardi-skills](https://github.com/SkardiLabs/skardi-skills)** — a growing library of ready-to-use Skardi setups.
 
-The rest of this doc tree walks the concrete pieces:
+The full public roadmap (with live `[x]` / `[ ]` checkboxes for what's shipped vs. open) lives in the [main README](../README.md#roadmap). The rest of this doc tree walks the concrete pieces:
 
 - [Server](server.md) — the HTTP process that hosts both peer surfaces.
 - [Pipelines](pipelines.md) — online serving (parameterized SQL as REST).
 - [Jobs](jobs.md) — offline jobs (async batch writes to Lance or a DB).
 - [CLI](cli.md) — `skardi run`, aliases, federated SQL from the shell.
+- [Semantics](semantics.md) — the agent's discovery surface.
 - [llm_wiki demo](../demo/llm_wiki/) — the fullest end-to-end demonstration of agent autonomy on Skardi.


### PR DESCRIPTION
## Summary

- Reframe the "agent data plane" pitch around a **control-plane vs data-plane teach-in** rather than dropping the term as jargon. Hero now bolds *agent data plane* with a one-paragraph definition through what it does; the body section opens by naming the pain (a Pinecone client here, a Postgres query there, a hand-rolled RRF merge in Python) before introducing the term.
- Add a **before/after Python snippet** showing the messy retrieval code Skardi replaces, an **inline glossary** (Pipeline, Job, `ctx.yaml`, DataFusion, Lance, Hybrid search/RRF/FTS/KNN, Catalog mode, `sqlite_knn`/`sqlite_fts`, SeekDB), the **real `ctx.yaml` + pipeline + aliases YAML** from `demo/llm_wiki/cli/`, and a full curl request + JSON response cycle for `/wiki-search-hybrid/execute`.
- **Promote drop-in skills** (`auto_knowledge_base`, `auto_rag`) above Quick Start so agent builders who don't want to write YAML have a 60-second path to grounded retrieval. Move the unshipped "coming soon" list (memory primitive, MCP binding, lineage, snapshot-as-branch) down next to the roadmap so it doesn't break the path from "what is this?" to "how do I try it?".
- Replace "What's already in the box" (overlapped the Roadmap) with a tighter top-of-page topology block; deepen the "Why not just write a Python function?" section with five concrete reasons and an honest "if you only need one Postgres query, a Python function is simpler."

Driven by a multi-iteration review with an agent-builder persona (Claude/GPT agent dev, comfortable with REST and `SELECT * FROM`, not a data engineer) who bounced off the original framing. The persona's final verdict on the revision: *"agent data plane works because it's been earned by the explanation right below it. Ship it."*

Net change: **+168 / −71 lines** in [README.md](README.md). All YAML / curl / JSON snippets verified against the codebase (`demo/llm_wiki/cli/*`, `crates/server/src/pipeline_handlers.rs`, `crates/cli/src/main.rs`).

## Test plan

- [ ] Render the README on the PR page and confirm the hero, glossary block, ASCII topology, and code blocks display correctly
- [ ] Confirm all relative links resolve (`docs/agent_data_plane.md`, `docs/sqlite/`, `docs/postgres/`, `demo/llm_wiki/cli/`, `#quick-start`, `#roadmap`)
- [ ] Confirm the `auto_knowledge_base` and `auto_rag` skill links land on the right `skardi-skills` directories
- [ ] Sanity-check the inlined `ctx.yaml` / pipeline / aliases snippets against the real files in `demo/llm_wiki/cli/`
- [ ] Verify the `curl` example body shape matches the parameter list in `demo/llm_wiki/cli/pipelines/search_hybrid.yaml`
- [ ] Read once cold from the perspective of someone seeing the project for the first time — does the flow hero → "what is an agent data plane?" → drop-in skills → why not roll my own → Quick Start make sense?

🤖 Generated with [Claude Code](https://claude.com/claude-code)