### PR TITLE
feat(sources): add DynamoDB table provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,13 @@ jobs:
           --health-timeout=10s
           --health-retries=20
 
+      # DynamoDB Local has no in-image shell tooling for a healthcheck, so
+      # readiness is polled with the AWS CLI in a dedicated step below.
+      dynamodb:
+        image: amazon/dynamodb-local:2.5.2
+        ports:
+          - 8000:8000
+
     env:
       MYSQL_USER: skardi_user
       MYSQL_PASSWORD: skardi_pass
@@ -117,6 +124,11 @@ jobs:
       SEEKDB_PASSWORD: ""
       INFLUXDB_URL: "http://127.0.0.1:8181"
       INFLUXDB_DATABASE: "metrics"
+      # DynamoDB Local ignores credential values but the AWS SDK requires them
+      # to be present. The endpoint is supplied via the context/test config.
+      AWS_ACCESS_KEY_ID: dummy
+      AWS_SECRET_ACCESS_KEY: dummy
+      AWS_DEFAULT_REGION: us-east-1
 
     steps:
       - name: Checkout code
@@ -447,6 +459,35 @@ jobs:
           mem,host=host2,region=us-west used_percent=73.9 1700000000
           mem,host=host3,region=us-east used_percent=31.5 1700000000
           EOF
