### PR TITLE
README: flag that Quick Start Step 3 is not zero-dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ skardi query --ctx ./ctx.yaml --sql "SELECT * FROM products LIMIT 10"
 
 **Step 3 — turn a parameterized SQL into an agent-callable verb.** Two YAMLs from [`demo/llm_wiki/cli/`](demo/llm_wiki/cli/) — the actual files, not pseudo-code:
 
+> ⚠️ Unlike Steps 1–2 (zero-dependency), this hybrid-search verb also needs a local embedding model at `models/…` + the `sqlite-vec` extension (`SQLITE_VEC_PATH`) and a seeded DB — so it is **not runnable by copy-paste alone**. The [`auto_knowledge_base` skill](https://github.com/SkardiLabs/skardi-skills) sets all of this up for you; use it if you just want the verb working.
+
 ```yaml
 # pipelines/search_hybrid.yaml — declares the SQL once; Skardi infers the params
 kind: pipeline

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ skardi query --ctx ./ctx.yaml --sql "SELECT * FROM products LIMIT 10"
 
 **Step 3 — turn a parameterized SQL into an agent-callable verb.** Two YAMLs from [`demo/llm_wiki/cli/`](demo/llm_wiki/cli/) — the actual files, not pseudo-code:
 
-> ⚠️ Unlike Steps 1–2 (zero-dependency), this hybrid-search verb also needs a local embedding model at `models/…` + the `sqlite-vec` extension (`SQLITE_VEC_PATH`) and a seeded DB — so it is **not runnable by copy-paste alone**. The [`auto_knowledge_base` skill](https://github.com/SkardiLabs/skardi-skills) sets all of this up for you; use it if you just want the verb working.
+> ⚠️ Unlike Steps 1–2 (zero-dependency), this hybrid-search verb also needs a local embedding model at `models/…` + the `sqlite-vec` extension (`SQLITE_VEC_PATH`) and a seeded DB — so it is **not runnable by copy-paste alone**. The [`auto_knowledge_base` skill](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_knowledge_base) sets all of this up for you; use it if you just want the verb working.
 
 ```yaml
 # pipelines/search_hybrid.yaml — declares the SQL once; Skardi infers the params


### PR DESCRIPTION
In the "First-time agent loop (two minutes)" section, Steps 1–2 are genuinely zero-dependency, but Step 3 (the hybrid-search verb) also requires a local embedding model at `models/…`, the `sqlite-vec` extension (`SQLITE_VEC_PATH`), and a seeded DB — so the YAML isn't runnable by copy-paste alone, and the model source isn't mentioned. Adds a one-line note distinguishing Step 3 and pointing to the `auto_knowledge_base` skill that sets this up.
