### PR TITLE
ci: build dev Docker images for both architectures

### DIFF
--- a/.github/workflows/dev-docker.yml
+++ b/.github/workflows/dev-docker.yml
@@ -18,15 +18,13 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
-  docker:
-    name: "Build and push ${{ inputs.branch }}"
+  tag:
+    name: "Generate image tag"
     runs-on: ubuntu-latest
+    outputs:
+      safe_branch: ${{ steps.tag.outputs.safe_branch }}
+      value: ${{ steps.tag.outputs.value }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.branch }}
-
       - name: Generate image tag
         id: tag
         run: |
@@ -34,7 +32,28 @@ jobs:
           # Sanitize branch name: replace any non-alphanumeric chars with -
           SAFE_BRANCH=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9]/-/g' | sed 's/-\+/-/g' | sed 's/^-\|-$//g')
           TIMESTAMP=$(date -u +%Y%m%d%H%M%S)
+          echo "safe_branch=${SAFE_BRANCH}" >> $GITHUB_OUTPUT
           echo "value=${SAFE_BRANCH}-test-img-${TIMESTAMP}" >> $GITHUB_OUTPUT
+
+  docker:
+    name: "Build ${{ matrix.platform }} for ${{ inputs.branch }}"
+    needs: tag
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
 
       - name: Free up disk space
         run: |
@@ -58,16 +77,40 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           provenance: false
-          tags: ghcr.io/skardilabs/skardi/skardi-server:${{ steps.tag.outputs.value }}
-          cache-from: type=gha,scope=dev-${{ inputs.branch }}
-          cache-to: type=gha,mode=max,scope=dev-${{ inputs.branch }}
+          tags: ghcr.io/skardilabs/skardi/skardi-server:${{ needs.tag.outputs.value }}-${{ matrix.arch }}
+          cache-from: type=gha,scope=dev-${{ needs.tag.outputs.safe_branch }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=dev-${{ needs.tag.outputs.safe_branch }}-${{ matrix.arch }}
+
+  docker-manifest:
+    name: "Publish multi-arch tag for ${{ inputs.branch }}"
+    needs: [tag, docker]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        run: |
+          IMAGE="ghcr.io/skardilabs/skardi/skardi-server"
+          TAG="${{ needs.tag.outputs.value }}"
+
+          docker manifest create "${IMAGE}:${TAG}" \
+            "${IMAGE}:${TAG}-amd64" \
+            "${IMAGE}:${TAG}-arm64"
+          docker manifest push "${IMAGE}:${TAG}"
 
       - name: Summary
         run: |
           echo "### Docker image published" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "docker pull ghcr.io/skardilabs/skardi/skardi-server:${{ steps.tag.outputs.value }}" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ghcr.io/skardilabs/skardi/skardi-server:${{ needs.tag.outputs.value }}" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ghcr.io/skardilabs/skardi/skardi-server:${{ needs.tag.outputs.value }}-amd64" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ghcr.io/skardilabs/skardi/skardi-server:${{ needs.tag.outputs.value }}-arm64" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- split the dev Docker workflow into tag, arch-specific build, and manifest jobs
- build linux/amd64 and linux/arm64 skardi-server images with native runners
- publish arch-specific tags plus a multi-arch ad hoc tag

## Tests
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/dev-docker.yml")'
- git diff --check