+
+      - name: Seed DynamoDB data
+        env:
+          EP: http://127.0.0.1:8000
+        run: |
+          # Wait for DynamoDB Local to accept connections.
+          for i in $(seq 1 30); do
+            if aws dynamodb list-tables --endpoint-url "$EP" >/dev/null 2>&1; then
+              echo "DynamoDB Local is ready"
+              break
+            fi
+            echo "Waiting for DynamoDB Local... (attempt $i/30)"
+            sleep 2
+          done
+
+          aws dynamodb create-table --endpoint-url "$EP" \
+            --table-name products \
+            --attribute-definitions AttributeName=product_id,AttributeType=S \
+            --key-schema AttributeName=product_id,KeyType=HASH \
+            --billing-mode PAY_PER_REQUEST
+          aws dynamodb wait table-exists --endpoint-url "$EP" --table-name products
+
+          put() { aws dynamodb put-item --endpoint-url "$EP" --table-name products --item "$1"; }
+          put '{"product_id":{"S":"PROD001"},"name":{"S":"Laptop"},"category":{"S":"Electronics"},"price":{"N":"999.99"},"in_stock":{"BOOL":true}}'
+          put '{"product_id":{"S":"PROD002"},"name":{"S":"Keyboard"},"category":{"S":"Electronics"},"price":{"N":"79.99"},"in_stock":{"BOOL":true}}'
+          put '{"product_id":{"S":"PROD003"},"name":{"S":"Monitor"},"category":{"S":"Electronics"},"price":{"N":"299.99"},"in_stock":{"BOOL":false}}'
+          put '{"product_id":{"S":"PROD004"},"name":{"S":"Mouse"},"category":{"S":"Electronics"},"price":{"N":"29.99"},"in_stock":{"BOOL":true}}'
+          # NULL-bearing row: no `category` attribute, exercising NULL handling.
+          put '{"product_id":{"S":"PROD005"},"name":{"S":"Desk Chair"},"price":{"N":"199.99"},"in_stock":{"BOOL":true}}'
 
       - name: Execute Integration tests
         run: cargo llvm-cov --no-report nextest --all-features -- --ignored

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,6 +642,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-config"
+version = "1.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33f815b73a3899c03b380d543532e5865f230dce9678d108dc10732a8682275"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema 0.1.0",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.4.2",
+ "sha1",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,6 +708,403 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-runtime"
+version = "1.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c9b9de216a988dd54b754a82a7660cfe14cee4f6782ae4524470972fa0ccb39"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-dynamodb"
+version = "1.116.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c937c55ae3030bec4431c0d9146e33d2b3e5f54bb47ed32597068200c56affc"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json",
+ "aws-smithy-observability 0.2.6",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c82b3ac19f1431854f7ace3a7531674633e286bfdde21976893bfee36fd493b"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json",
+ "aws-smithy-observability 0.2.6",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.104.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321000d2b4c5519ee573f73167f612efd7329322d9b26969ad1979f0427f1913"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json",
+ "aws-smithy-observability 0.2.6",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.107.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0d328ba962af23ecfa3c9f23b98d3d35e325fa218d7f13d17a6bf522f8a560"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json",
+ "aws-smithy-observability 0.2.6",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac 0.13.0",
+ "http 0.2.12",
+ "http 1.4.2",
+ "percent-encoding",
+ "sha2 0.11.0",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "635d23afda0a6ab48d666c4d447c4873e8d1e83518a2be2093122397e50b838e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.3.27",
+ "h2 0.4.15",
+ "http 0.2.12",
+ "http 1.4.2",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper 1.10.1",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.9",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.41",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower 0.5.3",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema 0.1.0",
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bea94a9ff8464016338c851e24b472d7131c388c88898a502e781815b2ee6045"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http 0.64.0",
+ "aws-smithy-http-client",
+ "aws-smithy-observability 0.3.0",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema 0.2.0",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ed1ebe6e0a95ea84570225f5a8208dec4b8f77e61a9b0d6f51773fcb4612f0"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.2",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "aws-smithy-schema"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.2",
+]
+
+[[package]]
+name = "aws-smithy-schema"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.2",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6dc683efb34b9e755675b37fedbe0103141e5b6df7bdc9eb6967756a8c167d8"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.2",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema 0.1.0",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,10 +1114,10 @@ dependencies = [
  "axum-core 0.4.5",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.10.1",
  "hyper-util",
  "itoa",
  "matchit 0.7.3",
@@ -707,8 +1147,8 @@ dependencies = [
  "axum-core 0.5.6",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "http-body-util",
  "itoa",
  "matchit 0.8.4",
@@ -732,8 +1172,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -752,8 +1192,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -790,6 +1230,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -1244,6 +1694,16 @@ name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "bzip2"
@@ -3249,7 +3709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4012,6 +4472,25 @@ dependencies = [
 
 [[package]]
 name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
@@ -4021,7 +4500,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.2",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -4243,6 +4722,17 @@ checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
@@ -4253,12 +4743,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -4269,8 +4770,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -4309,6 +4810,30 @@ dependencies = [
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
@@ -4317,9 +4842,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.15",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -4331,17 +4856,32 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.2",
+ "hyper 1.10.1",
  "hyper-util",
- "rustls",
+ "rustls 0.23.41",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
  "webpki-roots 1.0.8",
 ]
@@ -4352,7 +4892,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.10.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -4367,7 +4907,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.10.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -4385,9 +4925,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "hyper 1.10.1",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -5317,7 +5857,7 @@ dependencies = [
  "chrono",
  "deepsize",
  "futures",
- "http",
+ "http 1.4.2",
  "lance-arrow",
  "lance-core",
  "lance-namespace",
@@ -6073,7 +6613,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.9.4",
  "rustc_version_runtime",
- "rustls",
+ "rustls 0.23.41",
  "serde",
  "serde_bytes",
  "serde_with",
@@ -6085,7 +6625,7 @@ dependencies = [
  "take_mut",
  "thiserror 2.0.18",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "typed-builder 0.22.0",
  "uuid",
@@ -6472,11 +7012,11 @@ dependencies = [
  "chrono",
  "form_urlencoded",
  "futures",
- "http",
+ "http 1.4.2",
  "http-body-util",
  "httparse",
  "humantime",
- "hyper",
+ "hyper 1.10.1",
  "itertools 0.14.0",
  "md-5 0.10.6",
  "parking_lot",
@@ -6561,8 +7101,8 @@ dependencies = [
  "crc32c",
  "futures",
  "getrandom 0.2.17",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "jiff",
  "log",
  "md-5 0.10.6",
@@ -6642,7 +7182,7 @@ checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
 dependencies = [
  "async-trait",
  "futures-core",
- "http",
+ "http 1.4.2",
  "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry_sdk",
@@ -6758,6 +7298,12 @@ dependencies = [
  "lzma-rust2",
  "ureq",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "ownedbytes"
@@ -6977,6 +7523,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -7200,7 +7752,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -7374,7 +7926,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.41",
  "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
@@ -7396,7 +7948,7 @@ dependencies = [
  "rand_pcg",
  "ring",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -7416,7 +7968,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.4",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7809,7 +8361,7 @@ dependencies = [
  "hex",
  "hmac 0.12.1",
  "home",
- "http",
+ "http 1.4.2",
  "log",
  "percent-encoding",
  "quick-xml 0.37.5",
@@ -7834,12 +8386,12 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.15",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.10.1",
+ "hyper-rustls 0.27.9",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -7850,7 +8402,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.41",
  "rustls-native-certs",
  "rustls-pki-types",
  "serde",
@@ -7859,7 +8411,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower 0.5.3",
  "tower-http 0.6.11",
@@ -7882,11 +8434,11 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.10.1",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
  "log",
@@ -7894,7 +8446,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -7902,7 +8454,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower 0.5.3",
  "tower-http 0.6.11",
  "tower-service",
@@ -8090,7 +8642,19 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
 ]
 
 [[package]]
@@ -8104,7 +8668,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -8151,14 +8715,14 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.41",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8166,6 +8730,16 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -8269,6 +8843,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "sea-query"
@@ -8625,6 +9209,8 @@ dependencies = [
  "anyhow",
  "arrow",
  "async-trait",
+ "aws-config",
+ "aws-sdk-dynamodb",
  "base64 0.22.1",
  "blake3",
  "candle-core",
@@ -8781,7 +9367,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f103c50866b8743da9429b8a581d81a27c2d3a9c4ac7df8f8571c1dd7896eda"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -8922,7 +9508,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rustls",
+ "rustls 0.23.41",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -9405,10 +9991,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9682,11 +10268,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.41",
  "tokio",
 ]
 
@@ -9790,11 +10386,11 @@ dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
  "bytes",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.15",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.10.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -9819,11 +10415,11 @@ dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
  "bytes",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.15",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.10.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -9832,7 +10428,7 @@ dependencies = [
  "socket2 0.6.4",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
  "tower 0.5.3",
  "tower-layer",
@@ -9916,8 +10512,8 @@ dependencies = [
  "bitflags 2.13.0",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "http-body-util",
  "http-range-header",
  "httpdate",
@@ -9943,8 +10539,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
  "tokio",
@@ -10315,7 +10911,7 @@ dependencies = [
  "flate2",
  "log",
  "percent-encoding",
- "rustls",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "socks",
  "ureq-proto",
@@ -10330,7 +10926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
- "http",
+ "http 1.4.2",
  "httparse",
  "log",
 ]
@@ -10436,6 +11032,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -10662,7 +11264,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10944,6 +11546,12 @@ dependencies = [
  "libc",
  "rustix 1.1.4",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xxhash-rust"

--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ For end-to-end walkthroughs — RAG, recommendations, an agent-native wiki, a si
 | Redis | Full | Hashes mapped to SQL rows | [docs/redis/](docs/redis/) |
 | SeekDB | Full | MySQL-wire CRUD, native FULLTEXT FTS, HNSW VECTOR KNN | [docs/seekdb/](docs/seekdb/) |
 | InfluxDB 3 | Read | Time-series measurements over Arrow Flight SQL | [docs/influxdb/](docs/influxdb/) |
+| DynamoDB | Full | Items mapped to SQL rows, scan + filter pushdown | [docs/dynamodb/](docs/dynamodb/) |
 | Apache Iceberg | Read | Schema evolution, partition pruning | [docs/iceberg/](docs/iceberg/) |
 | Lance | Read (job-write) | KNN vector search, BM25 FTS; job destination | [docs/lance/](docs/lance/) |
 | S3 / GCS / Azure | Read | CSV, Parquet, Lance from object stores | [docs/S3_USAGE.md](docs/S3_USAGE.md) |

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2792,4 +2792,51 @@ spec:
             );
         }
     }
+
+    // Guards for the `dynamodb` arm of `register_source`. Both failure modes
+    // trip before any network call, so no live endpoint is needed.
+    mod register_dynamodb_source {
+        use super::*;
+
+        fn dynamodb_source(connection_string: Option<&str>) -> LocalDataSource {
+            LocalDataSource {
+                name: "products".to_string(),
+                source_type: "dynamodb".to_string(),
+                path: None,
+                connection_string: connection_string.map(String::from),
+                options: None,
+                hierarchy_level: HierarchyLevel::default(),
+                access_mode: None,
+                description: None,
+            }
+        }
+
+        #[tokio::test]
+        async fn errors_without_connection_string() {
+            let (mut session_ctx, registry) = new_session_context();
+            let err = register_source(&mut session_ctx, &dynamodb_source(None), &registry)
+                .await
+                .unwrap_err();
+            let msg = format!("{err:?}");
+            assert!(
+                msg.contains("connection_string (endpoint URL) required"),
+                "unexpected error: {msg}"
+            );
+        }
+
+        #[tokio::test]
+        async fn errors_without_options() {
+            let (mut session_ctx, registry) = new_session_context();
+            let source = dynamodb_source(Some("http://localhost:8000"));
+            let err = register_source(&mut session_ctx, &source, &registry)
+                .await
+                .unwrap_err();
+            let msg = format!("{err:?}");
+            assert!(
+                msg.contains("Failed to register DynamoDB 'products'"),
+                "unexpected error: {msg}"
+            );
+            assert!(msg.contains("requires options"), "unexpected error: {msg}");
+        }
+    }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -922,9 +922,15 @@ async fn register_source(
                     source.name
                 )
             })?;
-            register_dynamodb_tables(session_ctx, &source.name, endpoint, source.options.as_ref())
-                .await
-                .with_context(|| format!("Failed to register DynamoDB '{}'", source.name))?;
+            register_dynamodb_tables(
+                session_ctx,
+                &source.name,
+                endpoint,
+                source.options.as_ref(),
+                source.is_read_write(),
+            )
+            .await
+            .with_context(|| format!("Failed to register DynamoDB '{}'", source.name))?;
         }
         "lance" => {
             let path_str = source

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -45,6 +45,7 @@ use skardi::sources::providers::mongo::fts_table_function::register_mongo_fts_ud
 use skardi::sources::providers::sqlx::{register_pg_fts_udtf, register_pg_knn_udtf};
 use skardi::sources::providers::{
     DatasetRegistry,
+    dynamodb::register_dynamodb_tables,
     iceberg::register_iceberg_table,
     influxdb::register_influxdb_tables,
     lance::register_lance_table,
@@ -913,6 +914,17 @@ async fn register_source(
             register_influxdb_tables(session_ctx, &source.name, conn_str, source.options.as_ref())
                 .await
                 .with_context(|| format!("Failed to register InfluxDB '{}'", source.name))?;
+        }
+        "dynamodb" => {
+            let endpoint = source.connection_string.as_deref().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "DynamoDB source '{}': connection_string (endpoint URL) required",
+                    source.name
+                )
+            })?;
+            register_dynamodb_tables(session_ctx, &source.name, endpoint, source.options.as_ref())
+                .await
+                .with_context(|| format!("Failed to register DynamoDB '{}'", source.name))?;
         }
         "lance" => {
             let path_str = source

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -2206,4 +2206,100 @@ options:
             "Duplicate data source name: duplicate_source"
         );
     }
+
+    fn dynamodb_source(
+        name: &str,
+        connection_string: Option<&str>,
+        options: Option<HashMap<String, String>>,
+        access_mode: AccessMode,
+    ) -> DataSource {
+        DataSource {
+            name: name.to_string(),
+            source_type: DataSourceType::Dynamodb,
+            path: PathBuf::new(),
+            connection_string: connection_string.map(String::from),
+            schema: None,
+            options,
+            hierarchy_level: HierarchyLevel::default(),
+            access_mode,
+            enable_cache: false,
+            description: None,
+        }
+    }
+
+    #[test]
+    fn validate_accepts_dynamodb_read_write() {
+        let source = dynamodb_source(
+            "products",
+            Some("http://localhost:8000"),
+            None,
+            AccessMode::ReadWrite,
+        );
+        validate_data_sources(&[source]).expect("dynamodb supports read_write");
+    }
+
+    #[test]
+    fn validate_rejects_dynamodb_without_connection_string() {
+        let source = dynamodb_source("products", None, None, AccessMode::ReadOnly);
+        let err = validate_data_sources(&[source]).unwrap_err();
+        let config_err = err.downcast_ref::<ConfigError>().unwrap();
+        assert!(
+            matches!(
+                config_err,
+                ConfigError::MissingConnectionString { name } if name == "products"
+            ),
+            "got {config_err}"
+        );
+    }
+
+    #[test]
+    fn unsupported_write_mode_error_lists_dynamodb() {
+        let err = ConfigError::UnsupportedWriteMode {
+            name: "events".to_string(),
+            source_type: DataSourceType::Csv,
+        };
+        assert!(err.to_string().contains("'dynamodb'"), "got {err}");
+    }
+
+    #[tokio::test]
+    async fn register_dynamodb_without_connection_string_errors() {
+        let mut session_ctx = SessionContext::new();
+        let source = dynamodb_source("products", None, None, AccessMode::ReadOnly);
+        let err = register_data_sources(&mut session_ctx, &[source])
+            .await
+            .unwrap_err();
+        let config_err = err.downcast_ref::<ConfigError>().unwrap();
+        assert!(
+            matches!(
+                config_err,
+                ConfigError::MissingConnectionString { name } if name == "products"
+            ),
+            "got {config_err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn register_dynamodb_without_options_reports_registration_failure() {
+        let mut session_ctx = SessionContext::new();
+        // `register_dynamodb_tables` fails before any network call when no
+        // options are provided, so this exercises the registration arm and
+        // its error mapping without a live endpoint.
+        let source = dynamodb_source(
+            "products",
+            Some("http://localhost:8000"),
+            None,
+            AccessMode::ReadOnly,
+        );
+        let err = register_data_sources(&mut session_ctx, &[source])
+            .await
+            .unwrap_err();
+        let config_err = err.downcast_ref::<ConfigError>().unwrap();
+        match config_err {
+            ConfigError::DataSourceRegistrationFailed { name, error } => {
+                assert_eq!(name, "products");
+                assert!(error.contains("requires options"), "got {error}");
+            }
+            other => panic!("expected DataSourceRegistrationFailed, got {other}"),
+        }
+    }
 }

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -1291,6 +1291,7 @@ async fn register_data_source(
                 &source.name,
                 connection_string,
                 source.options.as_ref(),
+                source.access_mode.is_read_write(),
             )
             .await
             .map_err(|e| {

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -5,6 +5,7 @@ use datafusion::prelude::*;
 use serde::{Deserialize, Serialize};
 use skardi::jobs::JobDefinition;
 use skardi::pipeline::pipeline::{Pipeline, StandardPipeline};
+use skardi::sources::providers::dynamodb::register_dynamodb_tables;
 use skardi::sources::providers::iceberg::register_iceberg_table;
 use skardi::sources::providers::influxdb::register_influxdb_tables;
 use skardi::sources::providers::lance::register_lance_table;
@@ -209,7 +210,7 @@ pub enum ConfigError {
     S3ObjectStoreRegistrationFailed { name: String, error: String },
 
     #[error(
-        "Data source '{name}' has access_mode 'read_write' but type '{source_type:?}' does not support write operations. Only 'postgres', 'mysql', 'sqlite', 'mongo', 'redis', and 'seekdb' sources support read_write mode."
+        "Data source '{name}' has access_mode 'read_write' but type '{source_type:?}' does not support write operations. Only 'postgres', 'mysql', 'sqlite', 'mongo', 'redis', 'seekdb', and 'dynamodb' sources support read_write mode."
     )]
     UnsupportedWriteMode {
         name: String,
@@ -717,6 +718,7 @@ const WRITABLE_SOURCE_TYPES: &[DataSourceType] = &[
     DataSourceType::Mongo,
     DataSourceType::Redis,
     DataSourceType::Seekdb,
+    DataSourceType::Dynamodb,
 ];
 
 /// Validate data source configurations
@@ -796,7 +798,8 @@ fn validate_data_sources(data_sources: &[DataSource]) -> Result<()> {
                 | DataSourceType::Mongo
                 | DataSourceType::Redis
                 | DataSourceType::Seekdb
-                | DataSourceType::Influxdb,
+                | DataSourceType::Influxdb
+                | DataSourceType::Dynamodb,
                 false,
             ) => {
                 // For database connections, ensure connection string is provided
@@ -969,7 +972,8 @@ async fn register_data_source(
             | DataSourceType::Mongo
             | DataSourceType::Redis
             | DataSourceType::Seekdb
-            | DataSourceType::Influxdb,
+            | DataSourceType::Influxdb
+            | DataSourceType::Dynamodb,
             _,
         ) => {
             // Database sources don't need file path validation
@@ -1260,6 +1264,41 @@ async fn register_data_source(
             .await
             .map_err(|e| {
                 tracing::error!("MongoDB registration failed for '{}': {:?}", source.name, e);
+                ConfigError::DataSourceRegistrationFailed {
+                    name: source.name.clone(),
+                    error: format!("{:?}", e),
+                }
+            })?;
+        }
+        DataSourceType::Dynamodb => {
+            tracing::info!("Registering DynamoDB table: {}", source.name);
+
+            let connection_string = source.connection_string.as_ref().ok_or_else(|| {
+                ConfigError::MissingConnectionString {
+                    name: source.name.clone(),
+                }
+            })?;
+
+            tracing::debug!(
+                "Endpoint for {}: {} (options: {:?})",
+                source.name,
+                connection_string,
+                source.options
+            );
+
+            register_dynamodb_tables(
+                session_ctx,
+                &source.name,
+                connection_string,
+                source.options.as_ref(),
+            )
+            .await
+            .map_err(|e| {
+                tracing::error!(
+                    "DynamoDB registration failed for '{}': {:?}",
+                    source.name,
+                    e
+                );
                 ConfigError::DataSourceRegistrationFailed {
                     name: source.name.clone(),
                     error: format!("{:?}", e),

--- a/crates/server/src/gui.rs
+++ b/crates/server/src/gui.rs
@@ -457,3 +457,13 @@ pub async fn serve_dashboard(State(app_state): State<AppState>) -> axum::respons
         .replace("{{SEMANTICS_CONTENT}}", &semantics_html);
     axum::response::Html(html)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn data_source_type_str_covers_dynamodb() {
+        assert_eq!(data_source_type_str(&DataSourceType::Dynamodb), "dynamodb");
+    }
+}

--- a/crates/server/src/gui.rs
+++ b/crates/server/src/gui.rs
@@ -320,6 +320,7 @@ fn data_source_type_str(t: &DataSourceType) -> &'static str {
         DataSourceType::Seekdb => "seekdb",
         DataSourceType::Influxdb => "influxdb",
         DataSourceType::Documents => "documents",
+        DataSourceType::Dynamodb => "dynamodb",
     }
 }
 

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -5,6 +5,21 @@ use skardi_server::{CliArgs, create_server, load_server_config, telemetry};
 use tracing::{error, info};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
+/// Build the tracing filter from the given `RUST_LOG` value (`None` when the
+/// variable is unset or invalid unicode), defaulting to `info`.
+///
+/// aws_config logs the AWS access key id in plaintext at INFO when resolving
+/// credentials, so cap it at WARN unless RUST_LOG explicitly opts in.
+fn build_env_filter(rust_log: Option<&str>) -> tracing_subscriber::EnvFilter {
+    let mut env_filter = rust_log
+        .and_then(|v| tracing_subscriber::EnvFilter::try_new(v).ok())
+        .unwrap_or_else(|| "info".into());
+    if !rust_log.is_some_and(|v| v.contains("aws_config")) {
+        env_filter = env_filter.add_directive("aws_config=warn".parse().expect("valid directive"));
+    }
+    env_filter
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialise OpenTelemetry only when OTLP_ENDPOINT is explicitly set.
@@ -18,15 +33,8 @@ async fn main() -> Result<()> {
     };
 
     // Initialize tracing subscriber: fmt to stdout, plus OTel layer when enabled.
-    // aws_config logs the AWS access key id in plaintext at INFO when resolving
-    // credentials, so cap it at WARN unless RUST_LOG explicitly opts in.
-    let mut env_filter =
-        tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into());
-    if !std::env::var("RUST_LOG").is_ok_and(|v| v.contains("aws_config")) {
-        env_filter = env_filter.add_directive("aws_config=warn".parse().expect("valid directive"));
-    }
     tracing_subscriber::registry()
-        .with(env_filter)
+        .with(build_env_filter(std::env::var("RUST_LOG").ok().as_deref()))
         .with(
             tracing_subscriber::fmt::layer()
                 .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE),
@@ -88,4 +96,37 @@ async fn main() -> Result<()> {
 
     info!("👋 Skardi server shutting down");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_filter_defaults_to_info_and_caps_aws_config() {
+        let filter = build_env_filter(None).to_string();
+        assert!(filter.contains("info"), "got {filter}");
+        assert!(filter.contains("aws_config=warn"), "got {filter}");
+    }
+
+    #[test]
+    fn env_filter_caps_aws_config_for_unrelated_rust_log() {
+        let filter = build_env_filter(Some("debug")).to_string();
+        assert!(filter.contains("debug"), "got {filter}");
+        assert!(filter.contains("aws_config=warn"), "got {filter}");
+    }
+
+    #[test]
+    fn env_filter_honors_explicit_aws_config_opt_in() {
+        let filter = build_env_filter(Some("info,aws_config=debug")).to_string();
+        assert!(filter.contains("aws_config=debug"), "got {filter}");
+        assert!(!filter.contains("aws_config=warn"), "got {filter}");
+    }
+
+    #[test]
+    fn env_filter_falls_back_to_info_on_invalid_rust_log() {
+        let filter = build_env_filter(Some("not a [valid directive")).to_string();
+        assert!(filter.contains("info"), "got {filter}");
+        assert!(filter.contains("aws_config=warn"), "got {filter}");
+    }
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -18,10 +18,15 @@ async fn main() -> Result<()> {
     };
 
     // Initialize tracing subscriber: fmt to stdout, plus OTel layer when enabled.
+    // aws_config logs the AWS access key id in plaintext at INFO when resolving
+    // credentials, so cap it at WARN unless RUST_LOG explicitly opts in.
+    let mut env_filter =
+        tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into());
+    if !std::env::var("RUST_LOG").is_ok_and(|v| v.contains("aws_config")) {
+        env_filter = env_filter.add_directive("aws_config=warn".parse().expect("valid directive"));
+    }
     tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
-        )
+        .with(env_filter)
         .with(
             tracing_subscriber::fmt::layer()
                 .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE),

--- a/crates/server/src/pipeline_handlers.rs
+++ b/crates/server/src/pipeline_handlers.rs
@@ -411,6 +411,7 @@ pub async fn get_data_sources(
             DataSourceType::Seekdb => "seekdb",
             DataSourceType::Influxdb => "influxdb",
             DataSourceType::Documents => "documents",
+            DataSourceType::Dynamodb => "dynamodb",
         };
 
         // Determine path or URL based on source type
@@ -426,7 +427,8 @@ pub async fn get_data_sources(
             | DataSourceType::Mongo
             | DataSourceType::Redis
             | DataSourceType::Seekdb
-            | DataSourceType::Influxdb => None,
+            | DataSourceType::Influxdb
+            | DataSourceType::Dynamodb => None,
         };
 
         let url = match data_source.source_type {
@@ -435,7 +437,8 @@ pub async fn get_data_sources(
             | DataSourceType::Mongo
             | DataSourceType::Redis
             | DataSourceType::Seekdb
-            | DataSourceType::Influxdb => {
+            | DataSourceType::Influxdb
+            | DataSourceType::Dynamodb => {
                 // For database sources, return the connection string as-is
                 // (credentials are not stored in connection strings, only in env vars)
                 data_source.connection_string.clone()

--- a/crates/server/src/pipeline_handlers.rs
+++ b/crates/server/src/pipeline_handlers.rs
@@ -1592,4 +1592,34 @@ spec:
             panic!("Expected second row to be an object");
         }
     }
+
+    #[tokio::test]
+    async fn get_data_sources_reports_dynamodb_as_url_source() {
+        let app_state = create_test_app_state().await;
+        {
+            let mut config = app_state.config.write().unwrap();
+            config.data_sources.push(DataSource {
+                name: "products".to_string(),
+                source_type: DataSourceType::Dynamodb,
+                path: PathBuf::new(),
+                connection_string: Some("http://localhost:8000".to_string()),
+                schema: None,
+                options: None,
+                hierarchy_level: Default::default(),
+                access_mode: AccessMode::ReadWrite,
+                enable_cache: false,
+                description: None,
+            });
+        }
+
+        let Json(body) = get_data_sources(State(app_state)).await.unwrap();
+        let data = body["data"].as_array().unwrap();
+        let entry = data
+            .iter()
+            .find(|d| d["name"] == "products")
+            .expect("dynamodb source should be listed");
+        assert_eq!(entry["type"], "dynamodb");
+        assert!(entry["path"].is_null(), "db sources expose no path");
+        assert_eq!(entry["url"], "http://localhost:8000");
+    }
 }

--- a/crates/skardi/Cargo.toml
+++ b/crates/skardi/Cargo.toml
@@ -57,6 +57,8 @@ candle-transformers = { version = "0.8", optional = true }
 tokenizers = { version = "0.21", default-features = false, features = ["onig"], optional = true }
 text-splitter = { version = "0.30", features = ["markdown"], optional = true }
 # sources
+aws-config = { version = "1", features = ["behavior-version-latest"] }
+aws-sdk-dynamodb = "1"
 datafusion-federation = { workspace = true }
 datafusion-table-providers = { workspace = true }
 derivative = "2.2.0"

--- a/crates/skardi/src/jobs/executor.rs
+++ b/crates/skardi/src/jobs/executor.rs
@@ -341,7 +341,8 @@ impl JobExecutor {
             Some(source_type @ DataSourceType::Mongo)
             | Some(source_type @ DataSourceType::Redis)
             | Some(source_type @ DataSourceType::Seekdb)
-            | Some(source_type @ DataSourceType::Influxdb) => {
+            | Some(source_type @ DataSourceType::Influxdb)
+            | Some(source_type @ DataSourceType::Dynamodb) => {
                 Err(JobSubmitError::NonTransactionalDestination {
                     table: dest.table.clone(),
                     source_type: source_type.clone(),

--- a/crates/skardi/src/jobs/executor.rs
+++ b/crates/skardi/src/jobs/executor.rs
@@ -871,8 +871,7 @@ spec:
         );
     }
 
-    #[tokio::test]
-    async fn submit_rejects_influxdb_destination_as_non_transactional() {
+    async fn assert_submit_rejects_non_transactional_destination(source_type: DataSourceType) {
         use std::io::Write;
 
         let ctx = Arc::new(SessionContext::new());
@@ -909,10 +908,11 @@ spec:
                 .unwrap(),
         );
 
-        // Mark `cpu` as InfluxDB-typed so the destination resolver classifies
-        // it as a non-transactional (read-only) backend and rejects it.
+        // Mark `cpu` with the given source type so the destination resolver
+        // classifies it as a non-transactional (read-only) backend and
+        // rejects it.
         let mut types = HashMap::new();
-        types.insert("cpu".to_string(), DataSourceType::Influxdb);
+        types.insert("cpu".to_string(), source_type);
         let exec = JobExecutor::new(map, store, ctx, types, HashMap::new());
 
         let err = exec.submit("ingest", HashMap::new()).await.unwrap_err();
@@ -920,5 +920,15 @@ spec:
             matches!(err, JobSubmitError::NonTransactionalDestination { .. }),
             "got {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn submit_rejects_influxdb_destination_as_non_transactional() {
+        assert_submit_rejects_non_transactional_destination(DataSourceType::Influxdb).await;
+    }
+
+    #[tokio::test]
+    async fn submit_rejects_dynamodb_destination_as_non_transactional() {
+        assert_submit_rejects_non_transactional_destination(DataSourceType::Dynamodb).await;
     }
 }

--- a/crates/skardi/src/sources/data_source_type.rs
+++ b/crates/skardi/src/sources/data_source_type.rs
@@ -17,6 +17,7 @@ pub enum DataSourceType {
     Seekdb,
     Influxdb,
     Documents,
+    Dynamodb,
 }
 
 impl DataSourceType {
@@ -34,6 +35,7 @@ impl DataSourceType {
             Self::Seekdb => "seekdb",
             Self::Influxdb => "influxdb",
             Self::Documents => "documents",
+            Self::Dynamodb => "dynamodb",
         }
     }
 }

--- a/crates/skardi/src/sources/data_source_type.rs
+++ b/crates/skardi/src/sources/data_source_type.rs
@@ -56,4 +56,11 @@ mod tests {
         assert_eq!(t, DataSourceType::Documents);
         assert_eq!(t.as_str(), "documents");
     }
+
+    #[test]
+    fn dynamodb_variant_roundtrips() {
+        let t: DataSourceType = serde_yaml::from_str("dynamodb").unwrap();
+        assert_eq!(t, DataSourceType::Dynamodb);
+        assert_eq!(t.as_str(), "dynamodb");
+    }
 }

--- a/crates/skardi/src/sources/providers/dynamodb.rs
+++ b/crates/skardi/src/sources/providers/dynamodb.rs
@@ -134,20 +134,7 @@ impl DynamoTableProvider {
             );
         }
 
-        // Merge attributes across the sampled items; first observation of an
-        // attribute fixes its type. The SDK item maps iterate in arbitrary
-        // order, so sort by name afterwards to give a deterministic non-key
-        // column order across runs (keys are placed explicitly downstream).
-        let mut attrs: Vec<(String, DataType)> = Vec::new();
-        let mut seen: HashSet<String> = HashSet::new();
-        for item in items {
-            for (key, value) in item.iter() {
-                if seen.insert(key.clone()) {
-                    attrs.push((key.clone(), attribute_value_to_arrow_type(value)));
-                }
-            }
-        }
-        attrs.sort_by(|(a, _), (b, _)| a.cmp(b));
+        let attrs = merge_sampled_attributes(items);
 
         Ok(build_schema_fields(partition_key, sort_key, &attrs))
     }
@@ -156,6 +143,24 @@ impl DynamoTableProvider {
     fn plan_read(&self, pushable: &[Expr]) -> DFResult<DynamoRead> {
         classify_read(&self.partition_key, self.sort_key.as_deref(), pushable)
     }
+}
+
+/// Merge attributes across sampled items; the first observation of an
+/// attribute fixes its type. The SDK item maps iterate in arbitrary order, so
+/// the merged list is sorted by name to give a deterministic non-key column
+/// order across runs (keys are placed explicitly downstream).
+fn merge_sampled_attributes(items: &[HashMap<String, AttributeValue>]) -> Vec<(String, DataType)> {
+    let mut attrs: Vec<(String, DataType)> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for item in items {
+        for (key, value) in item.iter() {
+            if seen.insert(key.clone()) {
+                attrs.push((key.clone(), attribute_value_to_arrow_type(value)));
+            }
+        }
+    }
+    attrs.sort_by(|(a, _), (b, _)| a.cmp(b));
+    attrs
 }
 
 /// Build an ordered field list: key attributes first (non-nullable, in key
@@ -1962,7 +1967,9 @@ mod tests {
     use super::*;
     use arrow::array::Array;
     use datafusion::common::ScalarValue;
+    use datafusion::logical_expr::dml::InsertOp;
     use datafusion::logical_expr::{BinaryExpr, col, lit};
+    use datafusion::physical_plan::empty::EmptyExec;
 
     fn n(s: &str) -> AttributeValue {
         AttributeValue::N(s.to_string())
@@ -2096,6 +2103,19 @@ mod tests {
         assert!(expr.contains(", "));
         assert_eq!(names.len(), 2);
         assert_eq!(values.len(), 2);
+    }
+
+    #[test]
+    fn update_expression_placeholders_cannot_collide_with_pk_guard() {
+        // UPDATE execution reserves "#pk" for its attribute_exists() resurrect
+        // guard, so SET placeholders must stay in the #s/:s namespace — even
+        // for a column literally named "pk".
+        let sets = vec![("pk".to_string(), n("1")), ("note".to_string(), n("2"))];
+        let (expr, names, values) = build_update_expression(&sets);
+        assert_eq!(expr, "SET #s0 = :s0, #s1 = :s1");
+        assert!(!names.contains_key("#pk"));
+        assert!(names.keys().all(|k| k.starts_with("#s")));
+        assert!(values.keys().all(|k| k.starts_with(":s")));
     }
 
     #[test]
@@ -2361,6 +2381,30 @@ mod tests {
         assert_eq!(schema.field(0).data_type(), &DataType::Utf8);
     }
 
+    #[test]
+    fn sampled_attribute_merge_is_sorted_and_first_type_wins() {
+        let items = vec![
+            HashMap::from([
+                ("zeta".to_string(), AttributeValue::S("x".into())),
+                ("alpha".to_string(), n("1")),
+            ]),
+            HashMap::from([
+                // Repeats `alpha` with a different type: the first observation
+                // fixed it, so this one must not flip the column type.
+                ("alpha".to_string(), AttributeValue::S("later".into())),
+                ("mid".to_string(), AttributeValue::Bool(true)),
+            ]),
+        ];
+        let attrs = merge_sampled_attributes(&items);
+        let names: Vec<&str> = attrs.iter().map(|(name, _)| name.as_str()).collect();
+        // HashMap iteration order is arbitrary, so the merged list must come
+        // back sorted for the inferred schema to be identical across runs.
+        assert_eq!(names, vec!["alpha", "mid", "zeta"]);
+        assert_eq!(attrs[0].1, DataType::Float64, "first-seen type wins");
+        assert_eq!(attrs[1].1, DataType::Boolean);
+        assert_eq!(attrs[2].1, DataType::Utf8);
+    }
+
     // ─── Item ⇄ RecordBatch conversion ──────────────────────────────────────
 
     #[test]
@@ -2456,11 +2500,38 @@ mod tests {
     }
 
     #[test]
-    fn av_to_string_formats_scalar_variants() {
-        assert_eq!(av_to_string(&AttributeValue::S("hi".into())), "hi");
-        assert_eq!(av_to_string(&n("9.99")), "9.99");
-        assert_eq!(av_to_string(&AttributeValue::Bool(true)), "true");
-        assert_eq!(av_to_string(&AttributeValue::Null(true)), "");
+    fn av_to_string_formats_scalars_and_maps_null_to_none() {
+        assert_eq!(
+            av_to_string(&AttributeValue::S("hi".into())).as_deref(),
+            Some("hi")
+        );
+        assert_eq!(av_to_string(&n("9.99")).as_deref(), Some("9.99"));
+        assert_eq!(
+            av_to_string(&AttributeValue::Bool(true)).as_deref(),
+            Some("true")
+        );
+        // An explicit DynamoDB NULL is None (an Arrow null), not "".
+        assert_eq!(av_to_string(&AttributeValue::Null(true)), None);
+    }
+
+    #[test]
+    fn explicit_null_attribute_is_arrow_null_in_string_columns() {
+        // `UPDATE ... SET col = NULL` stores AttributeValue::Null; reading it
+        // back must yield a NULL cell, not the empty string "".
+        let values = vec![
+            Some(AttributeValue::S("a".into())),
+            Some(AttributeValue::Null(true)),
+        ];
+        let arr = attribute_values_to_arrow_array(&values, &DataType::Utf8);
+        let strs = arr.as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(strs.value(0), "a");
+        assert!(strs.is_null(1), "explicit NULL reads as NULL, not \"\"");
+
+        // The fallback arm (unsupported column types render as strings)
+        // applies the same rule.
+        let arr = attribute_values_to_arrow_array(&values, &DataType::Date32);
+        assert!(!arr.is_null(0));
+        assert!(arr.is_null(1));
     }
 
     // ─── Projection / key-condition expression builders ─────────────────────
@@ -2594,6 +2665,20 @@ mod tests {
     }
 
     #[test]
+    fn count_plan_properties_describe_single_count_row() {
+        // Must stay in lockstep with count_batch()/count_schema(): one bounded,
+        // final partition whose schema is the `{count}` row.
+        let props = count_plan_properties();
+        assert_eq!(
+            props.equivalence_properties().schema().as_ref(),
+            count_schema().as_ref()
+        );
+        assert_eq!(props.output_partitioning().partition_count(), 1);
+        assert_eq!(props.emission_type, EmissionType::Final);
+        assert_eq!(props.boundedness, Boundedness::Bounded);
+    }
+
+    #[test]
     fn parse_columns_option_accepts_int_and_bool_aliases() {
         let schema =
             parse_columns_option("qty:integer, active:boolean", "id", None).expect("valid columns");
@@ -2706,6 +2791,29 @@ mod tests {
             .await
             .expect_err("updating the key column must be rejected");
         assert!(err.to_string().contains("immutable"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn insert_plan_reports_count_output_not_input_schema() {
+        // DynamoInsertExec's execute() streams a single `{count}` batch, so its
+        // advertised plan properties must describe that shape — not the input's
+        // schema (which is what `input.properties()` would leak).
+        let provider = test_provider("id", None, true).await;
+        let input: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(provider.schema()));
+        let ctx = SessionContext::new();
+        let plan = provider
+            .insert_into(&ctx.state(), input, InsertOp::Append)
+            .await
+            .expect("insert plan");
+        assert_eq!(plan.schema().as_ref(), count_schema().as_ref());
+        assert_eq!(plan.properties().output_partitioning().partition_count(), 1);
+
+        // Optimizer passes rebuild nodes via with_new_children; the count
+        // shape must survive the rewrite.
+        let rebuilt = plan
+            .with_new_children(vec![Arc::new(EmptyExec::new(provider.schema()))])
+            .expect("with_new_children");
+        assert_eq!(rebuilt.schema().as_ref(), count_schema().as_ref());
     }
 
     // ─── Integration tests (require DynamoDB Local) ─────────────────────────

--- a/crates/skardi/src/sources/providers/dynamodb.rs
+++ b/crates/skardi/src/sources/providers/dynamodb.rs
@@ -135,8 +135,9 @@ impl DynamoTableProvider {
         }
 
         // Merge attributes across the sampled items; first observation of an
-        // attribute fixes its type. Ordering is stable across environments
-        // because it follows first-seen order over a fixed-size sample.
+        // attribute fixes its type. The SDK item maps iterate in arbitrary
+        // order, so sort by name afterwards to give a deterministic non-key
+        // column order across runs (keys are placed explicitly downstream).
         let mut attrs: Vec<(String, DataType)> = Vec::new();
         let mut seen: HashSet<String> = HashSet::new();
         for item in items {
@@ -146,6 +147,7 @@ impl DynamoTableProvider {
                 }
             }
         }
+        attrs.sort_by(|(a, _), (b, _)| a.cmp(b));
 
         Ok(build_schema_fields(partition_key, sort_key, &attrs))
     }
@@ -326,6 +328,7 @@ impl TableProvider for DynamoTableProvider {
             client: self.client.clone(),
             table_name: self.table_name.clone(),
             schema: self.schema.clone(),
+            properties: count_plan_properties(),
             partition_key: self.partition_key.clone(),
             upsert,
         }))
@@ -573,7 +576,7 @@ pub(crate) fn attribute_values_to_arrow_array(
         DataType::Utf8 => {
             let arr: StringArray = values
                 .iter()
-                .map(|v| v.as_ref().map(av_to_string))
+                .map(|v| v.as_ref().and_then(av_to_string))
                 .collect();
             Arc::new(arr)
         }
@@ -608,20 +611,24 @@ pub(crate) fn attribute_values_to_arrow_array(
         _ => {
             let arr: StringArray = values
                 .iter()
-                .map(|v| v.as_ref().map(av_to_string))
+                .map(|v| v.as_ref().and_then(av_to_string))
                 .collect();
             Arc::new(arr)
         }
     }
 }
 
-fn av_to_string(v: &AttributeValue) -> String {
+/// Render a scalar attribute as the string form for a Utf8 column. An explicit
+/// DynamoDB `NULL` maps to `None` (Arrow null) rather than an empty string, so a
+/// SQL NULL written via `UPDATE ... SET col = NULL` round-trips as NULL instead
+/// of `""`.
+fn av_to_string(v: &AttributeValue) -> Option<String> {
     match v {
-        AttributeValue::S(s) => s.clone(),
-        AttributeValue::N(n) => n.clone(),
-        AttributeValue::Bool(b) => b.to_string(),
-        AttributeValue::Null(_) => String::new(),
-        other => format!("{other:?}"),
+        AttributeValue::S(s) => Some(s.clone()),
+        AttributeValue::N(n) => Some(n.clone()),
+        AttributeValue::Bool(b) => Some(b.to_string()),
+        AttributeValue::Null(_) => None,
+        other => Some(format!("{other:?}")),
     }
 }
 
@@ -1398,7 +1405,11 @@ struct DynamoInsertExec {
     input: Arc<dyn ExecutionPlan>,
     client: Client,
     table_name: String,
+    /// Target-table schema, used to shape input batches into items to write.
     schema: SchemaRef,
+    /// Properties of this node's own output (`{ count }`), distinct from
+    /// `input`'s schema — `execute` streams a count, not the inserted rows.
+    properties: PlanProperties,
     partition_key: String,
     /// True for INSERT OVERWRITE/REPLACE (upsert via `BatchWriteItem`); false
     /// for plain INSERT (Append), which uses a conditional `PutItem` so a
@@ -1485,7 +1496,7 @@ impl ExecutionPlan for DynamoInsertExec {
         self
     }
     fn properties(&self) -> &PlanProperties {
-        self.input.properties()
+        &self.properties
     }
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
         vec![&self.input]
@@ -1499,6 +1510,7 @@ impl ExecutionPlan for DynamoInsertExec {
             client: self.client.clone(),
             table_name: self.table_name.clone(),
             schema: self.schema.clone(),
+            properties: self.properties.clone(),
             partition_key: self.partition_key.clone(),
             upsert: self.upsert,
         }))
@@ -1581,18 +1593,11 @@ struct DynamoDmlExec {
 
 impl DynamoDmlExec {
     fn new(handle: DynamoHandle, op: DynamoDmlOp) -> Self {
-        let schema = count_schema();
-        let properties = PlanProperties::new(
-            EquivalenceProperties::new(schema.clone()),
-            Partitioning::UnknownPartitioning(1),
-            EmissionType::Final,
-            Boundedness::Bounded,
-        );
         Self {
             handle,
             op,
-            schema,
-            properties,
+            schema: count_schema(),
+            properties: count_plan_properties(),
         }
     }
 }
@@ -1652,23 +1657,43 @@ impl ExecutionPlan for DynamoDmlExec {
                         .matching_keys(&plan)
                         .await
                         .map_err(|e| DataFusionError::External(e.into()))?;
-                    let (expr, names, values) = build_update_expression(&sets);
+                    let (expr, mut names, values) = build_update_expression(&sets);
+                    // Guard against resurrecting a row deleted between key
+                    // resolution and this update: DynamoDB's UpdateItem creates
+                    // the item if absent, so without a condition a concurrently
+                    // deleted row would come back as key attributes plus the SET
+                    // fields. `attribute_exists` on the partition key (which can
+                    // never be a SET target, so `#pk` won't collide with `#s*`)
+                    // makes the update a no-op for a vanished row.
+                    names.insert("#pk".to_string(), handle.partition_key.clone());
                     let mut n = 0u64;
                     for key in keys {
-                        handle
+                        let result = handle
                             .client
                             .update_item()
                             .table_name(&handle.table_name)
                             .set_key(Some(key))
                             .update_expression(&expr)
+                            .condition_expression("attribute_exists(#pk)")
                             .set_expression_attribute_names(Some(names.clone()))
                             .set_expression_attribute_values(Some(values.clone()))
                             .send()
-                            .await
-                            .map_err(|e| {
-                                DataFusionError::Execution(format!("DynamoDB update failed: {e}"))
-                            })?;
-                        n += 1;
+                            .await;
+                        match result {
+                            Ok(_) => n += 1,
+                            // Row disappeared after matching_keys(); skip it
+                            // rather than recreating a partial item or failing
+                            // the whole statement.
+                            Err(e)
+                                if e.as_service_error().is_some_and(|se| {
+                                    se.is_conditional_check_failed_exception()
+                                }) => {}
+                            Err(e) => {
+                                return Err(DataFusionError::Execution(format!(
+                                    "DynamoDB update failed: {e}"
+                                )));
+                            }
+                        }
                     }
                     n
                 }
@@ -1710,6 +1735,18 @@ fn count_schema() -> SchemaRef {
         DataType::UInt64,
         false,
     )]))
+}
+
+/// `PlanProperties` for an insert/DML leaf whose execution emits a single
+/// `{ count }` row. Kept in sync with the schema returned by `execute` so
+/// planning/introspection see the real output shape, not the input's.
+fn count_plan_properties() -> PlanProperties {
+    PlanProperties::new(
+        EquivalenceProperties::new(count_schema()),
+        Partitioning::UnknownPartitioning(1),
+        EmissionType::Final,
+        Boundedness::Bounded,
+    )
 }
 
 fn count_batch(count: u64) -> DFResult<RecordBatch> {
@@ -2382,13 +2419,19 @@ mod tests {
         assert_eq!(items.len(), 2);
         assert!(matches!(items[0].get("id"), Some(AttributeValue::S(s)) if s == "A"));
         assert!(matches!(items[0].get("qty"), Some(AttributeValue::N(n)) if n == "7"));
-        assert!(matches!(items[0].get("active"), Some(AttributeValue::Bool(true))));
+        assert!(matches!(
+            items[0].get("active"),
+            Some(AttributeValue::Bool(true))
+        ));
         // Row 1 had a NULL qty → the attribute is absent, not a typed NULL.
         assert!(
             !items[1].contains_key("qty"),
             "NULL cell omits the attribute"
         );
-        assert!(matches!(items[1].get("active"), Some(AttributeValue::Bool(false))));
+        assert!(matches!(
+            items[1].get("active"),
+            Some(AttributeValue::Bool(false))
+        ));
     }
 
     #[test]
@@ -2406,7 +2449,10 @@ mod tests {
         let bools = arr.as_any().downcast_ref::<BooleanArray>().unwrap();
         assert!(bools.value(0));
         // A non-bool attribute in a Boolean column coerces to NULL, never `true`.
-        assert!(bools.is_null(1), "non-bool attribute is NULL in a Boolean column");
+        assert!(
+            bools.is_null(1),
+            "non-bool attribute is NULL in a Boolean column"
+        );
     }
 
     #[test]
@@ -2549,8 +2595,8 @@ mod tests {
 
     #[test]
     fn parse_columns_option_accepts_int_and_bool_aliases() {
-        let schema = parse_columns_option("qty:integer, active:boolean", "id", None)
-            .expect("valid columns");
+        let schema =
+            parse_columns_option("qty:integer, active:boolean", "id", None).expect("valid columns");
         assert_eq!(schema.field(1).data_type(), &DataType::Int64);
         assert_eq!(schema.field(2).data_type(), &DataType::Boolean);
     }
@@ -2604,7 +2650,9 @@ mod tests {
         let handle = test_provider("pk", Some("sk"), false).await.clone_handle();
         // Composite-key table but the item lacks the sort key.
         let item = HashMap::from([("pk".to_string(), AttributeValue::S("A".into()))]);
-        let err = handle.key_of(&item).expect_err("missing sort key must error");
+        let err = handle
+            .key_of(&item)
+            .expect_err("missing sort key must error");
         assert!(err.to_string().contains("sort key"), "got: {err}");
     }
 

--- a/crates/skardi/src/sources/providers/dynamodb.rs
+++ b/crates/skardi/src/sources/providers/dynamodb.rs
@@ -1923,6 +1923,7 @@ fn parse_columns_option(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow::array::Array;
     use datafusion::common::ScalarValue;
     use datafusion::logical_expr::{BinaryExpr, col, lit};
 
@@ -2288,6 +2289,375 @@ mod tests {
             .unwrap_err();
             assert!(err.to_string().contains("'table'"));
         });
+    }
+
+    // ─── Schema shaping (build_schema_fields) ───────────────────────────────
+
+    #[test]
+    fn schema_fields_put_keys_first_and_nullable_rest() {
+        // Attributes are given out of order and include the keys; the builder must
+        // emit partition key, then sort key (both non-nullable), then the rest in
+        // declared order (nullable), deduping any attribute that repeats a key.
+        let attrs = vec![
+            ("name".to_string(), DataType::Utf8),
+            ("sk".to_string(), DataType::Int64),
+            ("price".to_string(), DataType::Float64),
+            ("pk".to_string(), DataType::Utf8),
+        ];
+        let schema = build_schema_fields("pk", Some("sk"), &attrs);
+        let names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+        assert_eq!(names, vec!["pk", "sk", "name", "price"]);
+        assert!(!schema.field(0).is_nullable(), "partition key non-nullable");
+        assert!(!schema.field(1).is_nullable(), "sort key non-nullable");
+        assert!(schema.field(2).is_nullable(), "non-key column nullable");
+        // The sort key's declared type is honored even though it came from attrs.
+        assert_eq!(schema.field(1).data_type(), &DataType::Int64);
+    }
+
+    #[test]
+    fn schema_fields_default_key_type_is_utf8_when_unsampled() {
+        // A key never seen among the sampled attributes falls back to Utf8 rather
+        // than being dropped (an empty table still needs its key columns).
+        let schema = build_schema_fields("pk", None, &[]);
+        assert_eq!(schema.fields().len(), 1);
+        assert_eq!(schema.field(0).name(), "pk");
+        assert_eq!(schema.field(0).data_type(), &DataType::Utf8);
+    }
+
+    // ─── Item ⇄ RecordBatch conversion ──────────────────────────────────────
+
+    #[test]
+    fn items_to_batch_fills_missing_attributes_with_null() {
+        let schema: SchemaRef = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("price", DataType::Float64, true),
+        ]));
+        // Second item omits `price` entirely — it must become a NULL cell, not a
+        // dropped row or a shifted column.
+        let items = vec![
+            HashMap::from([
+                ("id".to_string(), AttributeValue::S("A".into())),
+                ("price".to_string(), n("9.5")),
+            ]),
+            HashMap::from([("id".to_string(), AttributeValue::S("B".into()))]),
+        ];
+        let batch = items_to_batch(items, &schema).expect("batch");
+        assert_eq!(batch.num_rows(), 2);
+        let ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let prices = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        assert_eq!(ids.value(0), "A");
+        assert_eq!(ids.value(1), "B");
+        assert_eq!(prices.value(0), 9.5);
+        assert!(prices.is_null(1), "missing attribute reads as NULL");
+    }
+
+    #[test]
+    fn record_batch_to_items_round_trips_and_omits_nulls() {
+        // A batch with a NULL cell must produce an item that simply lacks that
+        // attribute (DynamoDB has no typed NULL columns), while typed cells map
+        // back to the matching AttributeValue variant.
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("qty", DataType::Int64, true),
+            Field::new("active", DataType::Boolean, true),
+        ]);
+        let ids: StringArray = vec![Some("A"), Some("B")].into_iter().collect();
+        let qty: Int64Array = vec![Some(7i64), None].into_iter().collect();
+        let active: BooleanArray = vec![Some(true), Some(false)].into_iter().collect();
+        let batch = RecordBatch::try_new(
+            Arc::new(schema.clone()),
+            vec![Arc::new(ids), Arc::new(qty), Arc::new(active)],
+        )
+        .unwrap();
+
+        let items = record_batch_to_items(&batch, &schema).expect("items");
+        assert_eq!(items.len(), 2);
+        assert!(matches!(items[0].get("id"), Some(AttributeValue::S(s)) if s == "A"));
+        assert!(matches!(items[0].get("qty"), Some(AttributeValue::N(n)) if n == "7"));
+        assert!(matches!(items[0].get("active"), Some(AttributeValue::Bool(true))));
+        // Row 1 had a NULL qty → the attribute is absent, not a typed NULL.
+        assert!(
+            !items[1].contains_key("qty"),
+            "NULL cell omits the attribute"
+        );
+        assert!(matches!(items[1].get("active"), Some(AttributeValue::Bool(false))));
+    }
+
+    #[test]
+    fn arrow_array_builders_cover_numeric_and_bool_types() {
+        // Only the Utf8 path was covered before; exercise the Int64/Float64/Boolean
+        // arms (including a NULL passthrough) so a regression in any is caught.
+        let int_vals = vec![Some(n("3")), None];
+        let arr = attribute_values_to_arrow_array(&int_vals, &DataType::Int64);
+        let ints = arr.as_any().downcast_ref::<Int64Array>().unwrap();
+        assert_eq!(ints.value(0), 3);
+        assert!(ints.is_null(1));
+
+        let bool_vals = vec![Some(AttributeValue::Bool(true)), Some(n("1"))];
+        let arr = attribute_values_to_arrow_array(&bool_vals, &DataType::Boolean);
+        let bools = arr.as_any().downcast_ref::<BooleanArray>().unwrap();
+        assert!(bools.value(0));
+        // A non-bool attribute in a Boolean column coerces to NULL, never `true`.
+        assert!(bools.is_null(1), "non-bool attribute is NULL in a Boolean column");
+    }
+
+    #[test]
+    fn av_to_string_formats_scalar_variants() {
+        assert_eq!(av_to_string(&AttributeValue::S("hi".into())), "hi");
+        assert_eq!(av_to_string(&n("9.99")), "9.99");
+        assert_eq!(av_to_string(&AttributeValue::Bool(true)), "true");
+        assert_eq!(av_to_string(&AttributeValue::Null(true)), "");
+    }
+
+    // ─── Projection / key-condition expression builders ─────────────────────
+
+    #[test]
+    fn projection_expression_names_every_field() {
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("price", DataType::Float64, true),
+        ]);
+        let (expr, names) = build_projection_expression(&schema);
+        // Uses the #p namespace so it can share a request with #n/#k/:v bindings.
+        assert_eq!(expr, "#p0, #p1");
+        assert_eq!(names.len(), 2);
+        assert_eq!(names.get("#p0").map(String::as_str), Some("id"));
+        assert_eq!(names.get("#p1").map(String::as_str), Some("price"));
+    }
+
+    #[test]
+    fn key_condition_uses_k_namespace_and_folds_sort_cond() {
+        // Partition-only.
+        let f = build_key_condition("pk", AttributeValue::S("A".into()), "sk", None);
+        assert_eq!(f.expression, "#k0 = :k0");
+        assert_eq!(f.names.get("#k0").map(String::as_str), Some("pk"));
+        assert!(f.values.contains_key(":k0"));
+
+        // Partition + sort range → second clause on the #k1/:k1 pair.
+        let f = build_key_condition(
+            "pk",
+            AttributeValue::S("A".into()),
+            "sk",
+            Some((Operator::Gt, n("5"))),
+        );
+        assert_eq!(f.expression, "#k0 = :k0 AND #k1 > :k1");
+        assert_eq!(f.names.get("#k1").map(String::as_str), Some("sk"));
+        assert!(f.values.contains_key(":k1"));
+    }
+
+    // ─── Operator / normalization helpers ───────────────────────────────────
+
+    #[test]
+    fn normalize_binary_flips_left_literal_and_rejects_unusable() {
+        // `5 < price` normalizes to `(price, >, 5)` with the column on the left.
+        let expr = Expr::BinaryExpr(BinaryExpr::new(
+            Box::new(lit(5i64)),
+            Operator::Lt,
+            Box::new(col("price")),
+        ));
+        let (col_name, op, _) = normalize_binary(&expr).expect("normalizable");
+        assert_eq!(col_name, "price");
+        assert_eq!(op, Operator::Gt);
+
+        // Column-to-column has no literal → None.
+        assert!(normalize_binary(&col("a").eq(col("b"))).is_none());
+        // Pushable-shaped but with an inconvertible literal → None (not a panic).
+        let ts = Expr::BinaryExpr(BinaryExpr::new(
+            Box::new(col("a")),
+            Operator::Eq,
+            Box::new(Expr::Literal(
+                ScalarValue::TimestampNanosecond(Some(0), None),
+                None,
+            )),
+        ));
+        assert!(normalize_binary(&ts).is_none());
+    }
+
+    #[test]
+    fn flip_operator_is_a_mirror() {
+        assert_eq!(flip_operator(Operator::Lt), Operator::Gt);
+        assert_eq!(flip_operator(Operator::LtEq), Operator::GtEq);
+        assert_eq!(flip_operator(Operator::Gt), Operator::Lt);
+        assert_eq!(flip_operator(Operator::GtEq), Operator::LtEq);
+        // Symmetric comparisons are unchanged.
+        assert_eq!(flip_operator(Operator::Eq), Operator::Eq);
+        assert_eq!(flip_operator(Operator::NotEq), Operator::NotEq);
+    }
+
+    #[test]
+    fn is_key_condition_op_excludes_not_eq() {
+        // `<>` is a legal filter but illegal in a KeyConditionExpression.
+        assert!(is_key_condition_op(Operator::Eq));
+        assert!(is_key_condition_op(Operator::Gt));
+        assert!(is_key_condition_op(Operator::LtEq));
+        assert!(!is_key_condition_op(Operator::NotEq));
+    }
+
+    #[test]
+    fn operator_symbol_rejects_non_comparison() {
+        assert_eq!(operator_symbol(Operator::Eq).unwrap(), "=");
+        assert_eq!(operator_symbol(Operator::NotEq).unwrap(), "<>");
+        // A logical connective is not a DynamoDB comparison operator.
+        assert!(operator_symbol(Operator::And).is_err());
+    }
+
+    // ─── Value / count builders ─────────────────────────────────────────────
+
+    #[test]
+    fn expr_to_attribute_value_rejects_non_literal() {
+        // A bare column reference is not a value.
+        assert!(expr_to_attribute_value(&col("x")).is_err());
+        assert!(matches!(
+            expr_to_attribute_value(&lit(3.5f64)).unwrap(),
+            AttributeValue::N(s) if s == "3.5"
+        ));
+    }
+
+    #[test]
+    fn scalar_to_attribute_value_maps_float_and_null() {
+        assert!(matches!(
+            scalar_to_attribute_value(&ScalarValue::Float64(Some(1.5))).unwrap(),
+            AttributeValue::N(s) if s == "1.5"
+        ));
+        assert!(matches!(
+            scalar_to_attribute_value(&ScalarValue::Null).unwrap(),
+            AttributeValue::Null(true)
+        ));
+    }
+
+    #[test]
+    fn count_batch_is_single_uint64_row() {
+        let batch = count_batch(42).expect("count batch");
+        assert_eq!(batch.num_rows(), 1);
+        assert_eq!(batch.schema().field(0).name(), "count");
+        assert_eq!(batch.schema().field(0).data_type(), &DataType::UInt64);
+        let counts = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .unwrap();
+        assert_eq!(counts.value(0), 42);
+    }
+
+    #[test]
+    fn parse_columns_option_accepts_int_and_bool_aliases() {
+        let schema = parse_columns_option("qty:integer, active:boolean", "id", None)
+            .expect("valid columns");
+        assert_eq!(schema.field(1).data_type(), &DataType::Int64);
+        assert_eq!(schema.field(2).data_type(), &DataType::Boolean);
+    }
+
+    // ─── Key extraction / projection (provider methods) ─────────────────────
+
+    /// Build a provider with an explicit schema (no DynamoDB round-trip needed).
+    async fn test_provider(
+        partition_key: &str,
+        sort_key: Option<&str>,
+        read_write: bool,
+    ) -> DynamoTableProvider {
+        let mut fields = vec![Field::new(partition_key, DataType::Utf8, false)];
+        if let Some(sk) = sort_key {
+            fields.push(Field::new(sk, DataType::Utf8, false));
+        }
+        fields.push(Field::new("name", DataType::Utf8, true));
+        let schema = Arc::new(Schema::new(fields));
+        let mut opts = HashMap::new();
+        opts.insert("region".to_string(), "us-east-1".to_string());
+        let client = build_client("http://localhost:8000", "us-east-1", &opts)
+            .await
+            .expect("client");
+        DynamoTableProvider::new(
+            client,
+            "t",
+            partition_key,
+            sort_key,
+            Some(schema),
+            read_write,
+        )
+        .await
+        .expect("provider")
+    }
+
+    #[tokio::test]
+    async fn key_of_extracts_full_composite_key_and_drops_non_key_attrs() {
+        let handle = test_provider("pk", Some("sk"), false).await.clone_handle();
+        let item = HashMap::from([
+            ("pk".to_string(), AttributeValue::S("A".into())),
+            ("sk".to_string(), AttributeValue::S("B".into())),
+            ("name".to_string(), AttributeValue::S("ignored".into())),
+        ]);
+        let key = handle.key_of(&item).expect("key");
+        assert_eq!(key.len(), 2, "only the two key attributes are kept");
+        assert!(key.contains_key("pk") && key.contains_key("sk"));
+    }
+
+    #[tokio::test]
+    async fn key_of_errors_when_sort_key_missing() {
+        let handle = test_provider("pk", Some("sk"), false).await.clone_handle();
+        // Composite-key table but the item lacks the sort key.
+        let item = HashMap::from([("pk".to_string(), AttributeValue::S("A".into()))]);
+        let err = handle.key_of(&item).expect_err("missing sort key must error");
+        assert!(err.to_string().contains("sort key"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn key_projection_covers_partition_and_sort() {
+        let single = test_provider("pk", None, false).await.clone_handle();
+        let (expr, names) = single.key_projection();
+        assert_eq!(expr, "#p0");
+        assert_eq!(names.get("#p0").map(String::as_str), Some("pk"));
+
+        let composite = test_provider("pk", Some("sk"), false).await.clone_handle();
+        let (expr, names) = composite.key_projection();
+        assert_eq!(expr, "#p0, #p1");
+        assert_eq!(names.get("#p1").map(String::as_str), Some("sk"));
+    }
+
+    // ─── Plan-time write guards (no network) ────────────────────────────────
+
+    async fn register_provider(provider: DynamoTableProvider) -> SessionContext {
+        let ctx = SessionContext::new();
+        ctx.register_table("t", Arc::new(provider))
+            .expect("register");
+        ctx
+    }
+
+    #[tokio::test]
+    async fn read_only_source_rejects_delete_at_plan_time() {
+        // access_mode enforcement: a read-only source must block DML before any
+        // request reaches DynamoDB.
+        let ctx = register_provider(test_provider("id", None, false).await).await;
+        let err = ctx
+            .sql("DELETE FROM t WHERE id = 'A'")
+            .await
+            .expect("logical plan")
+            .collect()
+            .await
+            .expect_err("read-only DELETE must be rejected");
+        assert!(err.to_string().contains("read_only"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn update_of_key_column_is_rejected_at_plan_time() {
+        // DynamoDB key attributes are immutable; the guard must fire during
+        // planning rather than issuing an UpdateItem that would fail server-side.
+        let ctx = register_provider(test_provider("id", None, true).await).await;
+        let err = ctx
+            .sql("UPDATE t SET id = 'Z' WHERE id = 'A'")
+            .await
+            .expect("logical plan")
+            .collect()
+            .await
+            .expect_err("updating the key column must be rejected");
+        assert!(err.to_string().contains("immutable"), "got: {err}");
     }
 
     // ─── Integration tests (require DynamoDB Local) ─────────────────────────

--- a/crates/skardi/src/sources/providers/dynamodb.rs
+++ b/crates/skardi/src/sources/providers/dynamodb.rs
@@ -1,0 +1,1541 @@
+//! Amazon DynamoDB table provider for DataFusion.
+//!
+//! DynamoDB is a managed NoSQL document/key-value store. A DynamoDB table maps
+//! to one Skardi table: each item becomes a row and each top-level attribute a
+//! column. The shape mirrors the MongoDB provider (`super::mongo`) — a sample
+//! item drives schema inference, binary filters push down into the backend, and
+//! INSERT/UPDATE/DELETE are supported because DynamoDB is a read-write store.
+//!
+//! DynamoDB has no native full-text or vector search, so no FTS/KNN table
+//! functions are registered (unlike Lance or the pgvector-backed Postgres
+//! provider).
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::fmt::{self, Debug, Formatter};
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use arrow::array::{
+    ArrayRef, BooleanArray, Float64Array, Int32Array, Int64Array, RecordBatch, RecordBatchOptions,
+    StringArray, UInt64Array,
+};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use async_trait::async_trait;
+use aws_sdk_dynamodb::Client;
+use aws_sdk_dynamodb::config::{Credentials, Region};
+use aws_sdk_dynamodb::types::AttributeValue;
+use datafusion::catalog::Session;
+use datafusion::datasource::{TableProvider, TableType};
+use datafusion::error::{DataFusionError, Result as DFResult};
+use datafusion::logical_expr::{Expr, Operator, TableProviderFilterPushDown};
+use datafusion::physical_expr::EquivalenceProperties;
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
+    SendableRecordBatchStream,
+};
+use datafusion::prelude::SessionContext;
+use tokio::sync::RwLock;
+
+/// A DynamoDB table exposed to DataFusion as a `TableProvider`.
+pub struct DynamoTableProvider {
+    client: Client,
+    table_name: String,
+    schema: SchemaRef,
+    /// Partition (hash) key attribute name. Always present and not nullable.
+    partition_key: String,
+    /// Sort (range) key attribute name, if the table has a composite key.
+    sort_key: Option<String>,
+}
+
+impl Debug for DynamoTableProvider {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DynamoTableProvider")
+            .field("table_name", &self.table_name)
+            .field("partition_key", &self.partition_key)
+            .field("sort_key", &self.sort_key)
+            .field("schema", &self.schema)
+            .finish()
+    }
+}
+
+impl DynamoTableProvider {
+    /// Build a provider against an existing DynamoDB table, inferring the schema
+    /// from a sampled item unless one is supplied.
+    pub async fn new(
+        client: Client,
+        table_name: &str,
+        partition_key: &str,
+        sort_key: Option<&str>,
+        schema: Option<SchemaRef>,
+    ) -> Result<Self> {
+        let schema = match schema {
+            Some(s) => s,
+            None => {
+                Arc::new(Self::infer_schema(&client, table_name, partition_key, sort_key).await?)
+            }
+        };
+
+        Ok(Self {
+            client,
+            table_name: table_name.to_string(),
+            schema,
+            partition_key: partition_key.to_string(),
+            sort_key: sort_key.map(str::to_string),
+        })
+    }
+
+    /// Infer an Arrow schema by sampling a single item from the table. The
+    /// partition key (then the sort key, if any) are always emitted first and
+    /// non-nullable; remaining attributes are inferred from the sample and
+    /// marked nullable, since DynamoDB items are schemaless and any attribute
+    /// may be absent on other items.
+    async fn infer_schema(
+        client: &Client,
+        table_name: &str,
+        partition_key: &str,
+        sort_key: Option<&str>,
+    ) -> Result<Schema> {
+        let sample = client
+            .scan()
+            .table_name(table_name)
+            .limit(1)
+            .send()
+            .await
+            .with_context(|| format!("Failed to sample DynamoDB table '{table_name}'"))?;
+
+        let item = sample.items().first();
+
+        let mut fields: Vec<Field> = Vec::new();
+        let mut seen: Vec<&str> = Vec::new();
+
+        // Key attributes first, in key order, non-nullable.
+        let pk_type = item
+            .and_then(|i| i.get(partition_key))
+            .map(attribute_value_to_arrow_type)
+            .unwrap_or(DataType::Utf8);
+        fields.push(Field::new(partition_key, pk_type, false));
+        seen.push(partition_key);
+
+        if let Some(sk) = sort_key {
+            let sk_type = item
+                .and_then(|i| i.get(sk))
+                .map(attribute_value_to_arrow_type)
+                .unwrap_or(DataType::Utf8);
+            fields.push(Field::new(sk, sk_type, false));
+            seen.push(sk);
+        }
+
+        if let Some(item) = item {
+            for (key, value) in item.iter() {
+                if seen.contains(&key.as_str()) {
+                    continue;
+                }
+                fields.push(Field::new(key, attribute_value_to_arrow_type(value), true));
+            }
+        } else {
+            tracing::warn!(
+                table = %table_name,
+                "DynamoDB table is empty; schema limited to declared key attributes"
+            );
+        }
+
+        Ok(Schema::new(fields))
+    }
+
+    /// Run a (optionally filtered) `Scan`, paginating until the table is
+    /// exhausted, and return every matching item.
+    async fn scan_items(
+        &self,
+        filter: Option<&DynamoFilter>,
+        limit: Option<usize>,
+    ) -> Result<Vec<HashMap<String, AttributeValue>>> {
+        let mut items: Vec<HashMap<String, AttributeValue>> = Vec::new();
+        let mut start_key: Option<HashMap<String, AttributeValue>> = None;
+
+        loop {
+            let mut req = self.client.scan().table_name(&self.table_name);
+            if let Some(f) = filter {
+                req = req
+                    .filter_expression(&f.expression)
+                    .set_expression_attribute_names(Some(f.names.clone()))
+                    .set_expression_attribute_values(Some(f.values.clone()));
+            }
+            if let Some(sk) = &start_key {
+                req = req.set_exclusive_start_key(Some(sk.clone()));
+            }
+
+            let out = req
+                .send()
+                .await
+                .with_context(|| format!("DynamoDB scan failed for '{}'", self.table_name))?;
+
+            items.extend(out.items().iter().cloned());
+
+            if matches!(limit, Some(n) if items.len() >= n) {
+                if let Some(n) = limit {
+                    items.truncate(n);
+                }
+                break;
+            }
+
+            match out.last_evaluated_key() {
+                Some(key) if !key.is_empty() => start_key = Some(key.clone()),
+                _ => break,
+            }
+        }
+
+        Ok(items)
+    }
+
+    /// Convert scanned DynamoDB items into a single Arrow `RecordBatch` shaped
+    /// by this provider's schema. Missing attributes become NULLs.
+    fn items_to_record_batch(
+        &self,
+        items: Vec<HashMap<String, AttributeValue>>,
+    ) -> Result<RecordBatch> {
+        let mut columns: HashMap<String, Vec<Option<AttributeValue>>> = HashMap::new();
+        for field in self.schema.fields() {
+            columns.insert(field.name().clone(), Vec::with_capacity(items.len()));
+        }
+
+        for item in &items {
+            for field in self.schema.fields() {
+                let value = item.get(field.name()).cloned();
+                columns
+                    .get_mut(field.name())
+                    .expect("column inserted for every schema field above")
+                    .push(value);
+            }
+        }
+
+        let arrays: Vec<ArrayRef> = self
+            .schema
+            .fields()
+            .iter()
+            .map(|field| {
+                let values = columns
+                    .get(field.name())
+                    .expect("column inserted for every schema field above");
+                attribute_values_to_arrow_array(values, field.data_type())
+            })
+            .collect();
+
+        RecordBatch::try_new(self.schema.clone(), arrays)
+            .with_context(|| "Failed to build RecordBatch from DynamoDB items")
+    }
+}
+
+#[async_trait]
+impl TableProvider for DynamoTableProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> DFResult<Vec<TableProviderFilterPushDown>> {
+        Ok(filters
+            .iter()
+            .map(|expr| {
+                if is_pushable_binary_filter(expr) {
+                    // Inexact (not Exact) keeps the filter in the logical plan so
+                    // DataFusion's UPDATE/DELETE planner can still hand it to
+                    // delete_from/update — matching the MongoDB provider.
+                    TableProviderFilterPushDown::Inexact
+                } else {
+                    TableProviderFilterPushDown::Unsupported
+                }
+            })
+            .collect())
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        let pushable: Vec<Expr> = filters
+            .iter()
+            .filter(|e| is_pushable_binary_filter(e))
+            .cloned()
+            .collect();
+        let filter = build_filter_expression(&pushable)?;
+
+        let items = self
+            .scan_items(filter.as_ref(), limit)
+            .await
+            .map_err(|e| DataFusionError::External(e.into()))?;
+
+        let batch = self
+            .items_to_record_batch(items)
+            .map_err(|e| DataFusionError::External(e.into()))?;
+
+        let batch = if let Some(proj) = projection {
+            let projected_schema = Arc::new(self.schema.project(proj)?);
+            let columns: Vec<ArrayRef> = proj.iter().map(|&i| batch.column(i).clone()).collect();
+            if proj.is_empty() {
+                // Empty projection (e.g. `count(*)`) needs the row count passed
+                // explicitly or RecordBatch::try_new rejects the zero-column batch.
+                let options = RecordBatchOptions::new().with_row_count(Some(batch.num_rows()));
+                RecordBatch::try_new_with_options(projected_schema, columns, &options)?
+            } else {
+                RecordBatch::try_new(projected_schema, columns)?
+            }
+        } else {
+            batch
+        };
+
+        let schema = batch.schema();
+        let properties = PlanProperties::new(
+            EquivalenceProperties::new(schema.clone()),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Final,
+            Boundedness::Bounded,
+        );
+        Ok(Arc::new(DynamoScanExec {
+            schema,
+            batch: Arc::new(RwLock::new(Some(batch))),
+            properties,
+        }))
+    }
+
+    async fn insert_into(
+        &self,
+        _state: &dyn Session,
+        input: Arc<dyn ExecutionPlan>,
+        _insert_op: datafusion::logical_expr::dml::InsertOp,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(DynamoInsertExec {
+            input,
+            client: self.client.clone(),
+            table_name: self.table_name.clone(),
+            schema: self.schema.clone(),
+        }))
+    }
+
+    async fn delete_from(
+        &self,
+        _state: &dyn Session,
+        filters: Vec<Expr>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        let pushable: Vec<Expr> = filters
+            .iter()
+            .filter(|e| is_pushable_binary_filter(e))
+            .cloned()
+            .collect();
+        let filter = build_filter_expression(&pushable)?;
+        Ok(Arc::new(DynamoDmlExec::new(
+            self.clone_handle(),
+            DynamoDmlOp::Delete { filter },
+        )))
+    }
+
+    async fn update(
+        &self,
+        _state: &dyn Session,
+        assignments: Vec<(String, Expr)>,
+        filters: Vec<Expr>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        if assignments.is_empty() {
+            return Err(DataFusionError::Plan(
+                "UPDATE requires at least one assignment".to_string(),
+            ));
+        }
+        let mut sets: Vec<(String, AttributeValue)> = Vec::with_capacity(assignments.len());
+        for (col, expr) in &assignments {
+            if col == &self.partition_key || Some(col) == self.sort_key.as_ref() {
+                return Err(DataFusionError::Plan(format!(
+                    "Cannot modify key column '{col}' — DynamoDB key attributes are immutable"
+                )));
+            }
+            sets.push((col.clone(), expr_to_attribute_value(expr)?));
+        }
+
+        let pushable: Vec<Expr> = filters
+            .iter()
+            .filter(|e| is_pushable_binary_filter(e))
+            .cloned()
+            .collect();
+        let filter = build_filter_expression(&pushable)?;
+
+        Ok(Arc::new(DynamoDmlExec::new(
+            self.clone_handle(),
+            DynamoDmlOp::Update { filter, sets },
+        )))
+    }
+}
+
+impl DynamoTableProvider {
+    /// A cheap clone of the connection handle and key metadata for the DML
+    /// execution plans (the schema isn't needed there).
+    fn clone_handle(&self) -> DynamoHandle {
+        DynamoHandle {
+            client: self.client.clone(),
+            table_name: self.table_name.clone(),
+            partition_key: self.partition_key.clone(),
+            sort_key: self.sort_key.clone(),
+        }
+    }
+}
+
+/// Connection handle plus key metadata shared with DML execution plans.
+#[derive(Clone)]
+struct DynamoHandle {
+    client: Client,
+    table_name: String,
+    partition_key: String,
+    sort_key: Option<String>,
+}
+
+impl DynamoHandle {
+    fn key_of(
+        &self,
+        item: &HashMap<String, AttributeValue>,
+    ) -> Result<HashMap<String, AttributeValue>> {
+        let mut key = HashMap::new();
+        let pk = item.get(&self.partition_key).cloned().ok_or_else(|| {
+            anyhow::anyhow!("item missing partition key '{}'", self.partition_key)
+        })?;
+        key.insert(self.partition_key.clone(), pk);
+        if let Some(sk) = &self.sort_key {
+            let sk_val = item
+                .get(sk)
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("item missing sort key '{sk}'"))?;
+            key.insert(sk.clone(), sk_val);
+        }
+        Ok(key)
+    }
+
+    /// Scan keys of items matching `filter` (used to drive key-based DML).
+    async fn matching_keys(
+        &self,
+        filter: Option<&DynamoFilter>,
+    ) -> Result<Vec<HashMap<String, AttributeValue>>> {
+        let mut keys = Vec::new();
+        let mut start_key: Option<HashMap<String, AttributeValue>> = None;
+        loop {
+            let mut req = self.client.scan().table_name(&self.table_name);
+            if let Some(f) = filter {
+                req = req
+                    .filter_expression(&f.expression)
+                    .set_expression_attribute_names(Some(f.names.clone()))
+                    .set_expression_attribute_values(Some(f.values.clone()));
+            }
+            if let Some(sk) = &start_key {
+                req = req.set_exclusive_start_key(Some(sk.clone()));
+            }
+            let out = req
+                .send()
+                .await
+                .with_context(|| format!("DynamoDB scan failed for '{}'", self.table_name))?;
+            for item in out.items() {
+                keys.push(self.key_of(item)?);
+            }
+            match out.last_evaluated_key() {
+                Some(k) if !k.is_empty() => start_key = Some(k.clone()),
+                _ => break,
+            }
+        }
+        Ok(keys)
+    }
+}
+
+// ─── Schema inference & type mapping ────────────────────────────────────────
+
+/// Map a sampled DynamoDB attribute to an Arrow type. Numbers are inferred as
+/// `Int64` when the sample has no fractional part, else `Float64`. Everything
+/// non-scalar (maps, lists, sets, binary) falls back to `Utf8`.
+pub(crate) fn attribute_value_to_arrow_type(value: &AttributeValue) -> DataType {
+    match value {
+        AttributeValue::S(_) => DataType::Utf8,
+        AttributeValue::Bool(_) => DataType::Boolean,
+        AttributeValue::N(n) => {
+            if n.contains('.') || n.contains('e') || n.contains('E') {
+                DataType::Float64
+            } else if n.parse::<i64>().is_ok() {
+                DataType::Int64
+            } else {
+                DataType::Float64
+            }
+        }
+        AttributeValue::Null(_) => DataType::Utf8,
+        _ => DataType::Utf8,
+    }
+}
+
+/// Build a typed Arrow array from a column of optional DynamoDB attributes.
+pub(crate) fn attribute_values_to_arrow_array(
+    values: &[Option<AttributeValue>],
+    data_type: &DataType,
+) -> ArrayRef {
+    match data_type {
+        DataType::Utf8 => {
+            let arr: StringArray = values
+                .iter()
+                .map(|v| v.as_ref().map(av_to_string))
+                .collect();
+            Arc::new(arr)
+        }
+        DataType::Int32 => {
+            let arr: Int32Array = values
+                .iter()
+                .map(|v| v.as_ref().and_then(av_to_i64).map(|n| n as i32))
+                .collect();
+            Arc::new(arr)
+        }
+        DataType::Int64 => {
+            let arr: Int64Array = values
+                .iter()
+                .map(|v| v.as_ref().and_then(av_to_i64))
+                .collect();
+            Arc::new(arr)
+        }
+        DataType::Float64 => {
+            let arr: Float64Array = values
+                .iter()
+                .map(|v| v.as_ref().and_then(av_to_f64))
+                .collect();
+            Arc::new(arr)
+        }
+        DataType::Boolean => {
+            let arr: BooleanArray = values
+                .iter()
+                .map(|v| v.as_ref().and_then(av_to_bool))
+                .collect();
+            Arc::new(arr)
+        }
+        _ => {
+            let arr: StringArray = values
+                .iter()
+                .map(|v| v.as_ref().map(av_to_string))
+                .collect();
+            Arc::new(arr)
+        }
+    }
+}
+
+fn av_to_string(v: &AttributeValue) -> String {
+    match v {
+        AttributeValue::S(s) => s.clone(),
+        AttributeValue::N(n) => n.clone(),
+        AttributeValue::Bool(b) => b.to_string(),
+        AttributeValue::Null(_) => String::new(),
+        other => format!("{other:?}"),
+    }
+}
+
+fn av_to_i64(v: &AttributeValue) -> Option<i64> {
+    match v {
+        AttributeValue::N(n) => n
+            .parse::<i64>()
+            .ok()
+            .or_else(|| n.parse::<f64>().ok().map(|f| f as i64)),
+        AttributeValue::S(s) => s.parse::<i64>().ok(),
+        _ => None,
+    }
+}
+
+fn av_to_f64(v: &AttributeValue) -> Option<f64> {
+    match v {
+        AttributeValue::N(n) => n.parse::<f64>().ok(),
+        AttributeValue::S(s) => s.parse::<f64>().ok(),
+        _ => None,
+    }
+}
+
+fn av_to_bool(v: &AttributeValue) -> Option<bool> {
+    match v {
+        AttributeValue::Bool(b) => Some(*b),
+        _ => None,
+    }
+}
+
+/// Convert one Arrow cell into a DynamoDB attribute. Returns `None` for NULLs so
+/// the caller can omit the attribute (DynamoDB has no typed NULL columns).
+fn arrow_value_to_attribute(
+    array: &ArrayRef,
+    row: usize,
+    data_type: &DataType,
+) -> Result<Option<AttributeValue>> {
+    if array.is_null(row) {
+        return Ok(None);
+    }
+    let value = match data_type {
+        DataType::Utf8 => {
+            let arr = array
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .with_context(|| "expected StringArray for DataType::Utf8")?;
+            AttributeValue::S(arr.value(row).to_string())
+        }
+        DataType::Int32 => {
+            let arr = array
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .with_context(|| "expected Int32Array for DataType::Int32")?;
+            AttributeValue::N(arr.value(row).to_string())
+        }
+        DataType::Int64 => {
+            let arr = array
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .with_context(|| "expected Int64Array for DataType::Int64")?;
+            AttributeValue::N(arr.value(row).to_string())
+        }
+        DataType::Float64 => {
+            let arr = array
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .with_context(|| "expected Float64Array for DataType::Float64")?;
+            AttributeValue::N(arr.value(row).to_string())
+        }
+        DataType::Boolean => {
+            let arr = array
+                .as_any()
+                .downcast_ref::<BooleanArray>()
+                .with_context(|| "expected BooleanArray for DataType::Boolean")?;
+            AttributeValue::Bool(arr.value(row))
+        }
+        _ => {
+            let arr = array
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .with_context(|| "unsupported Arrow type for DynamoDB write")?;
+            AttributeValue::S(arr.value(row).to_string())
+        }
+    };
+    Ok(Some(value))
+}
+
+fn record_batch_to_items(
+    batch: &RecordBatch,
+    schema: &Schema,
+) -> Result<Vec<HashMap<String, AttributeValue>>> {
+    let mut items = Vec::with_capacity(batch.num_rows());
+    for row in 0..batch.num_rows() {
+        let mut item = HashMap::new();
+        for (idx, field) in schema.fields().iter().enumerate() {
+            let array = batch.column(idx);
+            if let Some(v) = arrow_value_to_attribute(array, row, field.data_type())? {
+                item.insert(field.name().clone(), v);
+            }
+        }
+        items.push(item);
+    }
+    Ok(items)
+}
+
+// ─── Filter pushdown ────────────────────────────────────────────────────────
+
+/// A DynamoDB `FilterExpression` plus its attribute-name/value placeholder maps.
+struct DynamoFilter {
+    expression: String,
+    names: HashMap<String, String>,
+    values: HashMap<String, AttributeValue>,
+}
+
+/// Same predicate the MongoDB provider uses: a comparison between a bare column
+/// and a literal, with an operator DynamoDB can evaluate server-side.
+pub(crate) fn is_pushable_binary_filter(expr: &Expr) -> bool {
+    match expr {
+        Expr::BinaryExpr(binary) => {
+            matches!(
+                binary.op,
+                Operator::Eq
+                    | Operator::NotEq
+                    | Operator::Lt
+                    | Operator::LtEq
+                    | Operator::Gt
+                    | Operator::GtEq
+            ) && matches!(
+                (binary.left.as_ref(), binary.right.as_ref()),
+                (Expr::Column(_), Expr::Literal(..)) | (Expr::Literal(..), Expr::Column(_))
+            )
+        }
+        _ => false,
+    }
+}
+
+/// Convert a list of pushable binary filters into one ANDed DynamoDB
+/// `FilterExpression`. Attribute names and values are passed as `#n`/`:v`
+/// placeholders so reserved words and types are handled safely.
+fn build_filter_expression(filters: &[Expr]) -> DFResult<Option<DynamoFilter>> {
+    if filters.is_empty() {
+        return Ok(None);
+    }
+    let mut parts = Vec::with_capacity(filters.len());
+    let mut names = HashMap::new();
+    let mut values = HashMap::new();
+
+    for (i, expr) in filters.iter().enumerate() {
+        let Expr::BinaryExpr(binary) = expr else {
+            return Err(DataFusionError::Plan(format!(
+                "Unsupported DynamoDB filter expression: {expr}"
+            )));
+        };
+        let (col, value_expr, flipped) = match (binary.left.as_ref(), binary.right.as_ref()) {
+            (Expr::Column(c), v) => (c.name.clone(), v, false),
+            (v, Expr::Column(c)) => (c.name.clone(), v, true),
+            _ => {
+                return Err(DataFusionError::Plan(format!(
+                    "DynamoDB filter must compare a column to a literal, got: {expr}"
+                )));
+            }
+        };
+        // If the literal is on the left (`5 < col`), invert the operator so the
+        // emitted expression keeps `#name <op> :val` form.
+        let op = if flipped {
+            flip_operator(binary.op)
+        } else {
+            binary.op
+        };
+        let name_ph = format!("#n{i}");
+        let val_ph = format!(":v{i}");
+        names.insert(name_ph.clone(), col);
+        values.insert(val_ph.clone(), expr_to_attribute_value(value_expr)?);
+        parts.push(format!("{name_ph} {} {val_ph}", operator_symbol(op)?));
+    }
+
+    Ok(Some(DynamoFilter {
+        expression: parts.join(" AND "),
+        names,
+        values,
+    }))
+}
+
+fn flip_operator(op: Operator) -> Operator {
+    match op {
+        Operator::Lt => Operator::Gt,
+        Operator::LtEq => Operator::GtEq,
+        Operator::Gt => Operator::Lt,
+        Operator::GtEq => Operator::LtEq,
+        other => other, // Eq / NotEq are symmetric
+    }
+}
+
+fn operator_symbol(op: Operator) -> DFResult<&'static str> {
+    match op {
+        Operator::Eq => Ok("="),
+        Operator::NotEq => Ok("<>"),
+        Operator::Lt => Ok("<"),
+        Operator::LtEq => Ok("<="),
+        Operator::Gt => Ok(">"),
+        Operator::GtEq => Ok(">="),
+        other => Err(DataFusionError::Plan(format!(
+            "Unsupported DynamoDB filter operator: {other}"
+        ))),
+    }
+}
+
+/// Convert a DataFusion literal expression into a DynamoDB attribute value.
+pub(crate) fn expr_to_attribute_value(expr: &Expr) -> DFResult<AttributeValue> {
+    match expr {
+        Expr::Literal(scalar, _) => scalar_to_attribute_value(scalar),
+        _ => Err(DataFusionError::Plan(format!(
+            "Unsupported expression for DynamoDB value: {expr}"
+        ))),
+    }
+}
+
+fn scalar_to_attribute_value(scalar: &datafusion::common::ScalarValue) -> DFResult<AttributeValue> {
+    use datafusion::common::ScalarValue;
+    let av = match scalar {
+        ScalarValue::Utf8(Some(s)) | ScalarValue::LargeUtf8(Some(s)) => {
+            AttributeValue::S(s.clone())
+        }
+        ScalarValue::Int8(Some(v)) => AttributeValue::N(v.to_string()),
+        ScalarValue::Int16(Some(v)) => AttributeValue::N(v.to_string()),
+        ScalarValue::Int32(Some(v)) => AttributeValue::N(v.to_string()),
+        ScalarValue::Int64(Some(v)) => AttributeValue::N(v.to_string()),
+        ScalarValue::UInt8(Some(v)) => AttributeValue::N(v.to_string()),
+        ScalarValue::UInt16(Some(v)) => AttributeValue::N(v.to_string()),
+        ScalarValue::UInt32(Some(v)) => AttributeValue::N(v.to_string()),
+        ScalarValue::UInt64(Some(v)) => AttributeValue::N(v.to_string()),
+        ScalarValue::Float32(Some(v)) => AttributeValue::N(v.to_string()),
+        ScalarValue::Float64(Some(v)) => AttributeValue::N(v.to_string()),
+        ScalarValue::Boolean(Some(v)) => AttributeValue::Bool(*v),
+        ScalarValue::Null => AttributeValue::Null(true),
+        _ => {
+            return Err(DataFusionError::Plan(format!(
+                "Unsupported scalar type for DynamoDB: {scalar}"
+            )));
+        }
+    };
+    Ok(av)
+}
+
+// ─── Scan execution plan ────────────────────────────────────────────────────
+
+/// Leaf plan holding a pre-fetched scan result batch.
+#[derive(Debug)]
+struct DynamoScanExec {
+    schema: SchemaRef,
+    batch: Arc<RwLock<Option<RecordBatch>>>,
+    properties: PlanProperties,
+}
+
+impl DisplayAs for DynamoScanExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> fmt::Result {
+        write!(f, "DynamoScanExec")
+    }
+}
+
+impl ExecutionPlan for DynamoScanExec {
+    fn name(&self) -> &str {
+        "DynamoScanExec"
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
+    }
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<datafusion::execution::TaskContext>,
+    ) -> DFResult<SendableRecordBatchStream> {
+        let schema = self.schema.clone();
+        let batch = self.batch.clone();
+        let stream = futures::stream::once(async move {
+            let guard = batch.read().await;
+            match guard.as_ref() {
+                Some(b) => Ok(b.clone()),
+                None => Err(DataFusionError::Execution(
+                    "Batch already consumed".to_string(),
+                )),
+            }
+        });
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    }
+}
+
+// ─── Insert execution plan ──────────────────────────────────────────────────
+
+struct DynamoInsertExec {
+    input: Arc<dyn ExecutionPlan>,
+    client: Client,
+    table_name: String,
+    schema: SchemaRef,
+}
+
+impl Debug for DynamoInsertExec {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DynamoInsertExec")
+            .field("table_name", &self.table_name)
+            .finish()
+    }
+}
+
+impl DisplayAs for DynamoInsertExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> fmt::Result {
+        write!(f, "DynamoInsertExec")
+    }
+}
+
+impl ExecutionPlan for DynamoInsertExec {
+    fn name(&self) -> &str {
+        "DynamoInsertExec"
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn properties(&self) -> &PlanProperties {
+        self.input.properties()
+    }
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(DynamoInsertExec {
+            input: children[0].clone(),
+            client: self.client.clone(),
+            table_name: self.table_name.clone(),
+            schema: self.schema.clone(),
+        }))
+    }
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<datafusion::execution::TaskContext>,
+    ) -> DFResult<SendableRecordBatchStream> {
+        let mut input_stream = self.input.execute(partition, context)?;
+        let client = self.client.clone();
+        let table_name = self.table_name.clone();
+        let schema = self.schema.clone();
+        let output_schema = count_schema();
+
+        let future = async move {
+            let mut count: u64 = 0;
+            use futures::StreamExt;
+            while let Some(batch) = input_stream.next().await {
+                let batch = batch?;
+                let items = record_batch_to_items(&batch, &schema)
+                    .map_err(|e| DataFusionError::External(e.into()))?;
+                for item in items {
+                    client
+                        .put_item()
+                        .table_name(&table_name)
+                        .set_item(Some(item))
+                        .send()
+                        .await
+                        .map_err(|e| {
+                            DataFusionError::Execution(format!("DynamoDB put_item failed: {e}"))
+                        })?;
+                    count += 1;
+                }
+            }
+            count_batch(count)
+        };
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            output_schema,
+            futures::stream::once(future),
+        )))
+    }
+}
+
+// ─── DELETE / UPDATE execution plan ─────────────────────────────────────────
+
+enum DynamoDmlOp {
+    Delete {
+        filter: Option<DynamoFilter>,
+    },
+    Update {
+        filter: Option<DynamoFilter>,
+        sets: Vec<(String, AttributeValue)>,
+    },
+}
+
+/// Leaf plan that runs a key-based DELETE or UPDATE and returns `{ count }`.
+///
+/// DynamoDB cannot delete or update by arbitrary predicate, so the matching
+/// keys are scanned first and then mutated one key at a time.
+struct DynamoDmlExec {
+    handle: DynamoHandle,
+    op: DynamoDmlOp,
+    schema: SchemaRef,
+    properties: PlanProperties,
+}
+
+impl DynamoDmlExec {
+    fn new(handle: DynamoHandle, op: DynamoDmlOp) -> Self {
+        let schema = count_schema();
+        let properties = PlanProperties::new(
+            EquivalenceProperties::new(schema.clone()),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Final,
+            Boundedness::Bounded,
+        );
+        Self {
+            handle,
+            op,
+            schema,
+            properties,
+        }
+    }
+}
+
+impl Debug for DynamoDmlExec {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "DynamoDmlExec")
+    }
+}
+
+impl DisplayAs for DynamoDmlExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> fmt::Result {
+        write!(f, "DynamoDmlExec")
+    }
+}
+
+impl ExecutionPlan for DynamoDmlExec {
+    fn name(&self) -> &str {
+        "DynamoDmlExec"
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
+    }
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<datafusion::execution::TaskContext>,
+    ) -> DFResult<SendableRecordBatchStream> {
+        let handle = self.handle.clone();
+        // Move the op out by cloning its parts (AttributeValue/maps are clonable).
+        let op = self.op.clone_op();
+        let future = async move {
+            let affected = match op {
+                DynamoDmlOp::Delete { filter } => {
+                    let keys = handle
+                        .matching_keys(filter.as_ref())
+                        .await
+                        .map_err(|e| DataFusionError::External(e.into()))?;
+                    let mut n = 0u64;
+                    for key in keys {
+                        handle
+                            .client
+                            .delete_item()
+                            .table_name(&handle.table_name)
+                            .set_key(Some(key))
+                            .send()
+                            .await
+                            .map_err(|e| {
+                                DataFusionError::Execution(format!("DynamoDB delete failed: {e}"))
+                            })?;
+                        n += 1;
+                    }
+                    n
+                }
+                DynamoDmlOp::Update { filter, sets } => {
+                    let keys = handle
+                        .matching_keys(filter.as_ref())
+                        .await
+                        .map_err(|e| DataFusionError::External(e.into()))?;
+                    let (expr, names, values) = build_update_expression(&sets);
+                    let mut n = 0u64;
+                    for key in keys {
+                        handle
+                            .client
+                            .update_item()
+                            .table_name(&handle.table_name)
+                            .set_key(Some(key))
+                            .update_expression(&expr)
+                            .set_expression_attribute_names(Some(names.clone()))
+                            .set_expression_attribute_values(Some(values.clone()))
+                            .send()
+                            .await
+                            .map_err(|e| {
+                                DataFusionError::Execution(format!("DynamoDB update failed: {e}"))
+                            })?;
+                        n += 1;
+                    }
+                    n
+                }
+            };
+            count_batch(affected)
+        };
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            self.schema.clone(),
+            futures::stream::once(future),
+        )))
+    }
+}
+
+impl DynamoDmlOp {
+    fn clone_op(&self) -> DynamoDmlOp {
+        match self {
+            DynamoDmlOp::Delete { filter } => DynamoDmlOp::Delete {
+                filter: filter.as_ref().map(clone_filter),
+            },
+            DynamoDmlOp::Update { filter, sets } => DynamoDmlOp::Update {
+                filter: filter.as_ref().map(clone_filter),
+                sets: sets.clone(),
+            },
+        }
+    }
+}
+
+fn clone_filter(f: &DynamoFilter) -> DynamoFilter {
+    DynamoFilter {
+        expression: f.expression.clone(),
+        names: f.names.clone(),
+        values: f.values.clone(),
+    }
+}
+
+/// Build a DynamoDB `SET` update expression from column→value assignments.
+fn build_update_expression(
+    sets: &[(String, AttributeValue)],
+) -> (
+    String,
+    HashMap<String, String>,
+    HashMap<String, AttributeValue>,
+) {
+    let mut names = HashMap::new();
+    let mut values = HashMap::new();
+    let mut parts = Vec::with_capacity(sets.len());
+    for (i, (col, av)) in sets.iter().enumerate() {
+        let name_ph = format!("#s{i}");
+        let val_ph = format!(":s{i}");
+        names.insert(name_ph.clone(), col.clone());
+        values.insert(val_ph.clone(), av.clone());
+        parts.push(format!("{name_ph} = {val_ph}"));
+    }
+    (format!("SET {}", parts.join(", ")), names, values)
+}
+
+fn count_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![Field::new(
+        "count",
+        DataType::UInt64,
+        false,
+    )]))
+}
+
+fn count_batch(count: u64) -> DFResult<RecordBatch> {
+    let array: UInt64Array = vec![count].into();
+    RecordBatch::try_new(count_schema(), vec![Arc::new(array)]).map_err(DataFusionError::from)
+}
+
+// ─── Registration ───────────────────────────────────────────────────────────
+
+/// Register a DynamoDB table as a DataFusion table.
+///
+/// # Arguments
+/// * `session_ctx` - session context to register the table into.
+/// * `name` - the SQL table name to expose.
+/// * `connection_string` - the DynamoDB endpoint URL. For Amazon DynamoDB use
+///   the regional endpoint (e.g. `https://dynamodb.us-east-1.amazonaws.com`);
+///   for DynamoDB Local use `http://localhost:8000`.
+/// * `options` - configuration options (see below).
+///
+/// # Options
+/// * `table` - DynamoDB table name (required).
+/// * `partition_key` - partition (hash) key attribute name (required).
+/// * `sort_key` - sort (range) key attribute name (optional).
+/// * `region` - AWS region (optional, default `us-east-1`).
+/// * `access_key_env` / `secret_key_env` - names of environment variables
+///   holding static AWS credentials (optional). When omitted, the default AWS
+///   credential provider chain is used.
+pub async fn register_dynamodb_tables(
+    session_ctx: &mut SessionContext,
+    name: &str,
+    connection_string: &str,
+    options: Option<&HashMap<String, String>>,
+) -> Result<()> {
+    tracing::info!(
+        source = %name,
+        endpoint = %connection_string,
+        "Registering DynamoDB table"
+    );
+
+    let opts = options.ok_or_else(|| {
+        anyhow::anyhow!("DynamoDB data source '{name}' requires options (table, partition_key)")
+    })?;
+
+    let table = opts
+        .get("table")
+        .ok_or_else(|| anyhow::anyhow!("DynamoDB data source '{name}' requires 'table' option"))?;
+    let partition_key = opts.get("partition_key").ok_or_else(|| {
+        anyhow::anyhow!("DynamoDB data source '{name}' requires 'partition_key' option")
+    })?;
+    let sort_key = opts.get("sort_key").map(String::as_str);
+    let region = opts
+        .get("region")
+        .cloned()
+        .unwrap_or_else(|| "us-east-1".to_string());
+
+    let client = build_client(connection_string, &region, opts).await?;
+
+    let provider = DynamoTableProvider::new(client, table, partition_key, sort_key, None)
+        .await
+        .with_context(|| format!("Failed to create DynamoDB table provider for '{name}'"))?;
+
+    session_ctx
+        .register_table(name, Arc::new(provider))
+        .with_context(|| format!("Failed to register DynamoDB table '{name}' with DataFusion"))?;
+
+    tracing::info!(source = %name, table = %table, "Registered DynamoDB table");
+    Ok(())
+}
+
+/// Build a DynamoDB client from the endpoint, region, and credential options.
+async fn build_client(
+    endpoint: &str,
+    region: &str,
+    opts: &HashMap<String, String>,
+) -> Result<Client> {
+    let mut loader = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .region(Region::new(region.to_string()))
+        .endpoint_url(endpoint);
+
+    if let (Some(ak_env), Some(sk_env)) = (opts.get("access_key_env"), opts.get("secret_key_env")) {
+        let access_key = std::env::var(ak_env).with_context(|| {
+            format!("Environment variable '{ak_env}' not found for DynamoDB access key")
+        })?;
+        let secret_key = std::env::var(sk_env).with_context(|| {
+            format!("Environment variable '{sk_env}' not found for DynamoDB secret key")
+        })?;
+        let creds = Credentials::new(access_key, secret_key, None, None, "skardi-dynamodb");
+        loader = loader.credentials_provider(creds);
+    }
+
+    let config = loader.load().await;
+    Ok(Client::new(&config))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::common::ScalarValue;
+    use datafusion::logical_expr::{BinaryExpr, col, lit};
+
+    fn n(s: &str) -> AttributeValue {
+        AttributeValue::N(s.to_string())
+    }
+
+    #[test]
+    fn attribute_type_inference() {
+        assert_eq!(
+            attribute_value_to_arrow_type(&AttributeValue::S("x".into())),
+            DataType::Utf8
+        );
+        assert_eq!(attribute_value_to_arrow_type(&n("42")), DataType::Int64);
+        assert_eq!(attribute_value_to_arrow_type(&n("4.5")), DataType::Float64);
+        assert_eq!(
+            attribute_value_to_arrow_type(&AttributeValue::Bool(true)),
+            DataType::Boolean
+        );
+        assert_eq!(
+            attribute_value_to_arrow_type(&AttributeValue::Null(true)),
+            DataType::Utf8
+        );
+    }
+
+    #[test]
+    fn number_coercions() {
+        assert_eq!(av_to_i64(&n("7")), Some(7));
+        assert_eq!(av_to_i64(&n("7.9")), Some(7));
+        assert_eq!(av_to_f64(&n("2.5")), Some(2.5));
+        assert_eq!(av_to_f64(&AttributeValue::S("nope".into())), None);
+        assert_eq!(av_to_bool(&AttributeValue::Bool(false)), Some(false));
+        assert_eq!(av_to_bool(&n("1")), None);
+    }
+
+    #[test]
+    fn null_bearing_column_builds_nullable_array() {
+        let values = vec![
+            Some(AttributeValue::S("a".into())),
+            None,
+            Some(AttributeValue::S("c".into())),
+        ];
+        let arr = attribute_values_to_arrow_array(&values, &DataType::Utf8);
+        assert_eq!(arr.len(), 3);
+        assert!(arr.is_null(1));
+        assert!(!arr.is_null(0));
+    }
+
+    #[test]
+    fn empty_column_builds_empty_array() {
+        let arr = attribute_values_to_arrow_array(&[], &DataType::Int64);
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn pushable_filter_detection() {
+        let pushable = col("a").eq(lit(1i64));
+        assert!(is_pushable_binary_filter(&pushable));
+        // column-to-column is not pushable
+        let not_pushable = col("a").eq(col("b"));
+        assert!(!is_pushable_binary_filter(&not_pushable));
+    }
+
+    #[test]
+    fn filter_expression_emits_placeholders() {
+        let filters = vec![
+            col("category").eq(lit("Electronics")),
+            col("price").gt(lit(100i64)),
+        ];
+        let f = build_filter_expression(&filters)
+            .expect("buildable")
+            .expect("non-empty");
+        assert!(f.expression.contains(" AND "));
+        assert_eq!(f.names.len(), 2);
+        assert_eq!(f.values.len(), 2);
+        // every #name placeholder in the expression has a binding
+        for ph in f.names.keys() {
+            assert!(f.expression.contains(ph.as_str()));
+        }
+    }
+
+    #[test]
+    fn literal_on_left_flips_operator() {
+        // 100 < price  ⇒  #name > :val
+        let expr = Expr::BinaryExpr(BinaryExpr::new(
+            Box::new(lit(100i64)),
+            Operator::Lt,
+            Box::new(col("price")),
+        ));
+        let f = build_filter_expression(&[expr])
+            .expect("buildable")
+            .expect("non-empty");
+        assert!(f.expression.contains('>'), "got: {}", f.expression);
+    }
+
+    #[test]
+    fn empty_filter_list_is_none() {
+        assert!(build_filter_expression(&[]).expect("ok").is_none());
+    }
+
+    #[test]
+    fn scalar_conversions() {
+        assert!(matches!(
+            scalar_to_attribute_value(&ScalarValue::Utf8(Some("hi".into()))).unwrap(),
+            AttributeValue::S(s) if s == "hi"
+        ));
+        assert!(matches!(
+            scalar_to_attribute_value(&ScalarValue::Int64(Some(5))).unwrap(),
+            AttributeValue::N(s) if s == "5"
+        ));
+        assert!(matches!(
+            scalar_to_attribute_value(&ScalarValue::Boolean(Some(true))).unwrap(),
+            AttributeValue::Bool(true)
+        ));
+    }
+
+    #[test]
+    fn update_expression_shape() {
+        let sets = vec![
+            ("price".to_string(), n("9.99")),
+            ("in_stock".to_string(), AttributeValue::Bool(true)),
+        ];
+        let (expr, names, values) = build_update_expression(&sets);
+        assert!(expr.starts_with("SET "));
+        assert!(expr.contains(", "));
+        assert_eq!(names.len(), 2);
+        assert_eq!(values.len(), 2);
+    }
+
+    #[test]
+    fn missing_options_errors() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let mut ctx = SessionContext::new();
+            let err = register_dynamodb_tables(&mut ctx, "ddb", "http://localhost:8000", None)
+                .await
+                .unwrap_err();
+            assert!(err.to_string().contains("requires options"));
+        });
+    }
+
+    #[test]
+    fn missing_table_option_errors() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let mut ctx = SessionContext::new();
+            let mut opts = HashMap::new();
+            opts.insert("partition_key".to_string(), "id".to_string());
+            let err =
+                register_dynamodb_tables(&mut ctx, "ddb", "http://localhost:8000", Some(&opts))
+                    .await
+                    .unwrap_err();
+            assert!(err.to_string().contains("'table'"));
+        });
+    }
+
+    // ─── Integration tests (require DynamoDB Local) ─────────────────────────
+    //
+    // Run a local endpoint first:
+    //   docker run -d -p 8000:8000 amazon/dynamodb-local:2.5.2
+    // then seed the `products` table (see docs/dynamodb/README.md) and run:
+    //   AWS_ACCESS_KEY_ID=dummy AWS_SECRET_ACCESS_KEY=dummy \
+    //     cargo nextest run --all-features -- --ignored
+
+    async fn ci_provider() -> DynamoTableProvider {
+        let mut opts = HashMap::new();
+        opts.insert("region".to_string(), "us-east-1".to_string());
+        let client = build_client("http://localhost:8000", "us-east-1", &opts)
+            .await
+            .expect("client");
+        DynamoTableProvider::new(client, "products", "product_id", None, None)
+            .await
+            .expect("provider")
+    }
+
+    async fn query_rows(sql: &str) -> usize {
+        let mut ctx = SessionContext::new();
+        let mut opts = HashMap::new();
+        opts.insert("table".to_string(), "products".to_string());
+        opts.insert("partition_key".to_string(), "product_id".to_string());
+        opts.insert("region".to_string(), "us-east-1".to_string());
+        register_dynamodb_tables(&mut ctx, "products", "http://localhost:8000", Some(&opts))
+            .await
+            .expect("register");
+        let df = ctx.sql(sql).await.expect("sql");
+        let batches = df.collect().await.expect("collect");
+        batches.iter().map(|b| b.num_rows()).sum()
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DynamoDB Local on :8000 with seeded `products` table"]
+    async fn integration_scan_all() {
+        let provider = ci_provider().await;
+        assert!(!provider.schema.fields().is_empty());
+        let rows = query_rows("SELECT * FROM products").await;
+        assert!(rows >= 3, "expected seeded rows, got {rows}");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DynamoDB Local on :8000 with seeded `products` table"]
+    async fn integration_filter_pushdown() {
+        let rows = query_rows("SELECT * FROM products WHERE category = 'Electronics'").await;
+        assert!(rows >= 1, "expected at least one Electronics row");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DynamoDB Local on :8000 with seeded `products` table"]
+    async fn integration_count_star() {
+        let rows = query_rows("SELECT count(*) FROM products").await;
+        // count(*) returns a single aggregate row
+        assert_eq!(rows, 1);
+    }
+
+    /// Create a throwaway single-key table for write tests (idempotent).
+    async fn ensure_dml_table(client: &Client, table: &str) {
+        use aws_sdk_dynamodb::types::{
+            AttributeDefinition, KeySchemaElement, KeyType, ScalarAttributeType,
+        };
+        if client
+            .describe_table()
+            .table_name(table)
+            .send()
+            .await
+            .is_ok()
+        {
+            return;
+        }
+        client
+            .create_table()
+            .table_name(table)
+            .attribute_definitions(
+                AttributeDefinition::builder()
+                    .attribute_name("id")
+                    .attribute_type(ScalarAttributeType::S)
+                    .build()
+                    .unwrap(),
+            )
+            .key_schema(
+                KeySchemaElement::builder()
+                    .attribute_name("id")
+                    .key_type(KeyType::Hash)
+                    .build()
+                    .unwrap(),
+            )
+            .billing_mode(aws_sdk_dynamodb::types::BillingMode::PayPerRequest)
+            .send()
+            .await
+            .expect("create dml table");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DynamoDB Local on :8000"]
+    async fn integration_insert_update_delete_round_trip() {
+        let table = "skardi_dml_roundtrip";
+        let mut opts = HashMap::new();
+        opts.insert("table".to_string(), table.to_string());
+        opts.insert("partition_key".to_string(), "id".to_string());
+        opts.insert("region".to_string(), "us-east-1".to_string());
+
+        let client = build_client("http://localhost:8000", "us-east-1", &opts)
+            .await
+            .expect("client");
+        ensure_dml_table(&client, table).await;
+
+        // Provider declares an explicit schema so writes have stable types even
+        // when the table is empty (inference can't see absent attributes).
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("name", DataType::Utf8, true),
+            Field::new("price", DataType::Float64, true),
+        ]));
+
+        async fn ctx_with(table: &str, schema: SchemaRef, client: Client) -> SessionContext {
+            let provider = DynamoTableProvider::new(client, table, "id", None, Some(schema))
+                .await
+                .expect("provider");
+            let ctx = SessionContext::new();
+            ctx.register_table(table, Arc::new(provider))
+                .expect("register");
+            ctx
+        }
+
+        let run = |sql: String| {
+            let schema = schema.clone();
+            let client = client.clone();
+            async move {
+                let ctx = ctx_with(table, schema, client).await;
+                ctx.sql(&sql)
+                    .await
+                    .expect("sql")
+                    .collect()
+                    .await
+                    .expect("collect")
+            }
+        };
+
+        // Clean slate
+        run(format!("DELETE FROM {table}")).await;
+
+        // INSERT
+        run(format!(
+            "INSERT INTO {table} (id, name, price) VALUES ('A1', 'Widget', 9.99)"
+        ))
+        .await;
+        let after_insert: usize = run(format!("SELECT * FROM {table} WHERE id = 'A1'"))
+            .await
+            .iter()
+            .map(|b| b.num_rows())
+            .sum();
+        assert_eq!(after_insert, 1, "row should exist after insert");
+
+        // UPDATE
+        run(format!("UPDATE {table} SET price = 19.99 WHERE id = 'A1'")).await;
+        let batches = run(format!("SELECT price FROM {table} WHERE id = 'A1'")).await;
+        let price = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .expect("price is f64")
+            .value(0);
+        assert_eq!(price, 19.99, "price should be updated");
+
+        // DELETE
+        run(format!("DELETE FROM {table} WHERE id = 'A1'")).await;
+        let after_delete: usize = run(format!("SELECT * FROM {table} WHERE id = 'A1'"))
+            .await
+            .iter()
+            .map(|b| b.num_rows())
+            .sum();
+        assert_eq!(after_delete, 0, "row should be gone after delete");
+    }
+}

