### PR TITLE
docs: fix broken crates.io badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 [Codecov]: https://codecov.io/gh/SkardiLabs/skardi
 [Codecov Badge]: https://codecov.io/gh/SkardiLabs/skardi/branch/main/graph/badge.svg
 [crates.io]: https://crates.io/crates/skardi
-[crates.io Badge]: https://img.shields.io/crates/v/skardi.svg
+[crates.io Badge]: https://img.shields.io/crates/v/skardi?logo=rust
 [Docs]: https://docs.rs/skardi
 [Docs Badge]: https://docs.rs/skardi/badge.svg
 [Discord]: https://discord.gg/S5YQQPEV2m


### PR DESCRIPTION
## Summary
- The crates.io badge on the repo homepage was rendering as a broken image, while every other badge (License, CI, Codecov, docs.rs, Discord) loaded fine.
- Root cause: GitHub serves README images through its `camo.githubusercontent.com` proxy. Camo had a poisoned cache entry for the badge URL — `curl -I` against the camo URL returned **502 Bad Gateway**, even though `https://img.shields.io/crates/v/skardi.svg` itself returned 200 OK with a valid SVG.
- Fix: change the badge source URL so camo mints a fresh cache entry. Switched to `https://img.shields.io/crates/v/skardi?logo=rust` (drops the redundant `.svg` extension and adds a Rust logo).

## Test plan
- [ ] After merge, hard-refresh the repo homepage and confirm the crates.io badge renders with the current version (`v0.4.0`) and a Rust logo
- [ ] Confirm the badge still links to https://crates.io/crates/skardi

🤖 Generated with [Claude Code](https://claude.com/claude-code)