### PR TITLE
docs: tidy architecture diagram labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ For the longer technical read — each primitive's shipped vs. in-progress statu
     </picture>
   </a>
   <br>
-  <sub><em>fig. 01 — skardi open source topology.</em> <a href="https://htmlpreview.github.io/?https://github.com/SkardiLabs/skardi/blob/main/asset/architecture-open-source.html">View interactive diagram →</a></sub>
+  <sub><a href="https://htmlpreview.github.io/?https://github.com/SkardiLabs/skardi/blob/main/asset/architecture-open-source.html">View interactive diagram →</a></sub>
 </p>
 
 ---

--- a/asset/architecture-open-source.html
+++ b/asset/architecture-open-source.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Skardi — Open Source Architecture</title>
+<title>Skardi — Architecture</title>
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -252,7 +252,7 @@
   </svg>
 </template>
 <div class="page">
-  <div class="eyebrow">Skardi · Open Source Architecture</div>
+  <div class="eyebrow">Skardi · Architecture</div>
   <h1>An <em>agent data plane</em> that gives AI agents data autonomy.</h1>
   <p class="sub">Any <strong>AI agent</strong> — Claude Code, Codex, your own — talks to <code>skardi-server</code> through a uniform set of skills (<code>rag</code>, <code>grep</code>, <code>batch</code>, <code>ingest</code>) and gets governed access to every database, file, and object store you connect. One control plane. Any source. Federated SQL + retrieval primitives, written in Rust.</p>
 

--- a/asset/architecture-open-source.html
+++ b/asset/architecture-open-source.html
@@ -258,7 +258,7 @@
 
   <div class="stage-wrap" id="stage-wrap">
   <div class="stage" id="stage">
-    <div class="stage-tag"><span class="dot"></span>SKARDI · OPEN SOURCE</div>
+    <div class="stage-tag"><span class="dot"></span>SKARDI</div>
 
     <svg class="diagram" viewBox="0 0 1280 640" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
       <defs>
@@ -567,7 +567,7 @@
   </script>
 
   <div class="footnote">
-    <div>fig. 01 — skardi · open source topology</div>
+    <div></div>
     <div><a href="https://github.com/SkardiLabs/skardi">github.com/SkardiLabs/skardi</a> · Apache 2.0</div>
   </div>
 </div>

--- a/asset/architecture-open-source.svg
+++ b/asset/architecture-open-source.svg
@@ -68,7 +68,7 @@
   <!-- header tag -->
   <g transform="translate(36, 38)">
     <circle class="blink" cx="6" cy="0" r="5" fill="#1a7f37"/>
-    <text x="20" y="5" class="mono ink3 upper b" font-size="14">SKARDI · OPEN SOURCE</text>
+    <text x="20" y="5" class="mono ink3 upper b" font-size="14">SKARDI</text>
   </g>
 
   <!-- ============== CONNECTOR FLOW LINES ============== -->


### PR DESCRIPTION
## Summary
- Drop the "fig. 01 — skardi open source topology" caption under the README diagram, leaving just the "View interactive diagram" link.
- Trim the SKARDI · OPEN SOURCE header tag to just SKARDI in both the interactive HTML and the static SVG.
- Clear the matching footnote in the interactive HTML.

## Test plan
- [ ] Render README on GitHub and confirm the diagram still embeds and the link still works.
- [ ] Open `asset/architecture-open-source.html` locally and verify the header tag and footnote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)