--- a/crates/skardi/src/sources/providers/dynamodb.rs
+++ b/crates/skardi/src/sources/providers/dynamodb.rs
@@ -24,7 +24,7 @@ use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use async_trait::async_trait;
 use aws_sdk_dynamodb::Client;
 use aws_sdk_dynamodb::config::{Credentials, Region};
-use aws_sdk_dynamodb::types::AttributeValue;
+use aws_sdk_dynamodb::types::{AttributeValue, KeyType};
 use datafusion::catalog::Session;
 use datafusion::datasource::{TableProvider, TableType};
 use datafusion::error::{DataFusionError, Result as DFResult};
@@ -190,6 +190,73 @@ impl DynamoTableProvider {
         Ok(items)
     }
 
+    /// Fetch a single item by its full primary key (`GetItem`). Returns an empty
+    /// vec when no item matches, else a one-element vec.
+    async fn get_item_one(
+        &self,
+        key: HashMap<String, AttributeValue>,
+    ) -> Result<Vec<HashMap<String, AttributeValue>>> {
+        let out = self
+            .client
+            .get_item()
+            .table_name(&self.table_name)
+            .set_key(Some(key))
+            .send()
+            .await
+            .with_context(|| format!("DynamoDB get_item failed for '{}'", self.table_name))?;
+        Ok(out.item().cloned().into_iter().collect())
+    }
+
+    /// Run a `Query` against the key schema, paginating until exhausted (or
+    /// `limit` is reached), and return every matching item.
+    async fn query_items(
+        &self,
+        key_condition: &DynamoFilter,
+        limit: Option<usize>,
+    ) -> Result<Vec<HashMap<String, AttributeValue>>> {
+        let mut items: Vec<HashMap<String, AttributeValue>> = Vec::new();
+        let mut start_key: Option<HashMap<String, AttributeValue>> = None;
+
+        loop {
+            let mut req = self
+                .client
+                .query()
+                .table_name(&self.table_name)
+                .key_condition_expression(&key_condition.expression)
+                .set_expression_attribute_names(Some(key_condition.names.clone()))
+                .set_expression_attribute_values(Some(key_condition.values.clone()));
+            if let Some(sk) = &start_key {
+                req = req.set_exclusive_start_key(Some(sk.clone()));
+            }
+
+            let out = req
+                .send()
+                .await
+                .with_context(|| format!("DynamoDB query failed for '{}'", self.table_name))?;
+
+            items.extend(out.items().iter().cloned());
+
+            if matches!(limit, Some(n) if items.len() >= n) {
+                if let Some(n) = limit {
+                    items.truncate(n);
+                }
+                break;
+            }
+
+            match out.last_evaluated_key() {
+                Some(key) if !key.is_empty() => start_key = Some(key.clone()),
+                _ => break,
+            }
+        }
+
+        Ok(items)
+    }
+
+    /// Pick the cheapest physical read strategy the pushable predicates allow.
+    fn plan_read(&self, pushable: &[Expr]) -> DFResult<DynamoRead> {
+        classify_read(&self.partition_key, self.sort_key.as_deref(), pushable)
+    }
+
     /// Convert scanned DynamoDB items into a single Arrow `RecordBatch` shaped
     /// by this provider's schema. Missing attributes become NULLs.
     fn items_to_record_batch(
@@ -273,12 +340,35 @@ impl TableProvider for DynamoTableProvider {
             .filter(|e| is_pushable_binary_filter(e))
             .cloned()
             .collect();
-        let filter = build_filter_expression(&pushable)?;
 
-        let items = self
-            .scan_items(filter.as_ref(), limit)
-            .await
-            .map_err(|e| DataFusionError::External(e.into()))?;
+        // Route to the cheapest physical access pattern the predicates allow:
+        // GetItem when the full primary key is pinned, Query when the partition
+        // key is, else a full Scan. Filters stay Inexact, so DataFusion
+        // re-applies every predicate after the fetch — a misroute can only cost
+        // a fallback, never a wrong row.
+        let items = match self.plan_read(&pushable)? {
+            DynamoRead::GetItem { key } => {
+                tracing::debug!(table = %self.table_name, "DynamoDB read via GetItem (full key)");
+                self.get_item_one(key).await
+            }
+            DynamoRead::Query { key_condition } => {
+                tracing::debug!(
+                    table = %self.table_name,
+                    key_condition = %key_condition.expression,
+                    "DynamoDB read via Query (partition key)"
+                );
+                self.query_items(&key_condition, limit).await
+            }
+            DynamoRead::Scan { filter } => {
+                tracing::debug!(
+                    table = %self.table_name,
+                    filtered = filter.is_some(),
+                    "DynamoDB read via Scan (no key constraint)"
+                );
+                self.scan_items(filter.as_ref(), limit).await
+            }
+        }
+        .map_err(|e| DataFusionError::External(e.into()))?;
 
         let batch = self
             .items_to_record_batch(items)
@@ -742,6 +832,135 @@ fn operator_symbol(op: Operator) -> DFResult<&'static str> {
     }
 }
 
