### PR TITLE
docs: lead with skills, add Claude Marketplace install button

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 [![Docs Badge]][Docs]
 [![Discord Badge]][Discord]
 
-[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/skardi/) [![Install skardi-skills from Claude Marketplace](https://img.shields.io/badge/Install-skardi--skills-D97757?style=for-the-badge&label=Claude%20Marketplace)](https://github.com/SkardiLabs/skardi-skills)
+[![Deploy on Sealos](https://img.shields.io/badge/Deploy-skardi-239BF8?style=for-the-badge&label=Sealos)](https://sealos.io/products/app-store/skardi/) [![Install skardi-skills from Claude Marketplace](https://img.shields.io/badge/Install-skardi--skills-D97757?style=for-the-badge&label=Claude%20Marketplace)](https://github.com/SkardiLabs/skardi-skills)
 
 </p>
 </div>

--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@
 
 <hr />
 
+## Why Skardi?
+
+**The most agent-friendly backend for builders shipping their first AI agent.** The painful part of agent-building isn't the prompt — it's the data plumbing: a vector DB to stand up, an embedding pipeline to maintain, a chunker to debug, a tool-call wrapper to write for every query. Skardi auto-bootstraps the primitives every agent needs so you ship in hours, not weeks:
+
+- **Auto-RAG (Retrieval Augmented Generation)** — hybrid search (vector + full-text + RRF) over your datastore, served as REST endpoints your agent calls as tools. One command from a datastore to a working retrieval API. No Python orchestration layer, no glue code.
+- **Auto agent knowledge base** — point at a directory of documents and get a queryable, citable knowledge base one command later. Chunking, embedding, indexing, hybrid retrieval — all handled.
+- **Zero bootstrap** — `ctx.yaml`, pipelines, schema, server, all rendered for you by **[skardi-skills](https://github.com/SkardiLabs/skardi-skills)**. Install once and your agent has a working data tool the same hour.
+
+You build the agent. Skardi handles the data plane.
+
+---
+
 ## Get started in 60 seconds — drop-in skills
 
 **Don't worry about the buzz words below — just install [skardi-skills](https://github.com/SkardiLabs/skardi-skills) and your agent gets a working Skardi tool.** No config, no infra.

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ You build the agent. Skardi handles the data plane.
 
 **Don't worry about the buzz words below — just install [skardi-skills](https://github.com/SkardiLabs/skardi-skills) and your agent gets a working Skardi tool.** No config, no infra.
 
-- **[`auto_knowledge_base`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_knowledge_base)** — point it at a directory of documents and you have a queryable local RAG one command later. Chunking, embedding, indexing, and hybrid search are exposed to your agent as a `skardi grep` verb. Zero infra by default (SQLite + local embeddings), so any Claude Code / Cursor session gets a grounded, citable knowledge base over your files.
 - **[`auto_rag`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_rag)** — server-backed hybrid-search RAG via `skardi-server` on top of a datastore you already control (Postgres + pgvector, MongoDB, or Lance). The skill renders the config, starts the server, and drives ingestion and queries through REST — for when retrieval needs to be shared across multiple agents or processes.
+- **[`auto_knowledge_base`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_knowledge_base)** — point it at a directory of documents and you have a queryable local RAG one command later. Chunking, embedding, indexing, and hybrid search are exposed to your agent as a `skardi grep` verb. Zero infra by default (SQLite + local embeddings), so any Claude Code / Cursor session gets a grounded, citable knowledge base over your files.
 
 Read-only RAG is a perfectly good first use case for the plane: you get the semantic overlay (the agent reads what your tables are for), one engine that can later JOIN against your operational data, and a swappable backend (move from SQLite-on-disk to Postgres + pgvector to Lance without touching the agent). The same plane keeps earning as the agent starts to *write* — that's where lineage and branching kick in.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 [![Docs Badge]][Docs]
 [![Discord Badge]][Discord]
 
-[![Deploy on Sealos](https://img.shields.io/badge/Deploy-skardi-239BF8?style=for-the-badge&label=Sealos)](https://sealos.io/products/app-store/skardi/) [![Install skardi-skills from Claude Marketplace](https://img.shields.io/badge/Install-skardi--skills-D97757?style=for-the-badge&label=Claude%20Marketplace)](https://github.com/SkardiLabs/skardi-skills)
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/skardi/) [![Install on Claude Skills](asset/Install-Claude-Skills.svg)](https://github.com/SkardiLabs/skardi-skills)
 
 </p>
 </div>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <img src="asset/logo.png" alt="Skardi Logo" width="700">
 
-**Skardi is an open-source agent data plane** — every read and write your agent makes flows through one uniform layer of parameterized SQL pipelines, served as REST endpoints and shell verbs your agent calls as tools. Putting reads and writes behind the same plane is what makes the durable thing possible: semantic discovery, audit, and rollback compose across your whole stack instead of fragmenting across SDKs — turning *data autonomy* (letting the agent decide what to query and write) from a gamble into a default you can actually govern.
+**Skardi is an open-source agent data plane** — parameterized SQL templates served as REST endpoints (and shell verbs) your agent calls as tools, turning *data autonomy* (letting the agent decide what to query and write) into a default you can govern.
 
 **Federated** · one engine over every source &nbsp;·&nbsp; **Governed** · semantic overlay, lineage, branching &nbsp;·&nbsp; **Agent-native** · REST + shell + MCP-soon
 

--- a/README.md
+++ b/README.md
@@ -42,24 +42,17 @@
 
 **The most agent-friendly backend for builders shipping their first AI agent.** The painful part of agent-building isn't the prompt — it's the data plumbing: a vector DB to stand up, an embedding pipeline to maintain, a chunker to debug, a tool-call wrapper to write for every query. Skardi auto-bootstraps the primitives every agent needs so you ship in hours, not weeks:
 
-- **Auto-RAG (Retrieval Augmented Generation)** — hybrid search (vector + full-text + RRF) over your datastore, served as REST endpoints your agent calls as tools. One command from a datastore to a working retrieval API. No Python orchestration layer, no glue code.
-- **Auto agent knowledge base** — point at a directory of documents and get a queryable, citable knowledge base one command later. Chunking, embedding, indexing, hybrid retrieval — all handled.
+- **[`auto_rag`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_rag) — Auto-RAG (Retrieval Augmented Generation).** Server-backed hybrid search (vector + full-text + RRF) via `skardi-server` over a datastore you already control (Postgres + pgvector, MongoDB, or Lance). The skill renders the config, starts the server, and drives ingestion and queries through REST. One command from a datastore to a working retrieval API your agent calls as a tool — no Python orchestration layer, no glue code.
+- **[`auto_knowledge_base`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_knowledge_base) — Auto agent knowledge base.** Point it at a directory of documents and you have a queryable, citable local KB one command later. Chunking, embedding, indexing, and hybrid search are exposed to your agent as a `skardi grep` verb. Zero infra by default (SQLite + local embeddings), so any Claude Code / Cursor session gets a grounded knowledge base over your files.
 - **Zero bootstrap** — `ctx.yaml`, pipelines, schema, server, all rendered for you by **[skardi-skills](https://github.com/SkardiLabs/skardi-skills)**. Install once and your agent has a working data tool the same hour.
 
 You build the agent. Skardi handles the data plane.
 
 ---
 
-## Get started in 60 seconds — drop-in skills
+## Get started in 60 seconds — install on Claude Code
 
-**Don't worry about the buzz words below — just install [skardi-skills](https://github.com/SkardiLabs/skardi-skills) and your agent gets a working Skardi tool.** No config, no infra.
-
-- **[`auto_rag`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_rag)** — server-backed hybrid-search RAG via `skardi-server` on top of a datastore you already control (Postgres + pgvector, MongoDB, or Lance). The skill renders the config, starts the server, and drives ingestion and queries through REST — for when retrieval needs to be shared across multiple agents or processes.
-- **[`auto_knowledge_base`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_knowledge_base)** — point it at a directory of documents and you have a queryable local RAG one command later. Chunking, embedding, indexing, and hybrid search are exposed to your agent as a `skardi grep` verb. Zero infra by default (SQLite + local embeddings), so any Claude Code / Cursor session gets a grounded, citable knowledge base over your files.
-
-Read-only RAG is a perfectly good first use case for the plane: you get the semantic overlay (the agent reads what your tables are for), one engine that can later JOIN against your operational data, and a swappable backend (move from SQLite-on-disk to Postgres + pgvector to Lance without touching the agent). The same plane keeps earning as the agent starts to *write* — that's where lineage and branching kick in.
-
-**Install in Claude Code** — run these inside any Claude Code session:
+Open any Claude Code session and run:
 
 ```text
 /plugin marketplace add SkardiLabs/skardi-skills
@@ -68,7 +61,7 @@ Read-only RAG is a perfectly good first use case for the plane: you get the sema
 /plugin install auto-rag@skardi-skills
 ```
 
-That's it — the skills are now available across all your projects, and `/plugin marketplace update skardi-skills` pulls future versions. Cursor and other [Agent Skills](https://agentskills.io/)-compatible tools, plus a manual-copy fallback, are documented in the [skardi-skills README](https://github.com/SkardiLabs/skardi-skills#installation).
+That's it — the skills are now available across all your projects, and `/plugin marketplace update skardi-skills` pulls future versions. For Cursor and other [Agent Skills](https://agentskills.io/)-compatible tools, plus a manual-copy fallback, see the [skardi-skills README](https://github.com/SkardiLabs/skardi-skills#installation).
 
 Curious why a uniform plane matters? Read on.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 
 ## Get started in 60 seconds — drop-in skills
 
-**The fastest way to put Skardi in your agent's hands.** Install a ready-made skill from **[skardi-skills](https://github.com/SkardiLabs/skardi-skills)** — each one renders the `ctx.yaml` + pipelines for you and wires them up as agent-callable verbs. Zero config to write, zero infra to provision by default. Open Claude Code, install, ask your agent to query your data — that's the loop.
+**It's ok not to fully understand all the buzz words we are talking about** — you can just try out Skardi by putting it in your agent's hands through **[skardi-skills](https://github.com/SkardiLabs/skardi-skills)**! Each skill renders the `ctx.yaml` + pipelines for you and wires them up as agent-callable verbs. Zero config to write, zero infra to provision by default. Open Claude Code, install, ask your agent to query your data — that's the loop.
 
 - **[`auto_knowledge_base`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_knowledge_base)** — point it at a directory of documents and you have a queryable local RAG one command later. Chunking, embedding, indexing, and hybrid search are exposed to your agent as a `skardi grep` verb. Zero infra by default (SQLite + local embeddings), so any Claude Code / Cursor session gets a grounded, citable knowledge base over your files.
 - **[`auto_rag`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_rag)** — server-backed hybrid-search RAG via `skardi-server` on top of a datastore you already control (Postgres + pgvector, MongoDB, or Lance). The skill renders the config, starts the server, and drives ingestion and queries through REST — for when retrieval needs to be shared across multiple agents or processes.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ Curious why a uniform plane matters? Read on.
 
 ---
 
+## ⭐️ Star the Repository
+
+If **skardi-skills** lands well in your agentic stack — auto-RAG up in a minute, a knowledge base your agent actually grounds in — drop a ⭐️ on this repo. It helps other agent builders discover Skardi, makes onboarding their first agent that much shorter, and signals which directions are worth pushing on.
+
+<p align="center">
+  <a href="https://github.com/SkardiLabs/skardi">
+    <img src="asset/skardi-star.gif" alt="Star Skardi" width="700">
+  </a>
+</p>
+
+---
+
 ## What is an "agent data plane"?
 
 Borrowing the phrase from cloud infra: your AI agent has two layers. The **control plane** is the reasoning loop — prompts, tool selection, your orchestration code. The **data plane** is where every byte of context comes from and goes to: vector DB hits, SQL queries, file reads, writes back, audit trails.
@@ -139,18 +151,6 @@ Direct SDKs work fine for a single read-only RAG bot — you can wire one to Pos
 If your agent only ever reads from one source, direct SDKs are simpler. If it reads from many, or writes back, or you want to govern what it does — the plane is what makes data autonomy a responsible default rather than a gamble.
 
 Full breakdown of the three primitives — semantic-overlay YAML, the verbatim run-ledger schema, and why each primitive requires a chokepoint — in [docs/agent_data_plane.md](docs/agent_data_plane.md).
-
----
-
-## ⭐️ Star the Repository
-
-If you find Skardi useful or interesting, a GitHub Star ⭐️ would be greatly appreciated — it helps others discover the project and signals which directions are worth pushing on.
-
-<p align="center">
-  <a href="https://github.com/SkardiLabs/skardi">
-    <img src="asset/skardi-star.gif" alt="Star Skardi" width="700">
-  </a>
-</p>
 
 ---
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 
 ## Get started in 60 seconds — drop-in skills
 
-**It's ok not to fully understand all the buzz words we are talking about** — you can just try out Skardi by putting it in your agent's hands through **[skardi-skills](https://github.com/SkardiLabs/skardi-skills)**! Each skill renders the `ctx.yaml` + pipelines for you and wires them up as agent-callable verbs. Zero config to write, zero infra to provision by default. Open Claude Code, install, ask your agent to query your data — that's the loop.
+**Don't worry about the buzz words below — just install [skardi-skills](https://github.com/SkardiLabs/skardi-skills) and your agent gets a working Skardi tool.** No config, no infra.
 
 - **[`auto_knowledge_base`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_knowledge_base)** — point it at a directory of documents and you have a queryable local RAG one command later. Chunking, embedding, indexing, and hybrid search are exposed to your agent as a `skardi grep` verb. Zero infra by default (SQLite + local embeddings), so any Claude Code / Cursor session gets a grounded, citable knowledge base over your files.
 - **[`auto_rag`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_rag)** — server-backed hybrid-search RAG via `skardi-server` on top of a datastore you already control (Postgres + pgvector, MongoDB, or Lance). The skill renders the config, starts the server, and drives ingestion and queries through REST — for when retrieval needs to be shared across multiple agents or processes.

--- a/README.md
+++ b/README.md
@@ -31,12 +31,25 @@
 [![Docs Badge]][Docs]
 [![Discord Badge]][Discord]
 
-[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/skardi/)
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/skardi/) [![Install skardi-skills from Claude Marketplace](https://img.shields.io/badge/Install-skardi--skills-D97757?style=for-the-badge&label=Claude%20Marketplace)](https://github.com/SkardiLabs/skardi-skills)
 
 </p>
 </div>
 
 <hr />
+
+## Get started in 60 seconds — drop-in skills
+
+**The fastest way to put Skardi in your agent's hands.** Install a ready-made skill from **[skardi-skills](https://github.com/SkardiLabs/skardi-skills)** — each one renders the `ctx.yaml` + pipelines for you and wires them up as agent-callable verbs. Zero config to write, zero infra to provision by default. Open Claude Code, install, ask your agent to query your data — that's the loop.
+
+- **[`auto_knowledge_base`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_knowledge_base)** — point it at a directory of documents and you have a queryable local RAG one command later. Chunking, embedding, indexing, and hybrid search are exposed to your agent as a `skardi grep` verb. Zero infra by default (SQLite + local embeddings), so any Claude Code / Cursor session gets a grounded, citable knowledge base over your files.
+- **[`auto_rag`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_rag)** — server-backed hybrid-search RAG via `skardi-server` on top of a datastore you already control (Postgres + pgvector, MongoDB, or Lance). The skill renders the config, starts the server, and drives ingestion and queries through REST — for when retrieval needs to be shared across multiple agents or processes.
+
+Read-only RAG is a perfectly good first use case for the plane: you get the semantic overlay (the agent reads what your tables are for), one engine that can later JOIN against your operational data, and a swappable backend (move from SQLite-on-disk to Postgres + pgvector to Lance without touching the agent). The same plane keeps earning as the agent starts to *write* — that's where lineage and branching kick in.
+
+Curious why a uniform plane matters? Read on.
+
+---
 
 ## What is an "agent data plane"?
 
@@ -94,17 +107,6 @@ For the longer technical read — each primitive's shipped vs. in-progress statu
   <br>
   <sub><a href="https://htmlpreview.github.io/?https://github.com/SkardiLabs/skardi/blob/main/asset/architecture-open-source.html">View interactive diagram →</a></sub>
 </p>
-
----
-
-## Drop-in skills — go from zero to grounded retrieval in 60 seconds
-
-The fastest path to put Skardi in front of your agent is to install one of our ready-made skills from **[skardi-skills](https://github.com/SkardiLabs/skardi-skills)**. Each skill renders the `ctx.yaml` + pipelines for you and wires them up as agent-callable verbs — zero config to write yourself.
-
-- **[`auto_knowledge_base`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_knowledge_base)** — point it at a directory of documents and you have a queryable local RAG one command later. Chunking, embedding, indexing, and hybrid search are exposed to your agent as a `skardi grep` verb. Zero infra by default (SQLite + local embeddings), so any Claude Code / Cursor session gets a grounded, citable knowledge base over your files.
-- **[`auto_rag`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_rag)** — server-backed hybrid-search RAG via `skardi-server` on top of a datastore you already control (Postgres + pgvector, MongoDB, or Lance). The skill renders the config, starts the server, and drives ingestion and queries through REST — for when retrieval needs to be shared across multiple agents or processes.
-
-Read-only RAG is a perfectly good first use case for the plane: you get the semantic overlay (the agent reads what your tables are for), one engine that can later JOIN against your operational data, and a swappable backend (move from SQLite-on-disk to Postgres + pgvector to Lance without touching the agent). The same plane keeps earning as the agent starts to *write* — that's where lineage and branching kick in. Drop a skill in to see the shape; read on if you want to build pipelines of your own.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@
 
 Read-only RAG is a perfectly good first use case for the plane: you get the semantic overlay (the agent reads what your tables are for), one engine that can later JOIN against your operational data, and a swappable backend (move from SQLite-on-disk to Postgres + pgvector to Lance without touching the agent). The same plane keeps earning as the agent starts to *write* — that's where lineage and branching kick in.
 
+**Install in Claude Code** — run these inside any Claude Code session:
+
+```text
+/plugin marketplace add SkardiLabs/skardi-skills
+/plugin install skardi-deploy-and-patterns@skardi-skills
+/plugin install auto-knowledge-base@skardi-skills
+/plugin install auto-rag@skardi-skills
+```
+
+That's it — the skills are now available across all your projects, and `/plugin marketplace update skardi-skills` pulls future versions. Cursor and other [Agent Skills](https://agentskills.io/)-compatible tools, plus a manual-copy fallback, are documented in the [skardi-skills README](https://github.com/SkardiLabs/skardi-skills#installation).
+
 Curious why a uniform plane matters? Read on.
 
 ---

--- a/asset/Install-Claude-Skills.svg
+++ b/asset/Install-Claude-Skills.svg
@@ -1,0 +1,10 @@
+<svg width="185" height="42" viewBox="0 0 185 42" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0.5" width="184" height="41.2" rx="6.7" fill="#D97757"/>
+  <g transform="translate(14, 11)">
+    <path d="M10 0 L11.6 7.4 L19 9 L11.6 10.6 L10 18 L8.4 10.6 L1 9 L8.4 7.4 Z" fill="#FFFFFF"/>
+    <circle cx="2.5" cy="2" r="1.5" fill="#FFFFFF" fill-opacity="0.75"/>
+    <circle cx="17.5" cy="17" r="1.2" fill="#FFFFFF" fill-opacity="0.75"/>
+  </g>
+  <text x="46" y="19" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="10" font-weight="500" fill="#FFFFFF" fill-opacity="0.85">Install on</text>
+  <text x="46" y="33" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="14" font-weight="600" fill="#FFFFFF">Claude Skills</text>
+</svg>


### PR DESCRIPTION
## Summary
- Move the **Drop-in skills** section from below the architecture diagram to directly under the README header — so readers see the fastest on-ramp first, and the longer "what is an agent data plane" explainer comes after.
- Rename the heading to **"Get started in 60 seconds — drop-in skills"** and add a short attractive lead-in encouraging readers to install a skill and try it.
- Add an **Install skardi-skills** button next to the existing **Deploy on Sealos** badge.

## Note on the install button URL
The button currently points at `https://github.com/SkardiLabs/skardi-skills` because I don't have a verified Claude Marketplace one-click install URL. If there's a canonical marketplace URL (e.g. a `claude://` deep link or a `claude.com/...` redirect), swap it into the badge link target — the badge artwork stays the same.

## Test plan
- [ ] Render README on GitHub and confirm the new section appears first, the architecture diagram still embeds, and the deeper "agent data plane" explainer reads correctly underneath.
- [ ] Click the new **Install skardi-skills** badge and confirm the link target.
- [ ] Confirm the **Deploy on Sealos** button still works and renders next to the new badge on common viewport widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)