### PR TITLE
fix(cli): make embedding/rag feature umbrellas enable the CLI's own flags

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,10 +18,13 @@ candle = ["skardi/candle"]
 gguf = ["skardi/gguf"]
 onnx = ["skardi/onnx"]
 remote-embed = ["skardi/remote-embed"]
-embedding = ["skardi/embedding"]
+# Umbrellas must enable the CLI's OWN feature flags (which the UDF registration
+# in main.rs is gated on), not just the underlying `skardi` crate's — otherwise
+# `--features embedding` compiles the deps but the CLI never registers the UDFs.
+embedding = ["onnx", "candle", "gguf", "remote-embed"]
 chunking = ["skardi/chunking"]
 # RAG umbrella: chunk → embed → write loop in one feature.
-rag = ["skardi/rag"]
+rag = ["embedding", "chunking"]
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
## Problem
`embedding` forwarded only to `skardi/embedding`, so `--features embedding` compiled the embedding deps but left the CLI's own UDF registration (gated on the CLI's `onnx` / `candle` / `gguf` / `remote-embed` flags in `main.rs`) disabled.

## Fix
Redefine the umbrellas to enable the CLI's own flags:
- `embedding = ["onnx", "candle", "gguf", "remote-embed"]`
- `rag = ["embedding", "chunking"]`

Split out of the `skardi doctor` branch as an independent change.