+// ─── Key-aware read planning ────────────────────────────────────────────────
+
+/// How a `scan()` should physically read DynamoDB given its pushable filters.
+enum DynamoRead {
+    /// Full primary key pinned by equality — a single-item `GetItem`.
+    GetItem {
+        key: HashMap<String, AttributeValue>,
+    },
+    /// Partition key pinned by equality, with an optional sort-key condition —
+    /// a `Query` against the key schema.
+    Query { key_condition: DynamoFilter },
+    /// No usable key constraint — a full `Scan` with an optional filter.
+    Scan { filter: Option<DynamoFilter> },
+}
+
+/// Operators DynamoDB accepts in a `KeyConditionExpression` on the sort key.
+/// `NotEq` (`<>`) is intentionally excluded — it is pushable as a regular filter
+/// but illegal on a key.
+fn is_key_condition_op(op: Operator) -> bool {
+    matches!(
+        op,
+        Operator::Eq | Operator::Lt | Operator::LtEq | Operator::Gt | Operator::GtEq
+    )
+}
+
+/// Normalize a pushable binary filter into `(column, operator, value)` with the
+/// column on the left (operator flipped if the literal was on the left).
+fn normalize_binary(expr: &Expr) -> Option<(String, Operator, AttributeValue)> {
+    let Expr::BinaryExpr(binary) = expr else {
+        return None;
+    };
+    let (col, value_expr, flipped) = match (binary.left.as_ref(), binary.right.as_ref()) {
+        (Expr::Column(c), v) => (c.name.clone(), v, false),
+        (v, Expr::Column(c)) => (c.name.clone(), v, true),
+        _ => return None,
+    };
+    let op = if flipped {
+        flip_operator(binary.op)
+    } else {
+        binary.op
+    };
+    Some((col, op, expr_to_attribute_value(value_expr).ok()?))
+}
+
+/// Build a DynamoDB `KeyConditionExpression` (`#k0 = :k0 [AND #k1 <op> :k1]`).
+/// Uses a `#k`/`:k` placeholder namespace distinct from the `#n`/`:v` used by
+/// filter expressions, so the two never collide if combined on one request.
+fn build_key_condition(
+    partition_key: &str,
+    partition_value: AttributeValue,
+    sort_key: &str,
+    sort_cond: Option<(Operator, AttributeValue)>,
+) -> DynamoFilter {
+    let mut names = HashMap::new();
+    let mut values = HashMap::new();
+    names.insert("#k0".to_string(), partition_key.to_string());
+    values.insert(":k0".to_string(), partition_value);
+    let mut expression = "#k0 = :k0".to_string();
+
+    if let Some((op, value)) = sort_cond {
+        names.insert("#k1".to_string(), sort_key.to_string());
+        values.insert(":k1".to_string(), value);
+        let symbol =
+            operator_symbol(op).expect("sort condition op validated by is_key_condition_op");
+        expression.push_str(&format!(" AND #k1 {symbol} :k1"));
+    }
+
+    DynamoFilter {
+        expression,
+        names,
+        values,
+    }
+}
+
+/// Classify pushable filters into the cheapest DynamoDB access pattern.
+///
+/// Only the *key* portion of the predicate set drives the choice; any other
+/// predicate is left for DataFusion to re-apply (filters are pushed `Inexact`),
+/// so the result is always correct regardless of which path is chosen.
+fn classify_read(
+    partition_key: &str,
+    sort_key: Option<&str>,
+    pushable: &[Expr],
+) -> DFResult<DynamoRead> {
+    let mut partition_value: Option<AttributeValue> = None;
+    let mut sort_cond: Option<(Operator, AttributeValue)> = None;
+
+    for expr in pushable {
+        let Some((col, op, value)) = normalize_binary(expr) else {
+            continue;
+        };
+        if col == partition_key {
+            // The partition key only narrows the access pattern under equality.
+            if op == Operator::Eq && partition_value.is_none() {
+                partition_value = Some(value);
+            }
+        } else if Some(col.as_str()) == sort_key && is_key_condition_op(op) && sort_cond.is_none() {
+            sort_cond = Some((op, value));
+        }
+    }
+
+    let Some(partition_value) = partition_value else {
+        // Partition key not pinned by equality → must Scan.
+        return Ok(DynamoRead::Scan {
+            filter: build_filter_expression(pushable)?,
+        });
+    };
+
+    match (sort_key, sort_cond) {
+        // Single-key table: the partition key IS the full primary key → GetItem.
+        (None, _) => {
+            let mut key = HashMap::new();
+            key.insert(partition_key.to_string(), partition_value);
+            Ok(DynamoRead::GetItem { key })
+        }
+        // Composite key fully pinned by equality → GetItem.
+        (Some(sk), Some((Operator::Eq, sort_value))) => {
+            let mut key = HashMap::new();
+            key.insert(partition_key.to_string(), partition_value);
+            key.insert(sk.to_string(), sort_value);
+            Ok(DynamoRead::GetItem { key })
+        }
+        // Composite key with a sort-key range (or no sort constraint) → Query.
+        (Some(sk), sort_cond) => Ok(DynamoRead::Query {
+            key_condition: build_key_condition(partition_key, partition_value, sk, sort_cond),
+        }),
+    }
+}
+
 /// Convert a DataFusion literal expression into a DynamoDB attribute value.
 pub(crate) fn expr_to_attribute_value(expr: &Expr) -> DFResult<AttributeValue> {
     match expr {
@@ -1131,12 +1350,19 @@ fn count_batch(count: u64) -> DFResult<RecordBatch> {
 ///
 /// # Options
 /// * `table` - DynamoDB table name (required).
-/// * `partition_key` - partition (hash) key attribute name (required).
-/// * `sort_key` - sort (range) key attribute name (optional).
+/// * `partition_key` - partition (hash) key attribute name. Optional: the key
+///   schema is read authoritatively via `DescribeTable`; this is only a fallback
+///   used when `DescribeTable` is unavailable (e.g. restricted IAM permissions).
+/// * `sort_key` - sort (range) key attribute name. Optional and likewise
+///   auto-detected from `DescribeTable`; only a fallback otherwise.
 /// * `region` - AWS region (optional, default `us-east-1`).
 /// * `access_key_env` / `secret_key_env` - names of environment variables
 ///   holding static AWS credentials (optional). When omitted, the default AWS
 ///   credential provider chain is used.
+///
+/// The resolved key schema drives key-aware reads: a query that pins the full
+/// primary key uses `GetItem`, one that pins the partition key uses `Query`, and
+/// anything else falls back to a full `Scan`.
 pub async fn register_dynamodb_tables(
     session_ctx: &mut SessionContext,
     name: &str,
@@ -1156,10 +1382,6 @@ pub async fn register_dynamodb_tables(
     let table = opts
         .get("table")
         .ok_or_else(|| anyhow::anyhow!("DynamoDB data source '{name}' requires 'table' option"))?;
-    let partition_key = opts.get("partition_key").ok_or_else(|| {
-        anyhow::anyhow!("DynamoDB data source '{name}' requires 'partition_key' option")
-    })?;
-    let sort_key = opts.get("sort_key").map(String::as_str);
     let region = opts
         .get("region")
         .cloned()
@@ -1167,9 +1389,30 @@ pub async fn register_dynamodb_tables(
 
     let client = build_client(connection_string, &region, opts).await?;
 
-    let provider = DynamoTableProvider::new(client, table, partition_key, sort_key, None)
-        .await
-        .with_context(|| format!("Failed to create DynamoDB table provider for '{name}'"))?;
+    // Prefer the table's authoritative key schema (this also auto-detects the
+    // sort key). Fall back to the configured options if DescribeTable is
+    // unavailable, e.g. under restricted IAM permissions.
+    let (partition_key, sort_key) = match describe_keys(&client, table).await {
+        Ok(keys) => keys,
+        Err(e) => {
+            tracing::warn!(
+                source = %name,
+                error = %e,
+                "DescribeTable failed; falling back to configured key options"
+            );
+            let pk = opts.get("partition_key").cloned().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "DynamoDB data source '{name}': DescribeTable failed ({e}) and no 'partition_key' option was provided"
+                )
+            })?;
+            (pk, opts.get("sort_key").cloned())
+        }
+    };
+
+    let provider =
+        DynamoTableProvider::new(client, table, &partition_key, sort_key.as_deref(), None)
+            .await
+            .with_context(|| format!("Failed to create DynamoDB table provider for '{name}'"))?;
 
     session_ctx
         .register_table(name, Arc::new(provider))
@@ -1202,6 +1445,34 @@ async fn build_client(
 
     let config = loader.load().await;
     Ok(Client::new(&config))
+}
+
+/// Read the table's authoritative key schema via `DescribeTable`, returning
+/// `(partition_key, sort_key)`. This drives key-aware read planning without
+/// trusting (possibly mismatched) configured key names, and auto-detects the
+/// sort key for composite-key tables.
+async fn describe_keys(client: &Client, table: &str) -> Result<(String, Option<String>)> {
+    let out = client
+        .describe_table()
+        .table_name(table)
+        .send()
+        .await
+        .with_context(|| format!("DescribeTable failed for '{table}'"))?;
+    let key_schema = out.table().map(|t| t.key_schema()).unwrap_or_default();
+
+    let mut partition_key: Option<String> = None;
+    let mut sort_key: Option<String> = None;
+    for element in key_schema {
+        match element.key_type() {
+            KeyType::Hash => partition_key = Some(element.attribute_name().to_string()),
+            KeyType::Range => sort_key = Some(element.attribute_name().to_string()),
+            _ => {}
+        }
+    }
+
+    let partition_key = partition_key
+        .ok_or_else(|| anyhow::anyhow!("table '{table}' has no HASH key in its key schema"))?;
+    Ok((partition_key, sort_key))
 }
 
 #[cfg(test)]
@@ -1334,6 +1605,86 @@ mod tests {
         assert!(expr.contains(", "));
         assert_eq!(names.len(), 2);
         assert_eq!(values.len(), 2);
+    }
+
+    #[test]
+    fn classify_single_key_eq_is_get_item() {
+        let filters = vec![col("product_id").eq(lit("PROD001"))];
+        match classify_read("product_id", None, &filters).unwrap() {
+            DynamoRead::GetItem { key } => {
+                assert_eq!(key.len(), 1);
+                assert!(key.contains_key("product_id"));
+            }
+            _ => panic!("expected GetItem for a full single-key lookup"),
+        }
+    }
+
+    #[test]
+    fn classify_composite_full_key_is_get_item() {
+        let filters = vec![col("pk").eq(lit("A")), col("sk").eq(lit("B"))];
+        match classify_read("pk", Some("sk"), &filters).unwrap() {
+            DynamoRead::GetItem { key } => assert_eq!(key.len(), 2),
+            _ => panic!("expected GetItem when both key parts are pinned"),
+        }
+    }
+
+    #[test]
+    fn classify_partition_eq_sort_range_is_query() {
+        let filters = vec![col("pk").eq(lit("A")), col("sk").gt(lit(5i64))];
+        match classify_read("pk", Some("sk"), &filters).unwrap() {
+            DynamoRead::Query { key_condition } => {
+                assert!(key_condition.expression.contains("#k0 = :k0"));
+                assert!(key_condition.expression.contains(" AND "));
+                assert!(key_condition.expression.contains('>'));
+                assert_eq!(key_condition.names.len(), 2);
+            }
+            _ => panic!("expected Query for partition-eq + sort-range"),
+        }
+    }
+
+    #[test]
+    fn classify_partition_eq_only_on_composite_is_query() {
+        let filters = vec![col("pk").eq(lit("A"))];
+        match classify_read("pk", Some("sk"), &filters).unwrap() {
+            DynamoRead::Query { key_condition } => {
+                assert_eq!(key_condition.expression, "#k0 = :k0");
+                assert_eq!(key_condition.names.len(), 1);
+            }
+            _ => panic!("expected partition-only Query on a composite-key table"),
+        }
+    }
+
+    #[test]
+    fn classify_partition_non_eq_is_scan() {
+        // A non-equality predicate on the partition key cannot drive Query/GetItem.
+        let filters = vec![col("product_id").gt(lit("PROD000"))];
+        assert!(matches!(
+            classify_read("product_id", None, &filters).unwrap(),
+            DynamoRead::Scan { .. }
+        ));
+    }
+
+    #[test]
+    fn classify_non_key_filter_is_scan() {
+        let filters = vec![col("category").eq(lit("Electronics"))];
+        match classify_read("product_id", None, &filters).unwrap() {
+            DynamoRead::Scan { filter } => assert!(filter.is_some()),
+            _ => panic!("expected Scan for a non-key filter"),
+        }
+    }
+
+    #[test]
+    fn classify_sort_key_noteq_is_not_a_key_condition() {
+        // `sk <> B` is pushable as a filter but illegal in a KeyConditionExpression,
+        // so it must NOT become a key condition. With the partition key pinned this
+        // yields a partition-only Query (the `<>` is left for DataFusion).
+        let filters = vec![col("pk").eq(lit("A")), col("sk").not_eq(lit("B"))];
+        match classify_read("pk", Some("sk"), &filters).unwrap() {
+            DynamoRead::Query { key_condition } => {
+                assert_eq!(key_condition.expression, "#k0 = :k0");
+            }
+            _ => panic!("expected partition-only Query; `<>` must not become a key condition"),
+        }
     }
 
     #[test]
@@ -1537,5 +1888,130 @@ mod tests {
             .map(|b| b.num_rows())
             .sum();
         assert_eq!(after_delete, 0, "row should be gone after delete");
+    }
+
+    /// Create a composite-key (HASH + RANGE) table for Query-path tests.
+    async fn ensure_composite_table(client: &Client, table: &str) {
+        use aws_sdk_dynamodb::types::{AttributeDefinition, KeySchemaElement, ScalarAttributeType};
+        if client
+            .describe_table()
+            .table_name(table)
+            .send()
+            .await
+            .is_ok()
+        {
+            return;
+        }
+        client
+            .create_table()
+            .table_name(table)
+            .attribute_definitions(
+                AttributeDefinition::builder()
+                    .attribute_name("pk")
+                    .attribute_type(ScalarAttributeType::S)
+                    .build()
+                    .unwrap(),
+            )
+            .attribute_definitions(
+                AttributeDefinition::builder()
+                    .attribute_name("sk")
+                    .attribute_type(ScalarAttributeType::N)
+                    .build()
+                    .unwrap(),
+            )
+            .key_schema(
+                KeySchemaElement::builder()
+                    .attribute_name("pk")
+                    .key_type(KeyType::Hash)
+                    .build()
+                    .unwrap(),
+            )
+            .key_schema(
+                KeySchemaElement::builder()
+                    .attribute_name("sk")
+                    .key_type(KeyType::Range)
+                    .build()
+                    .unwrap(),
+            )
+            .billing_mode(aws_sdk_dynamodb::types::BillingMode::PayPerRequest)
+            .send()
+            .await
+            .expect("create composite table");
+    }
+
+    /// End-to-end coverage of the Query path (partition-only predicate) and the
+    /// composite-key GetItem path (pk + sk equality) against DynamoDB Local. Also
+    /// exercises DescribeTable-based sort-key auto-detection via registration.
+    #[tokio::test]
+    #[ignore = "requires DynamoDB Local on :8000"]
+    async fn integration_composite_key_query_and_get() {
+        let table = "skardi_composite";
+        let mut opts = HashMap::new();
+        opts.insert("table".to_string(), table.to_string());
+        opts.insert("region".to_string(), "us-east-1".to_string());
+
+        let client = build_client("http://localhost:8000", "us-east-1", &opts)
+            .await
+            .expect("client");
+        ensure_composite_table(&client, table).await;
+
+        // Seed three items in one partition + one in another.
+        let put = |pk: &str, sk: i64| {
+            let client = client.clone();
+            let table = table.to_string();
+            let pk = pk.to_string();
+            async move {
+                client
+                    .put_item()
+                    .table_name(&table)
+                    .item("pk", AttributeValue::S(pk))
+                    .item("sk", AttributeValue::N(sk.to_string()))
+                    .send()
+                    .await
+                    .expect("put");
+            }
+        };
+        put("A", 1).await;
+        put("A", 2).await;
+        put("A", 3).await;
+        put("B", 1).await;
+
+        // Register via the public path so DescribeTable auto-detects the sort key
+        // (note: no partition_key/sort_key options supplied).
+        let mut ctx = SessionContext::new();
+        register_dynamodb_tables(&mut ctx, table, "http://localhost:8000", Some(&opts))
+            .await
+            .expect("register");
+
+        let rows = |sql: String| {
+            let ctx = &ctx;
+            async move {
+                ctx.sql(&sql)
+                    .await
+                    .expect("sql")
+                    .collect()
+                    .await
+                    .expect("collect")
+                    .iter()
+                    .map(|b| b.num_rows())
+                    .sum::<usize>()
+            }
+        };
+
+        // Partition-only predicate → Query path → all 3 items in partition A.
+        assert_eq!(
+            rows(format!("SELECT * FROM {table} WHERE pk = 'A'")).await,
+            3
+        );
+        // Full composite key by equality → GetItem path → exactly one item.
+        assert_eq!(
+            rows(format!("SELECT * FROM {table} WHERE pk = 'A' AND sk = 2")).await,
+            1
+        );
+        // Partition + sort range → Query path with a sort condition → 2 items.
+        assert_eq!(
+            rows(format!("SELECT * FROM {table} WHERE pk = 'A' AND sk >= 2")).await,
+            2
+        );
     }
 }

--- a/crates/skardi/src/sources/providers/dynamodb.rs
+++ b/crates/skardi/src/sources/providers/dynamodb.rs
@@ -11,7 +11,7 @@
 //! provider).
 
 use std::any::Any;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::{self, Debug, Formatter};
 use std::sync::Arc;
 
@@ -24,7 +24,9 @@ use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use async_trait::async_trait;
 use aws_sdk_dynamodb::Client;
 use aws_sdk_dynamodb::config::{Credentials, Region};
-use aws_sdk_dynamodb::types::{AttributeValue, KeyType};
+use aws_sdk_dynamodb::types::{
+    AttributeValue, DeleteRequest, KeyType, PutRequest, Select, WriteRequest,
+};
 use datafusion::catalog::Session;
 use datafusion::datasource::{TableProvider, TableType};
 use datafusion::error::{DataFusionError, Result as DFResult};
@@ -37,7 +39,18 @@ use datafusion::physical_plan::{
     SendableRecordBatchStream,
 };
 use datafusion::prelude::SessionContext;
-use tokio::sync::RwLock;
+use futures::StreamExt;
+use futures::stream::{self, Stream};
+
+use super::is_pushable_binary_filter;
+
+/// Maximum items sampled to infer a schema when no explicit `columns` option is
+/// given. Merging several items (rather than one) makes the inferred column set
+/// deterministic and complete enough for most tables.
+const SCHEMA_SAMPLE_SIZE: i32 = 50;
+
+/// DynamoDB `BatchWriteItem` accepts at most 25 write requests per call.
+const BATCH_WRITE_CHUNK: usize = 25;
 
 /// A DynamoDB table exposed to DataFusion as a `TableProvider`.
 pub struct DynamoTableProvider {
@@ -48,6 +61,9 @@ pub struct DynamoTableProvider {
     partition_key: String,
     /// Sort (range) key attribute name, if the table has a composite key.
     sort_key: Option<String>,
+    /// When false, INSERT/UPDATE/DELETE are rejected at plan time so a
+    /// `read_only` source can never mutate a live table.
+    read_write: bool,
 }
 
 impl Debug for DynamoTableProvider {
@@ -56,6 +72,7 @@ impl Debug for DynamoTableProvider {
             .field("table_name", &self.table_name)
             .field("partition_key", &self.partition_key)
             .field("sort_key", &self.sort_key)
+            .field("read_write", &self.read_write)
             .field("schema", &self.schema)
             .finish()
     }
@@ -63,13 +80,15 @@ impl Debug for DynamoTableProvider {
 
 impl DynamoTableProvider {
     /// Build a provider against an existing DynamoDB table, inferring the schema
-    /// from a sampled item unless one is supplied.
+    /// from sampled items unless one is supplied. `read_write` gates the DML
+    /// methods; a read-only provider rejects INSERT/UPDATE/DELETE at plan time.
     pub async fn new(
         client: Client,
         table_name: &str,
         partition_key: &str,
         sort_key: Option<&str>,
         schema: Option<SchemaRef>,
+        read_write: bool,
     ) -> Result<Self> {
         let schema = match schema {
             Some(s) => s,
@@ -84,14 +103,15 @@ impl DynamoTableProvider {
             schema,
             partition_key: partition_key.to_string(),
             sort_key: sort_key.map(str::to_string),
+            read_write,
         })
     }
 
-    /// Infer an Arrow schema by sampling a single item from the table. The
-    /// partition key (then the sort key, if any) are always emitted first and
-    /// non-nullable; remaining attributes are inferred from the sample and
-    /// marked nullable, since DynamoDB items are schemaless and any attribute
-    /// may be absent on other items.
+    /// Infer an Arrow schema by sampling several items and merging their
+    /// attribute sets. The partition key (then the sort key, if any) are always
+    /// emitted first and non-nullable; remaining attributes are inferred from
+    /// the samples and marked nullable, since DynamoDB items are schemaless and
+    /// any attribute may be absent on other items.
     async fn infer_schema(
         client: &Client,
         table_name: &str,
@@ -101,198 +121,104 @@ impl DynamoTableProvider {
         let sample = client
             .scan()
             .table_name(table_name)
-            .limit(1)
+            .limit(SCHEMA_SAMPLE_SIZE)
             .send()
             .await
             .with_context(|| format!("Failed to sample DynamoDB table '{table_name}'"))?;
 
-        let item = sample.items().first();
-
-        let mut fields: Vec<Field> = Vec::new();
-        let mut seen: Vec<&str> = Vec::new();
-
-        // Key attributes first, in key order, non-nullable.
-        let pk_type = item
-            .and_then(|i| i.get(partition_key))
-            .map(attribute_value_to_arrow_type)
-            .unwrap_or(DataType::Utf8);
-        fields.push(Field::new(partition_key, pk_type, false));
-        seen.push(partition_key);
-
-        if let Some(sk) = sort_key {
-            let sk_type = item
-                .and_then(|i| i.get(sk))
-                .map(attribute_value_to_arrow_type)
-                .unwrap_or(DataType::Utf8);
-            fields.push(Field::new(sk, sk_type, false));
-            seen.push(sk);
-        }
-
-        if let Some(item) = item {
-            for (key, value) in item.iter() {
-                if seen.contains(&key.as_str()) {
-                    continue;
-                }
-                fields.push(Field::new(key, attribute_value_to_arrow_type(value), true));
-            }
-        } else {
+        let items = sample.items();
+        if items.is_empty() {
             tracing::warn!(
                 table = %table_name,
                 "DynamoDB table is empty; schema limited to declared key attributes"
             );
         }
 
-        Ok(Schema::new(fields))
-    }
-
-    /// Run a (optionally filtered) `Scan`, paginating until the table is
-    /// exhausted, and return every matching item.
-    async fn scan_items(
-        &self,
-        filter: Option<&DynamoFilter>,
-        limit: Option<usize>,
-    ) -> Result<Vec<HashMap<String, AttributeValue>>> {
-        let mut items: Vec<HashMap<String, AttributeValue>> = Vec::new();
-        let mut start_key: Option<HashMap<String, AttributeValue>> = None;
-
-        loop {
-            let mut req = self.client.scan().table_name(&self.table_name);
-            if let Some(f) = filter {
-                req = req
-                    .filter_expression(&f.expression)
-                    .set_expression_attribute_names(Some(f.names.clone()))
-                    .set_expression_attribute_values(Some(f.values.clone()));
-            }
-            if let Some(sk) = &start_key {
-                req = req.set_exclusive_start_key(Some(sk.clone()));
-            }
-
-            let out = req
-                .send()
-                .await
-                .with_context(|| format!("DynamoDB scan failed for '{}'", self.table_name))?;
-
-            items.extend(out.items().iter().cloned());
-
-            if matches!(limit, Some(n) if items.len() >= n) {
-                if let Some(n) = limit {
-                    items.truncate(n);
+        // Merge attributes across the sampled items; first observation of an
+        // attribute fixes its type. Ordering is stable across environments
+        // because it follows first-seen order over a fixed-size sample.
+        let mut attrs: Vec<(String, DataType)> = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
+        for item in items {
+            for (key, value) in item.iter() {
+                if seen.insert(key.clone()) {
+                    attrs.push((key.clone(), attribute_value_to_arrow_type(value)));
                 }
-                break;
-            }
-
-            match out.last_evaluated_key() {
-                Some(key) if !key.is_empty() => start_key = Some(key.clone()),
-                _ => break,
             }
         }
 
-        Ok(items)
-    }
-
-    /// Fetch a single item by its full primary key (`GetItem`). Returns an empty
-    /// vec when no item matches, else a one-element vec.
-    async fn get_item_one(
-        &self,
-        key: HashMap<String, AttributeValue>,
-    ) -> Result<Vec<HashMap<String, AttributeValue>>> {
-        let out = self
-            .client
-            .get_item()
-            .table_name(&self.table_name)
-            .set_key(Some(key))
-            .send()
-            .await
-            .with_context(|| format!("DynamoDB get_item failed for '{}'", self.table_name))?;
-        Ok(out.item().cloned().into_iter().collect())
-    }
-
-    /// Run a `Query` against the key schema, paginating until exhausted (or
-    /// `limit` is reached), and return every matching item.
-    async fn query_items(
-        &self,
-        key_condition: &DynamoFilter,
-        limit: Option<usize>,
-    ) -> Result<Vec<HashMap<String, AttributeValue>>> {
-        let mut items: Vec<HashMap<String, AttributeValue>> = Vec::new();
-        let mut start_key: Option<HashMap<String, AttributeValue>> = None;
-
-        loop {
-            let mut req = self
-                .client
-                .query()
-                .table_name(&self.table_name)
-                .key_condition_expression(&key_condition.expression)
-                .set_expression_attribute_names(Some(key_condition.names.clone()))
-                .set_expression_attribute_values(Some(key_condition.values.clone()));
-            if let Some(sk) = &start_key {
-                req = req.set_exclusive_start_key(Some(sk.clone()));
-            }
-
-            let out = req
-                .send()
-                .await
-                .with_context(|| format!("DynamoDB query failed for '{}'", self.table_name))?;
-
-            items.extend(out.items().iter().cloned());
-
-            if matches!(limit, Some(n) if items.len() >= n) {
-                if let Some(n) = limit {
-                    items.truncate(n);
-                }
-                break;
-            }
-
-            match out.last_evaluated_key() {
-                Some(key) if !key.is_empty() => start_key = Some(key.clone()),
-                _ => break,
-            }
-        }
-
-        Ok(items)
+        Ok(build_schema_fields(partition_key, sort_key, &attrs))
     }
 
     /// Pick the cheapest physical read strategy the pushable predicates allow.
     fn plan_read(&self, pushable: &[Expr]) -> DFResult<DynamoRead> {
         classify_read(&self.partition_key, self.sort_key.as_deref(), pushable)
     }
+}
 
-    /// Convert scanned DynamoDB items into a single Arrow `RecordBatch` shaped
-    /// by this provider's schema. Missing attributes become NULLs.
-    fn items_to_record_batch(
-        &self,
-        items: Vec<HashMap<String, AttributeValue>>,
-    ) -> Result<RecordBatch> {
-        let mut columns: HashMap<String, Vec<Option<AttributeValue>>> = HashMap::new();
-        for field in self.schema.fields() {
-            columns.insert(field.name().clone(), Vec::with_capacity(items.len()));
-        }
-
-        for item in &items {
-            for field in self.schema.fields() {
-                let value = item.get(field.name()).cloned();
-                columns
-                    .get_mut(field.name())
-                    .expect("column inserted for every schema field above")
-                    .push(value);
-            }
-        }
-
-        let arrays: Vec<ArrayRef> = self
-            .schema
-            .fields()
+/// Build an ordered field list: key attributes first (non-nullable, in key
+/// order), then every other attribute (nullable). Shared by schema inference
+/// and the explicit `columns` option so both produce identical shapes.
+fn build_schema_fields(
+    partition_key: &str,
+    sort_key: Option<&str>,
+    attrs: &[(String, DataType)],
+) -> Schema {
+    let type_of = |name: &str| {
+        attrs
             .iter()
-            .map(|field| {
-                let values = columns
-                    .get(field.name())
-                    .expect("column inserted for every schema field above");
-                attribute_values_to_arrow_array(values, field.data_type())
-            })
-            .collect();
+            .find(|(n, _)| n == name)
+            .map(|(_, t)| t.clone())
+            .unwrap_or(DataType::Utf8)
+    };
 
-        RecordBatch::try_new(self.schema.clone(), arrays)
-            .with_context(|| "Failed to build RecordBatch from DynamoDB items")
+    let mut fields: Vec<Field> = Vec::new();
+    let mut seen: HashSet<&str> = HashSet::new();
+
+    fields.push(Field::new(partition_key, type_of(partition_key), false));
+    seen.insert(partition_key);
+    if let Some(sk) = sort_key {
+        fields.push(Field::new(sk, type_of(sk), false));
+        seen.insert(sk);
     }
+    for (name, dtype) in attrs {
+        if seen.insert(name.as_str()) {
+            fields.push(Field::new(name, dtype.clone(), true));
+        }
+    }
+    Schema::new(fields)
+}
+
+/// Convert a page of DynamoDB items into an Arrow `RecordBatch` shaped by
+/// `schema`. Consumes the items (attribute values are moved, not cloned) and
+/// fills missing attributes with NULL.
+fn items_to_batch(
+    items: Vec<HashMap<String, AttributeValue>>,
+    schema: &SchemaRef,
+) -> DFResult<RecordBatch> {
+    let n_rows = items.len();
+    let mut columns: Vec<Vec<Option<AttributeValue>>> = schema
+        .fields()
+        .iter()
+        .map(|_| Vec::with_capacity(n_rows))
+        .collect();
+
+    for mut item in items {
+        for (idx, field) in schema.fields().iter().enumerate() {
+            columns[idx].push(item.remove(field.name()));
+        }
+    }
+
+    let arrays: Vec<ArrayRef> = schema
+        .fields()
+        .iter()
+        .zip(columns.iter())
+        .map(|(field, values)| attribute_values_to_arrow_array(values, field.data_type()))
+        .collect();
+
+    let options = RecordBatchOptions::new().with_row_count(Some(n_rows));
+    RecordBatch::try_new_with_options(schema.clone(), arrays, &options)
+        .map_err(DataFusionError::from)
 }
 
 #[async_trait]
@@ -335,70 +261,48 @@ impl TableProvider for DynamoTableProvider {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        // Only push filters we can actually convert. A pushable-shaped predicate
+        // with an inconvertible literal (e.g. a Timestamp) is skipped rather than
+        // failing the whole query — safe because pushdown is Inexact, so
+        // DataFusion re-applies every predicate after the fetch.
         let pushable: Vec<Expr> = filters
             .iter()
-            .filter(|e| is_pushable_binary_filter(e))
+            .filter(|e| is_convertible_pushdown(e))
             .cloned()
             .collect();
+        let read = self.plan_read(&pushable)?;
 
-        // Route to the cheapest physical access pattern the predicates allow:
-        // GetItem when the full primary key is pinned, Query when the partition
-        // key is, else a full Scan. Filters stay Inexact, so DataFusion
-        // re-applies every predicate after the fetch — a misroute can only cost
-        // a fallback, never a wrong row.
-        let items = match self.plan_read(&pushable)? {
-            DynamoRead::GetItem { key } => {
-                tracing::debug!(table = %self.table_name, "DynamoDB read via GetItem (full key)");
-                self.get_item_one(key).await
+        // Empty projection (e.g. `count(*)`) means nothing above the scan
+        // references any column — including filters, so there are none — and we
+        // can read counts server-side. A non-empty projection is fetched with a
+        // ProjectionExpression so only those attributes cross the wire.
+        let (output_schema, projection_expr, count_only) = match projection {
+            Some(p) if p.is_empty() => (Arc::new(self.schema.project(&[])?), None, true),
+            Some(p) => {
+                let ps = Arc::new(self.schema.project(p)?);
+                let pe = build_projection_expression(&ps);
+                (ps, Some(pe), false)
             }
-            DynamoRead::Query { key_condition } => {
-                tracing::debug!(
-                    table = %self.table_name,
-                    key_condition = %key_condition.expression,
-                    "DynamoDB read via Query (partition key)"
-                );
-                self.query_items(&key_condition, limit).await
+            None => {
+                let pe = build_projection_expression(&self.schema);
+                (self.schema.clone(), Some(pe), false)
             }
-            DynamoRead::Scan { filter } => {
-                tracing::debug!(
-                    table = %self.table_name,
-                    filtered = filter.is_some(),
-                    "DynamoDB read via Scan (no key constraint)"
-                );
-                self.scan_items(filter.as_ref(), limit).await
-            }
-        }
-        .map_err(|e| DataFusionError::External(e.into()))?;
-
-        let batch = self
-            .items_to_record_batch(items)
-            .map_err(|e| DataFusionError::External(e.into()))?;
-
-        let batch = if let Some(proj) = projection {
-            let projected_schema = Arc::new(self.schema.project(proj)?);
-            let columns: Vec<ArrayRef> = proj.iter().map(|&i| batch.column(i).clone()).collect();
-            if proj.is_empty() {
-                // Empty projection (e.g. `count(*)`) needs the row count passed
-                // explicitly or RecordBatch::try_new rejects the zero-column batch.
-                let options = RecordBatchOptions::new().with_row_count(Some(batch.num_rows()));
-                RecordBatch::try_new_with_options(projected_schema, columns, &options)?
-            } else {
-                RecordBatch::try_new(projected_schema, columns)?
-            }
-        } else {
-            batch
         };
 
-        let schema = batch.schema();
         let properties = PlanProperties::new(
-            EquivalenceProperties::new(schema.clone()),
+            EquivalenceProperties::new(output_schema.clone()),
             Partitioning::UnknownPartitioning(1),
-            EmissionType::Final,
+            EmissionType::Incremental,
             Boundedness::Bounded,
         );
         Ok(Arc::new(DynamoScanExec {
-            schema,
-            batch: Arc::new(RwLock::new(Some(batch))),
+            client: self.client.clone(),
+            table_name: self.table_name.clone(),
+            output_schema,
+            read,
+            projection_expr,
+            count_only,
+            limit,
             properties,
         }))
     }
@@ -407,13 +311,23 @@ impl TableProvider for DynamoTableProvider {
         &self,
         _state: &dyn Session,
         input: Arc<dyn ExecutionPlan>,
-        _insert_op: datafusion::logical_expr::dml::InsertOp,
+        insert_op: datafusion::logical_expr::dml::InsertOp,
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        if !self.read_write {
+            return Err(read_only_error("INSERT", &self.table_name));
+        }
+        use datafusion::logical_expr::dml::InsertOp;
+        // Plain INSERT (Append) must not clobber an existing item — DynamoDB
+        // PutItem is an upsert, so a duplicate key would silently replace the
+        // whole item. Overwrite/Replace opt into upsert semantics.
+        let upsert = matches!(insert_op, InsertOp::Overwrite | InsertOp::Replace);
         Ok(Arc::new(DynamoInsertExec {
             input,
             client: self.client.clone(),
             table_name: self.table_name.clone(),
             schema: self.schema.clone(),
+            partition_key: self.partition_key.clone(),
+            upsert,
         }))
     }
 
@@ -422,15 +336,13 @@ impl TableProvider for DynamoTableProvider {
         _state: &dyn Session,
         filters: Vec<Expr>,
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
-        let pushable: Vec<Expr> = filters
-            .iter()
-            .filter(|e| is_pushable_binary_filter(e))
-            .cloned()
-            .collect();
-        let filter = build_filter_expression(&pushable)?;
+        if !self.read_write {
+            return Err(read_only_error("DELETE", &self.table_name));
+        }
+        let plan = self.plan_dml(&filters)?;
         Ok(Arc::new(DynamoDmlExec::new(
             self.clone_handle(),
-            DynamoDmlOp::Delete { filter },
+            DynamoDmlOp::Delete { plan },
         )))
     }
 
@@ -440,6 +352,9 @@ impl TableProvider for DynamoTableProvider {
         assignments: Vec<(String, Expr)>,
         filters: Vec<Expr>,
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        if !self.read_write {
+            return Err(read_only_error("UPDATE", &self.table_name));
+        }
         if assignments.is_empty() {
             return Err(DataFusionError::Plan(
                 "UPDATE requires at least one assignment".to_string(),
@@ -455,16 +370,10 @@ impl TableProvider for DynamoTableProvider {
             sets.push((col.clone(), expr_to_attribute_value(expr)?));
         }
 
-        let pushable: Vec<Expr> = filters
-            .iter()
-            .filter(|e| is_pushable_binary_filter(e))
-            .cloned()
-            .collect();
-        let filter = build_filter_expression(&pushable)?;
-
+        let plan = self.plan_dml(&filters)?;
         Ok(Arc::new(DynamoDmlExec::new(
             self.clone_handle(),
-            DynamoDmlOp::Update { filter, sets },
+            DynamoDmlOp::Update { plan, sets },
         )))
     }
 }
@@ -480,6 +389,33 @@ impl DynamoTableProvider {
             sort_key: self.sort_key.clone(),
         }
     }
+
+    /// Plan a DELETE/UPDATE against the key schema.
+    ///
+    /// DynamoDB cannot mutate by arbitrary predicate, so we first resolve the
+    /// matching keys. Every WHERE predicate must be a convertible pushable
+    /// comparison: otherwise the residual predicate could not be applied
+    /// server-side and we would mutate rows it should have excluded. We refuse
+    /// rather than silently over-delete (`DELETE WHERE a = 1 OR b = 2` must not
+    /// wipe the table).
+    fn plan_dml(&self, filters: &[Expr]) -> DFResult<DmlKeyPlan> {
+        if let Some(bad) = filters.iter().find(|e| !is_convertible_pushdown(e)) {
+            return Err(DataFusionError::Plan(format!(
+                "DynamoDB DELETE/UPDATE requires every WHERE predicate to be a pushable comparison \
+                 (a column compared to a literal via =, <>, <, <=, >, >=). Unsupported predicate: {bad}. \
+                 Refusing to run to avoid mutating rows the predicate should have excluded."
+            )));
+        }
+        classify_dml(&self.partition_key, self.sort_key.as_deref(), filters)
+    }
+}
+
+/// Error returned when a write is attempted against a read-only source.
+fn read_only_error(op: &str, table: &str) -> DataFusionError {
+    DataFusionError::Plan(format!(
+        "{op} not allowed on DynamoDB table '{table}': the data source is configured read_only. \
+         Set access_mode: read_write to enable write operations."
+    ))
 }
 
 /// Connection handle plus key metadata shared with DML execution plans.
@@ -511,58 +447,118 @@ impl DynamoHandle {
         Ok(key)
     }
 
-    /// Scan keys of items matching `filter` (used to drive key-based DML).
+    /// A `ProjectionExpression` (plus its name bindings) that fetches only the
+    /// key attributes — all the DML paths need, since they mutate by key.
+    fn key_projection(&self) -> (String, HashMap<String, String>) {
+        let mut names = HashMap::new();
+        let mut parts = vec!["#p0".to_string()];
+        names.insert("#p0".to_string(), self.partition_key.clone());
+        if let Some(sk) = &self.sort_key {
+            names.insert("#p1".to_string(), sk.clone());
+            parts.push("#p1".to_string());
+        }
+        (parts.join(", "), names)
+    }
+
+    /// Resolve the keys of items matching a DML plan, routing to Query when the
+    /// partition key is pinned (any residual predicate is applied server-side as
+    /// a `FilterExpression`) and falling back to a full Scan otherwise — instead
+    /// of always scanning the whole table.
     async fn matching_keys(
         &self,
-        filter: Option<&DynamoFilter>,
+        plan: &DmlKeyPlan,
     ) -> Result<Vec<HashMap<String, AttributeValue>>> {
+        let source = match plan {
+            DmlKeyPlan::Query {
+                key_condition,
+                residual,
+            } => PageSource::Query {
+                key_condition: key_condition.clone(),
+                filter: residual.clone(),
+            },
+            DmlKeyPlan::Scan { filter } => PageSource::Scan {
+                filter: filter.clone(),
+            },
+        };
+        let key_projection = self.key_projection();
+
         let mut keys = Vec::new();
         let mut start_key: Option<HashMap<String, AttributeValue>> = None;
         loop {
-            let mut req = self.client.scan().table_name(&self.table_name);
-            if let Some(f) = filter {
-                req = req
-                    .filter_expression(&f.expression)
-                    .set_expression_attribute_names(Some(f.names.clone()))
-                    .set_expression_attribute_values(Some(f.values.clone()));
-            }
-            if let Some(sk) = &start_key {
-                req = req.set_exclusive_start_key(Some(sk.clone()));
-            }
-            let out = req
-                .send()
-                .await
-                .with_context(|| format!("DynamoDB scan failed for '{}'", self.table_name))?;
-            for item in out.items() {
+            let (items, last) = fetch_page(
+                &self.client,
+                &self.table_name,
+                &source,
+                Some(&key_projection),
+                start_key.take(),
+                None,
+            )
+            .await?;
+            for item in &items {
                 keys.push(self.key_of(item)?);
             }
-            match out.last_evaluated_key() {
-                Some(k) if !k.is_empty() => start_key = Some(k.clone()),
-                _ => break,
+            match last {
+                Some(k) => start_key = Some(k),
+                None => break,
             }
         }
         Ok(keys)
     }
+
+    /// Delete a set of keys via `BatchWriteItem` (25 per request), retrying any
+    /// unprocessed keys. Returns the number of keys submitted (all of which
+    /// correspond to matched items).
+    async fn batch_delete(&self, keys: Vec<HashMap<String, AttributeValue>>) -> Result<u64> {
+        let total = keys.len() as u64;
+        for chunk in keys.chunks(BATCH_WRITE_CHUNK) {
+            let requests: Vec<WriteRequest> = chunk
+                .iter()
+                .map(|k| {
+                    let del = DeleteRequest::builder()
+                        .set_key(Some(k.clone()))
+                        .build()
+                        .expect("DeleteRequest requires only a key, which is set");
+                    WriteRequest::builder().delete_request(del).build()
+                })
+                .collect();
+            batch_write(&self.client, &self.table_name, requests).await?;
+        }
+        Ok(total)
+    }
+}
+
+/// Submit one chunk of write requests, retrying `UnprocessedItems` (which
+/// DynamoDB returns under throttling) up to a bounded number of times.
+async fn batch_write(client: &Client, table: &str, requests: Vec<WriteRequest>) -> Result<()> {
+    let mut pending: HashMap<String, Vec<WriteRequest>> =
+        HashMap::from([(table.to_string(), requests)]);
+    for _ in 0..8 {
+        let out = client
+            .batch_write_item()
+            .set_request_items(Some(pending))
+            .send()
+            .await
+            .with_context(|| format!("DynamoDB batch_write_item failed for '{table}'"))?;
+        match out.unprocessed_items {
+            Some(u) if !u.is_empty() => pending = u,
+            _ => return Ok(()),
+        }
+    }
+    anyhow::bail!("DynamoDB batch_write_item left items unprocessed after retries for '{table}'")
 }
 
 // ─── Schema inference & type mapping ────────────────────────────────────────
 
-/// Map a sampled DynamoDB attribute to an Arrow type. Numbers are inferred as
-/// `Int64` when the sample has no fractional part, else `Float64`. Everything
-/// non-scalar (maps, lists, sets, binary) falls back to `Utf8`.
+/// Map a sampled DynamoDB attribute to an Arrow type. Numbers are always
+/// inferred as `Float64`: a single sampled item can't prove a column is
+/// integer-only, and a later fractional value would otherwise be silently
+/// truncated (or drop the row via the Inexact re-filter). Everything non-scalar
+/// (maps, lists, sets, binary) falls back to `Utf8`.
 pub(crate) fn attribute_value_to_arrow_type(value: &AttributeValue) -> DataType {
     match value {
         AttributeValue::S(_) => DataType::Utf8,
         AttributeValue::Bool(_) => DataType::Boolean,
-        AttributeValue::N(n) => {
-            if n.contains('.') || n.contains('e') || n.contains('E') {
-                DataType::Float64
-            } else if n.parse::<i64>().is_ok() {
-                DataType::Int64
-            } else {
-                DataType::Float64
-            }
-        }
+        AttributeValue::N(_) => DataType::Float64,
         AttributeValue::Null(_) => DataType::Utf8,
         _ => DataType::Utf8,
     }
@@ -629,21 +625,23 @@ fn av_to_string(v: &AttributeValue) -> String {
     }
 }
 
+/// Coerce to `i64` only from an exactly-integer `N`. A fractional value
+/// (`N("7.9")`) or a string (`S("7")`) yields `None` (SQL NULL) rather than a
+/// silently truncated or cross-type value — which would violate the Inexact
+/// pushdown superset contract, since DynamoDB's server-side filter is type- and
+/// value-strict.
 fn av_to_i64(v: &AttributeValue) -> Option<i64> {
     match v {
-        AttributeValue::N(n) => n
-            .parse::<i64>()
-            .ok()
-            .or_else(|| n.parse::<f64>().ok().map(|f| f as i64)),
-        AttributeValue::S(s) => s.parse::<i64>().ok(),
+        AttributeValue::N(n) => n.parse::<i64>().ok(),
         _ => None,
     }
 }
 
+/// Coerce to `f64` only from a numeric `N`. A string is not coerced (see
+/// `av_to_i64` for why cross-type coercion is unsafe under Inexact pushdown).
 fn av_to_f64(v: &AttributeValue) -> Option<f64> {
     match v {
         AttributeValue::N(n) => n.parse::<f64>().ok(),
-        AttributeValue::S(s) => s.parse::<f64>().ok(),
         _ => None,
     }
 }
@@ -733,32 +731,19 @@ fn record_batch_to_items(
 // ─── Filter pushdown ────────────────────────────────────────────────────────
 
 /// A DynamoDB `FilterExpression` plus its attribute-name/value placeholder maps.
+#[derive(Clone, Debug)]
 struct DynamoFilter {
     expression: String,
     names: HashMap<String, String>,
     values: HashMap<String, AttributeValue>,
 }
 
-/// Same predicate the MongoDB provider uses: a comparison between a bare column
-/// and a literal, with an operator DynamoDB can evaluate server-side.
-pub(crate) fn is_pushable_binary_filter(expr: &Expr) -> bool {
-    match expr {
-        Expr::BinaryExpr(binary) => {
-            matches!(
-                binary.op,
-                Operator::Eq
-                    | Operator::NotEq
-                    | Operator::Lt
-                    | Operator::LtEq
-                    | Operator::Gt
-                    | Operator::GtEq
-            ) && matches!(
-                (binary.left.as_ref(), binary.right.as_ref()),
-                (Expr::Column(_), Expr::Literal(..)) | (Expr::Literal(..), Expr::Column(_))
-            )
-        }
-        _ => false,
-    }
+/// A pushable-shaped filter (see `is_pushable_binary_filter`) whose literal can
+/// also be converted to a DynamoDB attribute value. The shape check alone is not
+/// enough: a comparison against e.g. a Timestamp literal is pushable-shaped but
+/// not convertible, and pushing it would fail the request.
+fn is_convertible_pushdown(expr: &Expr) -> bool {
+    is_pushable_binary_filter(expr) && normalize_binary(expr).is_some()
 }
 
 /// Convert a list of pushable binary filters into one ANDed DynamoDB
@@ -832,9 +817,24 @@ fn operator_symbol(op: Operator) -> DFResult<&'static str> {
     }
 }
 
+/// Build a `ProjectionExpression` naming exactly the fields in `schema`, using a
+/// `#p` placeholder namespace (distinct from filter `#n`/`:v` and key-condition
+/// `#k`/`:k`) so it can be merged onto the same request without collision.
+fn build_projection_expression(schema: &Schema) -> (String, HashMap<String, String>) {
+    let mut names = HashMap::new();
+    let mut parts = Vec::with_capacity(schema.fields().len());
+    for (i, field) in schema.fields().iter().enumerate() {
+        let ph = format!("#p{i}");
+        names.insert(ph.clone(), field.name().clone());
+        parts.push(ph);
+    }
+    (parts.join(", "), names)
+}
+
 // ─── Key-aware read planning ────────────────────────────────────────────────
 
 /// How a `scan()` should physically read DynamoDB given its pushable filters.
+#[derive(Clone, Debug)]
 enum DynamoRead {
     /// Full primary key pinned by equality — a single-item `GetItem`.
     GetItem {
@@ -961,6 +961,97 @@ fn classify_read(
     }
 }
 
+/// How a DELETE/UPDATE should resolve the keys it will mutate. Unlike the read
+/// path (whose residual predicates DataFusion re-applies via Inexact pushdown),
+/// DML must apply *every* predicate server-side, so any residual non-key
+/// predicate travels as a `FilterExpression`.
+#[derive(Clone, Debug)]
+enum DmlKeyPlan {
+    /// Partition key pinned by equality → `Query` (with an optional sort-key
+    /// condition folded in), plus a residual `FilterExpression` over non-key
+    /// attributes. Far cheaper than scanning the whole table.
+    Query {
+        key_condition: DynamoFilter,
+        residual: Option<DynamoFilter>,
+    },
+    /// Partition key not pinned (or an inexpressible sort predicate) → full
+    /// `Scan` carrying every predicate as a `FilterExpression`.
+    Scan { filter: Option<DynamoFilter> },
+}
+
+/// Plan the key-resolution strategy for a DELETE/UPDATE. Callers must have
+/// already ensured every predicate is a convertible pushable comparison (see
+/// `plan_dml`), so nothing is silently dropped.
+///
+/// We can drive a `Query` only when the partition key is pinned by equality and
+/// every sort-key predicate is expressible on the key: a `Query`'s
+/// `FilterExpression` may not reference key attributes, and its
+/// `KeyConditionExpression` allows at most one sort-key condition using a legal
+/// operator (so `sk <> …`, or two sort predicates, force a `Scan`). A `Scan`'s
+/// filter, by contrast, may reference keys, so it always expresses the full
+/// predicate set.
+fn classify_dml(
+    partition_key: &str,
+    sort_key: Option<&str>,
+    filters: &[Expr],
+) -> DFResult<DmlKeyPlan> {
+    let mut partition_value: Option<AttributeValue> = None;
+    let mut partition_query_ok = true;
+    let mut sort_conds: Vec<(Operator, AttributeValue)> = Vec::new();
+    let mut sort_key_expressible = true;
+    let mut residual: Vec<Expr> = Vec::new();
+
+    for expr in filters {
+        let Some((col, op, value)) = normalize_binary(expr) else {
+            // Unreachable after plan_dml's guard, but stay safe: force a Scan.
+            partition_query_ok = false;
+            residual.push(expr.clone());
+            continue;
+        };
+        if col == partition_key {
+            if op == Operator::Eq && partition_value.is_none() {
+                partition_value = Some(value);
+            } else {
+                // A non-equality (or duplicate) partition predicate can't drive
+                // a Query and can't live in a Query filter → must Scan.
+                partition_query_ok = false;
+            }
+        } else if Some(col.as_str()) == sort_key {
+            if !is_key_condition_op(op) {
+                sort_key_expressible = false;
+            }
+            sort_conds.push((op, value));
+        } else {
+            residual.push(expr.clone());
+        }
+    }
+
+    let can_query = partition_query_ok
+        && partition_value.is_some()
+        && sort_conds.len() <= 1
+        && sort_key_expressible;
+
+    if can_query {
+        let partition_value = partition_value.expect("checked by can_query");
+        let sort_cond = sort_conds.into_iter().next();
+        let key_condition = build_key_condition(
+            partition_key,
+            partition_value,
+            sort_key.unwrap_or(""),
+            sort_cond,
+        );
+        Ok(DmlKeyPlan::Query {
+            key_condition,
+            residual: build_filter_expression(&residual)?,
+        })
+    } else {
+        // Scan carries every predicate; a Scan filter may reference key columns.
+        Ok(DmlKeyPlan::Scan {
+            filter: build_filter_expression(filters)?,
+        })
+    }
+}
+
 /// Convert a DataFusion literal expression into a DynamoDB attribute value.
 pub(crate) fn expr_to_attribute_value(expr: &Expr) -> DFResult<AttributeValue> {
     match expr {
@@ -998,13 +1089,210 @@ fn scalar_to_attribute_value(scalar: &datafusion::common::ScalarValue) -> DFResu
     Ok(av)
 }
 
+// ─── Page fetching & streaming ──────────────────────────────────────────────
+
+/// One page source for the shared scan/query paginator.
+#[derive(Clone, Debug)]
+enum PageSource {
+    Scan {
+        filter: Option<DynamoFilter>,
+    },
+    Query {
+        key_condition: DynamoFilter,
+        filter: Option<DynamoFilter>,
+    },
+}
+
+/// Fetch a single page from a Scan or Query, merging any filter, key-condition
+/// and projection expressions onto one request (their `#n`/`#k`/`#p` namespaces
+/// never collide). Returns the page's items — moved, not cloned — and the next
+/// `ExclusiveStartKey` (`None` when the table is exhausted).
+async fn fetch_page(
+    client: &Client,
+    table: &str,
+    source: &PageSource,
+    projection: Option<&(String, HashMap<String, String>)>,
+    start_key: Option<HashMap<String, AttributeValue>>,
+    page_limit: Option<i32>,
+) -> Result<(
+    Vec<HashMap<String, AttributeValue>>,
+    Option<HashMap<String, AttributeValue>>,
+)> {
+    let mut names: HashMap<String, String> = HashMap::new();
+    if let Some((_, pnames)) = projection {
+        names.extend(pnames.clone());
+    }
+
+    let (items, last_key) = match source {
+        PageSource::Scan { filter } => {
+            let mut req = client.scan().table_name(table);
+            if let Some(f) = filter {
+                req = req
+                    .filter_expression(&f.expression)
+                    .set_expression_attribute_values(Some(f.values.clone()));
+                names.extend(f.names.clone());
+            }
+            if let Some((expr, _)) = projection {
+                req = req.projection_expression(expr);
+            }
+            if !names.is_empty() {
+                req = req.set_expression_attribute_names(Some(names));
+            }
+            if let Some(l) = page_limit {
+                req = req.limit(l);
+            }
+            if let Some(sk) = start_key {
+                req = req.set_exclusive_start_key(Some(sk));
+            }
+            let out = req
+                .send()
+                .await
+                .with_context(|| format!("DynamoDB scan failed for '{table}'"))?;
+            (out.items.unwrap_or_default(), out.last_evaluated_key)
+        }
+        PageSource::Query {
+            key_condition,
+            filter,
+        } => {
+            let mut req = client
+                .query()
+                .table_name(table)
+                .key_condition_expression(&key_condition.expression);
+            let mut values = key_condition.values.clone();
+            names.extend(key_condition.names.clone());
+            if let Some(f) = filter {
+                req = req.filter_expression(&f.expression);
+                values.extend(f.values.clone());
+                names.extend(f.names.clone());
+            }
+            if let Some((expr, _)) = projection {
+                req = req.projection_expression(expr);
+            }
+            req = req
+                .set_expression_attribute_names(Some(names))
+                .set_expression_attribute_values(Some(values));
+            if let Some(l) = page_limit {
+                req = req.limit(l);
+            }
+            if let Some(sk) = start_key {
+                req = req.set_exclusive_start_key(Some(sk));
+            }
+            let out = req
+                .send()
+                .await
+                .with_context(|| format!("DynamoDB query failed for '{table}'"))?;
+            (out.items.unwrap_or_default(), out.last_evaluated_key)
+        }
+    };
+
+    Ok((items, last_key.filter(|k| !k.is_empty())))
+}
+
+/// State carried between paginator steps.
+struct PageState {
+    start_key: Option<HashMap<String, AttributeValue>>,
+    remaining: Option<usize>,
+}
+
+/// Stream a Scan/Query one page at a time as projected `RecordBatch`es. Memory
+/// is bounded to a single page (~1MB) instead of buffering the whole result,
+/// and a SQL `LIMIT` caps both the rows returned and the per-page request size.
+fn stream_pages(
+    client: Client,
+    table: String,
+    source: PageSource,
+    projection: Option<(String, HashMap<String, String>)>,
+    schema: SchemaRef,
+    limit: Option<usize>,
+) -> impl Stream<Item = DFResult<RecordBatch>> {
+    let initial = Some(PageState {
+        start_key: None,
+        remaining: limit,
+    });
+    stream::unfold(initial, move |maybe_state| {
+        let client = client.clone();
+        let table = table.clone();
+        let source = source.clone();
+        let projection = projection.clone();
+        let schema = schema.clone();
+        async move {
+            let state = maybe_state?;
+            let page_limit = state.remaining.map(|r| r.min(i32::MAX as usize) as i32);
+            let fetched = fetch_page(
+                &client,
+                &table,
+                &source,
+                projection.as_ref(),
+                state.start_key,
+                page_limit,
+            )
+            .await
+            .map_err(|e| DataFusionError::External(e.into()));
+
+            let (mut items, last_key) = match fetched {
+                Ok(v) => v,
+                Err(e) => return Some((Err(e), None)),
+            };
+            if let Some(r) = state.remaining {
+                items.truncate(r);
+            }
+            let got = items.len();
+            let batch = items_to_batch(items, &schema);
+            let next_remaining = state.remaining.map(|r| r.saturating_sub(got));
+            let stop = next_remaining == Some(0) || last_key.is_none();
+            let next = if stop {
+                None
+            } else {
+                Some(PageState {
+                    start_key: last_key,
+                    remaining: next_remaining,
+                })
+            };
+            Some((batch, next))
+        }
+    })
+}
+
+/// Count items server-side via `Scan` with `Select=COUNT`, emitting a single
+/// zero-column batch whose row count is the total (drives `count(*)`). Only
+/// reached when the projection is empty, i.e. no predicate references any
+/// column, so an unfiltered count is exact.
+async fn count_scan(client: &Client, table: &str, schema: SchemaRef) -> DFResult<RecordBatch> {
+    let mut total = 0usize;
+    let mut start: Option<HashMap<String, AttributeValue>> = None;
+    loop {
+        let mut req = client.scan().table_name(table).select(Select::Count);
+        if let Some(sk) = start.take() {
+            req = req.set_exclusive_start_key(Some(sk));
+        }
+        let out = req
+            .send()
+            .await
+            .map_err(|e| DataFusionError::Execution(format!("DynamoDB count scan failed: {e}")))?;
+        total += out.count() as usize;
+        match out.last_evaluated_key {
+            Some(k) if !k.is_empty() => start = Some(k),
+            _ => break,
+        }
+    }
+    let options = RecordBatchOptions::new().with_row_count(Some(total));
+    RecordBatch::try_new_with_options(schema, vec![], &options).map_err(DataFusionError::from)
+}
+
 // ─── Scan execution plan ────────────────────────────────────────────────────
 
-/// Leaf plan holding a pre-fetched scan result batch.
+/// Leaf plan that streams a DynamoDB read, page by page, on execution.
 #[derive(Debug)]
 struct DynamoScanExec {
-    schema: SchemaRef,
-    batch: Arc<RwLock<Option<RecordBatch>>>,
+    client: Client,
+    table_name: String,
+    output_schema: SchemaRef,
+    read: DynamoRead,
+    /// `ProjectionExpression` (and its `#p` bindings) for the projected columns,
+    /// or `None` for a `count(*)` (empty projection).
+    projection_expr: Option<(String, HashMap<String, String>)>,
+    count_only: bool,
+    limit: Option<usize>,
     properties: PlanProperties,
 }
 
@@ -1038,18 +1326,69 @@ impl ExecutionPlan for DynamoScanExec {
         _partition: usize,
         _context: Arc<datafusion::execution::TaskContext>,
     ) -> DFResult<SendableRecordBatchStream> {
-        let schema = self.schema.clone();
-        let batch = self.batch.clone();
-        let stream = futures::stream::once(async move {
-            let guard = batch.read().await;
-            match guard.as_ref() {
-                Some(b) => Ok(b.clone()),
-                None => Err(DataFusionError::Execution(
-                    "Batch already consumed".to_string(),
-                )),
+        let schema = self.output_schema.clone();
+        let client = self.client.clone();
+        let table = self.table_name.clone();
+
+        if self.count_only {
+            let count_schema = schema.clone();
+            let fut = async move { count_scan(&client, &table, count_schema).await };
+            return Ok(Box::pin(RecordBatchStreamAdapter::new(
+                schema,
+                stream::once(fut),
+            )));
+        }
+
+        match self.read.clone() {
+            DynamoRead::GetItem { key } => {
+                let projection = self.projection_expr.clone();
+                let item_schema = schema.clone();
+                let fut = async move {
+                    let mut req = client.get_item().table_name(&table).set_key(Some(key));
+                    if let Some((expr, names)) = projection {
+                        req = req
+                            .projection_expression(expr)
+                            .set_expression_attribute_names(Some(names));
+                    }
+                    let out = req.send().await.map_err(|e| {
+                        DataFusionError::Execution(format!("DynamoDB get_item failed: {e}"))
+                    })?;
+                    let items: Vec<_> = out.item.into_iter().collect();
+                    items_to_batch(items, &item_schema)
+                };
+                Ok(Box::pin(RecordBatchStreamAdapter::new(
+                    schema,
+                    stream::once(fut),
+                )))
             }
-        });
-        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+            DynamoRead::Query { key_condition } => {
+                let src = PageSource::Query {
+                    key_condition,
+                    filter: None,
+                };
+                let s = stream_pages(
+                    client,
+                    table,
+                    src,
+                    self.projection_expr.clone(),
+                    schema.clone(),
+                    self.limit,
+                );
+                Ok(Box::pin(RecordBatchStreamAdapter::new(schema, s)))
+            }
+            DynamoRead::Scan { filter } => {
+                let src = PageSource::Scan { filter };
+                let s = stream_pages(
+                    client,
+                    table,
+                    src,
+                    self.projection_expr.clone(),
+                    schema.clone(),
+                    self.limit,
+                );
+                Ok(Box::pin(RecordBatchStreamAdapter::new(schema, s)))
+            }
+        }
     }
 }
 
@@ -1060,12 +1399,18 @@ struct DynamoInsertExec {
     client: Client,
     table_name: String,
     schema: SchemaRef,
+    partition_key: String,
+    /// True for INSERT OVERWRITE/REPLACE (upsert via `BatchWriteItem`); false
+    /// for plain INSERT (Append), which uses a conditional `PutItem` so a
+    /// duplicate key errors instead of silently replacing the item.
+    upsert: bool,
 }
 
 impl Debug for DynamoInsertExec {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("DynamoInsertExec")
             .field("table_name", &self.table_name)
+            .field("upsert", &self.upsert)
             .finish()
     }
 }
@@ -1074,6 +1419,62 @@ impl DisplayAs for DynamoInsertExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> fmt::Result {
         write!(f, "DynamoInsertExec")
     }
+}
+
+/// Append INSERT: `PutItem` guarded by `attribute_not_exists` on the partition
+/// key so an existing item is not silently overwritten.
+async fn put_conditional(
+    client: &Client,
+    table: &str,
+    partition_key: &str,
+    item: HashMap<String, AttributeValue>,
+) -> DFResult<()> {
+    let names = HashMap::from([("#pk".to_string(), partition_key.to_string())]);
+    client
+        .put_item()
+        .table_name(table)
+        .set_item(Some(item))
+        .condition_expression("attribute_not_exists(#pk)")
+        .set_expression_attribute_names(Some(names))
+        .send()
+        .await
+        .map_err(|e| {
+            let svc = e.into_service_error();
+            if svc.is_conditional_check_failed_exception() {
+                DataFusionError::Execution(format!(
+                    "DynamoDB INSERT: an item with this key already exists in '{table}'. \
+                     Use INSERT OVERWRITE to replace it."
+                ))
+            } else {
+                DataFusionError::Execution(format!("DynamoDB put_item failed: {svc}"))
+            }
+        })?;
+    Ok(())
+}
+
+/// Upsert INSERT (Overwrite/Replace): batch the items via `BatchWriteItem`
+/// (25 per request), cutting a large insert from one round-trip per row.
+async fn batch_put(
+    client: &Client,
+    table: &str,
+    items: Vec<HashMap<String, AttributeValue>>,
+) -> DFResult<()> {
+    for chunk in items.chunks(BATCH_WRITE_CHUNK) {
+        let requests: Vec<WriteRequest> = chunk
+            .iter()
+            .map(|it| {
+                let put = PutRequest::builder()
+                    .set_item(Some(it.clone()))
+                    .build()
+                    .expect("PutRequest requires only an item, which is set");
+                WriteRequest::builder().put_request(put).build()
+            })
+            .collect();
+        batch_write(client, table, requests)
+            .await
+            .map_err(|e| DataFusionError::External(e.into()))?;
+    }
+    Ok(())
 }
 
 impl ExecutionPlan for DynamoInsertExec {
@@ -1098,6 +1499,8 @@ impl ExecutionPlan for DynamoInsertExec {
             client: self.client.clone(),
             table_name: self.table_name.clone(),
             schema: self.schema.clone(),
+            partition_key: self.partition_key.clone(),
+            upsert: self.upsert,
         }))
     }
     fn execute(
@@ -1109,46 +1512,56 @@ impl ExecutionPlan for DynamoInsertExec {
         let client = self.client.clone();
         let table_name = self.table_name.clone();
         let schema = self.schema.clone();
+        let partition_key = self.partition_key.clone();
+        let upsert = self.upsert;
         let output_schema = count_schema();
 
         let future = async move {
             let mut count: u64 = 0;
-            use futures::StreamExt;
+            // Bound memory for upsert batching: flush every full chunk instead of
+            // buffering the entire input.
+            let mut buf: Vec<HashMap<String, AttributeValue>> = Vec::new();
             while let Some(batch) = input_stream.next().await {
                 let batch = batch?;
                 let items = record_batch_to_items(&batch, &schema)
                     .map_err(|e| DataFusionError::External(e.into()))?;
                 for item in items {
-                    client
-                        .put_item()
-                        .table_name(&table_name)
-                        .set_item(Some(item))
-                        .send()
-                        .await
-                        .map_err(|e| {
-                            DataFusionError::Execution(format!("DynamoDB put_item failed: {e}"))
-                        })?;
-                    count += 1;
+                    if upsert {
+                        buf.push(item);
+                        if buf.len() >= BATCH_WRITE_CHUNK {
+                            let chunk = std::mem::take(&mut buf);
+                            count += chunk.len() as u64;
+                            batch_put(&client, &table_name, chunk).await?;
+                        }
+                    } else {
+                        put_conditional(&client, &table_name, &partition_key, item).await?;
+                        count += 1;
+                    }
                 }
+            }
+            if !buf.is_empty() {
+                count += buf.len() as u64;
+                batch_put(&client, &table_name, buf).await?;
             }
             count_batch(count)
         };
 
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             output_schema,
-            futures::stream::once(future),
+            stream::once(future),
         )))
     }
 }
 
 // ─── DELETE / UPDATE execution plan ─────────────────────────────────────────
 
+#[derive(Clone)]
 enum DynamoDmlOp {
     Delete {
-        filter: Option<DynamoFilter>,
+        plan: DmlKeyPlan,
     },
     Update {
-        filter: Option<DynamoFilter>,
+        plan: DmlKeyPlan,
         sets: Vec<(String, AttributeValue)>,
     },
 }
@@ -1156,7 +1569,9 @@ enum DynamoDmlOp {
 /// Leaf plan that runs a key-based DELETE or UPDATE and returns `{ count }`.
 ///
 /// DynamoDB cannot delete or update by arbitrary predicate, so the matching
-/// keys are scanned first and then mutated one key at a time.
+/// keys are resolved first (via Query or Scan) and then mutated: DELETE batches
+/// them through `BatchWriteItem`, UPDATE issues one `UpdateItem` per key
+/// (`BatchWriteItem` cannot express updates).
 struct DynamoDmlExec {
     handle: DynamoHandle,
     op: DynamoDmlOp,
@@ -1219,34 +1634,22 @@ impl ExecutionPlan for DynamoDmlExec {
         _context: Arc<datafusion::execution::TaskContext>,
     ) -> DFResult<SendableRecordBatchStream> {
         let handle = self.handle.clone();
-        // Move the op out by cloning its parts (AttributeValue/maps are clonable).
-        let op = self.op.clone_op();
+        let op = self.op.clone();
         let future = async move {
             let affected = match op {
-                DynamoDmlOp::Delete { filter } => {
+                DynamoDmlOp::Delete { plan } => {
                     let keys = handle
-                        .matching_keys(filter.as_ref())
+                        .matching_keys(&plan)
                         .await
                         .map_err(|e| DataFusionError::External(e.into()))?;
-                    let mut n = 0u64;
-                    for key in keys {
-                        handle
-                            .client
-                            .delete_item()
-                            .table_name(&handle.table_name)
-                            .set_key(Some(key))
-                            .send()
-                            .await
-                            .map_err(|e| {
-                                DataFusionError::Execution(format!("DynamoDB delete failed: {e}"))
-                            })?;
-                        n += 1;
-                    }
-                    n
+                    handle
+                        .batch_delete(keys)
+                        .await
+                        .map_err(|e| DataFusionError::External(e.into()))?
                 }
-                DynamoDmlOp::Update { filter, sets } => {
+                DynamoDmlOp::Update { plan, sets } => {
                     let keys = handle
-                        .matching_keys(filter.as_ref())
+                        .matching_keys(&plan)
                         .await
                         .map_err(|e| DataFusionError::External(e.into()))?;
                     let (expr, names, values) = build_update_expression(&sets);
@@ -1275,30 +1678,8 @@ impl ExecutionPlan for DynamoDmlExec {
 
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             self.schema.clone(),
-            futures::stream::once(future),
+            stream::once(future),
         )))
-    }
-}
-
-impl DynamoDmlOp {
-    fn clone_op(&self) -> DynamoDmlOp {
-        match self {
-            DynamoDmlOp::Delete { filter } => DynamoDmlOp::Delete {
-                filter: filter.as_ref().map(clone_filter),
-            },
-            DynamoDmlOp::Update { filter, sets } => DynamoDmlOp::Update {
-                filter: filter.as_ref().map(clone_filter),
-                sets: sets.clone(),
-            },
-        }
-    }
-}
-
-fn clone_filter(f: &DynamoFilter) -> DynamoFilter {
-    DynamoFilter {
-        expression: f.expression.clone(),
-        names: f.names.clone(),
-        values: f.values.clone(),
     }
 }
 
@@ -1359,6 +1740,14 @@ fn count_batch(count: u64) -> DFResult<RecordBatch> {
 /// * `access_key_env` / `secret_key_env` - names of environment variables
 ///   holding static AWS credentials (optional). When omitted, the default AWS
 ///   credential provider chain is used.
+/// * `columns` - explicit column schema as `name:type[,name:type…]` (types:
+///   `string`, `int`, `float`, `bool`). Optional; when omitted the schema is
+///   inferred by sampling. Declaring it makes writes to an empty table possible
+///   (inference can't see attributes absent from every sampled item) and pins a
+///   stable column set.
+///
+/// `read_write` gates DML: a read-only source rejects INSERT/UPDATE/DELETE at
+/// plan time.
 ///
 /// The resolved key schema drives key-aware reads: a query that pins the full
 /// primary key uses `GetItem`, one that pins the partition key uses `Query`, and
@@ -1368,10 +1757,12 @@ pub async fn register_dynamodb_tables(
     name: &str,
     connection_string: &str,
     options: Option<&HashMap<String, String>>,
+    read_write: bool,
 ) -> Result<()> {
     tracing::info!(
         source = %name,
         endpoint = %connection_string,
+        read_write,
         "Registering DynamoDB table"
     );
 
@@ -1409,10 +1800,26 @@ pub async fn register_dynamodb_tables(
         }
     };
 
-    let provider =
-        DynamoTableProvider::new(client, table, &partition_key, sort_key.as_deref(), None)
-            .await
-            .with_context(|| format!("Failed to create DynamoDB table provider for '{name}'"))?;
+    // An explicit `columns` option pins the schema; otherwise it is inferred by
+    // sampling inside `DynamoTableProvider::new`.
+    let declared_schema = match opts.get("columns") {
+        Some(spec) => Some(
+            parse_columns_option(spec, &partition_key, sort_key.as_deref())
+                .with_context(|| format!("DynamoDB data source '{name}': invalid 'columns'"))?,
+        ),
+        None => None,
+    };
+
+    let provider = DynamoTableProvider::new(
+        client,
+        table,
+        &partition_key,
+        sort_key.as_deref(),
+        declared_schema,
+        read_write,
+    )
+    .await
+    .with_context(|| format!("Failed to create DynamoDB table provider for '{name}'"))?;
 
     session_ctx
         .register_table(name, Arc::new(provider))
@@ -1475,6 +1882,44 @@ async fn describe_keys(client: &Client, table: &str) -> Result<(String, Option<S
     Ok((partition_key, sort_key))
 }
 
+/// Parse the `columns` option (`name:type[,name:type…]`) into an explicit
+/// schema, ordered with the key attributes first (see `build_schema_fields`).
+fn parse_columns_option(
+    spec: &str,
+    partition_key: &str,
+    sort_key: Option<&str>,
+) -> Result<SchemaRef> {
+    let mut attrs: Vec<(String, DataType)> = Vec::new();
+    for part in spec.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let (name, ty) = part
+            .split_once(':')
+            .ok_or_else(|| anyhow::anyhow!("column '{part}' must be 'name:type'"))?;
+        let dtype = match ty.trim().to_ascii_lowercase().as_str() {
+            "string" | "str" | "utf8" | "text" => DataType::Utf8,
+            "int" | "integer" | "bigint" | "int64" | "long" => DataType::Int64,
+            "float" | "double" | "float64" | "number" | "num" => DataType::Float64,
+            "bool" | "boolean" => DataType::Boolean,
+            other => anyhow::bail!(
+                "column '{}' has unknown type '{other}' (use string, int, float, or bool)",
+                name.trim()
+            ),
+        };
+        attrs.push((name.trim().to_string(), dtype));
+    }
+    if attrs.is_empty() {
+        anyhow::bail!("'columns' option is empty");
+    }
+    Ok(Arc::new(build_schema_fields(
+        partition_key,
+        sort_key,
+        &attrs,
+    )))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1491,7 +1936,10 @@ mod tests {
             attribute_value_to_arrow_type(&AttributeValue::S("x".into())),
             DataType::Utf8
         );
-        assert_eq!(attribute_value_to_arrow_type(&n("42")), DataType::Int64);
+        // Numbers always infer as Float64 — a single sampled whole number can't
+        // prove a column is integer-only, and later fractional values would be
+        // truncated or dropped by the Inexact re-filter.
+        assert_eq!(attribute_value_to_arrow_type(&n("42")), DataType::Float64);
         assert_eq!(attribute_value_to_arrow_type(&n("4.5")), DataType::Float64);
         assert_eq!(
             attribute_value_to_arrow_type(&AttributeValue::Bool(true)),
@@ -1506,9 +1954,14 @@ mod tests {
     #[test]
     fn number_coercions() {
         assert_eq!(av_to_i64(&n("7")), Some(7));
-        assert_eq!(av_to_i64(&n("7.9")), Some(7));
+        // Fractional N does not silently truncate into an Int64 column; it
+        // becomes NULL so the row can't disappear via the Inexact re-filter.
+        assert_eq!(av_to_i64(&n("7.9")), None);
+        // Cross-type coercion is refused: a string is never parsed into a
+        // numeric column (would violate the pushdown superset contract).
+        assert_eq!(av_to_i64(&AttributeValue::S("7".into())), None);
         assert_eq!(av_to_f64(&n("2.5")), Some(2.5));
-        assert_eq!(av_to_f64(&AttributeValue::S("nope".into())), None);
+        assert_eq!(av_to_f64(&AttributeValue::S("2.5".into())), None);
         assert_eq!(av_to_bool(&AttributeValue::Bool(false)), Some(false));
         assert_eq!(av_to_bool(&n("1")), None);
     }
@@ -1687,14 +2140,132 @@ mod tests {
         }
     }
 
+    // ─── DML planning (key-aware routing + guard) ───────────────────────────
+
+    #[test]
+    fn classify_dml_partition_eq_routes_query_with_residual() {
+        // pk pinned + a non-key predicate → Query, with the non-key predicate
+        // carried as a residual FilterExpression (a Query filter can't touch keys).
+        let filters = vec![col("pk").eq(lit("A")), col("category").eq(lit("x"))];
+        match classify_dml("pk", None, &filters).unwrap() {
+            DmlKeyPlan::Query {
+                key_condition,
+                residual,
+            } => {
+                assert_eq!(key_condition.expression, "#k0 = :k0");
+                let residual = residual.expect("non-key predicate becomes a residual filter");
+                assert!(residual.expression.contains("#n0"));
+            }
+            _ => panic!("expected Query when the partition key is pinned"),
+        }
+    }
+
+    #[test]
+    fn classify_dml_no_partition_routes_scan() {
+        // Partition key not pinned → Scan carrying the full predicate set.
+        let filters = vec![col("category").eq(lit("x"))];
+        match classify_dml("pk", None, &filters).unwrap() {
+            DmlKeyPlan::Scan { filter } => assert!(filter.is_some()),
+            _ => panic!("expected Scan when the partition key is not pinned"),
+        }
+    }
+
+    #[test]
+    fn classify_dml_sort_noteq_forces_scan() {
+        // `sk <> B` can live in neither a KeyCondition nor a Query filter, so the
+        // whole DML must Scan (a Scan filter may reference key attributes).
+        let filters = vec![col("pk").eq(lit("A")), col("sk").not_eq(lit("B"))];
+        match classify_dml("pk", Some("sk"), &filters).unwrap() {
+            DmlKeyPlan::Scan { filter } => {
+                let f = filter.expect("filter present");
+                // Both predicates are expressed (two placeholders).
+                assert_eq!(f.names.len(), 2);
+            }
+            _ => panic!("expected Scan when a sort predicate is inexpressible on a Query"),
+        }
+    }
+
+    #[test]
+    fn convertible_pushdown_excludes_inconvertible_literal() {
+        // Pushable-shaped but with an inconvertible literal → not convertible.
+        let ok = col("a").eq(lit(1i64));
+        assert!(is_convertible_pushdown(&ok));
+        let ts = Expr::BinaryExpr(BinaryExpr::new(
+            Box::new(col("a")),
+            Operator::Eq,
+            Box::new(Expr::Literal(
+                ScalarValue::TimestampNanosecond(Some(0), None),
+                None,
+            )),
+        ));
+        assert!(is_pushable_binary_filter(&ts));
+        assert!(!is_convertible_pushdown(&ts));
+    }
+
+    #[test]
+    fn parse_columns_option_orders_keys_first() {
+        let schema = parse_columns_option(
+            "price:float, name:string, product_id:string",
+            "product_id",
+            None,
+        )
+        .expect("valid columns");
+        // Key comes first and is non-nullable; declared cols follow, nullable.
+        assert_eq!(schema.field(0).name(), "product_id");
+        assert!(!schema.field(0).is_nullable());
+        assert_eq!(schema.fields().len(), 3);
+        assert_eq!(schema.field(1).data_type(), &DataType::Float64);
+    }
+
+    #[test]
+    fn parse_columns_option_rejects_bad_type() {
+        assert!(parse_columns_option("x:widget", "id", None).is_err());
+        assert!(parse_columns_option("noColon", "id", None).is_err());
+    }
+
+    #[tokio::test]
+    async fn delete_with_non_pushable_predicate_is_rejected() {
+        // The guard must fire at plan time (no network) rather than silently
+        // dropping the OR and deleting every row. Uses an explicit schema so
+        // registration doesn't touch DynamoDB.
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+        let mut opts = HashMap::new();
+        opts.insert("region".to_string(), "us-east-1".to_string());
+        let client = build_client("http://localhost:8000", "us-east-1", &opts)
+            .await
+            .expect("client");
+        let provider = DynamoTableProvider::new(client, "t", "id", None, Some(schema), true)
+            .await
+            .expect("provider");
+        let ctx = SessionContext::new();
+        ctx.register_table("t", Arc::new(provider))
+            .expect("register");
+
+        let err = ctx
+            .sql("DELETE FROM t WHERE id = 'A' OR name = 'x'")
+            .await
+            .expect("logical plan")
+            .collect()
+            .await
+            .expect_err("non-pushable DELETE predicate must be rejected");
+        assert!(
+            err.to_string().contains("pushable comparison"),
+            "unexpected error: {err}"
+        );
+    }
+
     #[test]
     fn missing_options_errors() {
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
             let mut ctx = SessionContext::new();
-            let err = register_dynamodb_tables(&mut ctx, "ddb", "http://localhost:8000", None)
-                .await
-                .unwrap_err();
+            let err =
+                register_dynamodb_tables(&mut ctx, "ddb", "http://localhost:8000", None, false)
+                    .await
+                    .unwrap_err();
             assert!(err.to_string().contains("requires options"));
         });
     }
@@ -1706,10 +2277,15 @@ mod tests {
             let mut ctx = SessionContext::new();
             let mut opts = HashMap::new();
             opts.insert("partition_key".to_string(), "id".to_string());
-            let err =
-                register_dynamodb_tables(&mut ctx, "ddb", "http://localhost:8000", Some(&opts))
-                    .await
-                    .unwrap_err();
+            let err = register_dynamodb_tables(
+                &mut ctx,
+                "ddb",
+                "http://localhost:8000",
+                Some(&opts),
+                false,
+            )
+            .await
+            .unwrap_err();
             assert!(err.to_string().contains("'table'"));
         });
     }
@@ -1728,7 +2304,7 @@ mod tests {
         let client = build_client("http://localhost:8000", "us-east-1", &opts)
             .await
             .expect("client");
-        DynamoTableProvider::new(client, "products", "product_id", None, None)
+        DynamoTableProvider::new(client, "products", "product_id", None, None, false)
             .await
             .expect("provider")
     }
@@ -1739,9 +2315,15 @@ mod tests {
         opts.insert("table".to_string(), "products".to_string());
         opts.insert("partition_key".to_string(), "product_id".to_string());
         opts.insert("region".to_string(), "us-east-1".to_string());
-        register_dynamodb_tables(&mut ctx, "products", "http://localhost:8000", Some(&opts))
-            .await
-            .expect("register");
+        register_dynamodb_tables(
+            &mut ctx,
+            "products",
+            "http://localhost:8000",
+            Some(&opts),
+            false,
+        )
+        .await
+        .expect("register");
         let df = ctx.sql(sql).await.expect("sql");
         let batches = df.collect().await.expect("collect");
         batches.iter().map(|b| b.num_rows()).sum()
@@ -1831,7 +2413,7 @@ mod tests {
         ]));
 
         async fn ctx_with(table: &str, schema: SchemaRef, client: Client) -> SessionContext {
-            let provider = DynamoTableProvider::new(client, table, "id", None, Some(schema))
+            let provider = DynamoTableProvider::new(client, table, "id", None, Some(schema), true)
                 .await
                 .expect("provider");
             let ctx = SessionContext::new();
@@ -1979,7 +2561,7 @@ mod tests {
         // Register via the public path so DescribeTable auto-detects the sort key
         // (note: no partition_key/sort_key options supplied).
         let mut ctx = SessionContext::new();
-        register_dynamodb_tables(&mut ctx, table, "http://localhost:8000", Some(&opts))
+        register_dynamodb_tables(&mut ctx, table, "http://localhost:8000", Some(&opts), false)
             .await
             .expect("register");
 

--- a/crates/skardi/src/sources/providers/mod.rs
+++ b/crates/skardi/src/sources/providers/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "documents")]
 pub mod documents;
+pub mod dynamodb;
 pub mod iceberg;
 pub mod influxdb;
 pub mod knn_utils;

--- a/crates/skardi/src/sources/providers/mod.rs
+++ b/crates/skardi/src/sources/providers/mod.rs
@@ -36,3 +36,28 @@ pub enum DatasetEntry {
 /// Shared by `lance_knn`, `lance_fts`, `pg_knn`, `pg_fts`, `mongo_fts`,
 /// `sqlite_knn`, `sqlite_fts`, `seekdb_knn`, and `seekdb_fts` table functions.
 pub type DatasetRegistry = Arc<RwLock<HashMap<String, DatasetEntry>>>;
+
+/// Returns true if the expression is a binary comparison (`=`, `<>`, `<`, `<=`,
+/// `>`, `>=`) between a bare column and a literal — the shape both the MongoDB
+/// and DynamoDB providers can push into their backends. Shared here so the two
+/// providers cannot silently diverge on what counts as pushable.
+pub(crate) fn is_pushable_binary_filter(expr: &datafusion::logical_expr::Expr) -> bool {
+    use datafusion::logical_expr::{Expr, Operator};
+    match expr {
+        Expr::BinaryExpr(binary) => {
+            matches!(
+                binary.op,
+                Operator::Eq
+                    | Operator::NotEq
+                    | Operator::Lt
+                    | Operator::LtEq
+                    | Operator::Gt
+                    | Operator::GtEq
+            ) && matches!(
+                (binary.left.as_ref(), binary.right.as_ref()),
+                (Expr::Column(_), Expr::Literal(..)) | (Expr::Literal(..), Expr::Column(_))
+            )
+        }
+        _ => false,
+    }
+}

--- a/crates/skardi/src/sources/providers/mongo/mod.rs
+++ b/crates/skardi/src/sources/providers/mongo/mod.rs
@@ -512,28 +512,7 @@ impl TableProvider for MongoTableProvider {
     }
 }
 
-/// Returns true if the expression is a binary comparison (=, !=, <, <=, >, >=)
-/// between a column and a literal value, which can be pushed down to MongoDB.
-pub(crate) fn is_pushable_binary_filter(expr: &Expr) -> bool {
-    use datafusion::logical_expr::Operator;
-    match expr {
-        Expr::BinaryExpr(binary) => {
-            matches!(
-                binary.op,
-                Operator::Eq
-                    | Operator::NotEq
-                    | Operator::Lt
-                    | Operator::LtEq
-                    | Operator::Gt
-                    | Operator::GtEq
-            ) && matches!(
-                (binary.left.as_ref(), binary.right.as_ref()),
-                (Expr::Column(_), Expr::Literal(..)) | (Expr::Literal(..), Expr::Column(_))
-            )
-        }
-        _ => false,
-    }
-}
+pub(crate) use super::is_pushable_binary_filter;
 
 pub(crate) fn bson_to_arrow_type(value: &Bson) -> DataType {
     match value {

--- a/docs/dynamodb/README.md
+++ b/docs/dynamodb/README.md
@@ -59,15 +59,22 @@ Attribute types are mapped to Arrow types as follows:
 | DynamoDB type | Arrow type |
 |---|---|
 | `S` (string) | `Utf8` |
-| `N` (number, integral) | `Int64` |
-| `N` (number, fractional) | `Float64` |
+| `N` (number) | `Float64` |
 | `BOOL` | `Boolean` |
 | everything else (`M`, `L`, `SS`, `B`, …) | `Utf8` (debug-rendered) |
 
-DynamoDB is schemaless, so the column set is inferred by sampling one item at
-startup. **An attribute that is absent from an item reads as SQL `NULL`.** If
-your table can be empty at startup, only the declared key attributes will be
-discoverable — see [Schema notes](#schema-notes).
+Numbers always map to `Float64`: a single sampled whole number can't prove a
+column is integer-only, and a later fractional value in an `Int64` column would
+be silently truncated (or dropped by the re-filter). A number value stored as a
+string — or vice versa — reads as `NULL` in the numeric/typed column rather than
+being cross-type coerced, keeping filter pushdown consistent with what you see.
+
+DynamoDB is schemaless, so the column set is inferred by sampling several items
+at startup and merging their attributes. **An attribute absent from an item
+reads as SQL `NULL`.** If your table can be empty at startup, or you want a
+stable/typed column set, declare it explicitly with the `columns` option
+(`name:type,…` — types `string`, `int`, `float`, `bool`) — see
+[Schema notes](#schema-notes).
 
 ## Available Pipelines
 
@@ -156,7 +163,12 @@ DataFusion after the scan.
 
 ## 4. Insert
 
-Inserts use DynamoDB `PutItem`, which upserts on the partition key.
+A plain `INSERT` is a guarded `PutItem` (`attribute_not_exists` on the partition
+key): inserting a row whose key already exists **errors** instead of silently
+replacing the whole item. Use `INSERT OVERWRITE` for upsert semantics (which also
+batches the writes via `BatchWriteItem`). Writes require the source to be
+configured `access_mode: read_write`; a read-only source rejects
+INSERT/UPDATE/DELETE at plan time.
 
 ```bash
 curl -X POST http://localhost:8080/insert_product/execute \
@@ -180,8 +192,12 @@ curl -X POST http://localhost:8080/query_product_by_id/execute \
 
 ## 5. Update
 
-DynamoDB cannot update by arbitrary predicate, so Skardi scans for the matching
-keys (using filter pushdown) and issues an `UpdateItem` per key. Key columns
+DynamoDB cannot update by arbitrary predicate, so Skardi first resolves the
+matching keys — via a `Query` when the partition key is pinned by equality (any
+remaining predicate is applied server-side as a `FilterExpression`), else a full
+`Scan` — then issues an `UpdateItem` per key. Every WHERE predicate must be a
+pushable comparison; a non-pushable predicate (e.g. `OR`, `LIKE`) is rejected
+rather than silently ignored (which would over-update). Key columns
 (`partition_key` / `sort_key`) cannot be updated.
 
 ```bash
@@ -199,8 +215,10 @@ curl -X POST http://localhost:8080/update_product_price/execute \
 
 ## 6. Delete
 
-Like UPDATE, DELETE resolves matching keys via a filtered scan, then issues a
-`DeleteItem` per key.
+Like UPDATE, DELETE resolves matching keys (routing to a `Query` when the
+partition key is pinned, else a `Scan`), then removes them via `BatchWriteItem`
+(25 per request). The same all-predicates-must-be-pushable rule applies, so a
+`DELETE ... WHERE a = 1 OR b = 2` is rejected rather than wiping the table.
 
 ```bash
 curl -X POST http://localhost:8080/delete_product/execute \
@@ -249,8 +267,12 @@ curl -X POST http://localhost:8080/federated_join/execute \
 | `partition_key` | string | no | Partition (hash) key attribute name. Auto-detected from the table's key schema via `DescribeTable`; supply it only as a fallback for when `DescribeTable` is unavailable (e.g. restricted IAM permissions) |
 | `sort_key` | string | no | Sort (range) key attribute name for composite-key tables. Also auto-detected from `DescribeTable`; a fallback otherwise |
 | `region` | string | no | AWS region (default `us-east-1`) |
+| `columns` | string | no | Explicit schema as `name:type,…` (types `string`, `int`, `float`, `bool`). Pins a stable/typed column set and lets you write non-key columns to an empty table. When omitted, the schema is inferred by sampling |
 | `access_key_env` | string | no | Env var holding the AWS access key id |
 | `secret_key_env` | string | no | Env var holding the AWS secret access key |
+
+Writes (INSERT/UPDATE/DELETE) additionally require `access_mode: read_write` on
+the source; the default `read_only` rejects them at plan time.
 
 ### Read planning (key-aware access)
 
@@ -281,15 +303,16 @@ ECS / Lambda no credential options are needed.
 
 ## Schema notes
 
-The schema is inferred by sampling a single item at startup. Because DynamoDB
-items are schemaless:
+The schema is inferred by sampling several items at startup and merging their
+attribute sets. Because DynamoDB items are schemaless:
 
-- An attribute missing from the sampled item won't appear as a column. If
-  different items have different attributes, declare the union you care about by
-  ensuring the sampled item is representative, or keep attributes consistent.
+- An attribute missing from **every** sampled item won't appear as a column. If
+  items have widely varying attributes, declare the columns you care about
+  explicitly with the `columns` option instead of relying on the sample.
 - An attribute absent on a given row reads as SQL `NULL`.
 - If the table is **empty** at startup, only the partition key (and sort key, if
-  configured) are available until data is written.
+  configured) are inferable — declare the rest with `columns` so you can write
+  non-key attributes before any row exists.
 
 ## Cleanup
 

--- a/docs/dynamodb/README.md
+++ b/docs/dynamodb/README.md
@@ -1,0 +1,281 @@
+# Amazon DynamoDB Integration
+
+This guide demonstrates how to integrate Amazon DynamoDB tables with Skardi. A
+DynamoDB table maps to one Skardi table: each item becomes a row and each
+top-level attribute becomes a column. Reads (scan + filter pushdown) and writes
+(INSERT / UPDATE / DELETE) are both supported.
+
+The examples below use [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html)
+so they run without an AWS account. The same context file works against real
+Amazon DynamoDB — just change `connection_string` to the regional endpoint.
+
+## Quick Start
+
+```bash
+# 1. Start DynamoDB Local in Docker
+docker run --name dynamodb-skardi -p 8000:8000 -d amazon/dynamodb-local:2.5.2
+
+# 2. DynamoDB Local ignores credential values but the AWS SDK still requires
+#    them to be set. Any non-empty value works.
+export AWS_ACCESS_KEY_ID=dummy
+export AWS_SECRET_ACCESS_KEY=dummy
+export AWS_DEFAULT_REGION=us-east-1
+EP="http://localhost:8000"
+
+# 3. Create the products table (partition key: product_id) and seed sample data
+aws dynamodb create-table --endpoint-url "$EP" \
+  --table-name products \
+  --attribute-definitions AttributeName=product_id,AttributeType=S \
+  --key-schema AttributeName=product_id,KeyType=HASH \
+  --billing-mode PAY_PER_REQUEST
+aws dynamodb wait table-exists --endpoint-url "$EP" --table-name products
+
+put() { aws dynamodb put-item --endpoint-url "$EP" --table-name products --item "$1"; }
+put '{"product_id":{"S":"PROD001"},"name":{"S":"Laptop"},"category":{"S":"Electronics"},"price":{"N":"999.99"},"in_stock":{"BOOL":true}}'
+put '{"product_id":{"S":"PROD002"},"name":{"S":"Keyboard"},"category":{"S":"Electronics"},"price":{"N":"79.99"},"in_stock":{"BOOL":true}}'
+put '{"product_id":{"S":"PROD003"},"name":{"S":"Monitor"},"category":{"S":"Electronics"},"price":{"N":"299.99"},"in_stock":{"BOOL":false}}'
+put '{"product_id":{"S":"PROD004"},"name":{"S":"Mouse"},"category":{"S":"Electronics"},"price":{"N":"29.99"},"in_stock":{"BOOL":true}}'
+put '{"product_id":{"S":"PROD005"},"name":{"S":"Desk Chair"},"category":{"S":"Furniture"},"price":{"N":"199.99"},"in_stock":{"BOOL":true}}'
+
+# 4. Start the Skardi server against the demo context + pipelines
+cargo run --bin skardi-server -- \
+  --ctx docs/dynamodb/ctx_dynamodb_demo.yaml \
+  --pipeline docs/dynamodb/pipelines/ \
+  --port 8080
+```
+
+## Data Model
+
+| DynamoDB concept | Maps to |
+|---|---|
+| Table | One Skardi SQL table |
+| Item | Row |
+| Top-level attribute | Column |
+| Partition key (hash) | First, non-nullable column (`partition_key` option) |
+| Sort key (range), if any | Second, non-nullable column (`sort_key` option) |
+
+Attribute types are mapped to Arrow types as follows:
+
+| DynamoDB type | Arrow type |
+|---|---|
+| `S` (string) | `Utf8` |
+| `N` (number, integral) | `Int64` |
+| `N` (number, fractional) | `Float64` |
+| `BOOL` | `Boolean` |
+| everything else (`M`, `L`, `SS`, `B`, …) | `Utf8` (debug-rendered) |
+
+DynamoDB is schemaless, so the column set is inferred by sampling one item at
+startup. **An attribute that is absent from an item reads as SQL `NULL`.** If
+your table can be empty at startup, only the declared key attributes will be
+discoverable — see [Schema notes](#schema-notes).
+
+## Available Pipelines
+
+| Pipeline | Description |
+|----------|-------------|
+| `query_product_by_id` | Point lookup by partition key |
+| `list_all_products` | Full scan of all products |
+| `filter_by_category` | Filter pushed down as a DynamoDB `FilterExpression` |
+| `insert_product` | Insert (put) a single product |
+| `update_product_price` | Update a product's price by ID |
+| `delete_product` | Delete a product by ID |
+| `federated_join` | Join the CSV inventory with the DynamoDB table |
+
+---
+
+## 1. Point Lookup
+
+```bash
+curl -X POST http://localhost:8080/query_product_by_id/execute \
+  -H "Content-Type: application/json" \
+  -d '{"product_id": "PROD001"}' | jq .
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": [{"product_id": "PROD001", "category": "Electronics", "in_stock": true, "name": "Laptop", "price": 999.99}],
+  "rows": 1
+}
+```
+
+---
+
+## 2. Full Scan
+
+```bash
+curl -X POST http://localhost:8080/list_all_products/execute \
+  -H "Content-Type: application/json" \
+  -d '{}' | jq .
+```
+
+**Response** (DynamoDB scans return items in unspecified order):
+```json
+{
+  "success": true,
+  "data": [
+    {"product_id": "PROD001", "category": "Electronics", "in_stock": true,  "name": "Laptop",     "price": 999.99},
+    {"product_id": "PROD005", "category": "Furniture",   "in_stock": true,  "name": "Desk Chair", "price": 199.99},
+    {"product_id": "PROD004", "category": "Electronics", "in_stock": true,  "name": "Mouse",      "price": 29.99},
+    {"product_id": "PROD003", "category": "Electronics", "in_stock": false, "name": "Monitor",    "price": 299.99},
+    {"product_id": "PROD002", "category": "Electronics", "in_stock": true,  "name": "Keyboard",   "price": 79.99}
+  ],
+  "rows": 5
+}
+```
+
+---
+
+## 3. Filter Pushdown
+
+`WHERE category = {category}` is translated into a DynamoDB `FilterExpression`
+(`#n0 = :v0`) and evaluated server-side, so only matching items are returned
+over the wire.
+
+```bash
+curl -X POST http://localhost:8080/filter_by_category/execute \
+  -H "Content-Type: application/json" \
+  -d '{"category": "Furniture"}' | jq .
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": [{"product_id": "PROD005", "category": "Furniture", "in_stock": true, "name": "Desk Chair", "price": 199.99}],
+  "rows": 1
+}
+```
+
+Equality, inequality (`<>`), and range comparisons (`<`, `<=`, `>`, `>=`)
+between a column and a literal push down. Other predicates are still applied by
+DataFusion after the scan.
+
+---
+
+## 4. Insert
+
+Inserts use DynamoDB `PutItem`, which upserts on the partition key.
+
+```bash
+curl -X POST http://localhost:8080/insert_product/execute \
+  -H "Content-Type: application/json" \
+  -d '{"product_id": "PROD006", "name": "Webcam", "category": "Electronics", "price": 89.99, "in_stock": true}' | jq .
+```
+
+**Response:**
+```json
+{"success": true, "data": [{"count": 1}], "rows": 1}
+```
+
+**Verify:**
+```bash
+curl -X POST http://localhost:8080/query_product_by_id/execute \
+  -H "Content-Type: application/json" -d '{"product_id": "PROD006"}' | jq .
+# => {"product_id":"PROD006","category":"Electronics","in_stock":true,"name":"Webcam","price":89.99}
+```
+
+---
+
+## 5. Update
+
+DynamoDB cannot update by arbitrary predicate, so Skardi scans for the matching
+keys (using filter pushdown) and issues an `UpdateItem` per key. Key columns
+(`partition_key` / `sort_key`) cannot be updated.
+
+```bash
+curl -X POST http://localhost:8080/update_product_price/execute \
+  -H "Content-Type: application/json" \
+  -d '{"product_id": "PROD001", "price": 899.99}' | jq .
+```
+
+**Response:**
+```json
+{"success": true, "data": [{"count": 1}], "rows": 1}
+```
+
+---
+
+## 6. Delete
+
+Like UPDATE, DELETE resolves matching keys via a filtered scan, then issues a
+`DeleteItem` per key.
+
+```bash
+curl -X POST http://localhost:8080/delete_product/execute \
+  -H "Content-Type: application/json" \
+  -d '{"product_id": "PROD006"}' | jq .
+```
+
+**Response:**
+```json
+{"success": true, "data": [{"count": 1}], "rows": 1}
+```
+
+---
+
+## 7. Federated Query: Join CSV + DynamoDB
+
+Join the CSV inventory file with the DynamoDB `products` table and aggregate.
+
+```bash
+curl -X POST http://localhost:8080/federated_join/execute \
+  -H "Content-Type: application/json" \
+  -d '{"category": "Electronics"}' | jq .
+```
+
+**Response** (order unspecified):
+```json
+{
+  "success": true,
+  "data": [
+    {"product_id": "PROD001", "name": "Laptop",   "category": "Electronics", "price": 899.99, "total_quantity": 80},
+    {"product_id": "PROD002", "name": "Keyboard", "category": "Electronics", "price": 79.99,  "total_quantity": 100},
+    {"product_id": "PROD003", "name": "Monitor",  "category": "Electronics", "price": 299.99, "total_quantity": 0},
+    {"product_id": "PROD004", "name": "Mouse",    "category": "Electronics", "price": 29.99,  "total_quantity": 350}
+  ],
+  "rows": 4
+}
+```
+
+---
+
+## Connection Options
+
+| Option | Type | Required | Description |
+|---|---|---|---|
+| `table` | string | yes | DynamoDB table name |
+| `partition_key` | string | yes | Partition (hash) key attribute name |
+| `sort_key` | string | no | Sort (range) key attribute name for composite-key tables |
+| `region` | string | no | AWS region (default `us-east-1`) |
+| `access_key_env` | string | no | Env var holding the AWS access key id |
+| `secret_key_env` | string | no | Env var holding the AWS secret access key |
+
+`connection_string` is the **endpoint URL**:
+
+- DynamoDB Local: `http://localhost:8000`
+- Amazon DynamoDB: the regional endpoint, e.g. `https://dynamodb.us-east-1.amazonaws.com`
+
+When `access_key_env` / `secret_key_env` are omitted, the default AWS credential
+provider chain is used (environment, shared config, IAM role, etc.), so on EC2 /
+ECS / Lambda no credential options are needed.
+
+## Schema notes
+
+The schema is inferred by sampling a single item at startup. Because DynamoDB
+items are schemaless:
+
+- An attribute missing from the sampled item won't appear as a column. If
+  different items have different attributes, declare the union you care about by
+  ensuring the sampled item is representative, or keep attributes consistent.
+- An attribute absent on a given row reads as SQL `NULL`.
+- If the table is **empty** at startup, only the partition key (and sort key, if
+  configured) are available until data is written.
+
+## Cleanup
+
+```bash
+docker stop dynamodb-skardi && docker rm dynamodb-skardi
+pkill -f skardi-server
+```

--- a/docs/dynamodb/README.md
+++ b/docs/dynamodb/README.md
@@ -246,11 +246,29 @@ curl -X POST http://localhost:8080/federated_join/execute \
 | Option | Type | Required | Description |
 |---|---|---|---|
 | `table` | string | yes | DynamoDB table name |
-| `partition_key` | string | yes | Partition (hash) key attribute name |
-| `sort_key` | string | no | Sort (range) key attribute name for composite-key tables |
+| `partition_key` | string | no | Partition (hash) key attribute name. Auto-detected from the table's key schema via `DescribeTable`; supply it only as a fallback for when `DescribeTable` is unavailable (e.g. restricted IAM permissions) |
+| `sort_key` | string | no | Sort (range) key attribute name for composite-key tables. Also auto-detected from `DescribeTable`; a fallback otherwise |
 | `region` | string | no | AWS region (default `us-east-1`) |
 | `access_key_env` | string | no | Env var holding the AWS access key id |
 | `secret_key_env` | string | no | Env var holding the AWS secret access key |
+
+### Read planning (key-aware access)
+
+Skardi inspects each query's `WHERE` clause and picks the cheapest DynamoDB
+access pattern the predicates allow:
+
+| Predicate on the key | DynamoDB API used |
+|---|---|
+| Full primary key by equality (`pk = …`, or `pk = … AND sk = …`) | `GetItem` — single-item read |
+| Partition key by equality, with an optional sort-key condition (`pk = … [AND sk >= …]`) | `Query` — reads only that partition |
+| Anything else (non-key filter, or partition key not pinned by equality) | `Scan` — full table read + `FilterExpression` |
+
+A `Scan` reads (and bills for) the entire table regardless of how selective the
+filter is, so pinning the partition key turns an O(table) read into an O(1) /
+O(partition) one. Equality on a key is required: `pk > …` cannot use
+`Query`/`GetItem` and falls back to `Scan`. Non-key predicates are always
+re-applied by the query engine after the fetch, so results are identical
+whichever path is chosen.
 
 `connection_string` is the **endpoint URL**:
 

--- a/docs/dynamodb/ctx_dynamodb_demo.yaml
+++ b/docs/dynamodb/ctx_dynamodb_demo.yaml
@@ -1,0 +1,31 @@
+kind: context
+
+metadata:
+  name: ctx_dynamodb_demo
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: "products"
+      type: "dynamodb"
+      access_mode: "read_write"
+      # Endpoint URL. For DynamoDB Local use http://localhost:8000.
+      # For Amazon DynamoDB use the regional endpoint, e.g.
+      #   https://dynamodb.us-east-1.amazonaws.com
+      connection_string: "http://localhost:8000"
+      description: "DynamoDB products table"
+      options:
+        table: "products"
+        partition_key: "product_id"
+        region: "us-east-1"
+        # Optional: read static AWS credentials from environment variables.
+        # When omitted, the default AWS credential provider chain is used
+        # (env vars, shared config, IAM role, etc.).
+        access_key_env: "AWS_ACCESS_KEY_ID"
+        secret_key_env: "AWS_SECRET_ACCESS_KEY"
+
+    # CSV data source (for the federated query demo)
+    - name: "csv_inventory"
+      type: "csv"
+      path: "docs/sample_data/product_inventory.csv"
+      description: "CSV file containing product inventory data"

--- a/docs/dynamodb/pipelines/delete_product.yaml
+++ b/docs/dynamodb/pipelines/delete_product.yaml
@@ -1,0 +1,9 @@
+kind: pipeline
+
+metadata:
+  name: "delete_product"
+  version: "1.0"
+  description: "Delete a product by product ID"
+
+spec:
+  query: "DELETE FROM products WHERE product_id = {product_id}"

--- a/docs/dynamodb/pipelines/federated_join.yaml
+++ b/docs/dynamodb/pipelines/federated_join.yaml
@@ -1,0 +1,14 @@
+kind: pipeline
+
+metadata:
+  name: "federated_join"
+  version: "1.0"
+  description: "Join CSV inventory with the DynamoDB products table"
+
+spec:
+  query: |
+    SELECT p.product_id, p.name, p.category, p.price, SUM(i.quantity) AS total_quantity
+    FROM products p
+    JOIN csv_inventory i ON p.product_id = i.product_id
+    WHERE p.category = {category}
+    GROUP BY p.product_id, p.name, p.category, p.price

--- a/docs/dynamodb/pipelines/filter_by_category.yaml
+++ b/docs/dynamodb/pipelines/filter_by_category.yaml
@@ -1,0 +1,9 @@
+kind: pipeline
+
+metadata:
+  name: "filter_by_category"
+  version: "1.0"
+  description: "Filter products by category (pushed down as a DynamoDB FilterExpression)"
+
+spec:
+  query: "SELECT * FROM products WHERE category = {category}"

--- a/docs/dynamodb/pipelines/insert_product.yaml
+++ b/docs/dynamodb/pipelines/insert_product.yaml
@@ -1,0 +1,11 @@
+kind: pipeline
+
+metadata:
+  name: "insert_product"
+  version: "1.0"
+  description: "Insert (put) a single product"
+
+spec:
+  query: |
+    INSERT INTO products (product_id, name, category, price, in_stock)
+    VALUES ({product_id}, {name}, {category}, {price}, {in_stock})

--- a/docs/dynamodb/pipelines/list_all_products.yaml
+++ b/docs/dynamodb/pipelines/list_all_products.yaml
@@ -1,0 +1,9 @@
+kind: pipeline
+
+metadata:
+  name: "list_all_products"
+  version: "1.0"
+  description: "Full scan of all products"
+
+spec:
+  query: "SELECT * FROM products"

--- a/docs/dynamodb/pipelines/query_product_by_id.yaml
+++ b/docs/dynamodb/pipelines/query_product_by_id.yaml
@@ -1,0 +1,9 @@
+kind: pipeline
+
+metadata:
+  name: "query_product_by_id"
+  version: "1.0"
+  description: "Query a specific product by ID (point lookup on the partition key)"
+
+spec:
+  query: "SELECT * FROM products WHERE product_id = {product_id}"

--- a/docs/dynamodb/pipelines/update_product_price.yaml
+++ b/docs/dynamodb/pipelines/update_product_price.yaml
@@ -1,0 +1,10 @@
+kind: pipeline
+
+metadata:
+  name: "update_product_price"
+  version: "1.0"
+  description: "Update a product's price by product ID"
+
+spec:
+  query: |
+    UPDATE products SET price = {price} WHERE product_id = {product_id}

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -78,8 +78,8 @@ taken as the data source name — the executor uses it to decide whether
 the destination is a lake (Lance) or a transactional SQL DB
 (**Postgres / MySQL / SQLite**).
 
-Non-transactional backends (Redis, MongoDB, SeekDB) are **rejected at
-submit time** with `error_type: non_transactional_destination`. Those
+Non-transactional backends (Redis, MongoDB, SeekDB, InfluxDB, DynamoDB) are
+**rejected at submit time** with `error_type: non_transactional_destination`. Those
 providers' write paths do not wrap an INSERT in a transaction, so a
 mid-run failure could leave partial rows visible — which violates the
 atomicity contract every other destination honors. They remain fine as

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -254,7 +254,7 @@ for agent handling:
 | `missing_parameters` | One or more `{placeholders}` not bound |
 | `unsupported_parameter` | Bound value is an array / object |
 | `destination_missing` | DB table doesn't exist; or lake + `create_if_missing: false` |
-| `non_transactional_destination` | Destination source type is Redis / MongoDB / SeekDB — rejected because its write path cannot guarantee atomicity |
+| `non_transactional_destination` | Destination source type is Redis / MongoDB / SeekDB / InfluxDB / DynamoDB — rejected because its write path cannot guarantee atomicity |
 | `schema_mismatch` | Column diff — `details.diff` carries a human-readable string |
 | `sql_plan_failure` | DataFusion rejected the rendered SQL |
 


### PR DESCRIPTION
## What

Adds **Amazon DynamoDB** as a read-write data source. A DynamoDB table maps to one Skardi table (item → row, top-level attribute → column).

- Full `TableProvider`: scan, `insert_into`, `delete_from`, `update`
- Binary-filter **pushdown** as DynamoDB `FilterExpression` (`=`, `<>`, `<`, `<=`, `>`, `>=` on column vs. literal)
- INSERT via `PutItem`; UPDATE/DELETE resolve matching keys via a filtered scan then mutate per key (DynamoDB can't mutate by predicate); key columns are immutable
- Schema inferred by sampling one item; `N`→Int64/Float64, `S`→Utf8, `BOOL`→Boolean; missing attribute → SQL NULL
- No FTS/KNN — matches the backend's native capabilities
- `connection_string` is the endpoint URL (DynamoDB Local or AWS regional endpoint); credentials via default AWS chain or `*_env` options

## Wiring

`DataSourceType::Dynamodb` + every exhaustive match site: `config.rs` (dispatch, validation, `WRITABLE_SOURCE_TYPES`, error string), `pipeline_handlers.rs`, `gui.rs`, `jobs/executor.rs` (classified non-transactional), CLI.

## Tests & verification

- 12 unit tests + 4 `#[ignore]`-gated integration tests (scan, filter pushdown, count(*), INSERT→UPDATE→DELETE round-trip) — pass against **DynamoDB Local**
- CI: `amazon/dynamodb-local` service + AWS-CLI seed step
- `docs/dynamodb/` (README + ctx + 7 pipelines); **every doc command was run end-to-end** against `skardi-server`, including a federated DynamoDB+CSV join
- `cargo fmt --check`, `cargo check --workspace --all-targets`, `cargo test -p skardi --lib` (420) and `-p skardi-server` (113) all green

## New dependencies

`aws-sdk-dynamodb`, `aws-config` (no prior AWS SDK in the tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)