### PR TITLE
feat(dynamodb): add catalog mode for whole-account table discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,23 +311,23 @@ For end-to-end walkthroughs — RAG, recommendations, an agent-native wiki, a si
 
 ## Supported Data Sources
 
-| Type | CRUD | Description | Docs |
-|------|------|-------------|------|
-| PostgreSQL | Full | Table or catalog registration, pgvector KNN | [docs/postgres/](docs/postgres/) |
-| MySQL | Full | Table or catalog registration | [docs/mysql/](docs/mysql/) |
-| SQLite | Full | Table or catalog registration, sqlite-vec KNN, FTS | [docs/sqlite/](docs/sqlite/) |
-| MongoDB | Full | Collections with point lookups | [docs/mongo/](docs/mongo/) |
-| Redis | Full | Hashes mapped to SQL rows | [docs/redis/](docs/redis/) |
-| DynamoDB | Full | Items mapped to SQL rows, scan + filter pushdown | [docs/dynamodb/](docs/dynamodb/) |
-| SeekDB | Full | MySQL-wire CRUD, native FULLTEXT FTS, HNSW VECTOR KNN | [docs/seekdb/](docs/seekdb/) |
-| Lance | Read (job-write) | KNN vector search, BM25 FTS; job destination | [docs/lance/](docs/lance/) |
-| CSV | Read | Local or remote CSV files | [docs/server.md](docs/server.md) |
-| Parquet | Read | Local or remote Parquet files | [docs/server.md](docs/server.md) |
-| JSON / NDJSON | Read | Local or remote JSON files | [docs/cli.md](docs/cli.md) |
-| S3 / GCS / Azure | Read | CSV, Parquet, Lance from object stores | [docs/S3_USAGE.md](docs/S3_USAGE.md) |
-| Apache Iceberg | Read | Schema evolution, partition pruning | [docs/iceberg/](docs/iceberg/) |
-| InfluxDB 3 | Read | Time-series measurements over Arrow Flight SQL | [docs/influxdb/](docs/influxdb/) |
-| Documents | Read | PDF/Office/ODF/image → per-page markdown, tables, images (local directories; `documents` feature) | [docs/documents.md](docs/documents.md) |
+| Type | CRUD | Catalog mode | Description | Docs |
+|------|------|--------------|-------------|------|
+| PostgreSQL | Full | Yes | Table or catalog registration, pgvector KNN | [docs/postgres/](docs/postgres/) |
+| MySQL | Full | Yes | Table or catalog registration | [docs/mysql/](docs/mysql/) |
+| SQLite | Full | Yes | Table or catalog registration, sqlite-vec KNN, FTS | [docs/sqlite/](docs/sqlite/) |
+| MongoDB | Full | No | Collections with point lookups | [docs/mongo/](docs/mongo/) |
+| Redis | Full | No | Hashes mapped to SQL rows | [docs/redis/](docs/redis/) |
+| DynamoDB | Full | Yes | Items mapped to SQL rows, table or catalog registration, scan + filter pushdown | [docs/dynamodb/](docs/dynamodb/) |
+| SeekDB | Full | Yes | MySQL-wire CRUD, native FULLTEXT FTS, HNSW VECTOR KNN | [docs/seekdb/](docs/seekdb/) |
+| Lance | Read (job-write) | No | KNN vector search, BM25 FTS; job destination | [docs/lance/](docs/lance/) |
+| CSV | Read | No | Local or remote CSV files | [docs/server.md](docs/server.md) |
+| Parquet | Read | No | Local or remote Parquet files | [docs/server.md](docs/server.md) |
+| JSON / NDJSON | Read | No | Local or remote JSON files | [docs/cli.md](docs/cli.md) |
+| S3 / GCS / Azure | Read | No | CSV, Parquet, Lance from object stores | [docs/S3_USAGE.md](docs/S3_USAGE.md) |
+| Apache Iceberg | Read | No | Schema evolution, partition pruning | [docs/iceberg/](docs/iceberg/) |
+| InfluxDB 3 | Read | No | Time-series measurements over Arrow Flight SQL | [docs/influxdb/](docs/influxdb/) |
+| Documents | Read | No | PDF/Office/ODF/image -> per-page markdown, tables, images (local directories; `documents` feature) | [docs/documents.md](docs/documents.md) |
 
 ---
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -928,6 +928,7 @@ async fn register_source(
                 endpoint,
                 source.options.as_ref(),
                 source.is_read_write(),
+                source.hierarchy_level,
             )
             .await
             .with_context(|| format!("Failed to register DynamoDB '{}'", source.name))?;

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -240,6 +240,11 @@ pub enum ConfigError {
     )]
     EmptyAllowedSchemas { name: String },
 
+    #[error(
+        "Data source '{name}' has an empty 'allowed_tables' option. Either omit it to load all DynamoDB tables, or provide a non-empty comma-separated list such as \"products,orders\"."
+    )]
+    EmptyAllowedTables { name: String },
+
     #[error("Data source '{name}' has a non-UTF8 path: {path:?}")]
     NonUtf8Path { name: String, path: PathBuf },
 }
@@ -784,6 +789,22 @@ fn validate_data_sources(data_sources: &[DataSource]) -> Result<()> {
                         name: source.name.clone(),
                     }
                     .into());
+                }
+            }
+
+            if source.source_type == DataSourceType::Dynamodb {
+                if let Some(value) = source
+                    .options
+                    .as_ref()
+                    .and_then(|o| o.get("allowed_tables"))
+                {
+                    let has_entry = value.split(',').any(|s| !s.trim().is_empty());
+                    if !has_entry {
+                        return Err(ConfigError::EmptyAllowedTables {
+                            name: source.name.clone(),
+                        }
+                        .into());
+                    }
                 }
             }
         }
@@ -2249,6 +2270,29 @@ options:
             matches!(
                 config_err,
                 ConfigError::MissingConnectionString { name } if name == "products"
+            ),
+            "got {config_err}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_dynamodb_catalog_empty_allowed_tables() {
+        let mut options = HashMap::new();
+        options.insert("allowed_tables".to_string(), " , , ".to_string());
+        let mut source = dynamodb_source(
+            "ddb",
+            Some("http://localhost:8000"),
+            Some(options),
+            AccessMode::ReadOnly,
+        );
+        source.hierarchy_level = HierarchyLevel::Catalog;
+
+        let err = validate_data_sources(&[source]).unwrap_err();
+        let config_err = err.downcast_ref::<ConfigError>().unwrap();
+        assert!(
+            matches!(
+                config_err,
+                ConfigError::EmptyAllowedTables { name } if name == "ddb"
             ),
             "got {config_err}"
         );

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -708,6 +708,7 @@ const CATALOG_SUPPORTED_SOURCES: &[DataSourceType] = &[
     DataSourceType::Mysql,
     DataSourceType::Sqlite,
     DataSourceType::Seekdb,
+    DataSourceType::Dynamodb,
 ];
 
 /// Data source types that support read_write access mode
@@ -1292,6 +1293,7 @@ async fn register_data_source(
                 connection_string,
                 source.options.as_ref(),
                 source.access_mode.is_read_write(),
+                source.hierarchy_level,
             )
             .await
             .map_err(|e| {

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -2299,6 +2299,45 @@ options:
     }
 
     #[test]
+    fn validate_accepts_dynamodb_catalog_allowed_tables() {
+        let mut options = HashMap::new();
+        options.insert("allowed_tables".to_string(), "products, orders".to_string());
+        let mut source = dynamodb_source(
+            "ddb",
+            Some("http://localhost:8000"),
+            Some(options),
+            AccessMode::ReadOnly,
+        );
+        source.hierarchy_level = HierarchyLevel::Catalog;
+
+        validate_data_sources(&[source]).expect("valid DynamoDB catalog allow-list");
+    }
+
+    #[test]
+    fn validate_rejects_dynamodb_catalog_table_option() {
+        let mut options = HashMap::new();
+        options.insert("table".to_string(), "products".to_string());
+        let mut source = dynamodb_source(
+            "ddb",
+            Some("http://localhost:8000"),
+            Some(options),
+            AccessMode::ReadOnly,
+        );
+        source.hierarchy_level = HierarchyLevel::Catalog;
+
+        let err = validate_data_sources(&[source]).unwrap_err();
+        let config_err = err.downcast_ref::<ConfigError>().unwrap();
+        assert!(
+            matches!(
+                config_err,
+                ConfigError::CatalogModeConflictingOptions { name, option }
+                    if name == "ddb" && option == "table"
+            ),
+            "got {config_err}"
+        );
+    }
+
+    #[test]
     fn unsupported_write_mode_error_lists_dynamodb() {
         let err = ConfigError::UnsupportedWriteMode {
             name: "events".to_string(),

--- a/crates/skardi/src/sources/hierarchy/mod.rs
+++ b/crates/skardi/src/sources/hierarchy/mod.rs
@@ -63,6 +63,13 @@ pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 /// Maximum attempts (including the first) for [`retry_with_timeout`].
 pub const MAX_RETRIES: u32 = 3;
 
+/// Summary returned by catalog assembly helpers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CatalogBuildReport {
+    pub registered: usize,
+    pub skipped: usize,
+}
+
 /// How much of an upstream database to expose in DataFusion (single table vs whole catalog).
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, Hash, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]
@@ -173,14 +180,35 @@ pub async fn build_catalog<F, Fut>(
     session_ctx: &SessionContext,
     catalog_name: &str,
     schema_tables: Vec<(String, String)>,
-    mut build_table: F,
+    build_table: F,
 ) -> Result<()>
 where
     F: FnMut(String, String) -> Fut,
     Fut: Future<Output = Result<Arc<dyn TableProvider>>>,
 {
-    let catalog_provider = Arc::new(MemoryCatalogProvider::new());
+    build_catalog_with_required_schemas(
+        session_ctx,
+        catalog_name,
+        schema_tables,
+        Vec::new(),
+        build_table,
+    )
+    .await
+    .map(|_| ())
+}
 
+/// Fail-fast catalog assembly with schemas that must exist even when no table is registered.
+pub async fn build_catalog_with_required_schemas<F, Fut>(
+    session_ctx: &SessionContext,
+    catalog_name: &str,
+    schema_tables: Vec<(String, String)>,
+    required_schemas: Vec<String>,
+    mut build_table: F,
+) -> Result<CatalogBuildReport>
+where
+    F: FnMut(String, String) -> Fut,
+    Fut: Future<Output = Result<Arc<dyn TableProvider>>>,
+{
     // Kick off provider construction concurrently. `build_table` (FnMut) is called eagerly
     // and sequentially in the map — the closures it returns are what run in parallel.
     let provider_futures: Vec<_> = schema_tables
@@ -200,15 +228,114 @@ where
         })
         .collect();
 
