### PR TITLE
feat(cli): add `skardi doctor` single-machine self-check

### DIFF
--- a/crates/cli/src/doctor.rs
+++ b/crates/cli/src/doctor.rs
@@ -1,0 +1,141 @@
+//! `skardi doctor` — quick self-check of the skardi binary.
+//!
+//! Scope (v1): this checks the BINARY itself — its version, and that the query
+//! engine can build a context and run SQL — plus which optional features were
+//! compiled in. It deliberately does NOT read your `ctx.yaml`, so it does not
+//! verify that your configured data sources are reachable or correctly set up.
+//! Verifying data sources is planned for a future version (via `--ctx`).
+//!
+//! Environment concerns outside the engine (Python deps, the
+//! `auto_knowledge_base` skill) are handled by the skills/setup side, not here.
+
+use anyhow::Result;
+
+/// Run the checks, print a report, and return whether all CORE checks passed.
+/// The caller decides the process exit code, so this stays testable and free of
+/// `process::exit`.
+pub async fn run() -> Result<bool> {
+    let query = check_query_engine().await;
+    let feats = compiled_optional_features();
+    let query_err = query.as_ref().err().map(|e| e.to_string());
+    print!("{}", render_report(query_err.as_deref(), &feats));
+    Ok(query.is_ok())
+}
+
+/// Render the full report text. Pure (no I/O), so it can be unit-tested.
+/// `query_err` is `None` when the query check passed, `Some(msg)` on failure.
+fn render_report(query_err: Option<&str>, feats: &[&str]) -> String {
+    let mut out = String::from("skardi doctor — self-check\n\n");
+
+    // Core: CLI version (always reportable).
+    out.push_str(&format!("  ✓ CLI version {}\n", env!("CARGO_PKG_VERSION")));
+
+    // Core: query engine.
+    match query_err {
+        None => out
+            .push_str("  ✓ Query engine: basic self-check passed (context built, SELECT 1 ran)\n"),
+        Some(e) => out.push_str(&format!("  ✗ Query engine: {e}\n")),
+    }
+
+    // Info: which optional features were compiled in — NOT a capability claim.
+    if feats.is_empty() {
+        out.push_str("  · Optional features compiled in: none\n");
+    } else {
+        out.push_str(&format!(
+            "  · Optional features compiled in: {}\n",
+            feats.join(", ")
+        ));
+    }
+    out.push_str("    (compile-time only; some still need runtime config — e.g. an API key — or ");
+    out.push_str(
+        "data to be useful. Vector search over existing embeddings works regardless.)\n\n",
+    );
+
+    // Summary.
+    if query_err.is_none() {
+        out.push_str("Core checks passed — the skardi binary is functional.\n");
+        out.push_str("Note: data sources were NOT checked. Verifying configured data sources is ");
+        out.push_str("planned for a future version (via `--ctx`).\n");
+    } else {
+        out.push_str("Core check FAILED — see ✗ above.\n");
+    }
+    out
+}
+
+/// Build the real skardi session context (the same `new_session_context()` the
+/// `query` command uses) and run a trivial query. Confirms context construction
+/// and basic SQL execution; does NOT exercise every UDF/UDTF or any configured
+/// data source.
+async fn check_query_engine() -> Result<()> {
+    let (ctx, _registry) = crate::new_session_context();
+    let batches = ctx.sql("SELECT 1 AS ok").await?.collect().await?;
+    anyhow::ensure!(!batches.is_empty(), "query returned no result batches");
+    Ok(())
+}
+
+/// Which optional (feature-gated) capabilities were compiled into this binary.
+/// Reflects compile-time features only — not whether they are usable at runtime
+/// (which may additionally need API keys, models, or data).
+fn compiled_optional_features() -> Vec<&'static str> {
+    let mut v = Vec::new();
+    if cfg!(feature = "onnx") {
+        v.push("onnx");
+    }
+    if cfg!(feature = "candle") {
+        v.push("candle");
+    }
+    if cfg!(feature = "gguf") {
+        v.push("gguf");
+    }
+    if cfg!(feature = "remote-embed") {
+        v.push("remote-embed");
+    }
+    if cfg!(feature = "chunking") {
+        v.push("chunking");
+    }
+    v
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The reported list must agree with the actual compile-time cfg flags —
+    /// not just be "a subset of known names" (which an empty list would pass).
+    #[test]
+    fn features_match_cfg_flags() {
+        let f = compiled_optional_features();
+        assert_eq!(f.contains(&"onnx"), cfg!(feature = "onnx"));
+        assert_eq!(f.contains(&"candle"), cfg!(feature = "candle"));
+        assert_eq!(f.contains(&"gguf"), cfg!(feature = "gguf"));
+        assert_eq!(f.contains(&"remote-embed"), cfg!(feature = "remote-embed"));
+        assert_eq!(f.contains(&"chunking"), cfg!(feature = "chunking"));
+    }
+
+    #[test]
+    fn report_on_success_is_honest_about_scope() {
+        let s = render_report(None, &["onnx", "candle"]);
+        assert!(s.contains("✓ Query engine"));
+        assert!(s.contains("onnx, candle"));
+        assert!(s.contains("Core checks passed"));
+        assert!(s.contains("data sources were NOT checked"));
+        assert!(!s.contains("Core check FAILED"));
+        // Must not present a not-yet-implemented command as runnable.
+        assert!(!s.contains("skardi doctor --ctx"));
+    }
+
+    #[test]
+    fn report_on_failure_is_flagged() {
+        let s = render_report(Some("boom"), &[]);
+        assert!(s.contains("✗ Query engine: boom"));
+        assert!(s.contains("Optional features compiled in: none"));
+        assert!(s.contains("Core check FAILED"));
+        assert!(!s.contains("Core checks passed"));
+    }
+
+    #[tokio::test]
+    async fn query_engine_check_passes_on_healthy_build() {
+        // A healthy build must be able to construct a context and run SELECT 1.
+        assert!(check_query_engine().await.is_ok());
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,5 +1,6 @@
 mod alias;
 mod alias_store;
+mod doctor;
 mod jobs_cli;
 mod pipeline;
 
@@ -132,6 +133,9 @@ enum Commands {
         #[command(subcommand)]
         cmd: jobs_cli::JobCmd,
     },
+    /// Run a single-machine self-check: CLI version, query engine, and capabilities.
+    #[command(name = "doctor")]
+    Doctor,
     /// Any unknown subcommand is looked up as a user-defined alias and
     /// dispatched to `run <pipeline>` with the alias's parameter bindings.
     #[command(external_subcommand)]
@@ -474,7 +478,7 @@ impl UrlTableFactory for SkardiUrlTableFactory {
 
 /// Create a new SessionContext with custom URL table support (built-in files + Lance)
 /// and the `lance_knn` / `pg_knn` UDTFs registered.
-fn new_session_context() -> (SessionContext, DatasetRegistry) {
+pub(crate) fn new_session_context() -> (SessionContext, DatasetRegistry) {
     let dataset_registry: DatasetRegistry = Arc::new(RwLock::new(HashMap::new()));
     let session_store = SessionStore::new();
     let factory = Arc::new(SkardiUrlTableFactory::new(
@@ -608,6 +612,14 @@ async fn main() -> Result<()> {
         }
         Commands::Alias { cmd } => handle_alias_cmd(cmd).await,
         Commands::Job { cmd } => jobs_cli::handle_job_cmd(cmd).await,
+        Commands::Doctor => {
+            // doctor prints its own report; a failed CORE check → non-zero exit
+            // so scripts / CI can detect a broken install.
+            if !doctor::run().await? {
+                std::process::exit(1);
+            }
+            Ok(())
+        }
         Commands::External(args) => {
             // The first token is the alias name; the rest are the alias's args
             // (plus any control flags we strip out before resolution).


### PR DESCRIPTION
## What
Adds a `skardi doctor` subcommand: a quick single-machine self-check of the skardi binary. It checks the CLI version, that the query engine can build a `SessionContext` and run SQL, and reports which optional features were compiled in. A failed **core** check exits non-zero so scripts / CI can detect a broken install.

## Scope (v1)
Binary only — it deliberately does **not** read `ctx.yaml`, so it does not verify that configured data sources are reachable (planned for a later version via `--ctx`). Environment concerns outside the engine (Python deps, the `auto_knowledge_base` skill) are handled on the skills side, not here.

## Motivation
Give users a one-command "is my install healthy?" check, so a broken binary is caught up front instead of failing later with an opaque error.

## Tests & verification
- Includes unit tests (query-engine check, feature reporting, report-on-success / -failure).
- `cargo test -p skardi-cli --no-default-features --features candle` → 59 passed (incl. the doctor tests); `cargo fmt --check` clean; clippy clean for the new files.
- Note: the full default build (with `gguf`) was not run locally (no `cmake` on the dev machine); CI covers that path.