-    let mut prepared: Vec<(String, String, Arc<dyn TableProvider>)> =
+    let prepared: Vec<(String, String, Arc<dyn TableProvider>)> = stream::iter(provider_futures)
+        .buffer_unordered(CATALOG_BUILD_CONCURRENCY)
+        .try_collect()
+        .await?;
+
+    register_catalog_tables(session_ctx, catalog_name, required_schemas, prepared, 0)
+}
+
+/// Best-effort catalog assembly. Failed table providers are skipped after a warning.
+pub async fn build_catalog_best_effort<F, Fut>(
+    session_ctx: &SessionContext,
+    catalog_name: &str,
+    schema_tables: Vec<(String, String)>,
+    required_schemas: Vec<String>,
+    mut build_table: F,
+) -> Result<CatalogBuildReport>
+where
+    F: FnMut(String, String) -> Fut,
+    Fut: Future<Output = Result<Arc<dyn TableProvider>>>,
+{
+    let provider_futures: Vec<_> = schema_tables
+        .into_iter()
+        .map(|(schema, table_name)| {
+            let fut = build_table(schema.clone(), table_name.clone());
+            let catalog_name = catalog_name.to_string();
+            async move {
+                let result = fut.await.with_context(|| {
+                    format!(
+                        "Failed to build table provider for '{}.{}' in catalog '{}'",
+                        schema, table_name, catalog_name
+                    )
+                });
+                (schema, table_name, result)
+            }
+        })
+        .collect();
+
+    let prepared_results: Vec<(String, String, Result<Arc<dyn TableProvider>>)> =
         stream::iter(provider_futures)
             .buffer_unordered(CATALOG_BUILD_CONCURRENCY)
-            .try_collect()
-            .await?;
+            .collect()
+            .await;
+
+    let mut skipped = 0usize;
+    let mut prepared = Vec::new();
+    for (schema, table_name, provider_result) in prepared_results {
+        match provider_result {
+            Ok(provider) => prepared.push((schema, table_name, provider)),
+            Err(e) => {
+                skipped += 1;
+                tracing::warn!(
+                    catalog = %catalog_name,
+                    schema = %schema,
+                    table = %table_name,
+                    error = %e,
+                    "Skipping catalog table after provider build failure"
+                );
+            }
+        }
+    }
+
+    if prepared.is_empty() && skipped > 0 {
+        tracing::warn!(
+            catalog = %catalog_name,
+            skipped,
+            "Catalog registered with no tables because every table was skipped"
+        );
+    }
+
+    register_catalog_tables(
+        session_ctx,
+        catalog_name,
+        required_schemas,
+        prepared,
+        skipped,
+    )
+}
+
+fn register_catalog_tables(
+    session_ctx: &SessionContext,
+    catalog_name: &str,
+    mut required_schemas: Vec<String>,
+    mut prepared: Vec<(String, String, Arc<dyn TableProvider>)>,
+    skipped: usize,
+) -> Result<CatalogBuildReport> {
+    let catalog_provider = Arc::new(MemoryCatalogProvider::new());
+
+    required_schemas.sort();
+    required_schemas.dedup();
+    for schema in required_schemas {
+        if catalog_provider.schema(&schema).is_none() {
+            catalog_provider
+                .register_schema(&schema, Arc::new(MemorySchemaProvider::new()))
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "Failed to register schema '{}' for catalog '{}': {}",
+                        schema,
+                        catalog_name,
+                        e
+                    )
+                })?;
+        }
+    }
 
     // Deterministic registration order for log output and downstream iteration.
     prepared.sort_by(|a, b| (a.0.as_str(), a.1.as_str()).cmp(&(b.0.as_str(), b.1.as_str())));
 
+    let registered = prepared.len();
     for (schema, table_name, table_provider) in prepared {
         if catalog_provider.schema(&schema).is_none() {
             catalog_provider
@@ -252,5 +379,8 @@ where
     }
 
     session_ctx.register_catalog(catalog_name, catalog_provider);
-    Ok(())
+    Ok(CatalogBuildReport {
+        registered,
+        skipped,
+    })
 }

--- a/crates/skardi/src/sources/providers/dynamodb.rs
+++ b/crates/skardi/src/sources/providers/dynamodb.rs
@@ -43,6 +43,13 @@ use futures::StreamExt;
 use futures::stream::{self, Stream};
 
 use super::is_pushable_binary_filter;
+use crate::sources::DataSourceType;
+use crate::sources::hierarchy::{HierarchyLevel, SourceLabel, build_catalog, retry_with_timeout};
+
+/// Schema name used for DynamoDB catalog mode. DynamoDB has no native schema/database
+/// layer; all tables live under a single endpoint/region. We expose them under a fixed
+/// schema so SQL references are consistently three-part: `catalog.tables.<table>`.
+const DYNAMODB_CATALOG_SCHEMA: &str = "tables";
 
 /// Maximum items sampled to infer a schema when no explicit `columns` option is
 /// given. Merging several items (rather than one) makes the inferred column set
@@ -51,6 +58,10 @@ const SCHEMA_SAMPLE_SIZE: i32 = 50;
 
 /// DynamoDB `BatchWriteItem` accepts at most 25 write requests per call.
 const BATCH_WRITE_CHUNK: usize = 25;
+
+/// Maximum tables returned per `ListTables` page. AWS allows up to 100; we use the
+/// default and follow `last_evaluated_table_name` when present.
+const LIST_TABLES_PAGE_SIZE: i32 = 100;
 
 /// A DynamoDB table exposed to DataFusion as a `TableProvider`.
 pub struct DynamoTableProvider {
@@ -1761,45 +1772,85 @@ fn count_batch(count: u64) -> DFResult<RecordBatch> {
 
 // ─── Registration ───────────────────────────────────────────────────────────
 
-/// Register a DynamoDB table as a DataFusion table.
+/// Register a DynamoDB table or a whole account/endpoint (catalog) into a DataFusion
+/// [`SessionContext`].
+///
+/// Single-table mode (default) registers one table under `name`. Catalog mode discovers all
+/// accessible DynamoDB tables via `ListTables` and registers each one under
+/// `name.tables.<table_name>`.
 ///
 /// # Arguments
-/// * `session_ctx` - session context to register the table into.
-/// * `name` - the SQL table name to expose.
+/// * `session_ctx` - session context to register the table(s) into.
+/// * `name` - the SQL table name (table mode) or catalog name (catalog mode) to expose.
 /// * `connection_string` - the DynamoDB endpoint URL. For Amazon DynamoDB use
 ///   the regional endpoint (e.g. `https://dynamodb.us-east-1.amazonaws.com`);
 ///   for DynamoDB Local use `http://localhost:8000`.
 /// * `options` - configuration options (see below).
+/// * `read_write` - gates DML for every table registered.
+/// * `hierarchy_level` - [`HierarchyLevel::Table`] (default) or [`HierarchyLevel::Catalog`].
 ///
 /// # Options
-/// * `table` - DynamoDB table name (required).
-/// * `partition_key` - partition (hash) key attribute name. Optional: the key
+/// * `table` - DynamoDB table name (required in table mode; not allowed in catalog mode).
+/// * `partition_key` - partition (hash) key attribute name. Optional in table mode: the key
 ///   schema is read authoritatively via `DescribeTable`; this is only a fallback
 ///   used when `DescribeTable` is unavailable (e.g. restricted IAM permissions).
-/// * `sort_key` - sort (range) key attribute name. Optional and likewise
-///   auto-detected from `DescribeTable`; only a fallback otherwise.
+///   Ignored in catalog mode.
+/// * `sort_key` - sort (range) key attribute name. Optional in table mode and likewise
+///   auto-detected from `DescribeTable`; ignored in catalog mode.
 /// * `region` - AWS region (optional, default `us-east-1`).
 /// * `access_key_env` / `secret_key_env` - names of environment variables
 ///   holding static AWS credentials (optional). When omitted, the default AWS
 ///   credential provider chain is used.
 /// * `columns` - explicit column schema as `name:type[,name:type…]` (types:
-///   `string`, `int`, `float`, `bool`). Optional; when omitted the schema is
-///   inferred by sampling. Declaring it makes writes to an empty table possible
-///   (inference can't see attributes absent from every sampled item) and pins a
-///   stable column set.
-///
-/// `read_write` gates DML: a read-only source rejects INSERT/UPDATE/DELETE at
-/// plan time.
-///
-/// The resolved key schema drives key-aware reads: a query that pins the full
-/// primary key uses `GetItem`, one that pins the partition key uses `Query`, and
-/// anything else falls back to a full `Scan`.
+///   `string`, `int`, `float`, `bool`). Optional in table mode; ignored in catalog
+///   mode because each DynamoDB table has its own attribute set.
 pub async fn register_dynamodb_tables(
     session_ctx: &mut SessionContext,
     name: &str,
     connection_string: &str,
     options: Option<&HashMap<String, String>>,
     read_write: bool,
+    hierarchy_level: HierarchyLevel,
+) -> Result<()> {
+    let mode_str = if read_write {
+        "read-write"
+    } else {
+        "read-only"
+    };
+    match hierarchy_level {
+        HierarchyLevel::Catalog => {
+            register_dynamodb_catalog(
+                session_ctx,
+                name,
+                connection_string,
+                options,
+                read_write,
+                mode_str,
+            )
+            .await
+        }
+        HierarchyLevel::Table => {
+            register_single_dynamodb_table(
+                session_ctx,
+                name,
+                connection_string,
+                options,
+                read_write,
+                mode_str,
+            )
+            .await
+        }
+    }
+}
+
+/// Register one DynamoDB table under `name` in the default catalog.
+async fn register_single_dynamodb_table(
+    session_ctx: &mut SessionContext,
+    name: &str,
+    connection_string: &str,
+    options: Option<&HashMap<String, String>>,
+    read_write: bool,
+    mode_str: &str,
 ) -> Result<()> {
     tracing::info!(
         source = %name,
@@ -1867,8 +1918,153 @@ pub async fn register_dynamodb_tables(
         .register_table(name, Arc::new(provider))
         .with_context(|| format!("Failed to register DynamoDB table '{name}' with DataFusion"))?;
 
-    tracing::info!(source = %name, table = %table, "Registered DynamoDB table");
+    tracing::info!(
+        source = %name,
+        table = %table,
+        "Successfully registered DynamoDB table '{}' as '{}' ({})",
+        table,
+        name,
+        mode_str
+    );
     Ok(())
+}
+
+/// Register all accessible DynamoDB tables as a named DataFusion catalog.
+///
+/// Tables are discovered via `ListTables` and registered under the fixed schema
+/// `tables`, so they are addressable as `catalog.tables.<table_name>`.
+///
+/// Tables whose key schema cannot be determined are skipped with a warning rather
+/// than failing the entire catalog registration, because DynamoDB permissions or
+/// table states can vary across a large account.
+async fn register_dynamodb_catalog(
+    session_ctx: &mut SessionContext,
+    catalog_name: &str,
+    connection_string: &str,
+    options: Option<&HashMap<String, String>>,
+    read_write: bool,
+    mode_str: &str,
+) -> Result<()> {
+    tracing::info!(
+        catalog = %catalog_name,
+        endpoint = %connection_string,
+        read_write,
+        "Registering DynamoDB catalog"
+    );
+
+    let opts = options.cloned().unwrap_or_default();
+    let region = opts
+        .get("region")
+        .cloned()
+        .unwrap_or_else(|| "us-east-1".to_string());
+
+    let label = SourceLabel::new(
+        DataSourceType::Dynamodb,
+        HierarchyLevel::Catalog,
+        catalog_name,
+    );
+    let client = retry_with_timeout(label, "DynamoDB client creation", || async {
+        build_client(connection_string, &region, &opts).await
+    })
+    .await
+    .with_context(|| format!("Failed to build DynamoDB client for catalog '{catalog_name}'"))?;
+
+    let table_names = retry_with_timeout(label, "ListTables", || async {
+        list_dynamodb_tables(&client).await
+    })
+    .await
+    .with_context(|| format!("Failed to list DynamoDB tables for catalog '{catalog_name}'"))?;
+
+    if table_names.is_empty() {
+        tracing::warn!(catalog = %catalog_name, "No DynamoDB tables found for catalog registration");
+    }
+
+    // Build the (schema, table) pairs expected by `build_catalog`. DynamoDB has no
+    // schema layer, so every table lives under the fixed `DYNAMODB_CATALOG_SCHEMA`.
+    let schema_tables: Vec<(String, String)> = table_names
+        .into_iter()
+        .map(|t| (DYNAMODB_CATALOG_SCHEMA.to_string(), t))
+        .collect();
+
+    let table_count = schema_tables.len();
+    let client = Arc::new(client);
+    let catalog_name_owned = catalog_name.to_string();
+
+    build_catalog(
+        session_ctx,
+        catalog_name,
+        schema_tables,
+        |_schema, table_name| {
+            let client = Arc::clone(&client);
+            let catalog_name = catalog_name_owned.clone();
+            async move {
+                let provider =
+                    build_dynamodb_table_provider(client, &table_name, read_write, &catalog_name)
+                        .await?;
+                Ok(Arc::new(provider) as Arc<dyn TableProvider>)
+            }
+        },
+    )
+    .await
+    .with_context(|| format!("Failed to build DynamoDB catalog '{catalog_name}'"))?;
+
+    tracing::info!(
+        "Successfully registered DynamoDB catalog '{}' with {} table(s) ({})",
+        catalog_name,
+        table_count,
+        mode_str
+    );
+    Ok(())
+}
+
+/// Build a [`DynamoTableProvider`] for `table_name`.
+async fn build_dynamodb_table_provider(
+    client: Arc<Client>,
+    table_name: &str,
+    read_write: bool,
+    catalog_name: &str,
+) -> Result<DynamoTableProvider> {
+    let (partition_key, sort_key) =
+        describe_keys(&client, table_name).await.with_context(|| {
+            format!("DynamoDB catalog '{catalog_name}': DescribeTable failed for '{table_name}'")
+        })?;
+
+    DynamoTableProvider::new(
+        (*client).clone(),
+        table_name,
+        &partition_key,
+        sort_key.as_deref(),
+        None,
+        read_write,
+    )
+    .await
+    .with_context(|| {
+        format!("DynamoDB catalog '{catalog_name}': failed to create provider for '{table_name}'")
+    })
+}
+
+/// List all DynamoDB table names accessible through `client`, following pagination.
+async fn list_dynamodb_tables(client: &Client) -> Result<Vec<String>> {
+    let mut table_names = Vec::new();
+    let mut last_evaluated: Option<String> = None;
+
+    loop {
+        let mut req = client.list_tables().limit(LIST_TABLES_PAGE_SIZE);
+        if let Some(exclusive_start) = last_evaluated.take() {
+            req = req.exclusive_start_table_name(exclusive_start);
+        }
+
+        let resp = req.send().await.with_context(|| "ListTables failed")?;
+        table_names.extend(resp.table_names().iter().cloned());
+
+        match resp.last_evaluated_table_name() {
+            Some(name) if !name.is_empty() => last_evaluated = Some(name.to_string()),
+            _ => break,
+        }
+    }
+
+    table_names.sort();
+    Ok(table_names)
 }
 
 /// Build a DynamoDB client from the endpoint, region, and credential options.
@@ -1965,6 +2161,7 @@ fn parse_columns_option(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sources::hierarchy::HierarchyLevel;
     use arrow::array::Array;
     use datafusion::common::ScalarValue;
     use datafusion::logical_expr::dml::InsertOp;
@@ -2320,10 +2517,16 @@ mod tests {
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
             let mut ctx = SessionContext::new();
-            let err =
-                register_dynamodb_tables(&mut ctx, "ddb", "http://localhost:8000", None, false)
-                    .await
-                    .unwrap_err();
+            let err = register_dynamodb_tables(
+                &mut ctx,
+                "ddb",
+                "http://localhost:8000",
+                None,
+                false,
+                HierarchyLevel::Table,
+            )
+            .await
+            .unwrap_err();
             assert!(err.to_string().contains("requires options"));
         });
     }
@@ -2341,11 +2544,90 @@ mod tests {
                 "http://localhost:8000",
                 Some(&opts),
                 false,
+                HierarchyLevel::Table,
             )
             .await
             .unwrap_err();
             assert!(err.to_string().contains("'table'"));
         });
+    }
+
+    #[test]
+    fn table_mode_explicitly_requires_options() {
+        // Explicit table mode (the default) still requires options so the provider
+        // can read the `table` name and credentials.
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let mut ctx = SessionContext::new();
+            let err = register_dynamodb_tables(
+                &mut ctx,
+                "ddb",
+                "http://localhost:8000",
+                None,
+                false,
+                HierarchyLevel::Table,
+            )
+            .await
+            .unwrap_err();
+            assert!(err.to_string().contains("requires options"));
+        });
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DynamoDB Local on :8000"]
+    async fn catalog_mode_accepts_empty_options() {
+        // Catalog mode discovers tables via ListTables, so it does not need a
+        // `table` option. This should reach the network layer without failing
+        // option validation.
+        let mut ctx = SessionContext::new();
+        register_dynamodb_tables(
+            &mut ctx,
+            "ddb",
+            "http://localhost:8000",
+            None,
+            false,
+            HierarchyLevel::Catalog,
+        )
+        .await
+        .expect("catalog registration should not fail due to missing options");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DynamoDB Local on :8000 with `products` and `orders` tables"]
+    async fn catalog_mode_registers_tables_under_fixed_schema() {
+        let mut ctx = SessionContext::new();
+        register_dynamodb_tables(
+            &mut ctx,
+            "ddb",
+            "http://localhost:8000",
+            None,
+            false,
+            HierarchyLevel::Catalog,
+        )
+        .await
+        .expect("register catalog");
+
+        // DynamoDB has no native schema layer; Skardi exposes every discovered
+        // table under the fixed `tables` schema.
+        let df = ctx
+            .sql("SELECT * FROM ddb.tables.products LIMIT 1")
+            .await
+            .expect("plan products");
+        let batches = df.collect().await.expect("collect products");
+        assert!(
+            batches.iter().map(|b| b.num_rows()).sum::<usize>() >= 1,
+            "expected products table under ddb.tables"
+        );
+
+        let df = ctx
+            .sql("SELECT * FROM ddb.tables.orders LIMIT 1")
+            .await
+            .expect("plan orders");
+        let batches = df.collect().await.expect("collect orders");
+        assert!(
+            batches.iter().map(|b| b.num_rows()).sum::<usize>() >= 1,
+            "expected orders table under ddb.tables"
+        );
     }
 
     // ─── Schema shaping (build_schema_fields) ───────────────────────────────
@@ -2847,6 +3129,7 @@ mod tests {
             "http://localhost:8000",
             Some(&opts),
             false,
+            HierarchyLevel::Table,
         )
         .await
         .expect("register");
@@ -3087,9 +3370,16 @@ mod tests {
         // Register via the public path so DescribeTable auto-detects the sort key
         // (note: no partition_key/sort_key options supplied).
         let mut ctx = SessionContext::new();
-        register_dynamodb_tables(&mut ctx, table, "http://localhost:8000", Some(&opts), false)
-            .await
-            .expect("register");
+        register_dynamodb_tables(
+            &mut ctx,
+            table,
+            "http://localhost:8000",
+            Some(&opts),
+            false,
+            HierarchyLevel::Table,
+        )
+        .await
+        .expect("register");
 
         let rows = |sql: String| {
             let ctx = &ctx;

--- a/crates/skardi/src/sources/providers/dynamodb.rs
+++ b/crates/skardi/src/sources/providers/dynamodb.rs
@@ -28,6 +28,7 @@ use aws_sdk_dynamodb::types::{
     AttributeValue, DeleteRequest, KeyType, PutRequest, Select, WriteRequest,
 };
 use datafusion::catalog::Session;
+use datafusion::catalog::{CatalogProvider, MemoryCatalogProvider, MemorySchemaProvider};
 use datafusion::datasource::{TableProvider, TableType};
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::logical_expr::{Expr, Operator, TableProviderFilterPushDown};
@@ -44,7 +45,7 @@ use futures::stream::{self, Stream};
 
 use super::is_pushable_binary_filter;
 use crate::sources::DataSourceType;
-use crate::sources::hierarchy::{HierarchyLevel, SourceLabel, build_catalog, retry_with_timeout};
+use crate::sources::hierarchy::{HierarchyLevel, SourceLabel, retry_with_timeout};
 
 /// Schema name used for DynamoDB catalog mode. DynamoDB has no native schema/database
 /// layer; all tables live under a single endpoint/region. We expose them under a fixed
@@ -62,6 +63,9 @@ const BATCH_WRITE_CHUNK: usize = 25;
 /// Maximum tables returned per `ListTables` page. AWS allows up to 100; we use the
 /// default and follow `last_evaluated_table_name` when present.
 const LIST_TABLES_PAGE_SIZE: i32 = 100;
+
+/// Upper bound on concurrent DynamoDB table introspection during catalog registration.
+const DYNAMODB_CATALOG_BUILD_CONCURRENCY: usize = 8;
 
 /// A DynamoDB table exposed to DataFusion as a `TableProvider`.
 pub struct DynamoTableProvider {
@@ -1804,6 +1808,8 @@ fn count_batch(count: u64) -> DFResult<RecordBatch> {
 /// * `columns` - explicit column schema as `name:type[,name:type…]` (types:
 ///   `string`, `int`, `float`, `bool`). Optional in table mode; ignored in catalog
 ///   mode because each DynamoDB table has its own attribute set.
+/// * `allowed_tables` - Comma-separated table allow-list (catalog mode only). When
+///   present, Skardi registers only those tables and skips `ListTables`.
 pub async fn register_dynamodb_tables(
     session_ctx: &mut SessionContext,
     name: &str,
@@ -1929,14 +1935,15 @@ async fn register_single_dynamodb_table(
     Ok(())
 }
 
-/// Register all accessible DynamoDB tables as a named DataFusion catalog.
+/// Register DynamoDB tables as a named DataFusion catalog.
 ///
-/// Tables are discovered via `ListTables` and registered under the fixed schema
-/// `tables`, so they are addressable as `catalog.tables.<table_name>`.
+/// Tables are discovered via `ListTables` unless `allowed_tables` is set. Registered
+/// tables live under the fixed schema `tables`, so they are addressable as
+/// `catalog.tables.<table_name>`.
 ///
-/// Tables whose key schema cannot be determined are skipped with a warning rather
-/// than failing the entire catalog registration, because DynamoDB permissions or
-/// table states can vary across a large account.
+/// Tables whose key schema or sampled schema cannot be determined are skipped with a
+/// warning rather than failing the entire catalog registration, because DynamoDB
+/// permissions or table states can vary across a large account.
 async fn register_dynamodb_catalog(
     session_ctx: &mut SessionContext,
     catalog_name: &str,
@@ -1969,52 +1976,165 @@ async fn register_dynamodb_catalog(
     .await
     .with_context(|| format!("Failed to build DynamoDB client for catalog '{catalog_name}'"))?;
 
-    let table_names = retry_with_timeout(label, "ListTables", || async {
-        list_dynamodb_tables(&client).await
-    })
-    .await
-    .with_context(|| format!("Failed to list DynamoDB tables for catalog '{catalog_name}'"))?;
+    let table_names = match parse_allowed_tables(Some(&opts))? {
+        Some(allowed) => {
+            tracing::info!(
+                catalog = %catalog_name,
+                allowed_tables = ?allowed,
+                "Using DynamoDB catalog table allow-list"
+            );
+            allowed
+        }
+        None => retry_with_timeout(label, "ListTables", || async {
+            list_dynamodb_tables(&client).await
+        })
+        .await
+        .with_context(|| format!("Failed to list DynamoDB tables for catalog '{catalog_name}'"))?,
+    };
 
     if table_names.is_empty() {
         tracing::warn!(catalog = %catalog_name, "No DynamoDB tables found for catalog registration");
     }
 
-    // Build the (schema, table) pairs expected by `build_catalog`. DynamoDB has no
-    // schema layer, so every table lives under the fixed `DYNAMODB_CATALOG_SCHEMA`.
-    let schema_tables: Vec<(String, String)> = table_names
-        .into_iter()
-        .map(|t| (DYNAMODB_CATALOG_SCHEMA.to_string(), t))
-        .collect();
-
-    let table_count = schema_tables.len();
+    let discovered_count = table_names.len();
     let client = Arc::new(client);
-    let catalog_name_owned = catalog_name.to_string();
-
-    build_catalog(
+    let (registered_count, skipped_count) = build_dynamodb_catalog_best_effort(
         session_ctx,
         catalog_name,
-        schema_tables,
-        |_schema, table_name| {
-            let client = Arc::clone(&client);
-            let catalog_name = catalog_name_owned.clone();
-            async move {
-                let provider =
-                    build_dynamodb_table_provider(client, &table_name, read_write, &catalog_name)
-                        .await?;
-                Ok(Arc::new(provider) as Arc<dyn TableProvider>)
-            }
-        },
+        table_names,
+        client,
+        read_write,
     )
     .await
     .with_context(|| format!("Failed to build DynamoDB catalog '{catalog_name}'"))?;
 
     tracing::info!(
-        "Successfully registered DynamoDB catalog '{}' with {} table(s) ({})",
+        "Successfully registered DynamoDB catalog '{}' with {} table(s), skipped {} of {} discovered ({})",
         catalog_name,
-        table_count,
+        registered_count,
+        skipped_count,
+        discovered_count,
         mode_str
     );
     Ok(())
+}
+
+/// Parse the comma-separated `allowed_tables` option.
+fn parse_allowed_tables(options: Option<&HashMap<String, String>>) -> Result<Option<Vec<String>>> {
+    let Some(value) = options.and_then(|opts| opts.get("allowed_tables")) else {
+        return Ok(None);
+    };
+    let mut tables = value
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    tables.sort();
+    tables.dedup();
+    if tables.is_empty() {
+        anyhow::bail!(
+            "DynamoDB catalog option 'allowed_tables' must be omitted or contain at least one table name"
+        );
+    } else {
+        Ok(Some(tables))
+    }
+}
+
+/// Build and register a DynamoDB catalog while skipping individual tables that
+/// cannot be described or sampled.
+async fn build_dynamodb_catalog_best_effort(
+    session_ctx: &SessionContext,
+    catalog_name: &str,
+    table_names: Vec<String>,
+    client: Arc<Client>,
+    read_write: bool,
+) -> Result<(usize, usize)> {
+    let catalog_provider = Arc::new(MemoryCatalogProvider::new());
+    let catalog_name_owned = catalog_name.to_string();
+
+    let build_futures = table_names.into_iter().map(|table_name| {
+        let client = Arc::clone(&client);
+        let catalog_name = catalog_name_owned.clone();
+        async move {
+            let result =
+                build_dynamodb_table_provider(client, &table_name, read_write, &catalog_name).await;
+            (table_name, result)
+        }
+    });
+
+    let prepared = stream::iter(build_futures)
+        .buffer_unordered(DYNAMODB_CATALOG_BUILD_CONCURRENCY)
+        .collect::<Vec<_>>()
+        .await;
+
+    let mut registered = 0usize;
+    let mut skipped = 0usize;
+    let schema_name = DYNAMODB_CATALOG_SCHEMA.to_string();
+
+    for (table_name, provider_result) in prepared {
+        match provider_result {
+            Ok(provider) => {
+                if catalog_provider.schema(&schema_name).is_none() {
+                    catalog_provider
+                        .register_schema(&schema_name, Arc::new(MemorySchemaProvider::new()))
+                        .map_err(|e| {
+                            anyhow::anyhow!(
+                                "Failed to register schema '{}' for DynamoDB catalog '{}': {}",
+                                schema_name,
+                                catalog_name,
+                                e
+                            )
+                        })?;
+                }
+                let schema_provider = catalog_provider.schema(&schema_name).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Schema '{}' was not found after registration in DynamoDB catalog '{}'",
+                        schema_name,
+                        catalog_name
+                    )
+                })?;
+                schema_provider
+                    .register_table(table_name.clone(), Arc::new(provider))
+                    .map_err(|e| {
+                        anyhow::anyhow!(
+                            "Failed to register table '{}.{}' in DynamoDB catalog '{}': {}",
+                            schema_name,
+                            table_name,
+                            catalog_name,
+                            e
+                        )
+                    })?;
+                registered += 1;
+                tracing::debug!(
+                    catalog = %catalog_name,
+                    schema = %schema_name,
+                    table = %table_name,
+                    "Registered DynamoDB catalog table"
+                );
+            }
+            Err(e) => {
+                skipped += 1;
+                tracing::warn!(
+                    catalog = %catalog_name,
+                    table = %table_name,
+                    error = %e,
+                    "Skipping DynamoDB catalog table after provider build failure"
+                );
+            }
+        }
+    }
+
+    if registered == 0 && skipped > 0 {
+        tracing::warn!(
+            catalog = %catalog_name,
+            skipped,
+            "DynamoDB catalog registered with no tables because every table was skipped"
+        );
+    }
+
+    session_ctx.register_catalog(catalog_name, catalog_provider);
+    Ok((registered, skipped))
 }
 
 /// Build a [`DynamoTableProvider`] for `table_name`.
@@ -2571,6 +2691,39 @@ mod tests {
             .unwrap_err();
             assert!(err.to_string().contains("requires options"));
         });
+    }
+
+    #[test]
+    fn parse_allowed_tables_absent_means_all_tables() {
+        assert!(parse_allowed_tables(None).unwrap().is_none());
+        assert!(
+            parse_allowed_tables(Some(&HashMap::new()))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn parse_allowed_tables_trims_sorts_and_deduplicates() {
+        let mut opts = HashMap::new();
+        opts.insert(
+            "allowed_tables".to_string(),
+            " orders, products,orders , inventory ".to_string(),
+        );
+
+        let tables = parse_allowed_tables(Some(&opts))
+            .expect("parse allowed_tables")
+            .expect("allowed tables");
+        assert_eq!(tables, vec!["inventory", "orders", "products"]);
+    }
+
+    #[test]
+    fn parse_allowed_tables_empty_segments_error() {
+        let mut opts = HashMap::new();
+        opts.insert("allowed_tables".to_string(), " , , ".to_string());
+
+        let err = parse_allowed_tables(Some(&opts)).unwrap_err();
+        assert!(err.to_string().contains("allowed_tables"));
     }
 
     #[tokio::test]

--- a/crates/skardi/src/sources/providers/dynamodb.rs
+++ b/crates/skardi/src/sources/providers/dynamodb.rs
@@ -25,10 +25,9 @@ use async_trait::async_trait;
 use aws_sdk_dynamodb::Client;
 use aws_sdk_dynamodb::config::{Credentials, Region};
 use aws_sdk_dynamodb::types::{
-    AttributeValue, DeleteRequest, KeyType, PutRequest, Select, WriteRequest,
+    AttributeValue, DeleteRequest, KeyType, PutRequest, ScalarAttributeType, Select, WriteRequest,
 };
 use datafusion::catalog::Session;
-use datafusion::catalog::{CatalogProvider, MemoryCatalogProvider, MemorySchemaProvider};
 use datafusion::datasource::{TableProvider, TableType};
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::logical_expr::{Expr, Operator, TableProviderFilterPushDown};
@@ -45,7 +44,10 @@ use futures::stream::{self, Stream};
 
 use super::is_pushable_binary_filter;
 use crate::sources::DataSourceType;
-use crate::sources::hierarchy::{HierarchyLevel, SourceLabel, retry_with_timeout};
+use crate::sources::hierarchy::{
+    HierarchyLevel, SourceLabel, build_catalog_best_effort, build_catalog_with_required_schemas,
+    retry_with_timeout,
+};
 
 /// Schema name used for DynamoDB catalog mode. DynamoDB has no native schema/database
 /// layer; all tables live under a single endpoint/region. We expose them under a fixed
@@ -64,8 +66,36 @@ const BATCH_WRITE_CHUNK: usize = 25;
 /// default and follow `last_evaluated_table_name` when present.
 const LIST_TABLES_PAGE_SIZE: i32 = 100;
 
-/// Upper bound on concurrent DynamoDB table introspection during catalog registration.
-const DYNAMODB_CATALOG_BUILD_CONCURRENCY: usize = 8;
+const DYNAMODB_CATALOG_CONFLICT_OPTIONS: &[&str] =
+    &["table", "schema", "partition_key", "sort_key", "columns"];
+
+#[derive(Clone, Debug, PartialEq)]
+struct DynamoKeySchema {
+    partition_key: String,
+    partition_type: DataType,
+    sort_key: Option<String>,
+    sort_type: Option<DataType>,
+}
+
+impl DynamoKeySchema {
+    fn new(
+        partition_key: String,
+        partition_type: DataType,
+        sort_key: Option<String>,
+        sort_type: Option<DataType>,
+    ) -> Self {
+        Self {
+            partition_key,
+            partition_type,
+            sort_key,
+            sort_type,
+        }
+    }
+
+    fn fallback(partition_key: String, sort_key: Option<String>) -> Self {
+        Self::new(partition_key, DataType::Utf8, sort_key, None)
+    }
+}
 
 /// A DynamoDB table exposed to DataFusion as a `TableProvider`.
 pub struct DynamoTableProvider {
@@ -105,11 +135,42 @@ impl DynamoTableProvider {
         schema: Option<SchemaRef>,
         read_write: bool,
     ) -> Result<Self> {
+        Self::new_with_key_types(
+            client,
+            table_name,
+            partition_key,
+            None,
+            sort_key,
+            None,
+            schema,
+            read_write,
+        )
+        .await
+    }
+
+    async fn new_with_key_types(
+        client: Client,
+        table_name: &str,
+        partition_key: &str,
+        partition_key_type: Option<DataType>,
+        sort_key: Option<&str>,
+        sort_key_type: Option<DataType>,
+        schema: Option<SchemaRef>,
+        read_write: bool,
+    ) -> Result<Self> {
         let schema = match schema {
             Some(s) => s,
-            None => {
-                Arc::new(Self::infer_schema(&client, table_name, partition_key, sort_key).await?)
-            }
+            None => Arc::new(
+                Self::infer_schema(
+                    &client,
+                    table_name,
+                    partition_key,
+                    partition_key_type,
+                    sort_key,
+                    sort_key_type,
+                )
+                .await?,
+            ),
         };
 
         Ok(Self {
@@ -131,7 +192,9 @@ impl DynamoTableProvider {
         client: &Client,
         table_name: &str,
         partition_key: &str,
+        partition_key_type: Option<DataType>,
         sort_key: Option<&str>,
+        sort_key_type: Option<DataType>,
     ) -> Result<Schema> {
         let sample = client
             .scan()
@@ -149,7 +212,18 @@ impl DynamoTableProvider {
             );
         }
 
-        let attrs = merge_sampled_attributes(items);
+        let mut attrs = Vec::new();
+        if let Some(dtype) = partition_key_type {
+            attrs.push((partition_key.to_string(), dtype));
+        }
+        if let (Some(sort_key), Some(dtype)) = (sort_key, sort_key_type) {
+            attrs.push((sort_key.to_string(), dtype));
+        }
+        let mut sampled_attrs = merge_sampled_attributes(items);
+        sampled_attrs.retain(|(name, _)| {
+            name != partition_key && sort_key.map(|sk| name != sk).unwrap_or(true)
+        });
+        attrs.extend(sampled_attrs);
 
         Ok(build_schema_fields(partition_key, sort_key, &attrs))
     }
@@ -1823,6 +1897,7 @@ pub async fn register_dynamodb_tables(
     } else {
         "read-only"
     };
+    validate_dynamodb_mode_options(name, hierarchy_level, options)?;
     match hierarchy_level {
         HierarchyLevel::Catalog => {
             register_dynamodb_catalog(
@@ -1847,6 +1922,37 @@ pub async fn register_dynamodb_tables(
             .await
         }
     }
+}
+
+fn validate_dynamodb_mode_options(
+    name: &str,
+    hierarchy_level: HierarchyLevel,
+    options: Option<&HashMap<String, String>>,
+) -> Result<()> {
+    let Some(opts) = options else {
+        return Ok(());
+    };
+
+    match hierarchy_level {
+        HierarchyLevel::Catalog => {
+            for option in DYNAMODB_CATALOG_CONFLICT_OPTIONS {
+                if opts.contains_key(*option) {
+                    anyhow::bail!(
+                        "DynamoDB catalog data source '{name}' cannot use option '{option}'; catalog mode supports endpoint/credential options plus optional 'allowed_tables'"
+                    );
+                }
+            }
+        }
+        HierarchyLevel::Table => {
+            if opts.contains_key("allowed_tables") {
+                anyhow::bail!(
+                    "DynamoDB table data source '{name}' cannot use catalog-only option 'allowed_tables'"
+                );
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Register one DynamoDB table under `name` in the default catalog.
@@ -1882,8 +1988,8 @@ async fn register_single_dynamodb_table(
     // Prefer the table's authoritative key schema (this also auto-detects the
     // sort key). Fall back to the configured options if DescribeTable is
     // unavailable, e.g. under restricted IAM permissions.
-    let (partition_key, sort_key) = match describe_keys(&client, table).await {
-        Ok(keys) => keys,
+    let key_schema = match describe_keys(&client, table).await {
+        Ok(schema) => schema,
         Err(e) => {
             tracing::warn!(
                 source = %name,
@@ -1895,7 +2001,7 @@ async fn register_single_dynamodb_table(
                     "DynamoDB data source '{name}': DescribeTable failed ({e}) and no 'partition_key' option was provided"
                 )
             })?;
-            (pk, opts.get("sort_key").cloned())
+            DynamoKeySchema::fallback(pk, opts.get("sort_key").cloned())
         }
     };
 
@@ -1903,17 +2009,23 @@ async fn register_single_dynamodb_table(
     // sampling inside `DynamoTableProvider::new`.
     let declared_schema = match opts.get("columns") {
         Some(spec) => Some(
-            parse_columns_option(spec, &partition_key, sort_key.as_deref())
-                .with_context(|| format!("DynamoDB data source '{name}': invalid 'columns'"))?,
+            parse_columns_option(
+                spec,
+                &key_schema.partition_key,
+                key_schema.sort_key.as_deref(),
+            )
+            .with_context(|| format!("DynamoDB data source '{name}': invalid 'columns'"))?,
         ),
         None => None,
     };
 
-    let provider = DynamoTableProvider::new(
+    let provider = DynamoTableProvider::new_with_key_types(
         client,
         table,
-        &partition_key,
-        sort_key.as_deref(),
+        &key_schema.partition_key,
+        Some(key_schema.partition_type.clone()),
+        key_schema.sort_key.as_deref(),
+        key_schema.sort_type.clone(),
         declared_schema,
         read_write,
     )
@@ -1976,7 +2088,9 @@ async fn register_dynamodb_catalog(
     .await
     .with_context(|| format!("Failed to build DynamoDB client for catalog '{catalog_name}'"))?;
 
-    let table_names = match parse_allowed_tables(Some(&opts))? {
+    let allowed_tables = parse_allowed_tables(Some(&opts))?;
+    let explicit_allowlist = allowed_tables.is_some();
+    let table_names = match allowed_tables {
         Some(allowed) => {
             tracing::info!(
                 catalog = %catalog_name,
@@ -1985,11 +2099,11 @@ async fn register_dynamodb_catalog(
             );
             allowed
         }
-        None => retry_with_timeout(label, "ListTables", || async {
-            list_dynamodb_tables(&client).await
-        })
-        .await
-        .with_context(|| format!("Failed to list DynamoDB tables for catalog '{catalog_name}'"))?,
+        None => list_dynamodb_tables(&client, label)
+            .await
+            .with_context(|| {
+                format!("Failed to list DynamoDB tables for catalog '{catalog_name}'")
+            })?,
     };
 
     if table_names.is_empty() {
@@ -1998,21 +2112,57 @@ async fn register_dynamodb_catalog(
 
     let discovered_count = table_names.len();
     let client = Arc::new(client);
-    let (registered_count, skipped_count) = build_dynamodb_catalog_best_effort(
-        session_ctx,
-        catalog_name,
-        table_names,
-        client,
-        read_write,
-    )
-    .await
+    let schema_tables = table_names
+        .into_iter()
+        .map(|table_name| (DYNAMODB_CATALOG_SCHEMA.to_string(), table_name))
+        .collect::<Vec<_>>();
+    let required_schemas = vec![DYNAMODB_CATALOG_SCHEMA.to_string()];
+
+    let build_table = |_: String, table_name: String| {
+        let client = Arc::clone(&client);
+        let catalog_name = catalog_name.to_string();
+        async move {
+            let op_name = format!("DynamoDB table provider build '{table_name}'");
+            retry_with_timeout(label, &op_name, || {
+                let client = Arc::clone(&client);
+                let table_name = table_name.clone();
+                let catalog_name = catalog_name.clone();
+                async move {
+                    build_dynamodb_table_provider(client, &table_name, read_write, &catalog_name)
+                        .await
+                        .map(|provider| Arc::new(provider) as Arc<dyn TableProvider>)
+                }
+            })
+            .await
+        }
+    };
+
+    let report = if explicit_allowlist {
+        build_catalog_with_required_schemas(
+            session_ctx,
+            catalog_name,
+            schema_tables,
+            required_schemas,
+            build_table,
+        )
+        .await
+    } else {
+        build_catalog_best_effort(
+            session_ctx,
+            catalog_name,
+            schema_tables,
+            required_schemas,
+            build_table,
+        )
+        .await
+    }
     .with_context(|| format!("Failed to build DynamoDB catalog '{catalog_name}'"))?;
 
     tracing::info!(
         "Successfully registered DynamoDB catalog '{}' with {} table(s), skipped {} of {} discovered ({})",
         catalog_name,
-        registered_count,
-        skipped_count,
+        report.registered,
+        report.skipped,
         discovered_count,
         mode_str
     );
@@ -2041,113 +2191,6 @@ fn parse_allowed_tables(options: Option<&HashMap<String, String>>) -> Result<Opt
     }
 }
 
-/// Build and register a DynamoDB catalog while skipping individual tables that
-/// cannot be described or sampled.
-async fn build_dynamodb_catalog_best_effort(
-    session_ctx: &SessionContext,
-    catalog_name: &str,
-    table_names: Vec<String>,
-    client: Arc<Client>,
-    read_write: bool,
-) -> Result<(usize, usize)> {
-    let catalog_name_owned = catalog_name.to_string();
-
-    let build_futures = table_names.into_iter().map(|table_name| {
-        let client = Arc::clone(&client);
-        let catalog_name = catalog_name_owned.clone();
-        async move {
-            let result =
-                build_dynamodb_table_provider(client, &table_name, read_write, &catalog_name)
-                    .await
-                    .map(|provider| Arc::new(provider) as Arc<dyn TableProvider>);
-            (table_name, result)
-        }
-    });
-
-    let prepared = stream::iter(build_futures)
-        .buffer_unordered(DYNAMODB_CATALOG_BUILD_CONCURRENCY)
-        .collect::<Vec<_>>()
-        .await;
-
-    register_prepared_dynamodb_catalog(session_ctx, catalog_name, prepared)
-}
-
-/// Register already-built DynamoDB catalog table providers, skipping failed builds.
-fn register_prepared_dynamodb_catalog(
-    session_ctx: &SessionContext,
-    catalog_name: &str,
-    prepared: Vec<(String, Result<Arc<dyn TableProvider>>)>,
-) -> Result<(usize, usize)> {
-    let catalog_provider = Arc::new(MemoryCatalogProvider::new());
-    let mut registered = 0usize;
-    let mut skipped = 0usize;
-    let schema_name = DYNAMODB_CATALOG_SCHEMA.to_string();
-
-    for (table_name, provider_result) in prepared {
-        match provider_result {
-            Ok(provider) => {
-                if catalog_provider.schema(&schema_name).is_none() {
-                    catalog_provider
-                        .register_schema(&schema_name, Arc::new(MemorySchemaProvider::new()))
-                        .map_err(|e| {
-                            anyhow::anyhow!(
-                                "Failed to register schema '{}' for DynamoDB catalog '{}': {}",
-                                schema_name,
-                                catalog_name,
-                                e
-                            )
-                        })?;
-                }
-                let schema_provider = catalog_provider.schema(&schema_name).ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "Schema '{}' was not found after registration in DynamoDB catalog '{}'",
-                        schema_name,
-                        catalog_name
-                    )
-                })?;
-                schema_provider
-                    .register_table(table_name.clone(), provider)
-                    .map_err(|e| {
-                        anyhow::anyhow!(
-                            "Failed to register table '{}.{}' in DynamoDB catalog '{}': {}",
-                            schema_name,
-                            table_name,
-                            catalog_name,
-                            e
-                        )
-                    })?;
-                registered += 1;
-                tracing::debug!(
-                    catalog = %catalog_name,
-                    schema = %schema_name,
-                    table = %table_name,
-                    "Registered DynamoDB catalog table"
-                );
-            }
-            Err(e) => {
-                skipped += 1;
-                tracing::warn!(
-                    catalog = %catalog_name,
-                    table = %table_name,
-                    error = %e,
-                    "Skipping DynamoDB catalog table after provider build failure"
-                );
-            }
-        }
-    }
-
-    if registered == 0 && skipped > 0 {
-        tracing::warn!(
-            catalog = %catalog_name,
-            skipped,
-            "DynamoDB catalog registered with no tables because every table was skipped"
-        );
-    }
-
-    session_ctx.register_catalog(catalog_name, catalog_provider);
-    Ok((registered, skipped))
-}
-
 /// Build a [`DynamoTableProvider`] for `table_name`.
 async fn build_dynamodb_table_provider(
     client: Arc<Client>,
@@ -2155,16 +2198,17 @@ async fn build_dynamodb_table_provider(
     read_write: bool,
     catalog_name: &str,
 ) -> Result<DynamoTableProvider> {
-    let (partition_key, sort_key) =
-        describe_keys(&client, table_name).await.with_context(|| {
-            format!("DynamoDB catalog '{catalog_name}': DescribeTable failed for '{table_name}'")
-        })?;
+    let key_schema = describe_keys(&client, table_name).await.with_context(|| {
+        format!("DynamoDB catalog '{catalog_name}': DescribeTable failed for '{table_name}'")
+    })?;
 
-    DynamoTableProvider::new(
+    DynamoTableProvider::new_with_key_types(
         (*client).clone(),
         table_name,
-        &partition_key,
-        sort_key.as_deref(),
+        &key_schema.partition_key,
+        Some(key_schema.partition_type.clone()),
+        key_schema.sort_key.as_deref(),
+        key_schema.sort_type.clone(),
         None,
         read_write,
     )
@@ -2175,17 +2219,23 @@ async fn build_dynamodb_table_provider(
 }
 
 /// List all DynamoDB table names accessible through `client`, following pagination.
-async fn list_dynamodb_tables(client: &Client) -> Result<Vec<String>> {
+async fn list_dynamodb_tables(client: &Client, label: SourceLabel<'_>) -> Result<Vec<String>> {
     let mut table_names = Vec::new();
     let mut last_evaluated: Option<String> = None;
 
     loop {
-        let mut req = client.list_tables().limit(LIST_TABLES_PAGE_SIZE);
-        if let Some(exclusive_start) = last_evaluated.take() {
-            req = req.exclusive_start_table_name(exclusive_start);
-        }
-
-        let resp = req.send().await.with_context(|| "ListTables failed")?;
+        let exclusive_start = last_evaluated.take();
+        let resp = retry_with_timeout(label, "ListTables page", || {
+            let exclusive_start = exclusive_start.clone();
+            async move {
+                let mut req = client.list_tables().limit(LIST_TABLES_PAGE_SIZE);
+                if let Some(exclusive_start) = exclusive_start {
+                    req = req.exclusive_start_table_name(exclusive_start);
+                }
+                req.send().await.with_context(|| "ListTables failed")
+            }
+        })
+        .await?;
         table_names.extend(resp.table_names().iter().cloned());
 
         match resp.last_evaluated_table_name() {
@@ -2223,18 +2273,41 @@ async fn build_client(
     Ok(Client::new(&config))
 }
 
-/// Read the table's authoritative key schema via `DescribeTable`, returning
-/// `(partition_key, sort_key)`. This drives key-aware read planning without
-/// trusting (possibly mismatched) configured key names, and auto-detects the
-/// sort key for composite-key tables.
-async fn describe_keys(client: &Client, table: &str) -> Result<(String, Option<String>)> {
+/// Map a DynamoDB key scalar type from `DescribeTable` to the Arrow type used by Skardi.
+fn scalar_attribute_type_to_arrow_type(attribute_type: &ScalarAttributeType) -> DataType {
+    match attribute_type {
+        ScalarAttributeType::S => DataType::Utf8,
+        ScalarAttributeType::N => DataType::Float64,
+        ScalarAttributeType::B => DataType::Utf8,
+        _ => DataType::Utf8,
+    }
+}
+
+/// Read the table's authoritative key schema via `DescribeTable`, returning key
+/// names and scalar types. This drives key-aware read planning without trusting
+/// (possibly mismatched) configured key names, and auto-detects the sort key for
+/// composite-key tables.
+async fn describe_keys(client: &Client, table: &str) -> Result<DynamoKeySchema> {
     let out = client
         .describe_table()
         .table_name(table)
         .send()
         .await
         .with_context(|| format!("DescribeTable failed for '{table}'"))?;
-    let key_schema = out.table().map(|t| t.key_schema()).unwrap_or_default();
+    let table_desc = out
+        .table()
+        .ok_or_else(|| anyhow::anyhow!("DescribeTable for '{table}' returned no table metadata"))?;
+    let key_schema = table_desc.key_schema();
+    let attr_types = table_desc
+        .attribute_definitions()
+        .iter()
+        .map(|attr| {
+            (
+                attr.attribute_name().to_string(),
+                scalar_attribute_type_to_arrow_type(attr.attribute_type()),
+            )
+        })
+        .collect::<HashMap<_, _>>();
 
     let mut partition_key: Option<String> = None;
     let mut sort_key: Option<String> = None;
@@ -2248,7 +2321,20 @@ async fn describe_keys(client: &Client, table: &str) -> Result<(String, Option<S
 
     let partition_key = partition_key
         .ok_or_else(|| anyhow::anyhow!("table '{table}' has no HASH key in its key schema"))?;
-    Ok((partition_key, sort_key))
+    let partition_type = attr_types
+        .get(&partition_key)
+        .cloned()
+        .unwrap_or(DataType::Utf8);
+    let sort_type = sort_key
+        .as_ref()
+        .and_then(|sort_key| attr_types.get(sort_key).cloned());
+
+    Ok(DynamoKeySchema::new(
+        partition_key,
+        partition_type,
+        sort_key,
+        sort_type,
+    ))
 }
 
 /// Parse the `columns` option (`name:type[,name:type…]`) into an explicit
@@ -2737,6 +2823,28 @@ mod tests {
         assert!(err.to_string().contains("allowed_tables"));
     }
 
+    #[test]
+    fn catalog_mode_rejects_table_scoped_options_at_provider_boundary() {
+        for option in DYNAMODB_CATALOG_CONFLICT_OPTIONS {
+            let mut opts = HashMap::new();
+            opts.insert((*option).to_string(), "value".to_string());
+
+            let err = validate_dynamodb_mode_options("ddb", HierarchyLevel::Catalog, Some(&opts))
+                .unwrap_err();
+            assert!(err.to_string().contains(option), "got: {err}");
+        }
+    }
+
+    #[test]
+    fn table_mode_rejects_catalog_only_allowed_tables() {
+        let mut opts = HashMap::new();
+        opts.insert("allowed_tables".to_string(), "products".to_string());
+
+        let err =
+            validate_dynamodb_mode_options("ddb", HierarchyLevel::Table, Some(&opts)).unwrap_err();
+        assert!(err.to_string().contains("allowed_tables"), "got: {err}");
+    }
+
     fn mem_table_provider() -> Arc<dyn TableProvider> {
         let schema: SchemaRef = Arc::new(Schema::new(vec![Field::new("id", DataType::Utf8, true)]));
         let batch = RecordBatch::new_empty(schema.clone());
@@ -2747,17 +2855,26 @@ mod tests {
     #[tokio::test]
     async fn catalog_registration_skips_failed_tables_and_uses_fixed_schema() {
         let ctx = SessionContext::new();
-        let prepared = vec![
-            ("orders".to_string(), Ok(mem_table_provider())),
-            (
-                "broken".to_string(),
-                Err(anyhow::anyhow!("DescribeTable failed")),
-            ),
-        ];
-
-        let counts =
-            register_prepared_dynamodb_catalog(&ctx, "ddb", prepared).expect("register catalog");
-        assert_eq!(counts, (1, 1));
+        let report = build_catalog_best_effort(
+            &ctx,
+            "ddb",
+            vec![
+                (DYNAMODB_CATALOG_SCHEMA.to_string(), "orders".to_string()),
+                (DYNAMODB_CATALOG_SCHEMA.to_string(), "broken".to_string()),
+            ],
+            vec![DYNAMODB_CATALOG_SCHEMA.to_string()],
+            |_, table_name| async move {
+                if table_name == "broken" {
+                    Err(anyhow::anyhow!("DescribeTable failed"))
+                } else {
+                    Ok(mem_table_provider())
+                }
+            },
+        )
+        .await
+        .expect("register catalog");
+        assert_eq!(report.registered, 1);
+        assert_eq!(report.skipped, 1);
 
         let df = ctx
             .sql("SELECT * FROM ddb.tables.orders")
@@ -2776,37 +2893,70 @@ mod tests {
     #[tokio::test]
     async fn catalog_registration_all_failed_is_still_best_effort() {
         let ctx = SessionContext::new();
-        let prepared = vec![
-            (
-                "products".to_string(),
-                Err(anyhow::anyhow!("schema inference failed")),
-            ),
-            (
-                "orders".to_string(),
-                Err(anyhow::anyhow!("DescribeTable denied")),
-            ),
-        ];
-
-        let counts =
-            register_prepared_dynamodb_catalog(&ctx, "ddb", prepared).expect("register catalog");
-        assert_eq!(counts, (0, 2));
+        let report = build_catalog_best_effort(
+            &ctx,
+            "ddb",
+            vec![
+                (DYNAMODB_CATALOG_SCHEMA.to_string(), "products".to_string()),
+                (DYNAMODB_CATALOG_SCHEMA.to_string(), "orders".to_string()),
+            ],
+            vec![DYNAMODB_CATALOG_SCHEMA.to_string()],
+            |_, table_name| async move { Err(anyhow::anyhow!("{table_name} unavailable")) },
+        )
+        .await
+        .expect("register catalog");
+        assert_eq!(report.registered, 0);
+        assert_eq!(report.skipped, 2);
         assert!(ctx.catalog("ddb").is_some(), "catalog should still exist");
 
         let err = ctx
             .sql("SELECT * FROM ddb.tables.orders")
             .await
             .expect_err("all failed tables should be absent");
-        assert!(err.to_string().contains("tables"), "got: {err}");
+        assert!(
+            err.to_string().contains("orders") && !err.to_string().contains("schema not found"),
+            "got: {err}"
+        );
     }
 
-    #[test]
-    fn catalog_registration_empty_input_registers_empty_catalog() {
+    #[tokio::test]
+    async fn catalog_registration_empty_input_registers_empty_catalog() {
         let ctx = SessionContext::new();
-        let counts =
-            register_prepared_dynamodb_catalog(&ctx, "ddb", Vec::new()).expect("register catalog");
+        let report = build_catalog_best_effort(
+            &ctx,
+            "ddb",
+            Vec::new(),
+            vec![DYNAMODB_CATALOG_SCHEMA.to_string()],
+            |_, _| async { Ok(mem_table_provider()) },
+        )
+        .await
+        .expect("register catalog");
 
-        assert_eq!(counts, (0, 0));
+        assert_eq!(report.registered, 0);
+        assert_eq!(report.skipped, 0);
         assert!(ctx.catalog("ddb").is_some(), "empty catalog should exist");
+        assert!(
+            ctx.catalog("ddb")
+                .and_then(|catalog| catalog.schema(DYNAMODB_CATALOG_SCHEMA))
+                .is_some(),
+            "fixed schema should exist even without tables"
+        );
+    }
+
+    #[tokio::test]
+    async fn catalog_registration_fail_fast_reports_allowlist_failures() {
+        let ctx = SessionContext::new();
+        let err = build_catalog_with_required_schemas(
+            &ctx,
+            "ddb",
+            vec![(DYNAMODB_CATALOG_SCHEMA.to_string(), "ordersx".to_string())],
+            vec![DYNAMODB_CATALOG_SCHEMA.to_string()],
+            |_, table_name| async move { Err(anyhow::anyhow!("{table_name} unavailable")) },
+        )
+        .await
+        .expect_err("explicit allow-list should fail fast");
+
+        assert!(err.to_string().contains("ordersx"), "got: {err}");
     }
 
     #[tokio::test]
@@ -2963,6 +3113,35 @@ mod tests {
         assert_eq!(schema.fields().len(), 1);
         assert_eq!(schema.field(0).name(), "pk");
         assert_eq!(schema.field(0).data_type(), &DataType::Utf8);
+    }
+
+    #[test]
+    fn schema_fields_preserve_described_key_types_when_unsampled() {
+        let key_schema = DynamoKeySchema::new(
+            "pk".to_string(),
+            scalar_attribute_type_to_arrow_type(&ScalarAttributeType::N),
+            Some("sk".to_string()),
+            Some(scalar_attribute_type_to_arrow_type(&ScalarAttributeType::S)),
+        );
+        let attrs = vec![
+            (
+                key_schema.partition_key.clone(),
+                key_schema.partition_type.clone(),
+            ),
+            (
+                key_schema.sort_key.clone().expect("sort key"),
+                key_schema.sort_type.clone().expect("sort key type"),
+            ),
+        ];
+        let schema = build_schema_fields("pk", Some("sk"), &attrs);
+
+        assert_eq!(schema.fields().len(), 2);
+        assert_eq!(schema.field(0).name(), "pk");
+        assert_eq!(schema.field(0).data_type(), &DataType::Float64);
+        assert!(!schema.field(0).is_nullable());
+        assert_eq!(schema.field(1).name(), "sk");
+        assert_eq!(schema.field(1).data_type(), &DataType::Utf8);
+        assert!(!schema.field(1).is_nullable());
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/dynamodb.rs
+++ b/crates/skardi/src/sources/providers/dynamodb.rs
@@ -2745,10 +2745,76 @@ mod tests {
         .expect("catalog registration should not fail due to missing options");
     }
 
+    async fn ensure_catalog_orders_table(client: &Client) {
+        use aws_sdk_dynamodb::types::{
+            AttributeDefinition, BillingMode, KeySchemaElement, ScalarAttributeType,
+        };
+
+        if client
+            .describe_table()
+            .table_name("orders")
+            .send()
+            .await
+            .is_err()
+        {
+            client
+                .create_table()
+                .table_name("orders")
+                .attribute_definitions(
+                    AttributeDefinition::builder()
+                        .attribute_name("order_id")
+                        .attribute_type(ScalarAttributeType::S)
+                        .build()
+                        .unwrap(),
+                )
+                .key_schema(
+                    KeySchemaElement::builder()
+                        .attribute_name("order_id")
+                        .key_type(KeyType::Hash)
+                        .build()
+                        .unwrap(),
+                )
+                .billing_mode(BillingMode::PayPerRequest)
+                .send()
+                .await
+                .expect("create orders table");
+        }
+
+        let put = |order_id: &str, product_id: &str, quantity: i64, status: &str| {
+            let client = client.clone();
+            let order_id = order_id.to_string();
+            let product_id = product_id.to_string();
+            let status = status.to_string();
+            async move {
+                client
+                    .put_item()
+                    .table_name("orders")
+                    .item("order_id", AttributeValue::S(order_id))
+                    .item("product_id", AttributeValue::S(product_id))
+                    .item("quantity", AttributeValue::N(quantity.to_string()))
+                    .item("status", AttributeValue::S(status))
+                    .send()
+                    .await
+                    .expect("put order");
+            }
+        };
+
+        put("ORD001", "PROD001", 2, "paid").await;
+        put("ORD002", "PROD002", 1, "pending").await;
+    }
+
     #[tokio::test]
     #[ignore = "requires DynamoDB Local on :8000 with `products` and `orders` tables"]
     async fn catalog_mode_registers_tables_under_fixed_schema() {
         let mut ctx = SessionContext::new();
+        let mut client_opts = HashMap::new();
+        client_opts.insert("region".to_string(), "us-east-1".to_string());
+
+        let client = build_client("http://localhost:8000", "us-east-1", &client_opts)
+            .await
+            .expect("client");
+        ensure_catalog_orders_table(&client).await;
+
         register_dynamodb_tables(
             &mut ctx,
             "ddb",

--- a/crates/skardi/src/sources/providers/dynamodb.rs
+++ b/crates/skardi/src/sources/providers/dynamodb.rs
@@ -2050,7 +2050,6 @@ async fn build_dynamodb_catalog_best_effort(
     client: Arc<Client>,
     read_write: bool,
 ) -> Result<(usize, usize)> {
-    let catalog_provider = Arc::new(MemoryCatalogProvider::new());
     let catalog_name_owned = catalog_name.to_string();
 
     let build_futures = table_names.into_iter().map(|table_name| {
@@ -2058,7 +2057,9 @@ async fn build_dynamodb_catalog_best_effort(
         let catalog_name = catalog_name_owned.clone();
         async move {
             let result =
-                build_dynamodb_table_provider(client, &table_name, read_write, &catalog_name).await;
+                build_dynamodb_table_provider(client, &table_name, read_write, &catalog_name)
+                    .await
+                    .map(|provider| Arc::new(provider) as Arc<dyn TableProvider>);
             (table_name, result)
         }
     });
@@ -2068,6 +2069,16 @@ async fn build_dynamodb_catalog_best_effort(
         .collect::<Vec<_>>()
         .await;
 
+    register_prepared_dynamodb_catalog(session_ctx, catalog_name, prepared)
+}
+
+/// Register already-built DynamoDB catalog table providers, skipping failed builds.
+fn register_prepared_dynamodb_catalog(
+    session_ctx: &SessionContext,
+    catalog_name: &str,
+    prepared: Vec<(String, Result<Arc<dyn TableProvider>>)>,
+) -> Result<(usize, usize)> {
+    let catalog_provider = Arc::new(MemoryCatalogProvider::new());
     let mut registered = 0usize;
     let mut skipped = 0usize;
     let schema_name = DYNAMODB_CATALOG_SCHEMA.to_string();
@@ -2095,7 +2106,7 @@ async fn build_dynamodb_catalog_best_effort(
                     )
                 })?;
                 schema_provider
-                    .register_table(table_name.clone(), Arc::new(provider))
+                    .register_table(table_name.clone(), provider)
                     .map_err(|e| {
                         anyhow::anyhow!(
                             "Failed to register table '{}.{}' in DynamoDB catalog '{}': {}",
@@ -2724,6 +2735,78 @@ mod tests {
 
         let err = parse_allowed_tables(Some(&opts)).unwrap_err();
         assert!(err.to_string().contains("allowed_tables"));
+    }
+
+    fn mem_table_provider() -> Arc<dyn TableProvider> {
+        let schema: SchemaRef = Arc::new(Schema::new(vec![Field::new("id", DataType::Utf8, true)]));
+        let batch = RecordBatch::new_empty(schema.clone());
+        Arc::new(datafusion::datasource::MemTable::try_new(schema, vec![vec![batch]]).unwrap())
+            as Arc<dyn TableProvider>
+    }
+
+    #[tokio::test]
+    async fn catalog_registration_skips_failed_tables_and_uses_fixed_schema() {
+        let ctx = SessionContext::new();
+        let prepared = vec![
+            ("orders".to_string(), Ok(mem_table_provider())),
+            (
+                "broken".to_string(),
+                Err(anyhow::anyhow!("DescribeTable failed")),
+            ),
+        ];
+
+        let counts =
+            register_prepared_dynamodb_catalog(&ctx, "ddb", prepared).expect("register catalog");
+        assert_eq!(counts, (1, 1));
+
+        let df = ctx
+            .sql("SELECT * FROM ddb.tables.orders")
+            .await
+            .expect("orders is registered under fixed schema");
+        let batches = df.collect().await.expect("collect orders");
+        assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 0);
+
+        let err = ctx
+            .sql("SELECT * FROM ddb.tables.broken")
+            .await
+            .expect_err("failed provider must be skipped");
+        assert!(err.to_string().contains("broken"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn catalog_registration_all_failed_is_still_best_effort() {
+        let ctx = SessionContext::new();
+        let prepared = vec![
+            (
+                "products".to_string(),
+                Err(anyhow::anyhow!("schema inference failed")),
+            ),
+            (
+                "orders".to_string(),
+                Err(anyhow::anyhow!("DescribeTable denied")),
+            ),
+        ];
+
+        let counts =
+            register_prepared_dynamodb_catalog(&ctx, "ddb", prepared).expect("register catalog");
+        assert_eq!(counts, (0, 2));
+        assert!(ctx.catalog("ddb").is_some(), "catalog should still exist");
+
+        let err = ctx
+            .sql("SELECT * FROM ddb.tables.orders")
+            .await
+            .expect_err("all failed tables should be absent");
+        assert!(err.to_string().contains("tables"), "got: {err}");
+    }
+
+    #[test]
+    fn catalog_registration_empty_input_registers_empty_catalog() {
+        let ctx = SessionContext::new();
+        let counts =
+            register_prepared_dynamodb_catalog(&ctx, "ddb", Vec::new()).expect("register catalog");
+
+        assert_eq!(counts, (0, 0));
+        assert!(ctx.catalog("ddb").is_some(), "empty catalog should exist");
     }
 
     #[tokio::test]

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -2,7 +2,7 @@
 
 Instead of registering tables one by one, set `hierarchy_level: "catalog"` on a data source to load the entire database automatically. Every table and view is registered under a named DataFusion catalog and queried with a three-part reference.
 
-Supported for **PostgreSQL**, **MySQL**, and **SQLite**.
+Supported for **PostgreSQL**, **MySQL**, **SQLite**, **SeekDB**, and **DynamoDB**.
 
 ## Configuration
 
@@ -36,6 +36,9 @@ SELECT * FROM mydb_catalog.public.users LIMIT 10;
 
 -- SQLite (schema is always "main")
 SELECT * FROM mydb_catalog.main.users LIMIT 10;
+
+-- DynamoDB (schema is always "tables")
+SELECT * FROM ddb_catalog.tables.products LIMIT 10;
 ```
 
 ## Working Examples
@@ -44,3 +47,4 @@ See the docs directories for full working examples:
 - [docs/postgres/](postgres/) — `ctx_postgres_catalog_demo.yaml`
 - [docs/mysql/](mysql/) — `ctx_mysql_catalog_demo.yaml`
 - [docs/sqlite/](sqlite/) — `ctx_sqlite_catalog_demo.yaml`
+- [docs/dynamodb/](dynamodb/) — use `hierarchy_level: "catalog"` with optional `allowed_tables`

--- a/docs/dynamodb/README.md
+++ b/docs/dynamodb/README.md
@@ -274,11 +274,12 @@ curl -X POST http://localhost:8080/federated_join/execute \
 
 | Option | Type | Required | Description |
 |---|---|---|---|
-| `table` | string | yes | DynamoDB table name |
-| `partition_key` | string | no | Partition (hash) key attribute name. Auto-detected from the table's key schema via `DescribeTable`; supply it only as a fallback for when `DescribeTable` is unavailable (e.g. restricted IAM permissions) |
-| `sort_key` | string | no | Sort (range) key attribute name for composite-key tables. Also auto-detected from `DescribeTable`; a fallback otherwise |
+| `table` | string | table mode only | DynamoDB table name |
+| `partition_key` | string | no, table mode only | Partition (hash) key attribute name. Auto-detected from the table's key schema via `DescribeTable`; supply it only as a fallback for when `DescribeTable` is unavailable (e.g. restricted IAM permissions) |
+| `sort_key` | string | no, table mode only | Sort (range) key attribute name for composite-key tables. Also auto-detected from `DescribeTable`; a fallback otherwise |
 | `region` | string | no | AWS region (default `us-east-1`) |
-| `columns` | string | no | Explicit schema as `name:type,…` (types `string`, `int`, `float`, `bool`). Pins a stable/typed column set and lets you write non-key columns to an empty table. When omitted, the schema is inferred by sampling |
+| `columns` | string | no, table mode only | Explicit schema as `name:type,…` (types `string`, `int`, `float`, `bool`). Pins a stable/typed column set and lets you write non-key columns to an empty table. When omitted, the schema is inferred by sampling |
+| `allowed_tables` | string | no, catalog mode only | Comma-separated table allow-list. Omit it to discover all DynamoDB tables with `ListTables` |
 | `access_key_env` | string | no | Env var holding the AWS access key id |
 | `secret_key_env` | string | no | Env var holding the AWS secret access key |
 
@@ -311,10 +312,11 @@ SELECT * FROM ddb.tables.products LIMIT 10;
 ```
 
 When `allowed_tables` is present, Skardi registers only those table names and
-does not call `ListTables`. When it is omitted, Skardi discovers tables with
-`ListTables`. Catalog registration is best-effort: if one table cannot be
-described or sampled for schema inference, that table is skipped with a warning
-and the remaining tables continue to load.
+does not call `ListTables`; every listed table must be describable, so typos fail
+catalog registration early. When `allowed_tables` is omitted, Skardi discovers
+tables with `ListTables`. Discovery-mode catalog registration is best-effort: if
+one discovered table cannot be described or sampled for schema inference, that
+table is skipped with a warning and the remaining tables continue to load.
 
 ### Read planning (key-aware access)
 

--- a/docs/dynamodb/README.md
+++ b/docs/dynamodb/README.md
@@ -274,6 +274,37 @@ curl -X POST http://localhost:8080/federated_join/execute \
 Writes (INSERT/UPDATE/DELETE) additionally require `access_mode: read_write` on
 the source; the default `read_only` rejects them at plan time.
 
+### Catalog mode
+
+Set `hierarchy_level: "catalog"` to expose multiple DynamoDB tables under one
+DataFusion catalog. DynamoDB has no native schema layer, so Skardi registers
+tables under the fixed `tables` schema:
+
+```yaml
+kind: context
+metadata:
+  name: dynamodb-catalog
+spec:
+  data_sources:
+    - name: "ddb"
+      type: "dynamodb"
+      hierarchy_level: "catalog"
+      connection_string: "http://localhost:8000"
+      options:
+        region: "us-east-1"
+        allowed_tables: "products,orders" # optional; omit to discover all tables
+```
+
+```sql
+SELECT * FROM ddb.tables.products LIMIT 10;
+```
+
+When `allowed_tables` is present, Skardi registers only those table names and
+does not call `ListTables`. When it is omitted, Skardi discovers tables with
+`ListTables`. Catalog registration is best-effort: if one table cannot be
+described or sampled for schema inference, that table is skipped with a warning
+and the remaining tables continue to load.
+
 ### Read planning (key-aware access)
 
 Skardi inspects each query's `WHERE` clause and picks the cheapest DynamoDB

--- a/docs/dynamodb/README.md
+++ b/docs/dynamodb/README.md
@@ -22,7 +22,7 @@ export AWS_SECRET_ACCESS_KEY=dummy
 export AWS_DEFAULT_REGION=us-east-1
 EP="http://localhost:8000"
 
-# 3. Create the products table (partition key: product_id) and seed sample data
+# 3. Create demo tables and seed sample data
 aws dynamodb create-table --endpoint-url "$EP" \
   --table-name products \
   --attribute-definitions AttributeName=product_id,AttributeType=S \
@@ -30,12 +30,23 @@ aws dynamodb create-table --endpoint-url "$EP" \
   --billing-mode PAY_PER_REQUEST
 aws dynamodb wait table-exists --endpoint-url "$EP" --table-name products
 
-put() { aws dynamodb put-item --endpoint-url "$EP" --table-name products --item "$1"; }
-put '{"product_id":{"S":"PROD001"},"name":{"S":"Laptop"},"category":{"S":"Electronics"},"price":{"N":"999.99"},"in_stock":{"BOOL":true}}'
-put '{"product_id":{"S":"PROD002"},"name":{"S":"Keyboard"},"category":{"S":"Electronics"},"price":{"N":"79.99"},"in_stock":{"BOOL":true}}'
-put '{"product_id":{"S":"PROD003"},"name":{"S":"Monitor"},"category":{"S":"Electronics"},"price":{"N":"299.99"},"in_stock":{"BOOL":false}}'
-put '{"product_id":{"S":"PROD004"},"name":{"S":"Mouse"},"category":{"S":"Electronics"},"price":{"N":"29.99"},"in_stock":{"BOOL":true}}'
-put '{"product_id":{"S":"PROD005"},"name":{"S":"Desk Chair"},"category":{"S":"Furniture"},"price":{"N":"199.99"},"in_stock":{"BOOL":true}}'
+aws dynamodb create-table --endpoint-url "$EP" \
+  --table-name orders \
+  --attribute-definitions AttributeName=order_id,AttributeType=S \
+  --key-schema AttributeName=order_id,KeyType=HASH \
+  --billing-mode PAY_PER_REQUEST
+aws dynamodb wait table-exists --endpoint-url "$EP" --table-name orders
+
+put_product() { aws dynamodb put-item --endpoint-url "$EP" --table-name products --item "$1"; }
+put_product '{"product_id":{"S":"PROD001"},"name":{"S":"Laptop"},"category":{"S":"Electronics"},"price":{"N":"999.99"},"in_stock":{"BOOL":true}}'
+put_product '{"product_id":{"S":"PROD002"},"name":{"S":"Keyboard"},"category":{"S":"Electronics"},"price":{"N":"79.99"},"in_stock":{"BOOL":true}}'
+put_product '{"product_id":{"S":"PROD003"},"name":{"S":"Monitor"},"category":{"S":"Electronics"},"price":{"N":"299.99"},"in_stock":{"BOOL":false}}'
+put_product '{"product_id":{"S":"PROD004"},"name":{"S":"Mouse"},"category":{"S":"Electronics"},"price":{"N":"29.99"},"in_stock":{"BOOL":true}}'
+put_product '{"product_id":{"S":"PROD005"},"name":{"S":"Desk Chair"},"category":{"S":"Furniture"},"price":{"N":"199.99"},"in_stock":{"BOOL":true}}'
+
+put_order() { aws dynamodb put-item --endpoint-url "$EP" --table-name orders --item "$1"; }
+put_order '{"order_id":{"S":"ORD001"},"product_id":{"S":"PROD001"},"quantity":{"N":"2"},"status":{"S":"paid"}}'
+put_order '{"order_id":{"S":"ORD002"},"product_id":{"S":"PROD002"},"quantity":{"N":"1"},"status":{"S":"pending"}}'
 
 # 4. Start the Skardi server against the demo context + pipelines
 cargo run --bin skardi-server -- \


### PR DESCRIPTION
## Summary

This PR adds `HierarchyLevel::Catalog` support to the DynamoDB provider, allowing users to register DynamoDB tables as a named DataFusion catalog instead of configuring one table at a time.

DynamoDB catalog mode now supports two registration shapes:

- Discover all accessible tables with `ListTables`.
- Register only an explicit comma-separated allow-list via `allowed_tables`, which avoids `ListTables` and bounds startup work.

Catalog registration is best-effort: if a single DynamoDB table cannot be described or sampled for schema inference, Skardi logs a warning, skips that table, and continues registering the remaining tables.

## Motivation

SQLite, PostgreSQL, MySQL, and SeekDB already support catalog mode: point Skardi at the database and it auto-discovers tables. DynamoDB was the odd one out, requiring a separate data-source entry per table. Catalog mode removes that friction for DynamoDB-backed workloads, while `allowed_tables` keeps large accounts or restricted IAM setups practical.

## What changed

- `crates/skardi/src/sources/providers/dynamodb.rs`
  - `register_dynamodb_tables` now accepts a `HierarchyLevel` and dispatches to either single-table registration (existing behavior) or catalog registration.
  - Catalog mode registers DynamoDB tables under `<catalog>.tables.<table_name>` because DynamoDB has no native schema/database layer.
  - Added paginated `ListTables` discovery for catalog mode.
  - Added `allowed_tables` parsing for catalog mode. When present, Skardi registers only those tables and skips `ListTables`.
  - Added best-effort catalog construction: per-table `DescribeTable` or schema inference failures now warn and skip only that table instead of failing the whole catalog.
  - Added bounded concurrent table introspection during catalog registration.

- `crates/server/src/config.rs`
  - Adds `DataSourceType::Dynamodb` to `CATALOG_SUPPORTED_SOURCES`.
  - Passes `source.hierarchy_level` to `register_dynamodb_tables`.
  - Rejects empty `allowed_tables` values such as `""` or `" , "`, so an empty allow-list cannot accidentally mean "load all tables".

- `crates/cli/src/main.rs`
  - Passes the parsed `hierarchy_level` through to DynamoDB registration, fixing the CLI compile break from the provider signature change.

- Documentation
  - Updates `docs/catalog.md` to list DynamoDB catalog support and show the fixed `tables` schema.
  - Updates `docs/dynamodb/README.md` with catalog mode, `allowed_tables`, and best-effort skip behavior.

## Usage example

Discover all accessible DynamoDB tables:

```yaml
kind: context
spec:
  data_sources:
    - name: myddb
      type: dynamodb
      connection_string: "http://localhost:8000"
      hierarchy_level: catalog
      access_mode: read_only
      options:
        region: us-east-1
```

```sql
SELECT * FROM myddb.tables.products WHERE product_id = 'PROD001';
```

Register only selected tables:

```yaml
kind: context
spec:
  data_sources:
    - name: myddb
      type: dynamodb
      connection_string: "http://localhost:8000"
      hierarchy_level: catalog
      options:
        region: us-east-1
        allowed_tables: "products,orders"
```

## Tests

- Updated existing `register_dynamodb_tables` test calls to pass `HierarchyLevel::Table`.
- Added table-mode regression coverage for missing options/table config.
- Added unit coverage for `allowed_tables` parsing, trimming, sorting, deduplication, and empty-value rejection.
- Added server config validation coverage for empty DynamoDB catalog `allowed_tables`.
- Kept DynamoDB Local catalog integration coverage as ignored tests (`catalog_mode_accepts_empty_options`, `catalog_mode_registers_tables_under_fixed_schema`).

Verified locally:

```bash
cargo fmt --all
cargo check -p skardi --all-targets
cargo check -p skardi-server --all-targets
cargo check -p skardi-cli --all-targets --no-default-features
cargo test -p skardi parse_allowed_tables
cargo test -p skardi-server validate_rejects_dynamodb_catalog_empty_allowed_tables
cargo test -p skardi missing_options_errors
cargo test -p skardi missing_table_option_errors
cargo test -p skardi table_mode_explicitly_requires_options
git diff --check
```

Note: full default-feature CLI check was not used for this verification because it triggers `llama-cpp-sys`/ccache writes outside the sandbox; the no-default-features CLI check verifies the DynamoDB registration path and signature synchronization.

## Checklist

- [x] Code follows the project's import and error-handling conventions
- [x] Unit tests added
- [x] Documentation updated
- [x] `cargo fmt --all` applied
- [x] `cargo check -p skardi --all-targets` passes
- [x] `cargo check -p skardi-server --all-targets` passes
- [x] `cargo check -p skardi-cli --all-targets --no-default-features` passes