### PR TITLE
feat(sources): add ClickHouse table provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,20 @@ jobs:
           --health-timeout=10s
           --health-retries=20
 
+      clickhouse:
+        image: clickhouse/clickhouse-server:24.8
+        env:
+          CLICKHOUSE_DB: mydb
+          CLICKHOUSE_USER: skardi_user
+          CLICKHOUSE_PASSWORD: skardi_pass
+        ports:
+          - 8123:8123
+        options: >-
+          --health-cmd="wget --no-verbose --tries=1 --spider http://127.0.0.1:8123/ping || exit 1"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
       # DynamoDB Local has no in-image shell tooling for a healthcheck, so
       # readiness is polled with the AWS CLI in a dedicated step below.
       dynamodb:
@@ -124,6 +138,10 @@ jobs:
       SEEKDB_PASSWORD: ""
       INFLUXDB_URL: "http://127.0.0.1:8181"
       INFLUXDB_DATABASE: "metrics"
+      CLICKHOUSE_URL: "http://127.0.0.1:8123"
+      CLICKHOUSE_DATABASE: "mydb"
+      CLICKHOUSE_USER: skardi_user
+      CLICKHOUSE_PASSWORD: skardi_pass
       # DynamoDB Local ignores credential values but the AWS SDK requires them
       # to be present. The endpoint is supplied via the context/test config.
       AWS_ACCESS_KEY_ID: dummy
@@ -459,6 +477,53 @@ jobs:
           mem,host=host2,region=us-west used_percent=73.9 1700000000
           mem,host=host3,region=us-east used_percent=31.5 1700000000
           EOF
+
+      - name: Seed ClickHouse data
+        # The HTTP interface accepts one statement per request, so the seed
+        # script is split on blank lines and posted statement by statement.
+        run: |
+          seed() {
+            curl -fsS "http://127.0.0.1:8123/?user=skardi_user&password=skardi_pass" \
+              --data-binary "$1" > /dev/null
+          }
+          seed "CREATE TABLE mydb.users (
+              id UInt32,
+              name String,
+              email String
+          ) ENGINE = MergeTree ORDER BY id"
+          seed "INSERT INTO mydb.users VALUES
+              (1, 'Alice Smith', 'alice@example.com'),
+              (2, 'Bob Johnson', 'bob@example.com'),
+              (3, 'Carol Williams', 'carol@example.com')"
+          seed "CREATE TABLE mydb.orders (
+              id UInt32,
+              user_id UInt32,
+              product String,
+              amount Float64
+          ) ENGINE = MergeTree ORDER BY id"
+          seed "INSERT INTO mydb.orders VALUES
+              (1, 1, 'Laptop', 999.99),
+              (2, 2, 'Keyboard', 79.99),
+              (3, 3, 'Monitor', 299.99)"
+          seed "CREATE TABLE mydb.products (
+              product_id String,
+              name String,
+              category Nullable(String),
+              price Float64,
+              in_stock Bool
+          ) ENGINE = MergeTree ORDER BY product_id"
+          # PROD005 has a NULL category on purpose — exercises NULL handling.
+          seed "INSERT INTO mydb.products VALUES
+              ('PROD001', 'Laptop', 'Electronics', 999.99, true),
+              ('PROD002', 'Keyboard', 'Electronics', 79.99, true),
+              ('PROD003', 'Monitor', 'Electronics', 299.99, false),
+              ('PROD004', 'Mouse', 'Electronics', 29.99, true),
+              ('PROD005', 'Desk Chair', NULL, 199.99, true)"
+          # Deliberately left empty — exercises schema inference on empty tables.
+          seed "CREATE TABLE mydb.empty_metrics (
+              ts DateTime,
+              value Float64
+          ) ENGINE = MergeTree ORDER BY ts"
 
       - name: Seed DynamoDB data
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9328,6 +9328,7 @@ dependencies = [
  "candle-nn",
  "candle-transformers",
  "chrono",
+ "clickhouse",
  "datafusion",
  "datafusion-common",
  "datafusion-federation",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1519,6 +1519,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bnum"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119771309b95163ec7aaf79810da82f7cd0599c19722d48b9c03894dca833966"
+
+[[package]]
 name = "bon"
 version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,6 +1627,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "btoi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,6 +1709,9 @@ name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytes-utils"
@@ -1864,6 +1882,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cityhash-rs"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93a719913643003b84bd13022b4b7e703c09342cd03b679c4641c7d2e50dc34d"
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1913,6 +1937,53 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clickhouse"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb36e41b644dcd5be4ef54a3b7d2abc9bb07eda777ab3f90d1b0dbb97c940a"
+dependencies = [
+ "bnum 0.13.0",
+ "bstr",
+ "bytes",
+ "cityhash-rs",
+ "clickhouse-macros",
+ "clickhouse-types",
+ "futures-channel",
+ "futures-util",
+ "http-body-util",
+ "hyper 1.10.1",
+ "hyper-util",
+ "lz4_flex 0.11.6",
+ "polonius-the-crab",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "clickhouse-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6669899e23cb87b43daf7996f0ea3b9c07d0fb933d745bb7b815b052515ae3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "clickhouse-types"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a5efddc880ce9e2573bd867413d9056fa2bea0206af88dec21e72178b9dc74"
+dependencies = [
+ "bytes",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "cmake"
@@ -3149,6 +3220,7 @@ checksum = "1da4da03279b1ce95c82d5b3fe0400018613aa96d1150367921f317f01f56de4"
 dependencies = [
  "arrow",
  "arrow-flight",
+ "arrow-ipc",
  "arrow-json",
  "arrow-schema",
  "async-stream",
@@ -3158,6 +3230,7 @@ dependencies = [
  "bigdecimal",
  "byteorder",
  "chrono",
+ "clickhouse",
  "dashmap",
  "datafusion",
  "datafusion-proto",
@@ -3813,7 +3886,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "020d1b59a944bc239d79903fbac2eda2365138b44890c27979562f6592059dcd"
 dependencies = [
- "bnum",
+ "bnum 0.12.1",
  "num-integer",
  "num-traits",
  "serde",
@@ -4670,6 +4743,17 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "higher-kinded-types"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e690f8474c6c5d8ff99656fcbc195a215acc3949481a8b0b3351c838972dc776"
+dependencies = [
+ "macro_rules_attribute",
+ "never-say-never",
+ "paste",
 ]
 
 [[package]]
@@ -6826,6 +6910,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
+name = "never-say-never"
+version = "6.6.666"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5a574dadd7941adeaa71823ecba5e28331b8313fb2e1c6a5c7e5981ea53ad6"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7553,6 +7643,16 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polonius-the-crab"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec242d7eccbb2fd8b3b5b6e3cf89f94a91a800f469005b44d154359609f8af72"
+dependencies = [
+ "higher-kinded-types",
+ "never-say-never",
 ]
 
 [[package]]
@@ -8975,6 +9075,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ arrow-json = { version = "57.0.1" }
 async-trait = "0.1.88"
 axum = "0.7"
 cookie = "0.18"
+clickhouse = "0.14"
 ctor = "0.4.1"
 datafusion = { version = "52.1.0", default-features = false, features = [
     "nested_expressions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ datafusion = { version = "52.1.0", default-features = false, features = [
 ] }
 datafusion-common = { version = "52.1.0" }
 datafusion-federation = "=0.5.1"
-datafusion-table-providers = { version = "0.10.0", default-features = false, features = ["postgres", "mysql", "flight"] }
+datafusion-table-providers = { version = "0.10.0", default-features = false, features = ["postgres", "mysql", "flight", "clickhouse"] }
 tokio-rusqlite = { version = "0.7", features = ["bundled", "load_extension"] }
 env_logger = "0.11"
 futures = "0.3"

--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ For end-to-end walkthroughs — RAG, recommendations, an agent-native wiki, a si
 | Redis | Full | No | Hashes mapped to SQL rows | [docs/redis/](docs/redis/) |
 | DynamoDB | Full | Yes | Items mapped to SQL rows, table or catalog registration, scan + filter pushdown | [docs/dynamodb/](docs/dynamodb/) |
 | SeekDB | Full | Yes | MySQL-wire CRUD, native FULLTEXT FTS, HNSW VECTOR KNN | [docs/seekdb/](docs/seekdb/) |
+| ClickHouse | Read | Yes | Columnar OLAP over HTTP, filter/limit pushdown, table or catalog registration | [docs/clickhouse/](docs/clickhouse/) |
 | Lance | Read (job-write) | No | KNN vector search, BM25 FTS; job destination | [docs/lance/](docs/lance/) |
 | CSV | Read | No | Local or remote CSV files | [docs/server.md](docs/server.md) |
 | Parquet | Read | No | Local or remote Parquet files | [docs/server.md](docs/server.md) |

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -973,6 +973,7 @@ async fn register_source(
                 &source.name,
                 conn_str,
                 source.options.as_ref(),
+                source.is_read_write(),
                 source.hierarchy_level,
             )
             .await
@@ -2902,6 +2903,54 @@ spec:
                 "unexpected error: {msg}"
             );
             assert!(msg.contains("requires options"), "unexpected error: {msg}");
+        }
+    }
+
+    // Guards for the `clickhouse` arm of `register_source`. All failure modes
+    // trip before any network call, so no live endpoint is needed.
+    mod register_clickhouse_source {
+        use super::*;
+
+        fn clickhouse_source(connection_string: Option<&str>) -> LocalDataSource {
+            LocalDataSource {
+                name: "events".to_string(),
+                source_type: "clickhouse".to_string(),
+                path: None,
+                connection_string: connection_string.map(String::from),
+                options: Some(HashMap::from([("table".to_string(), "events".to_string())])),
+                hierarchy_level: HierarchyLevel::default(),
+                access_mode: None,
+                description: None,
+                open_connector: None,
+            }
+        }
+
+        #[tokio::test]
+        async fn errors_without_connection_string() {
+            let (mut session_ctx, registry) = new_session_context();
+            let err = register_source(&mut session_ctx, &clickhouse_source(None), &registry)
+                .await
+                .unwrap_err();
+            let msg = format!("{err:?}");
+            assert!(
+                msg.contains("connection_string required"),
+                "unexpected error: {msg}"
+            );
+        }
+
+        #[tokio::test]
+        async fn errors_with_read_write_access_mode() {
+            // The provider is the single enforcement point for the read-only
+            // invariant — the CLI must reject read_write exactly like the
+            // server's UnsupportedWriteMode.
+            let (mut session_ctx, registry) = new_session_context();
+            let mut source = clickhouse_source(Some("http://127.0.0.1:1"));
+            source.access_mode = Some("read_write".to_string());
+            let err = register_source(&mut session_ctx, &source, &registry)
+                .await
+                .unwrap_err();
+            let msg = format!("{err:?}");
+            assert!(msg.contains("read-only"), "unexpected error: {msg}");
         }
     }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -45,6 +45,7 @@ use skardi::sources::providers::mongo::fts_table_function::register_mongo_fts_ud
 use skardi::sources::providers::sqlx::{register_pg_fts_udtf, register_pg_knn_udtf};
 use skardi::sources::providers::{
     DatasetRegistry,
+    clickhouse::register_clickhouse_tables,
     dynamodb::register_dynamodb_tables,
     iceberg::register_iceberg_table,
     influxdb::register_influxdb_tables,
@@ -959,6 +960,23 @@ async fn register_source(
             )
             .await
             .with_context(|| format!("Failed to register Open Connector '{}'", source.name))?;
+        }
+        "clickhouse" => {
+            let conn_str = source.connection_string.as_deref().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "ClickHouse source '{}': connection_string required",
+                    source.name
+                )
+            })?;
+            register_clickhouse_tables(
+                session_ctx,
+                &source.name,
+                conn_str,
+                source.options.as_ref(),
+                source.hierarchy_level,
+            )
+            .await
+            .with_context(|| format!("Failed to register ClickHouse '{}'", source.name))?;
         }
         "dynamodb" => {
             let endpoint = source.connection_string.as_deref().ok_or_else(|| {

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -830,10 +830,11 @@ fn validate_data_sources(data_sources: &[DataSource]) -> Result<()> {
         }
 
         // Catalog mode must not mix with per-table / per-schema options
+        // ("database" is ClickHouse's schema-analog spelling)
         if CATALOG_SUPPORTED_SOURCES.contains(&source.source_type)
             && source.hierarchy_level == HierarchyLevel::Catalog
         {
-            for conflicting in &["table", "schema"] {
+            for conflicting in &["table", "schema", "database"] {
                 if source
                     .options
                     .as_ref()
@@ -2685,6 +2686,72 @@ bindings:
                 config_err,
                 ConfigError::CatalogModeConflictingOptions { name, option }
                     if name == "ddb" && option == "table"
+            ),
+            "got {config_err}"
+        );
+    }
+
+    fn clickhouse_source(
+        name: &str,
+        options: Option<HashMap<String, String>>,
+        access_mode: AccessMode,
+    ) -> DataSource {
+        DataSource {
+            name: name.to_string(),
+            source_type: DataSourceType::Clickhouse,
+            path: PathBuf::new(),
+            connection_string: Some("http://localhost:8123".to_string()),
+            schema: None,
+            options,
+            hierarchy_level: HierarchyLevel::default(),
+            access_mode,
+            enable_cache: false,
+            description: None,
+        }
+    }
+
+    #[test]
+    fn validate_rejects_clickhouse_read_write() {
+        let mut options = HashMap::new();
+        options.insert("table".to_string(), "events".to_string());
+        let source = clickhouse_source("events", Some(options), AccessMode::ReadWrite);
+        let err = validate_data_sources(&[source]).unwrap_err();
+        let config_err = err.downcast_ref::<ConfigError>().unwrap();
+        assert!(
+            matches!(
+                config_err,
+                ConfigError::UnsupportedWriteMode { name, source_type }
+                    if name == "events" && *source_type == DataSourceType::Clickhouse
+            ),
+            "got {config_err}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_clickhouse_table_mode_with_database_option() {
+        let mut options = HashMap::new();
+        options.insert("table".to_string(), "events".to_string());
+        options.insert("database".to_string(), "analytics".to_string());
+        let source = clickhouse_source("events", Some(options), AccessMode::ReadOnly);
+        validate_data_sources(&[source]).expect("table mode accepts a database option");
+    }
+
+    #[test]
+    fn validate_rejects_clickhouse_catalog_database_option() {
+        // "database" is ClickHouse's schema-analog option; letting it through
+        // in catalog mode would silently change the pool's default database.
+        let mut options = HashMap::new();
+        options.insert("database".to_string(), "analytics".to_string());
+        let mut source = clickhouse_source("ch", Some(options), AccessMode::ReadOnly);
+        source.hierarchy_level = HierarchyLevel::Catalog;
+
+        let err = validate_data_sources(&[source]).unwrap_err();
+        let config_err = err.downcast_ref::<ConfigError>().unwrap();
+        assert!(
+            matches!(
+                config_err,
+                ConfigError::CatalogModeConflictingOptions { name, option }
+                    if name == "ch" && option == "database"
             ),
             "got {config_err}"
         );

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -1518,6 +1518,7 @@ async fn register_data_source(
                 &source.name,
                 connection_string,
                 source.options.as_ref(),
+                source.access_mode.is_read_write(),
                 source.hierarchy_level,
             )
             .await

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -2704,6 +2704,7 @@ bindings:
             connection_string: Some("http://localhost:8123".to_string()),
             schema: None,
             options,
+            open_connector: None,
             hierarchy_level: HierarchyLevel::default(),
             access_mode,
             enable_cache: false,

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -5,6 +5,7 @@ use datafusion::prelude::*;
 use serde::{Deserialize, Serialize};
 use skardi::jobs::JobDefinition;
 use skardi::pipeline::pipeline::{Pipeline, StandardPipeline};
+use skardi::sources::providers::clickhouse::register_clickhouse_tables;
 use skardi::sources::providers::dynamodb::register_dynamodb_tables;
 use skardi::sources::providers::iceberg::register_iceberg_table;
 use skardi::sources::providers::influxdb::register_influxdb_tables;
@@ -743,6 +744,7 @@ const CATALOG_SUPPORTED_SOURCES: &[DataSourceType] = &[
     DataSourceType::Sqlite,
     DataSourceType::Seekdb,
     DataSourceType::Dynamodb,
+    DataSourceType::Clickhouse,
     // OpenConnector is catalog-only; its tables come from typed bindings, so
     // the same catalog-mode guards (no per-table `options`) must apply.
     DataSourceType::OpenConnector,
@@ -890,6 +892,7 @@ fn validate_data_sources(data_sources: &[DataSource]) -> Result<()> {
                 | DataSourceType::Redis
                 | DataSourceType::Seekdb
                 | DataSourceType::Influxdb
+                | DataSourceType::Clickhouse
                 | DataSourceType::OpenConnector
                 | DataSourceType::Dynamodb,
                 false,
@@ -1065,6 +1068,7 @@ async fn register_data_source(
             | DataSourceType::Redis
             | DataSourceType::Seekdb
             | DataSourceType::Influxdb
+            | DataSourceType::Clickhouse
             | DataSourceType::OpenConnector
             | DataSourceType::Dynamodb,
             _,
@@ -1486,6 +1490,39 @@ async fn register_data_source(
             .map_err(|e| {
                 tracing::error!(
                     "InfluxDB registration failed for '{}': {:?}",
+                    source.name,
+                    e
+                );
+                ConfigError::DataSourceRegistrationFailed {
+                    name: source.name.clone(),
+                    error: format!("{:?}", e),
+                }
+            })?;
+        }
+        DataSourceType::Clickhouse => {
+            tracing::info!(
+                "Registering ClickHouse table: {} (hierarchy_level: {:?})",
+                source.name,
+                source.hierarchy_level
+            );
+
+            let connection_string = source.connection_string.as_ref().ok_or_else(|| {
+                ConfigError::MissingConnectionString {
+                    name: source.name.clone(),
+                }
+            })?;
+
+            register_clickhouse_tables(
+                session_ctx,
+                &source.name,
+                connection_string,
+                source.options.as_ref(),
+                source.hierarchy_level,
+            )
+            .await
+            .map_err(|e| {
+                tracing::error!(
+                    "ClickHouse registration failed for '{}': {:?}",
                     source.name,
                     e
                 );

--- a/crates/server/src/pipeline_handlers.rs
+++ b/crates/server/src/pipeline_handlers.rs
@@ -415,6 +415,7 @@ pub async fn get_data_sources(
             | DataSourceType::Redis
             | DataSourceType::Seekdb
             | DataSourceType::Influxdb
+            | DataSourceType::Clickhouse
             | DataSourceType::OpenConnector
             | DataSourceType::Dynamodb => None,
         };
@@ -426,6 +427,7 @@ pub async fn get_data_sources(
             | DataSourceType::Redis
             | DataSourceType::Seekdb
             | DataSourceType::Influxdb
+            | DataSourceType::Clickhouse
             | DataSourceType::OpenConnector
             | DataSourceType::Dynamodb => {
                 // For database sources, return the connection string as-is

--- a/crates/skardi/Cargo.toml
+++ b/crates/skardi/Cargo.toml
@@ -61,6 +61,9 @@ text-splitter = { version = "0.30", features = ["markdown"], optional = true }
 # sources
 aws-config = { version = "1", features = ["behavior-version-latest"] }
 aws-sdk-dynamodb = "1"
+# Direct dep on the same client `datafusion-table-providers` uses, so catalog
+# introspection can run one batched `system.tables` query instead of N+1.
+clickhouse = { workspace = true }
 datafusion-federation = { workspace = true }
 datafusion-table-providers = { workspace = true }
 derivative = "2.2.0"

--- a/crates/skardi/src/jobs/executor.rs
+++ b/crates/skardi/src/jobs/executor.rs
@@ -342,6 +342,7 @@ impl JobExecutor {
             | Some(source_type @ DataSourceType::Redis)
             | Some(source_type @ DataSourceType::Seekdb)
             | Some(source_type @ DataSourceType::Influxdb)
+            | Some(source_type @ DataSourceType::Clickhouse)
             | Some(source_type @ DataSourceType::OpenConnector)
             | Some(source_type @ DataSourceType::Dynamodb) => {
                 Err(JobSubmitError::NonTransactionalDestination {
@@ -938,5 +939,10 @@ spec:
         // Milestone one is strictly read-only, so Open Connector sources must
         // never become job destinations.
         assert_submit_rejects_non_transactional_destination(DataSourceType::OpenConnector).await;
+    }
+
+    #[tokio::test]
+    async fn submit_rejects_clickhouse_destination_as_non_transactional() {
+        assert_submit_rejects_non_transactional_destination(DataSourceType::Clickhouse).await;
     }
 }

--- a/crates/skardi/src/sources/data_source_type.rs
+++ b/crates/skardi/src/sources/data_source_type.rs
@@ -16,6 +16,7 @@ pub enum DataSourceType {
     Lance,
     Seekdb,
     Influxdb,
+    Clickhouse,
     Documents,
     Dynamodb,
     // Explicit rename: the `lowercase` rule would produce `openconnector`,
@@ -38,6 +39,7 @@ impl DataSourceType {
             Self::Lance => "lance",
             Self::Seekdb => "seekdb",
             Self::Influxdb => "influxdb",
+            Self::Clickhouse => "clickhouse",
             Self::Documents => "documents",
             Self::Dynamodb => "dynamodb",
             Self::OpenConnector => "open_connector",
@@ -60,6 +62,13 @@ mod tests {
         let t: DataSourceType = serde_yaml::from_str("documents").unwrap();
         assert_eq!(t, DataSourceType::Documents);
         assert_eq!(t.as_str(), "documents");
+    }
+
+    #[test]
+    fn clickhouse_variant_roundtrips() {
+        let t: DataSourceType = serde_yaml::from_str("clickhouse").unwrap();
+        assert_eq!(t, DataSourceType::Clickhouse);
+        assert_eq!(t.as_str(), "clickhouse");
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/clickhouse.rs
+++ b/crates/skardi/src/sources/providers/clickhouse.rs
@@ -1,0 +1,835 @@
+//! ClickHouse data source provider.
+//!
+//! ClickHouse is a columnar OLAP database with an HTTP query interface. This
+//! module drives the ClickHouse table provider shipped by
+//! `datafusion-table-providers`: filters, projections, and limits are unparsed
+//! back to ClickHouse SQL and executed server-side, so scans stream only the
+//! rows the query actually needs.
+//!
+//! Access is **read-only**. ClickHouse has no transactional UPDATE/DELETE —
+//! mutations (`ALTER TABLE ... UPDATE/DELETE`) are asynchronous background
+//! rewrites, and a mid-stream INSERT failure leaves partial parts visible.
+//! Neither matches the semantics Skardi's write path promises, so ClickHouse
+//! sources never participate in CRUD or job destinations.
+//!
+//! Two registration modes, mirroring the other SQL providers:
+//! - **Table mode** (default): one ClickHouse table registered under `name`.
+//! - **Catalog mode**: every table across the server's non-system databases is
+//!   registered under the `name` catalog as `name.<database>.<table>`.
+
+use crate::sources::DataSourceType;
+use crate::sources::hierarchy::{
+    HierarchyLevel, SourceLabel, build_catalog, parse_allowed_schemas, retry_with_timeout,
+};
+use anyhow::{Context, Result, anyhow};
+use async_trait::async_trait;
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::catalog::Session;
+use datafusion::common::Statistics;
+use datafusion::datasource::TableProvider;
+use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::projection::ProjectionExec;
+use datafusion::prelude::SessionContext;
+use datafusion::sql::TableReference;
+use datafusion_table_providers::clickhouse::ClickHouseTableFactory;
+use datafusion_table_providers::sql::db_connection_pool::clickhousepool::ClickHouseConnectionPool;
+use datafusion_table_providers::sql::db_connection_pool::dbconnection::AsyncDbConnection;
+use secrecy::SecretString;
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+// Skardi-side `options` keys (as written in a ctx YAML). Centralised so the
+// recognised vocabulary can't drift between the parser, the docs, and the
+// tests.
+
+/// ClickHouse table to register (required in table mode).
+const OPT_TABLE: &str = "table";
+/// ClickHouse database holding the table (table mode; optional — defaults to
+/// the server's default database, usually `default`).
+const OPT_DATABASE: &str = "database";
+/// Name of an environment variable holding the username. ClickHouse's
+/// out-of-the-box `default` user needs no credentials, so both are optional.
+const OPT_USER_ENV: &str = "user_env";
+/// Name of an environment variable holding the password.
+const OPT_PASS_ENV: &str = "pass_env";
+
+/// Register ClickHouse tables or a whole server (catalog) into a DataFusion
+/// [`SessionContext`].
+///
+/// Single-table mode (default) registers one table under `name`. Catalog mode
+/// registers one provider per table across all non-system databases.
+///
+/// # Arguments
+/// * `session_ctx` - DataFusion session context to register tables into
+/// * `name` - Name to register the table (table mode) or catalog (catalog mode) as
+/// * `connection_string` - ClickHouse HTTP endpoint, e.g. `http://localhost:8123`.
+///   Credentials must NOT be embedded in the URL; use `user_env` / `pass_env`.
+/// * `options` - Optional configuration (see below)
+/// * `hierarchy_level` - [`HierarchyLevel::Table`] (default) or [`HierarchyLevel::Catalog`]
+///
+/// # Options
+/// * `table` - Table name (required in table mode)
+/// * `database` - Database name (optional in table mode; defaults to the
+///   server's default database)
+/// * `allowed_schemas` - Comma-separated database allow-list (catalog mode only)
+/// * `user_env` - Environment variable name for the username
+/// * `pass_env` - Environment variable name for the password
+///
+/// # Example
+/// ```no_run
+/// use datafusion::prelude::SessionContext;
+/// use skardi::sources::hierarchy::HierarchyLevel;
+/// use skardi::sources::providers::clickhouse::register_clickhouse_tables;
+/// use std::collections::HashMap;
+///
+/// # async fn example() -> anyhow::Result<()> {
+/// let mut ctx = SessionContext::new();
+/// let options = HashMap::from([
+///     ("table".to_string(), "events".to_string()),
+///     ("database".to_string(), "analytics".to_string()),
+/// ]);
+/// register_clickhouse_tables(
+///     &mut ctx,
+///     "events",
+///     "http://localhost:8123",
+///     Some(&options),
+///     HierarchyLevel::Table,
+/// )
+/// .await?;
+/// # Ok(())
+/// # }
+/// ```
+pub async fn register_clickhouse_tables(
+    session_ctx: &mut SessionContext,
+    name: &str,
+    connection_string: &str,
+    options: Option<&HashMap<String, String>>,
+    hierarchy_level: HierarchyLevel,
+) -> Result<()> {
+    match hierarchy_level {
+        HierarchyLevel::Catalog => {
+            register_clickhouse_catalog(session_ctx, name, connection_string, options).await
+        }
+        HierarchyLevel::Table => {
+            register_single_clickhouse_table(session_ctx, name, connection_string, options).await
+        }
+    }
+}
+
+/// Register one ClickHouse table under `name` in the default catalog.
+async fn register_single_clickhouse_table(
+    session_ctx: &mut SessionContext,
+    name: &str,
+    connection_string: &str,
+    options: Option<&HashMap<String, String>>,
+) -> Result<()> {
+    let table_name = options
+        .and_then(|opts| opts.get(OPT_TABLE))
+        .ok_or_else(|| {
+            anyhow!("ClickHouse data source '{name}' requires a '{OPT_TABLE}' option")
+        })?;
+    let database = options.and_then(|opts| opts.get(OPT_DATABASE));
+
+    tracing::info!(
+        "Registering ClickHouse table '{}' as '{}' against endpoint {} (read-only)",
+        database
+            .map(|db| format!("{db}.{table_name}"))
+            .unwrap_or_else(|| table_name.clone()),
+        name,
+        connection_string
+    );
+
+    let params = parse_connection_params(connection_string, options)?;
+    let label = SourceLabel::new(DataSourceType::Clickhouse, HierarchyLevel::Table, name);
+    let pool = build_pool(label, params)
+        .await
+        .with_context(|| format!("Failed to create ClickHouse connection pool for '{name}'"))?;
+
+    let table_reference = match database {
+        Some(db) => TableReference::partial(db.as_str(), table_name.as_str()),
+        None => TableReference::bare(table_name.as_str()),
+    };
+
+    let table_provider = build_clickhouse_table_provider(&pool, table_reference.clone()).await?;
+
+    session_ctx
+        .register_table(name, table_provider)
+        .with_context(|| format!("Failed to register ClickHouse table '{name}' with DataFusion"))?;
+
+    tracing::info!(
+        "Successfully registered ClickHouse table '{}' as '{}' (read-only)",
+        table_reference,
+        name
+    );
+
+    Ok(())
+}
+
+/// Register an entire ClickHouse server as a named DataFusion catalog with one
+/// schema per database.
+async fn register_clickhouse_catalog(
+    session_ctx: &mut SessionContext,
+    catalog_name: &str,
+    connection_string: &str,
+    options: Option<&HashMap<String, String>>,
+) -> Result<()> {
+    tracing::info!(
+        "Registering ClickHouse catalog '{}' against endpoint {} (read-only)",
+        catalog_name,
+        connection_string
+    );
+
+    let params = parse_connection_params(connection_string, options)?;
+    let label = SourceLabel::new(
+        DataSourceType::Clickhouse,
+        HierarchyLevel::Catalog,
+        catalog_name,
+    );
+    let pool = build_pool(label, params).await.with_context(|| {
+        format!("Failed to create ClickHouse connection pool for catalog '{catalog_name}'")
+    })?;
+
+    let allowed_schemas = parse_allowed_schemas(options);
+    let schema_tables = retry_with_timeout(label, "system.tables introspection", || async {
+        list_clickhouse_tables(&pool, allowed_schemas.as_deref()).await
+    })
+    .await
+    .with_context(|| {
+        format!(
+            "Failed to list ClickHouse tables for catalog-wide registration in source \
+             '{catalog_name}'"
+        )
+    })?;
+
+    if schema_tables.is_empty() {
+        tracing::warn!(
+            "No tables found in ClickHouse catalog for source '{}'",
+            catalog_name
+        );
+    }
+
+    let table_count = schema_tables.len();
+
+    build_catalog(
+        session_ctx,
+        catalog_name,
+        schema_tables,
+        |schema, table_name| {
+            let pool = Arc::clone(&pool);
+            async move {
+                let table_reference = TableReference::partial(schema.as_str(), table_name.as_str());
+                build_clickhouse_table_provider(&pool, table_reference).await
+            }
+        },
+    )
+    .await
+    .with_context(|| format!("Failed to build ClickHouse catalog '{catalog_name}'"))?;
+
+    tracing::info!(
+        "Registered ClickHouse catalog '{}' with {} table(s) (read-only)",
+        catalog_name,
+        table_count
+    );
+
+    Ok(())
+}
+
+/// Create the connection pool with per-attempt timeout and retries. The pool
+/// constructor issues a `SELECT 1`, so an unreachable endpoint or bad
+/// credentials fail here — at config load — rather than at first query.
+async fn build_pool(
+    label: SourceLabel<'_>,
+    params: HashMap<String, SecretString>,
+) -> Result<Arc<ClickHouseConnectionPool>> {
+    let pool = retry_with_timeout(label, "pool creation", || async {
+        ClickHouseConnectionPool::new(params.clone())
+            .await
+            .map_err(|e| anyhow!(e))
+    })
+    .await?;
+    Ok(Arc::new(pool))
+}
+
+/// Build a read-only [`TableProvider`] for a single ClickHouse table. Schema is
+/// inferred eagerly via `DESCRIBE TABLE`, so a missing table fails registration
+/// with an actionable error instead of an opaque failure at query time.
+async fn build_clickhouse_table_provider(
+    pool: &Arc<ClickHouseConnectionPool>,
+    table_reference: TableReference,
+) -> Result<Arc<dyn TableProvider>> {
+    let factory = ClickHouseTableFactory::new(Arc::clone(pool));
+    let inner = factory
+        .table_provider(table_reference.clone(), None)
+        .await
+        .map_err(|e| {
+            anyhow!(
+                "Failed to create ClickHouse table provider for '{table_reference}' \
+                 (schema is fetched at registration time); check that the table exists \
+                 and the configured user can read it: {e}"
+            )
+        })?;
+    Ok(Arc::new(CountSafeClickHouseTable { inner }))
+}
+
+/// Thin wrapper working around an upstream `datafusion-table-providers` 0.10.1
+/// bug shared with the Flight provider (see `CountSafeFlightTable` in
+/// `influxdb.rs`): when DataFusion requests an **empty** projection (e.g.
+/// `SELECT count(*)`), the inner ClickHouse table's unparsed SQL still selects
+/// a column, so the physical plan advertises one field while the logical
+/// schema has zero — and DataFusion aborts with "Physical input schema should
+/// be the same as the one converted from logical input schema".
+///
+/// We intercept the empty-projection case: scan a single real column through
+/// the inner table, then strip it back to zero columns with a
+/// [`ProjectionExec`], which preserves the row count. All other projections
+/// delegate straight to the inner table.
+#[derive(Debug)]
+struct CountSafeClickHouseTable {
+    inner: Arc<dyn TableProvider>,
+}
+
+#[async_trait]
+impl TableProvider for CountSafeClickHouseTable {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.inner.schema()
+    }
+
+    fn table_type(&self) -> TableType {
+        self.inner.table_type()
+    }
+
+    // Forward the remaining planning hooks so the wrapper is transparent to
+    // the optimizer apart from the count(*) interception below.
+    fn statistics(&self) -> Option<Statistics> {
+        self.inner.statistics()
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> datafusion::common::Result<Vec<TableProviderFilterPushDown>> {
+        self.inner.supports_filters_pushdown(filters)
+    }
+
+    async fn scan(
+        &self,
+        state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+        match projection {
+            // Empty projection (count(*) / EXISTS): fetch one column so the
+            // unparsed ClickHouse SQL stays well-formed, then drop it again to
+            // honour the requested zero-column output.
+            Some(p) if p.is_empty() => {
+                let single = vec![0usize];
+                let plan = self
+                    .inner
+                    .scan(state, Some(&single), filters, limit)
+                    .await?;
+                let empty: Vec<(Arc<dyn PhysicalExpr>, String)> = Vec::new();
+                Ok(Arc::new(ProjectionExec::try_new(empty, plan)?))
+            }
+            _ => self.inner.scan(state, projection, filters, limit).await,
+        }
+    }
+}
+
+/// List `(database, table)` pairs across the server via `system.tables`.
+///
+/// When `allowed_schemas` is `Some`, only those databases are introspected (a
+/// database with no tables — or that doesn't exist — simply contributes
+/// nothing). Otherwise every non-system database on the server is included.
+async fn list_clickhouse_tables(
+    pool: &Arc<ClickHouseConnectionPool>,
+    allowed_schemas: Option<&[String]>,
+) -> Result<Vec<(String, String)>> {
+    let client = pool.client();
+
+    let databases = match allowed_schemas {
+        Some(allowed) => allowed.to_vec(),
+        None => client
+            .schemas()
+            .await
+            .map_err(|e| anyhow!("Failed to list ClickHouse databases: {e}"))?,
+    };
+
+    let mut schema_tables = Vec::new();
+    for database in databases {
+        let tables = client.tables(&database).await.map_err(|e| {
+            anyhow!("Failed to list tables in ClickHouse database '{database}': {e}")
+        })?;
+        schema_tables.extend(tables.into_iter().map(|t| (database.clone(), t)));
+    }
+
+    Ok(schema_tables)
+}
+
+/// Parse a ClickHouse HTTP connection string plus Skardi options into the
+/// parameter map expected by [`ClickHouseConnectionPool`].
+///
+/// The endpoint must be an `http://` or `https://` URL (ClickHouse's native
+/// TCP port 9000 speaks a different protocol — this provider uses the HTTP
+/// interface on port 8123). Credentials must come from `user_env` / `pass_env`
+/// options; `user:pass@host` embedded in the URL is ignored by the pool, so a
+/// warning is surfaced when detected.
+fn parse_connection_params(
+    connection_string: &str,
+    options: Option<&HashMap<String, String>>,
+) -> Result<HashMap<String, SecretString>> {
+    let parsed = url::Url::parse(connection_string)
+        .with_context(|| format!("Invalid ClickHouse connection string: {connection_string}"))?;
+
+    match parsed.scheme() {
+        "http" | "https" => {}
+        other => {
+            return Err(anyhow!(
+                "ClickHouse connection string must use the http:// or https:// interface \
+                 (got '{other}://'); the native TCP protocol is not supported"
+            ));
+        }
+    }
+
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        tracing::warn!(
+            "ClickHouse connection string contains embedded credentials; these are ignored. \
+             Use '{OPT_USER_ENV}' and '{OPT_PASS_ENV}' options instead."
+        );
+    }
+
+    let mut params: HashMap<String, SecretString> = HashMap::new();
+    params.insert(
+        "url".to_string(),
+        SecretString::new(connection_string.to_string().into_boxed_str()),
+    );
+
+    if let Some(opts) = options {
+        if let Some(database) = opts.get(OPT_DATABASE) {
+            params.insert(
+                "database".to_string(),
+                SecretString::new(database.clone().into_boxed_str()),
+            );
+        }
+
+        if let Some(user_env) = opts.get(OPT_USER_ENV) {
+            let username = std::env::var(user_env).with_context(|| {
+                format!("Environment variable '{user_env}' not found for ClickHouse user")
+            })?;
+            params.insert(
+                "user".to_string(),
+                SecretString::new(username.into_boxed_str()),
+            );
+        }
+
+        if let Some(pass_env) = opts.get(OPT_PASS_ENV) {
+            let password = std::env::var(pass_env).with_context(|| {
+                format!("Environment variable '{pass_env}' not found for ClickHouse password")
+            })?;
+            params.insert(
+                "password".to_string(),
+                SecretString::new(password.into_boxed_str()),
+            );
+        }
+    }
+
+    Ok(params)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secrecy::ExposeSecret;
+
+    fn opts(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn parse_connection_params_url_passthrough() {
+        let params = parse_connection_params("http://localhost:8123", None).unwrap();
+        assert_eq!(
+            params.get("url").unwrap().expose_secret(),
+            "http://localhost:8123"
+        );
+        assert!(!params.contains_key("database"));
+        assert!(!params.contains_key("user"));
+        assert!(!params.contains_key("password"));
+    }
+
+    #[test]
+    fn parse_connection_params_https_is_accepted() {
+        let params = parse_connection_params("https://ch.example.com:8443", None).unwrap();
+        assert_eq!(
+            params.get("url").unwrap().expose_secret(),
+            "https://ch.example.com:8443"
+        );
+    }
+
+    #[test]
+    fn parse_connection_params_database_option() {
+        let params = parse_connection_params(
+            "http://localhost:8123",
+            Some(&opts(&[("database", "analytics")])),
+        )
+        .unwrap();
+        assert_eq!(params.get("database").unwrap().expose_secret(), "analytics");
+    }
+
+    #[test]
+    fn parse_connection_params_rejects_native_protocol() {
+        let err = parse_connection_params("tcp://localhost:9000", None).unwrap_err();
+        assert!(err.to_string().contains("http:// or https://"), "got {err}");
+    }
+
+    #[test]
+    fn parse_connection_params_rejects_invalid_url() {
+        let err = parse_connection_params("not-a-valid-url", None).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Invalid ClickHouse connection string"),
+            "got {err}"
+        );
+    }
+
+    #[test]
+    fn parse_connection_params_env_credentials() {
+        let user_var = "SKARDI_TEST_CLICKHOUSE_USER_OK";
+        let pass_var = "SKARDI_TEST_CLICKHOUSE_PASS_OK";
+        unsafe {
+            std::env::set_var(user_var, "testuser");
+            std::env::set_var(pass_var, "testpass");
+        }
+        let params = parse_connection_params(
+            "http://localhost:8123",
+            Some(&opts(&[("user_env", user_var), ("pass_env", pass_var)])),
+        )
+        .unwrap();
+        unsafe {
+            std::env::remove_var(user_var);
+            std::env::remove_var(pass_var);
+        }
+        assert_eq!(params.get("user").unwrap().expose_secret(), "testuser");
+        assert_eq!(params.get("password").unwrap().expose_secret(), "testpass");
+    }
+
+    #[test]
+    fn parse_connection_params_missing_user_env_is_an_error() {
+        let err = parse_connection_params(
+            "http://localhost:8123",
+            Some(&opts(&[(
+                "user_env",
+                "SKARDI_TEST_CLICKHOUSE_USER_DEFINITELY_UNSET",
+            )])),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("not found"), "got {err}");
+    }
+
+    #[test]
+    fn parse_connection_params_missing_pass_env_is_an_error() {
+        let err = parse_connection_params(
+            "http://localhost:8123",
+            Some(&opts(&[(
+                "pass_env",
+                "SKARDI_TEST_CLICKHOUSE_PASS_DEFINITELY_UNSET",
+            )])),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("not found"), "got {err}");
+    }
+
+    #[test]
+    fn parse_connection_params_embedded_credentials_are_ignored() {
+        // Embedded creds only trigger a warning; they must not leak into the
+        // param map where they'd silently override the env-based options.
+        let params = parse_connection_params("http://user:pass@localhost:8123", None).unwrap();
+        assert!(!params.contains_key("user"));
+        assert!(!params.contains_key("password"));
+    }
+
+    #[tokio::test]
+    async fn register_without_table_option_errors_before_connecting() {
+        // The option-validation error must fire before any network call, so
+        // this is safe to run offline (the endpoint is deliberately unroutable).
+        let mut ctx = SessionContext::new();
+        let err = register_clickhouse_tables(
+            &mut ctx,
+            "events",
+            "http://127.0.0.1:1",
+            None,
+            HierarchyLevel::Table,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("requires a 'table'"), "got {err}");
+    }
+
+    #[tokio::test]
+    async fn register_with_bad_scheme_errors_before_connecting() {
+        let mut ctx = SessionContext::new();
+        let options = opts(&[("table", "events")]);
+        let err = register_clickhouse_tables(
+            &mut ctx,
+            "events",
+            "clickhouse://127.0.0.1:9000",
+            Some(&options),
+            HierarchyLevel::Table,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("http:// or https://"), "got {err}");
+    }
+
+    // ─── Integration tests (need a live ClickHouse endpoint) ────────────
+    //
+    // Gated with `#[ignore]`; CI runs them via `cargo nextest -- --ignored`
+    // after starting a ClickHouse service container and seeding the `mydb`
+    // database (see .github/workflows/ci.yml and docs/clickhouse/README.md).
+    // Endpoint, database, and credentials are read from env so the same tests
+    // run locally (against a default-user Docker container) and in CI.
+
+    fn clickhouse_url() -> String {
+        std::env::var("CLICKHOUSE_URL").unwrap_or_else(|_| "http://127.0.0.1:8123".to_string())
+    }
+
+    fn clickhouse_database() -> String {
+        std::env::var("CLICKHOUSE_DATABASE").unwrap_or_else(|_| "mydb".to_string())
+    }
+
+    /// Base options for the CI/local fixture: the seeded database plus
+    /// env-based credentials when `CLICKHOUSE_USER` / `CLICKHOUSE_PASSWORD`
+    /// are set (CI); a plain local container uses the `default` user with no
+    /// credentials, so the options are simply omitted there.
+    fn ci_options() -> HashMap<String, String> {
+        let mut options = opts(&[("database", clickhouse_database().as_str())]);
+        if std::env::var("CLICKHOUSE_USER").is_ok() {
+            options.insert("user_env".to_string(), "CLICKHOUSE_USER".to_string());
+        }
+        if std::env::var("CLICKHOUSE_PASSWORD").is_ok() {
+            options.insert("pass_env".to_string(), "CLICKHOUSE_PASSWORD".to_string());
+        }
+        options
+    }
+
+    async fn register_ci_table(ctx: &mut SessionContext, name: &str, table: &str) {
+        let mut options = ci_options();
+        options.insert("table".to_string(), table.to_string());
+        register_clickhouse_tables(
+            ctx,
+            name,
+            &clickhouse_url(),
+            Some(&options),
+            HierarchyLevel::Table,
+        )
+        .await
+        .unwrap_or_else(|e| panic!("register {name} failed: {e}"));
+    }
+
+    fn total_rows(batches: &[datafusion::arrow::record_batch::RecordBatch]) -> usize {
+        batches.iter().map(|b| b.num_rows()).sum()
+    }
+
+    async fn collect(
+        ctx: &SessionContext,
+        sql: &str,
+    ) -> Vec<datafusion::arrow::record_batch::RecordBatch> {
+        ctx.sql(sql)
+            .await
+            .unwrap_or_else(|e| panic!("plan {sql}: {e}"))
+            .collect()
+            .await
+            .unwrap_or_else(|e| panic!("collect {sql}: {e}"))
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn integration_register_table_and_scan() {
+        let mut ctx = SessionContext::new();
+        register_ci_table(&mut ctx, "users", "users").await;
+
+        let batches = collect(&ctx, "SELECT id, name, email FROM users ORDER BY id").await;
+        assert_eq!(total_rows(&batches), 3, "expected the 3 seeded users");
+        let names = batches[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::StringArray>()
+            .expect("name is Utf8");
+        assert_eq!(names.value(0), "Alice Smith");
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn integration_filter_pushdown() {
+        let mut ctx = SessionContext::new();
+        register_ci_table(&mut ctx, "users", "users").await;
+
+        let batches = collect(&ctx, "SELECT name FROM users WHERE id = 2").await;
+        assert_eq!(total_rows(&batches), 1);
+        let names = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::StringArray>()
+            .expect("name is Utf8");
+        assert_eq!(names.value(0), "Bob Johnson");
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn integration_count_star_empty_projection() {
+        // count(*) requests an empty projection — a shape that has broken
+        // other providers (see influxdb.rs); assert it returns the row count.
+        let mut ctx = SessionContext::new();
+        register_ci_table(&mut ctx, "users", "users").await;
+
+        let batches = collect(&ctx, "SELECT count(*) AS n FROM users").await;
+        let n = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::Int64Array>()
+            .expect("count is Int64")
+            .value(0);
+        assert_eq!(n, 3);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn integration_null_bearing_rows() {
+        // `products.category` is Nullable(String) and the fixture has exactly
+        // one row with a NULL category. Assert both NULL and non-NULL cells
+        // survive the trip into Arrow.
+        let mut ctx = SessionContext::new();
+        register_ci_table(&mut ctx, "products", "products").await;
+
+        let batches = collect(
+            &ctx,
+            "SELECT count(*) AS n FROM products WHERE category IS NULL",
+        )
+        .await;
+        let nulls = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::Int64Array>()
+            .expect("count is Int64")
+            .value(0);
+        assert_eq!(nulls, 1, "expected exactly one NULL-category product");
+
+        let batches = collect(
+            &ctx,
+            "SELECT count(*) AS n FROM products WHERE category IS NOT NULL",
+        )
+        .await;
+        let non_nulls = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::Int64Array>()
+            .expect("count is Int64")
+            .value(0);
+        assert_eq!(non_nulls, 4);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn integration_empty_table_schema_inference() {
+        // Schema inference must come from DESCRIBE, not from sampled rows —
+        // an empty table has to register and scan cleanly (regression case:
+        // several providers have shipped with panics here).
+        let mut ctx = SessionContext::new();
+        register_ci_table(&mut ctx, "empty_metrics", "empty_metrics").await;
+
+        let df = ctx
+            .sql("SELECT ts, value FROM empty_metrics")
+            .await
+            .expect("plan");
+        let schema = df.schema().clone();
+        assert_eq!(schema.fields().len(), 2);
+        assert_eq!(schema.field(0).name(), "ts");
+        assert_eq!(schema.field(1).name(), "value");
+
+        let batches = df.collect().await.expect("collect");
+        assert_eq!(total_rows(&batches), 0);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn integration_aggregation_over_numeric_types() {
+        // ClickHouse Float64 / UInt32 must coerce into Arrow numerics that
+        // DataFusion can aggregate. Assert an actual value, not just success.
+        let mut ctx = SessionContext::new();
+        register_ci_table(&mut ctx, "products", "products").await;
+
+        let batches = collect(
+            &ctx,
+            "SELECT min(price) AS lo, max(price) AS hi FROM products",
+        )
+        .await;
+        assert_eq!(total_rows(&batches), 1);
+        let lo = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::Float64Array>()
+            .expect("min(price) is Float64")
+            .value(0);
+        let hi = batches[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::Float64Array>()
+            .expect("max(price) is Float64")
+            .value(0);
+        assert_eq!(lo, 29.99);
+        assert_eq!(hi, 999.99);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn integration_catalog_mode_registers_all_tables() {
+        let mut ctx = SessionContext::new();
+        let mut options = ci_options();
+        // Catalog mode must not carry per-table options; keep database out too
+        // so the pool stays on the server default and references are qualified.
+        options.remove("database");
+        options.insert("allowed_schemas".to_string(), clickhouse_database());
+        register_clickhouse_tables(
+            &mut ctx,
+            "ch",
+            &clickhouse_url(),
+            Some(&options),
+            HierarchyLevel::Catalog,
+        )
+        .await
+        .expect("register catalog");
+
+        let db = clickhouse_database();
+        let batches = collect(&ctx, &format!("SELECT count(*) AS n FROM ch.{db}.users")).await;
+        let n = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::Int64Array>()
+            .expect("count is Int64")
+            .value(0);
+        assert_eq!(n, 3);
+
+        let batches = collect(
+            &ctx,
+            &format!("SELECT count(*) AS n FROM ch.{db}.products WHERE in_stock"),
+        )
+        .await;
+        let n = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::Int64Array>()
+            .expect("count is Int64")
+            .value(0);
+        assert_eq!(n, 4, "expected 4 in-stock products");
+    }
+}

--- a/crates/skardi/src/sources/providers/clickhouse.rs
+++ b/crates/skardi/src/sources/providers/clickhouse.rs
@@ -19,7 +19,8 @@
 
 use crate::sources::DataSourceType;
 use crate::sources::hierarchy::{
-    HierarchyLevel, SourceLabel, build_catalog, parse_allowed_schemas, retry_with_timeout,
+    HierarchyLevel, SourceLabel, build_catalog_best_effort, parse_allowed_schemas,
+    retry_with_timeout,
 };
 use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
@@ -35,7 +36,6 @@ use datafusion::prelude::SessionContext;
 use datafusion::sql::TableReference;
 use datafusion_table_providers::clickhouse::ClickHouseTableFactory;
 use datafusion_table_providers::sql::db_connection_pool::clickhousepool::ClickHouseConnectionPool;
-use datafusion_table_providers::sql::db_connection_pool::dbconnection::AsyncDbConnection;
 use secrecy::SecretString;
 use std::any::Any;
 use std::collections::HashMap;
@@ -133,6 +133,10 @@ async fn register_single_clickhouse_table(
         })?;
     let database = options.and_then(|opts| opts.get(OPT_DATABASE));
 
+    // Validate the connection string before logging it, so a URL that embeds
+    // credentials is rejected without the secret ever reaching the logs.
+    let params = parse_connection_params(connection_string, options)?;
+
     tracing::info!(
         "Registering ClickHouse table '{}' as '{}' against endpoint {} (read-only)",
         database
@@ -142,7 +146,6 @@ async fn register_single_clickhouse_table(
         connection_string
     );
 
-    let params = parse_connection_params(connection_string, options)?;
     let label = SourceLabel::new(DataSourceType::Clickhouse, HierarchyLevel::Table, name);
     let pool = build_pool(label, params)
         .await
@@ -153,7 +156,8 @@ async fn register_single_clickhouse_table(
         None => TableReference::bare(table_name.as_str()),
     };
 
-    let table_provider = build_clickhouse_table_provider(&pool, table_reference.clone()).await?;
+    let table_provider =
+        build_clickhouse_table_provider(&pool, label, table_reference.clone()).await?;
 
     session_ctx
         .register_table(name, table_provider)
@@ -176,13 +180,16 @@ async fn register_clickhouse_catalog(
     connection_string: &str,
     options: Option<&HashMap<String, String>>,
 ) -> Result<()> {
+    // Validate the connection string before logging it, so a URL that embeds
+    // credentials is rejected without the secret ever reaching the logs.
+    let params = parse_connection_params(connection_string, options)?;
+
     tracing::info!(
         "Registering ClickHouse catalog '{}' against endpoint {} (read-only)",
         catalog_name,
         connection_string
     );
 
-    let params = parse_connection_params(connection_string, options)?;
     let label = SourceLabel::new(
         DataSourceType::Clickhouse,
         HierarchyLevel::Catalog,
@@ -211,17 +218,20 @@ async fn register_clickhouse_catalog(
         );
     }
 
-    let table_count = schema_tables.len();
-
-    build_catalog(
+    // Best-effort assembly: a single unreadable table (broken view, engine
+    // that refuses direct SELECT, permissions gap) must not take down the
+    // whole catalog — and with it server startup. Failed tables are skipped
+    // with a warning, mirroring the DynamoDB catalog path.
+    let report = build_catalog_best_effort(
         session_ctx,
         catalog_name,
         schema_tables,
+        Vec::new(),
         |schema, table_name| {
             let pool = Arc::clone(&pool);
             async move {
                 let table_reference = TableReference::partial(schema.as_str(), table_name.as_str());
-                build_clickhouse_table_provider(&pool, table_reference).await
+                build_clickhouse_table_provider(&pool, label, table_reference).await
             }
         },
     )
@@ -229,9 +239,10 @@ async fn register_clickhouse_catalog(
     .with_context(|| format!("Failed to build ClickHouse catalog '{catalog_name}'"))?;
 
     tracing::info!(
-        "Registered ClickHouse catalog '{}' with {} table(s) (read-only)",
+        "Registered ClickHouse catalog '{}' with {} table(s), {} skipped (read-only)",
         catalog_name,
-        table_count
+        report.registered,
+        report.skipped
     );
 
     Ok(())
@@ -254,23 +265,37 @@ async fn build_pool(
 }
 
 /// Build a read-only [`TableProvider`] for a single ClickHouse table. Schema is
-/// inferred eagerly via `DESCRIBE TABLE`, so a missing table fails registration
-/// with an actionable error instead of an opaque failure at query time.
+/// inferred eagerly — upstream runs `SELECT * FROM <table> LIMIT 0` through the
+/// ArrowStream format (plus an engine lookup in `system.tables`) — so a missing
+/// or unreadable table fails registration with an actionable error instead of
+/// an opaque failure at query time. The fetch is wrapped in
+/// [`retry_with_timeout`] so an endpoint that hangs mid-introspection can't
+/// stall startup indefinitely.
 async fn build_clickhouse_table_provider(
     pool: &Arc<ClickHouseConnectionPool>,
+    label: SourceLabel<'_>,
     table_reference: TableReference,
 ) -> Result<Arc<dyn TableProvider>> {
     let factory = ClickHouseTableFactory::new(Arc::clone(pool));
-    let inner = factory
-        .table_provider(table_reference.clone(), None)
-        .await
-        .map_err(|e| {
-            anyhow!(
-                "Failed to create ClickHouse table provider for '{table_reference}' \
-                 (schema is fetched at registration time); check that the table exists \
-                 and the configured user can read it: {e}"
-            )
-        })?;
+    let op_name = format!("schema inference for '{table_reference}'");
+    let inner = retry_with_timeout(label, &op_name, || {
+        let table_reference = table_reference.clone();
+        let factory = &factory;
+        async move {
+            factory
+                .table_provider(table_reference, None)
+                .await
+                .map_err(|e| anyhow!(e))
+        }
+    })
+    .await
+    .map_err(|e| {
+        anyhow!(
+            "Failed to create ClickHouse table provider for '{table_reference}' \
+             (schema is fetched at registration time); check that the table exists \
+             and the configured user can read it: {e}"
+        )
+    })?;
     Ok(Arc::new(CountSafeClickHouseTable { inner }))
 }
 
@@ -286,6 +311,11 @@ async fn build_clickhouse_table_provider(
 /// the inner table, then strip it back to zero columns with a
 /// [`ProjectionExec`], which preserves the row count. All other projections
 /// delegate straight to the inner table.
+///
+/// The column still streams in full over HTTP (the enabled feature set does
+/// no aggregate pushdown — see `docs/clickhouse/README.md`), so we pick the
+/// narrowest fixed-width column rather than whatever sits at index 0, which
+/// could be an arbitrarily wide String.
 #[derive(Debug)]
 struct CountSafeClickHouseTable {
     inner: Arc<dyn TableProvider>,
@@ -330,7 +360,7 @@ impl TableProvider for CountSafeClickHouseTable {
             // unparsed ClickHouse SQL stays well-formed, then drop it again to
             // honour the requested zero-column output.
             Some(p) if p.is_empty() => {
-                let single = vec![0usize];
+                let single = vec![narrowest_column_index(&self.inner.schema())];
                 let plan = self
                     .inner
                     .scan(state, Some(&single), filters, limit)
@@ -343,31 +373,102 @@ impl TableProvider for CountSafeClickHouseTable {
     }
 }
 
-/// List `(database, table)` pairs across the server via `system.tables`.
+/// Index of the cheapest column to stream when only a row count is needed:
+/// the narrowest fixed-width field, falling back to index 0 when every column
+/// is variable-width. Ties resolve to the first such column, so the choice is
+/// deterministic.
+fn narrowest_column_index(schema: &SchemaRef) -> usize {
+    use datafusion::arrow::datatypes::DataType;
+    schema
+        .fields()
+        .iter()
+        .enumerate()
+        .min_by_key(|(_, field)| match field.data_type() {
+            // Bit-packed in Arrow, so `primitive_width` reports nothing; it's
+            // still the cheapest thing a ClickHouse table can hold.
+            DataType::Boolean => 1,
+            dt => dt.primitive_width().unwrap_or(usize::MAX),
+        })
+        .map(|(idx, _)| idx)
+        .unwrap_or(0)
+}
+
+/// Table engines that refuse direct SELECT by default (they exist to feed
+/// materialized views): querying one fails with `Code: 620 QUERY_NOT_ALLOWED`
+/// unless `stream_like_engine_allow_direct_select` is set server-side, so
+/// registering them would only produce unqueryable catalog entries.
+const STREAM_LIKE_ENGINES: &[&str] = &["Kafka", "RabbitMQ", "NATS", "FileLog"];
+
+/// List `(database, table)` pairs across the server with one `system.tables`
+/// query, so introspection cost doesn't scale with database count.
 ///
-/// When `allowed_schemas` is `Some`, only those databases are introspected (a
+/// When `allowed_schemas` is `Some`, only those databases are included (a
 /// database with no tables — or that doesn't exist — simply contributes
-/// nothing). Otherwise every non-system database on the server is included.
+/// nothing). Otherwise every non-system database on the server is included,
+/// matching upstream's `schemas()` exclusion list.
+///
+/// Stream-like engines (see [`STREAM_LIKE_ENGINES`]) and materialized-view
+/// inner tables (`.inner…` names in Atomic databases) are skipped with a log
+/// line: the former can't be SELECTed directly, the latter are implementation
+/// detail with near-unqueryable names.
 async fn list_clickhouse_tables(
     pool: &Arc<ClickHouseConnectionPool>,
     allowed_schemas: Option<&[String]>,
 ) -> Result<Vec<(String, String)>> {
+    #[derive(clickhouse::Row, serde::Deserialize)]
+    struct SystemTableRow {
+        database: String,
+        name: String,
+        engine: String,
+    }
+
     let client = pool.client();
 
-    let databases = match allowed_schemas {
-        Some(allowed) => allowed.to_vec(),
-        None => client
-            .schemas()
-            .await
-            .map_err(|e| anyhow!("Failed to list ClickHouse databases: {e}"))?,
+    let query = match allowed_schemas {
+        Some(allowed) => {
+            let placeholders = vec!["?"; allowed.len()].join(", ");
+            let mut query = client.query(&format!(
+                "SELECT database, name, engine FROM system.tables \
+                 WHERE database IN ({placeholders}) ORDER BY database, name"
+            ));
+            for database in allowed {
+                query = query.bind(database);
+            }
+            query
+        }
+        None => client.query(
+            "SELECT database, name, engine FROM system.tables \
+             WHERE database NOT IN ('system', 'information_schema', 'INFORMATION_SCHEMA') \
+             ORDER BY database, name",
+        ),
     };
 
+    let rows: Vec<SystemTableRow> = query
+        .fetch_all()
+        .await
+        .map_err(|e| anyhow!("Failed to list ClickHouse tables from system.tables: {e}"))?;
+
     let mut schema_tables = Vec::new();
-    for database in databases {
-        let tables = client.tables(&database).await.map_err(|e| {
-            anyhow!("Failed to list tables in ClickHouse database '{database}': {e}")
-        })?;
-        schema_tables.extend(tables.into_iter().map(|t| (database.clone(), t)));
+    for row in rows {
+        if row.name.starts_with(".inner") {
+            tracing::debug!(
+                "Skipping ClickHouse materialized-view inner table '{}.{}'",
+                row.database,
+                row.name
+            );
+            continue;
+        }
+        if STREAM_LIKE_ENGINES.contains(&row.engine.as_str()) {
+            tracing::info!(
+                "Skipping ClickHouse table '{}.{}' with stream-like engine {} \
+                 (direct SELECT is not allowed on this engine)",
+                row.database,
+                row.name,
+                row.engine
+            );
+            continue;
+        }
+        schema_tables.push((row.database, row.name));
     }
 
     Ok(schema_tables)
@@ -379,8 +480,10 @@ async fn list_clickhouse_tables(
 /// The endpoint must be an `http://` or `https://` URL (ClickHouse's native
 /// TCP port 9000 speaks a different protocol — this provider uses the HTTP
 /// interface on port 8123). Credentials must come from `user_env` / `pass_env`
-/// options; `user:pass@host` embedded in the URL is ignored by the pool, so a
-/// warning is surfaced when detected.
+/// options; `user:pass@host` embedded in the URL is a hard error. The pool
+/// ignores URL-embedded credentials, so accepting them would mean a confusing
+/// authentication failure at connect time — and the connection string (which
+/// is logged and exposed by the data-sources API) would carry a live secret.
 fn parse_connection_params(
     connection_string: &str,
     options: Option<&HashMap<String, String>>,
@@ -399,10 +502,12 @@ fn parse_connection_params(
     }
 
     if !parsed.username().is_empty() || parsed.password().is_some() {
-        tracing::warn!(
-            "ClickHouse connection string contains embedded credentials; these are ignored. \
-             Use '{OPT_USER_ENV}' and '{OPT_PASS_ENV}' options instead."
-        );
+        return Err(anyhow!(
+            "ClickHouse connection string must not embed credentials in the URL \
+             (they would be ignored by the connection pool, and the connection string \
+             is logged and exposed by the data-sources API). \
+             Use the '{OPT_USER_ENV}' and '{OPT_PASS_ENV}' options instead."
+        ));
     }
 
     let mut params: HashMap<String, SecretString> = HashMap::new();
@@ -550,12 +655,38 @@ mod tests {
     }
 
     #[test]
-    fn parse_connection_params_embedded_credentials_are_ignored() {
-        // Embedded creds only trigger a warning; they must not leak into the
-        // param map where they'd silently override the env-based options.
-        let params = parse_connection_params("http://user:pass@localhost:8123", None).unwrap();
-        assert!(!params.contains_key("user"));
-        assert!(!params.contains_key("password"));
+    fn parse_connection_params_embedded_credentials_are_rejected() {
+        // The pool ignores URL-embedded credentials, so accepting them would
+        // trade a clear config error for a confusing auth failure at connect
+        // time — while the secret leaks into logs and the data-sources API.
+        let err = parse_connection_params("http://user:pass@localhost:8123", None).unwrap_err();
+        assert!(err.to_string().contains("must not embed"), "got {err}");
+
+        // Username without password is rejected the same way.
+        let err = parse_connection_params("http://user@localhost:8123", None).unwrap_err();
+        assert!(err.to_string().contains("must not embed"), "got {err}");
+    }
+
+    #[test]
+    fn narrowest_column_index_prefers_narrowest_fixed_width() {
+        use datafusion::arrow::datatypes::{DataType, Field, Schema};
+        let schema: SchemaRef = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("price", DataType::Float64, false),
+            Field::new("flag", DataType::Boolean, false),
+            Field::new("id", DataType::UInt32, false),
+        ]));
+        assert_eq!(narrowest_column_index(&schema), 2, "Boolean is narrowest");
+    }
+
+    #[test]
+    fn narrowest_column_index_falls_back_to_first_column() {
+        use datafusion::arrow::datatypes::{DataType, Field, Schema};
+        let schema: SchemaRef = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Utf8, false),
+            Field::new("b", DataType::Binary, false),
+        ]));
+        assert_eq!(narrowest_column_index(&schema), 0);
     }
 
     #[tokio::test]
@@ -741,9 +872,9 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn integration_empty_table_schema_inference() {
-        // Schema inference must come from DESCRIBE, not from sampled rows —
-        // an empty table has to register and scan cleanly (regression case:
-        // several providers have shipped with panics here).
+        // Schema inference comes from a `LIMIT 0` query, not from sampled
+        // rows — an empty table has to register and scan cleanly (regression
+        // case: several providers have shipped with panics here).
         let mut ctx = SessionContext::new();
         register_ci_table(&mut ctx, "empty_metrics", "empty_metrics").await;
 

--- a/crates/skardi/src/sources/providers/clickhouse.rs
+++ b/crates/skardi/src/sources/providers/clickhouse.rs
@@ -68,6 +68,9 @@ const CATALOG_MODE_OPTIONS: &[&str] = &[OPT_ALLOWED_SCHEMAS, OPT_USER_ENV, OPT_P
 /// * `connection_string` - ClickHouse HTTP endpoint, e.g. `http://localhost:8123`.
 ///   Credentials must NOT be embedded in the URL; use `user_env` / `pass_env`.
 /// * `options` - Optional configuration (see below)
+/// * `read_write` - Must be `false`; ClickHouse sources are read-only, and
+///   `access_mode: read_write` is rejected here so the CLI and public API
+///   enforce the same contract as server config validation
 /// * `hierarchy_level` - [`HierarchyLevel::Table`] (default) or [`HierarchyLevel::Catalog`]
 ///
 /// # Options
@@ -96,6 +99,7 @@ const CATALOG_MODE_OPTIONS: &[&str] = &[OPT_ALLOWED_SCHEMAS, OPT_USER_ENV, OPT_P
 ///     "events",
 ///     "http://localhost:8123",
 ///     Some(&options),
+///     false,
 ///     HierarchyLevel::Table,
 /// )
 /// .await?;
@@ -107,8 +111,18 @@ pub async fn register_clickhouse_tables(
     name: &str,
     connection_string: &str,
     options: Option<&HashMap<String, String>>,
+    read_write: bool,
     hierarchy_level: HierarchyLevel,
 ) -> Result<()> {
+    // Enforced at the provider boundary — not just server config validation —
+    // so the CLI and public API reject `access_mode: read_write` identically
+    // instead of silently accepting a mode this provider cannot honor.
+    if read_write {
+        return Err(anyhow!(
+            "ClickHouse data source '{name}' does not support access_mode: read_write; \
+             ClickHouse sources are read-only"
+        ));
+    }
     validate_clickhouse_options(name, options, hierarchy_level)?;
     match hierarchy_level {
         HierarchyLevel::Catalog => {
@@ -663,6 +677,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn register_rejects_read_write_access_mode_before_connecting() {
+        // The provider is the single enforcement point for the read-only
+        // invariant — the CLI must reject read_write exactly like the
+        // server's UnsupportedWriteMode, not silently accept it.
+        let mut ctx = SessionContext::new();
+        let options = opts(&[("table", "events")]);
+        let err = register_clickhouse_tables(
+            &mut ctx,
+            "events",
+            "http://127.0.0.1:1",
+            Some(&options),
+            true,
+            HierarchyLevel::Table,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("read-only"), "got {err}");
+    }
+
+    #[tokio::test]
     async fn register_without_table_option_errors_before_connecting() {
         // The option-validation error must fire before any network call, so
         // this is safe to run offline (the endpoint is deliberately unroutable).
@@ -672,6 +706,7 @@ mod tests {
             "events",
             "http://127.0.0.1:1",
             None,
+            false,
             HierarchyLevel::Table,
         )
         .await
@@ -693,6 +728,7 @@ mod tests {
             "events",
             "http://127.0.0.1:1",
             Some(&options),
+            false,
             HierarchyLevel::Table,
         )
         .await
@@ -714,6 +750,7 @@ mod tests {
             "events",
             "http://127.0.0.1:1",
             Some(&options),
+            false,
             HierarchyLevel::Table,
         )
         .await
@@ -737,6 +774,7 @@ mod tests {
                 "ch",
                 "http://127.0.0.1:1",
                 Some(&options),
+                false,
                 HierarchyLevel::Catalog,
             )
             .await
@@ -760,6 +798,7 @@ mod tests {
             "ch",
             "http://127.0.0.1:1",
             Some(&options),
+            false,
             HierarchyLevel::Catalog,
         )
         .await
@@ -776,6 +815,7 @@ mod tests {
             "events",
             "clickhouse://127.0.0.1:9000",
             Some(&options),
+            false,
             HierarchyLevel::Table,
         )
         .await
@@ -822,6 +862,7 @@ mod tests {
             name,
             &clickhouse_url(),
             Some(&options),
+            false,
             HierarchyLevel::Table,
         )
         .await
@@ -996,6 +1037,7 @@ mod tests {
             "ch",
             &clickhouse_url(),
             Some(&options),
+            false,
             HierarchyLevel::Catalog,
         )
         .await

--- a/crates/skardi/src/sources/providers/clickhouse.rs
+++ b/crates/skardi/src/sources/providers/clickhouse.rs
@@ -17,27 +17,19 @@
 //! - **Catalog mode**: every table across the server's non-system databases is
 //!   registered under the `name` catalog as `name.<database>.<table>`.
 
+use super::CountSafeTable;
 use crate::sources::DataSourceType;
 use crate::sources::hierarchy::{
     HierarchyLevel, SourceLabel, build_catalog_best_effort, parse_allowed_schemas,
     retry_with_timeout,
 };
 use anyhow::{Context, Result, anyhow};
-use async_trait::async_trait;
-use datafusion::arrow::datatypes::SchemaRef;
-use datafusion::catalog::Session;
-use datafusion::common::Statistics;
 use datafusion::datasource::TableProvider;
-use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
-use datafusion::physical_expr::PhysicalExpr;
-use datafusion::physical_plan::ExecutionPlan;
-use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::prelude::SessionContext;
 use datafusion::sql::TableReference;
 use datafusion_table_providers::clickhouse::ClickHouseTableFactory;
 use datafusion_table_providers::sql::db_connection_pool::clickhousepool::ClickHouseConnectionPool;
 use secrecy::SecretString;
-use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -55,6 +47,14 @@ const OPT_DATABASE: &str = "database";
 const OPT_USER_ENV: &str = "user_env";
 /// Name of an environment variable holding the password.
 const OPT_PASS_ENV: &str = "pass_env";
+/// Comma-separated database allow-list (catalog mode; optional — omit to
+/// expose every non-system database). Parsed by `parse_allowed_schemas`.
+const OPT_ALLOWED_SCHEMAS: &str = "allowed_schemas";
+
+/// Option keys accepted in table mode / catalog mode. Used by
+/// [`validate_clickhouse_options`] to reject typos and mode mismatches.
+const TABLE_MODE_OPTIONS: &[&str] = &[OPT_TABLE, OPT_DATABASE, OPT_USER_ENV, OPT_PASS_ENV];
+const CATALOG_MODE_OPTIONS: &[&str] = &[OPT_ALLOWED_SCHEMAS, OPT_USER_ENV, OPT_PASS_ENV];
 
 /// Register ClickHouse tables or a whole server (catalog) into a DataFusion
 /// [`SessionContext`].
@@ -109,6 +109,7 @@ pub async fn register_clickhouse_tables(
     options: Option<&HashMap<String, String>>,
     hierarchy_level: HierarchyLevel,
 ) -> Result<()> {
+    validate_clickhouse_options(name, options, hierarchy_level)?;
     match hierarchy_level {
         HierarchyLevel::Catalog => {
             register_clickhouse_catalog(session_ctx, name, connection_string, options).await
@@ -117,6 +118,62 @@ pub async fn register_clickhouse_tables(
             register_single_clickhouse_table(session_ctx, name, connection_string, options).await
         }
     }
+}
+
+/// Enforce the option contract at the provider boundary, so every caller
+/// (server config load, CLI, public API) gets the same checks — the server's
+/// `validate_data_sources` is not the only gate.
+///
+/// Rejects option keys that are not recognised in the given mode: a typo like
+/// `password_env` would otherwise be silently ignored and the connection would
+/// proceed as ClickHouse's `default` user. Also mirrors the server-side
+/// catalog-mode checks: `table` / `database` conflict with catalog mode, and
+/// an `allowed_schemas` with no non-empty entry would fall through
+/// `parse_allowed_schemas` as "expose everything" — the opposite of intent.
+fn validate_clickhouse_options(
+    name: &str,
+    options: Option<&HashMap<String, String>>,
+    hierarchy_level: HierarchyLevel,
+) -> Result<()> {
+    let Some(opts) = options else {
+        return Ok(());
+    };
+
+    let (valid, other_mode_valid, mode, other_mode) = match hierarchy_level {
+        HierarchyLevel::Table => (TABLE_MODE_OPTIONS, CATALOG_MODE_OPTIONS, "table", "catalog"),
+        HierarchyLevel::Catalog => (CATALOG_MODE_OPTIONS, TABLE_MODE_OPTIONS, "catalog", "table"),
+    };
+
+    for key in opts.keys() {
+        if valid.contains(&key.as_str()) {
+            continue;
+        }
+        if other_mode_valid.contains(&key.as_str()) {
+            return Err(anyhow!(
+                "ClickHouse data source '{name}': option '{key}' is only valid in \
+                 {other_mode} mode, not with hierarchy_level: {mode}"
+            ));
+        }
+        return Err(anyhow!(
+            "ClickHouse data source '{name}': unknown option '{key}'; valid options \
+             in {mode} mode are: {}",
+            valid.join(", ")
+        ));
+    }
+
+    if hierarchy_level == HierarchyLevel::Catalog
+        && opts
+            .get(OPT_ALLOWED_SCHEMAS)
+            .is_some_and(|value| !value.split(',').any(|s| !s.trim().is_empty()))
+    {
+        return Err(anyhow!(
+            "ClickHouse data source '{name}': '{OPT_ALLOWED_SCHEMAS}' must list \
+             at least one database (an empty value would expose every \
+             non-system database; omit the option if that is the intent)"
+        ));
+    }
+
+    Ok(())
 }
 
 /// Register one ClickHouse table under `name` in the default catalog.
@@ -296,101 +353,9 @@ async fn build_clickhouse_table_provider(
              and the configured user can read it: {e}"
         )
     })?;
-    Ok(Arc::new(CountSafeClickHouseTable { inner }))
-}
-
-/// Thin wrapper working around an upstream `datafusion-table-providers` 0.10.1
-/// bug shared with the Flight provider (see `CountSafeFlightTable` in
-/// `influxdb.rs`): when DataFusion requests an **empty** projection (e.g.
-/// `SELECT count(*)`), the inner ClickHouse table's unparsed SQL still selects
-/// a column, so the physical plan advertises one field while the logical
-/// schema has zero — and DataFusion aborts with "Physical input schema should
-/// be the same as the one converted from logical input schema".
-///
-/// We intercept the empty-projection case: scan a single real column through
-/// the inner table, then strip it back to zero columns with a
-/// [`ProjectionExec`], which preserves the row count. All other projections
-/// delegate straight to the inner table.
-///
-/// The column still streams in full over HTTP (the enabled feature set does
-/// no aggregate pushdown — see `docs/clickhouse/README.md`), so we pick the
-/// narrowest fixed-width column rather than whatever sits at index 0, which
-/// could be an arbitrarily wide String.
-#[derive(Debug)]
-struct CountSafeClickHouseTable {
-    inner: Arc<dyn TableProvider>,
-}
-
-#[async_trait]
-impl TableProvider for CountSafeClickHouseTable {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn schema(&self) -> SchemaRef {
-        self.inner.schema()
-    }
-
-    fn table_type(&self) -> TableType {
-        self.inner.table_type()
-    }
-
-    // Forward the remaining planning hooks so the wrapper is transparent to
-    // the optimizer apart from the count(*) interception below.
-    fn statistics(&self) -> Option<Statistics> {
-        self.inner.statistics()
-    }
-
-    fn supports_filters_pushdown(
-        &self,
-        filters: &[&Expr],
-    ) -> datafusion::common::Result<Vec<TableProviderFilterPushDown>> {
-        self.inner.supports_filters_pushdown(filters)
-    }
-
-    async fn scan(
-        &self,
-        state: &dyn Session,
-        projection: Option<&Vec<usize>>,
-        filters: &[Expr],
-        limit: Option<usize>,
-    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
-        match projection {
-            // Empty projection (count(*) / EXISTS): fetch one column so the
-            // unparsed ClickHouse SQL stays well-formed, then drop it again to
-            // honour the requested zero-column output.
-            Some(p) if p.is_empty() => {
-                let single = vec![narrowest_column_index(&self.inner.schema())];
-                let plan = self
-                    .inner
-                    .scan(state, Some(&single), filters, limit)
-                    .await?;
-                let empty: Vec<(Arc<dyn PhysicalExpr>, String)> = Vec::new();
-                Ok(Arc::new(ProjectionExec::try_new(empty, plan)?))
-            }
-            _ => self.inner.scan(state, projection, filters, limit).await,
-        }
-    }
-}
-
-/// Index of the cheapest column to stream when only a row count is needed:
-/// the narrowest fixed-width field, falling back to index 0 when every column
-/// is variable-width. Ties resolve to the first such column, so the choice is
-/// deterministic.
-fn narrowest_column_index(schema: &SchemaRef) -> usize {
-    use datafusion::arrow::datatypes::DataType;
-    schema
-        .fields()
-        .iter()
-        .enumerate()
-        .min_by_key(|(_, field)| match field.data_type() {
-            // Bit-packed in Arrow, so `primitive_width` reports nothing; it's
-            // still the cheapest thing a ClickHouse table can hold.
-            DataType::Boolean => 1,
-            dt => dt.primitive_width().unwrap_or(usize::MAX),
-        })
-        .map(|(idx, _)| idx)
-        .unwrap_or(0)
+    // Wrapped so `SELECT count(*)` survives the upstream empty-projection bug
+    // (see `CountSafeTable` in `providers/mod.rs`).
+    Ok(Arc::new(CountSafeTable { inner }))
 }
 
 /// Table engines that refuse direct SELECT by default (they exist to feed
@@ -480,10 +445,11 @@ async fn list_clickhouse_tables(
 /// The endpoint must be an `http://` or `https://` URL (ClickHouse's native
 /// TCP port 9000 speaks a different protocol — this provider uses the HTTP
 /// interface on port 8123). Credentials must come from `user_env` / `pass_env`
-/// options; `user:pass@host` embedded in the URL is a hard error. The pool
-/// ignores URL-embedded credentials, so accepting them would mean a confusing
-/// authentication failure at connect time — and the connection string (which
-/// is logged and exposed by the data-sources API) would carry a live secret.
+/// options; `user:pass@host` embedded in the URL is a hard error, as is any
+/// query string (`?user=u&password=p` is valid ClickHouse HTTP auth). The pool
+/// ignores both, so accepting them would mean a confusing authentication
+/// failure at connect time — and the connection string (which is logged and
+/// exposed by the data-sources API) would carry a live secret.
 fn parse_connection_params(
     connection_string: &str,
     options: Option<&HashMap<String, String>>,
@@ -507,6 +473,19 @@ fn parse_connection_params(
              (they would be ignored by the connection pool, and the connection string \
              is logged and exposed by the data-sources API). \
              Use the '{OPT_USER_ENV}' and '{OPT_PASS_ENV}' options instead."
+        ));
+    }
+
+    // ClickHouse's HTTP interface also accepts credentials as query parameters
+    // (?user=u&password=p). The pool doesn't forward query parameters, so no
+    // query string can work here — and a credential-carrying one would leak
+    // through the same log/API surfaces as embedded userinfo. Reject them all.
+    if parsed.query().is_some() {
+        return Err(anyhow!(
+            "ClickHouse connection string must not contain query parameters \
+             (credentials in the query string would be logged and exposed by the \
+             data-sources API, and the connection pool ignores query parameters \
+             anyway). Use the '{OPT_USER_ENV}' and '{OPT_PASS_ENV}' options instead."
         ));
     }
 
@@ -668,25 +647,19 @@ mod tests {
     }
 
     #[test]
-    fn narrowest_column_index_prefers_narrowest_fixed_width() {
-        use datafusion::arrow::datatypes::{DataType, Field, Schema};
-        let schema: SchemaRef = Arc::new(Schema::new(vec![
-            Field::new("name", DataType::Utf8, false),
-            Field::new("price", DataType::Float64, false),
-            Field::new("flag", DataType::Boolean, false),
-            Field::new("id", DataType::UInt32, false),
-        ]));
-        assert_eq!(narrowest_column_index(&schema), 2, "Boolean is narrowest");
-    }
+    fn parse_connection_params_query_string_is_rejected() {
+        // ClickHouse's HTTP interface accepts credentials as query parameters
+        // (?user=u&password=p), which would sail past the embedded-credentials
+        // check and leak into logs and the data-sources API just the same.
+        let err =
+            parse_connection_params("http://localhost:8123/?user=admin&password=secret", None)
+                .unwrap_err();
+        assert!(err.to_string().contains("query parameters"), "got {err}");
 
-    #[test]
-    fn narrowest_column_index_falls_back_to_first_column() {
-        use datafusion::arrow::datatypes::{DataType, Field, Schema};
-        let schema: SchemaRef = Arc::new(Schema::new(vec![
-            Field::new("a", DataType::Utf8, false),
-            Field::new("b", DataType::Binary, false),
-        ]));
-        assert_eq!(narrowest_column_index(&schema), 0);
+        // Any query string is rejected, credential-shaped or not: the pool
+        // doesn't forward query parameters, so none of them can work anyway.
+        let err = parse_connection_params("http://localhost:8123/?compress=1", None).unwrap_err();
+        assert!(err.to_string().contains("query parameters"), "got {err}");
     }
 
     #[tokio::test]
@@ -704,6 +677,94 @@ mod tests {
         .await
         .unwrap_err();
         assert!(err.to_string().contains("requires a 'table'"), "got {err}");
+    }
+
+    #[tokio::test]
+    async fn register_rejects_unknown_option_before_connecting() {
+        // A misspelled option key (here `pass_env`) must be a hard error, not
+        // silently ignored — ignoring it would connect as ClickHouse's
+        // `default` user instead of the intended one. This guard runs at the
+        // provider boundary so the CLI path gets it too, not just the server's
+        // config validation.
+        let mut ctx = SessionContext::new();
+        let options = opts(&[("table", "events"), ("password_env", "CH_PASS")]);
+        let err = register_clickhouse_tables(
+            &mut ctx,
+            "events",
+            "http://127.0.0.1:1",
+            Some(&options),
+            HierarchyLevel::Table,
+        )
+        .await
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("unknown option 'password_env'"), "got {msg}");
+        assert!(
+            msg.contains("pass_env"),
+            "should list valid keys, got {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn register_rejects_allowed_schemas_in_table_mode() {
+        let mut ctx = SessionContext::new();
+        let options = opts(&[("table", "events"), ("allowed_schemas", "mydb")]);
+        let err = register_clickhouse_tables(
+            &mut ctx,
+            "events",
+            "http://127.0.0.1:1",
+            Some(&options),
+            HierarchyLevel::Table,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("catalog"),
+            "should point at catalog mode, got {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn register_catalog_rejects_table_scoped_options_before_connecting() {
+        // Mirrors the server-side CatalogModeConflictingOptions check so the
+        // CLI path enforces the same contract: `database` would otherwise
+        // silently change the pool's default database.
+        for conflicting in ["table", "database"] {
+            let mut ctx = SessionContext::new();
+            let options = opts(&[(conflicting, "mydb")]);
+            let err = register_clickhouse_tables(
+                &mut ctx,
+                "ch",
+                "http://127.0.0.1:1",
+                Some(&options),
+                HierarchyLevel::Catalog,
+            )
+            .await
+            .unwrap_err();
+            assert!(
+                err.to_string().contains(conflicting),
+                "should name '{conflicting}', got {err}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn register_catalog_rejects_empty_allowed_schemas_before_connecting() {
+        // An empty allow-list would fall through parse_allowed_schemas as
+        // None — i.e. "expose everything" — the opposite of what the user
+        // wrote. Mirrors the server-side EmptyAllowedSchemas check.
+        let mut ctx = SessionContext::new();
+        let options = opts(&[("allowed_schemas", " , ")]);
+        let err = register_clickhouse_tables(
+            &mut ctx,
+            "ch",
+            "http://127.0.0.1:1",
+            Some(&options),
+            HierarchyLevel::Catalog,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("allowed_schemas"), "got {err}");
     }
 
     #[tokio::test]

--- a/crates/skardi/src/sources/providers/influxdb.rs
+++ b/crates/skardi/src/sources/providers/influxdb.rs
@@ -15,23 +15,15 @@
 //! a SQL query engine, so InfluxDB sources never participate in CRUD or job
 //! destinations.
 
-use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::{Context, Result, anyhow};
-use async_trait::async_trait;
-use datafusion::arrow::datatypes::SchemaRef;
-use datafusion::catalog::Session;
-use datafusion::common::Statistics;
-use datafusion::datasource::TableProvider;
-use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
-use datafusion::physical_expr::PhysicalExpr;
-use datafusion::physical_plan::ExecutionPlan;
-use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::prelude::SessionContext;
+use datafusion_table_providers::flight::FlightTableFactory;
 use datafusion_table_providers::flight::sql::{FlightSqlDriver, HEADER_PREFIX, QUERY};
-use datafusion_table_providers::flight::{FlightTable, FlightTableFactory};
+
+use super::CountSafeTable;
 
 // Friendly `options` keys that Skardi treats specially for InfluxDB sources.
 //
@@ -182,75 +174,6 @@ fn build_flight_options(
     Ok(flight_opts)
 }
 
-/// Thin wrapper around [`FlightTable`] that works around a bug in
-/// `datafusion-table-providers` 0.10.1's `enforce_schema`: when DataFusion
-/// requests an **empty** projection (e.g. `SELECT count(*)`), that function
-/// returns the original, full-width batch instead of an empty-column one, so
-/// the `FlightExec` emits 5-column batches while advertising a 0-column schema.
-/// The downstream batch coalescer then panics on `assert_eq!(num_columns, 0)`.
-///
-/// We intercept the empty-projection case: scan a single real column through
-/// the inner table (which takes `enforce_schema`'s correct, non-empty path),
-/// then strip it back to zero columns with a [`ProjectionExec`], which
-/// preserves the row count via `RecordBatchOptions::with_row_count`. All other
-/// projections delegate straight to the inner table.
-#[derive(Debug)]
-struct CountSafeFlightTable {
-    inner: Arc<FlightTable>,
-}
-
-#[async_trait]
-impl TableProvider for CountSafeFlightTable {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn schema(&self) -> SchemaRef {
-        self.inner.schema()
-    }
-
-    fn table_type(&self) -> TableType {
-        self.inner.table_type()
-    }
-
-    // Forward the remaining planning hooks to the inner table so the wrapper is
-    // transparent to the optimizer apart from the count(*) interception below.
-    fn statistics(&self) -> Option<Statistics> {
-        self.inner.statistics()
-    }
-
-    fn supports_filters_pushdown(
-        &self,
-        filters: &[&Expr],
-    ) -> datafusion::common::Result<Vec<TableProviderFilterPushDown>> {
-        self.inner.supports_filters_pushdown(filters)
-    }
-
-    async fn scan(
-        &self,
-        state: &dyn Session,
-        projection: Option<&Vec<usize>>,
-        filters: &[Expr],
-        limit: Option<usize>,
-    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
-        match projection {
-            // Empty projection (count(*) / EXISTS): fetch one column so the
-            // upstream FlightExec produces a correctly-shaped batch, then drop
-            // it again to honour the requested zero-column output.
-            Some(p) if p.is_empty() => {
-                let single = vec![0usize];
-                let plan = self
-                    .inner
-                    .scan(state, Some(&single), filters, limit)
-                    .await?;
-                let empty: Vec<(Arc<dyn PhysicalExpr>, String)> = Vec::new();
-                Ok(Arc::new(ProjectionExec::try_new(empty, plan)?))
-            }
-            _ => self.inner.scan(state, projection, filters, limit).await,
-        }
-    }
-}
-
 /// Register an InfluxDB 3 measurement (or arbitrary SQL query) as a Skardi table
 /// backed by the source's Arrow Flight SQL endpoint.
 ///
@@ -303,7 +226,9 @@ pub async fn register_influxdb_tables(
             )
         })?;
 
-    let table = CountSafeFlightTable {
+    // Wrapped so `SELECT count(*)` survives the upstream `enforce_schema`
+    // empty-projection bug (see `CountSafeTable` in `providers/mod.rs`).
+    let table = CountSafeTable {
         inner: Arc::new(table),
     };
     session_ctx

--- a/crates/skardi/src/sources/providers/mod.rs
+++ b/crates/skardi/src/sources/providers/mod.rs
@@ -1,3 +1,4 @@
+pub mod clickhouse;
 #[cfg(feature = "documents")]
 pub mod documents;
 pub mod dynamodb;

--- a/crates/skardi/src/sources/providers/mod.rs
+++ b/crates/skardi/src/sources/providers/mod.rs
@@ -16,6 +16,7 @@ pub mod sqlite;
 pub mod sqlx;
 
 use ::lance::dataset::Dataset;
+use datafusion::datasource::TableProvider;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
@@ -39,6 +40,103 @@ pub enum DatasetEntry {
 /// `sqlite_knn`, `sqlite_fts`, `seekdb_knn`, and `seekdb_fts` table functions.
 pub type DatasetRegistry = Arc<RwLock<HashMap<String, DatasetEntry>>>;
 
+/// Wrapper working around a `datafusion-table-providers` 0.10.1 bug shared by
+/// the ClickHouse and Flight (InfluxDB) providers: when DataFusion requests an
+/// **empty** projection (e.g. `SELECT count(*)`), the inner table emits
+/// batches whose width disagrees with the advertised zero-column schema —
+/// ClickHouse's unparsed SQL still selects a column, and the Flight provider's
+/// `enforce_schema` returns the original full-width batch — so execution
+/// aborts downstream.
+///
+/// We intercept the empty-projection case: scan a single real column through
+/// the inner table, then strip it back to zero columns with a
+/// [`ProjectionExec`], which preserves the row count. All other projections
+/// delegate straight to the inner table.
+///
+/// The scanned column still streams in full when the source does no aggregate
+/// pushdown (see e.g. `docs/clickhouse/README.md`), so [`Self::scan`] picks
+/// the narrowest fixed-width column rather than whatever sits at index 0,
+/// which could be an arbitrarily wide String.
+#[derive(Debug)]
+pub(crate) struct CountSafeTable {
+    pub(crate) inner: Arc<dyn TableProvider>,
+}
+
+#[async_trait::async_trait]
+impl TableProvider for CountSafeTable {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn schema(&self) -> datafusion::arrow::datatypes::SchemaRef {
+        self.inner.schema()
+    }
+
+    fn table_type(&self) -> datafusion::logical_expr::TableType {
+        self.inner.table_type()
+    }
+
+    // Forward the remaining planning hooks so the wrapper is transparent to
+    // the optimizer apart from the count(*) interception below.
+    fn statistics(&self) -> Option<datafusion::common::Statistics> {
+        self.inner.statistics()
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&datafusion::logical_expr::Expr],
+    ) -> datafusion::common::Result<Vec<datafusion::logical_expr::TableProviderFilterPushDown>>
+    {
+        self.inner.supports_filters_pushdown(filters)
+    }
+
+    async fn scan(
+        &self,
+        state: &dyn datafusion::catalog::Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[datafusion::logical_expr::Expr],
+        limit: Option<usize>,
+    ) -> datafusion::common::Result<Arc<dyn datafusion::physical_plan::ExecutionPlan>> {
+        use datafusion::physical_plan::projection::ProjectionExec;
+        match projection {
+            // Empty projection (count(*) / EXISTS): fetch one column so the
+            // inner table produces a correctly-shaped batch, then drop it
+            // again to honour the requested zero-column output.
+            Some(p) if p.is_empty() => {
+                let single = vec![narrowest_column_index(&self.inner.schema())];
+                let plan = self
+                    .inner
+                    .scan(state, Some(&single), filters, limit)
+                    .await?;
+                let empty: Vec<(Arc<dyn datafusion::physical_expr::PhysicalExpr>, String)> =
+                    Vec::new();
+                Ok(Arc::new(ProjectionExec::try_new(empty, plan)?))
+            }
+            _ => self.inner.scan(state, projection, filters, limit).await,
+        }
+    }
+}
+
+/// Index of the cheapest column to stream when only a row count is needed:
+/// the narrowest fixed-width field, falling back to index 0 when every column
+/// is variable-width. Ties resolve to the first such column, so the choice is
+/// deterministic.
+pub(crate) fn narrowest_column_index(schema: &datafusion::arrow::datatypes::SchemaRef) -> usize {
+    use datafusion::arrow::datatypes::DataType;
+    schema
+        .fields()
+        .iter()
+        .enumerate()
+        .min_by_key(|(_, field)| match field.data_type() {
+            // Bit-packed in Arrow, so `primitive_width` reports nothing; it's
+            // still the cheapest fixed-width thing a table can hold.
+            DataType::Boolean => 1,
+            dt => dt.primitive_width().unwrap_or(usize::MAX),
+        })
+        .map(|(idx, _)| idx)
+        .unwrap_or(0)
+}
+
 /// Returns true if the expression is a binary comparison (`=`, `<>`, `<`, `<=`,
 /// `>`, `>=`) between a bare column and a literal — the shape both the MongoDB
 /// and DynamoDB providers can push into their backends. Shared here so the two
@@ -61,5 +159,31 @@ pub(crate) fn is_pushable_binary_filter(expr: &datafusion::logical_expr::Expr) -
             )
         }
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+
+    #[test]
+    fn narrowest_column_index_prefers_narrowest_fixed_width() {
+        let schema: SchemaRef = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("price", DataType::Float64, false),
+            Field::new("flag", DataType::Boolean, false),
+            Field::new("id", DataType::UInt32, false),
+        ]));
+        assert_eq!(narrowest_column_index(&schema), 2, "Boolean is narrowest");
+    }
+
+    #[test]
+    fn narrowest_column_index_falls_back_to_first_column() {
+        let schema: SchemaRef = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Utf8, false),
+            Field::new("b", DataType::Binary, false),
+        ]));
+        assert_eq!(narrowest_column_index(&schema), 0);
     }
 }

--- a/docs/clickhouse/README.md
+++ b/docs/clickhouse/README.md
@@ -90,7 +90,8 @@ A ClickHouse table maps 1:1 to a SQL table; column types map to Arrow:
 | `Float64` | `Float64` column |
 | `Nullable(T)` | nullable column of `T` |
 | `Bool` | `Boolean` column |
-| `DateTime` | `Timestamp` column |
+| `DateTime64` | `Timestamp` column |
+| `DateTime` / `Date` | `UInt32` / `UInt16` (raw epoch days/seconds — ClickHouse's ArrowStream format does not tag them as timestamps; use `DateTime64` for a real `Timestamp` column) |
 
 Each table-mode data source binds to **one** ClickHouse table (via the `table`
 option). To expose several tables, declare one data source per table — see
@@ -109,10 +110,12 @@ refuses direct SELECT (e.g. `Kafka`) cannot be registered in table mode.
 
 Pipeline SQL is planned by DataFusion, and the table scan underneath is
 unparsed back into ClickHouse SQL: predicates on the scanned table,
-projections, and `LIMIT`s run **inside ClickHouse**, so a
+projections, and bare `LIMIT`s run **inside ClickHouse**, so a
 `WHERE id = {user_id}` pipeline transfers one row, not the table. Joins and
-aggregations across sources execute in Skardi after the (already filtered)
-scans return.
+aggregations execute in Skardi after the (already filtered) scans return —
+including joins between two tables on the *same* ClickHouse server. `ORDER BY`
+is not pushed down either, so a `LIMIT` that sits above an `ORDER BY` also
+runs in Skardi (the scan still only fetches the projected columns).
 
 **Aggregates are not pushed down.** A bare `SELECT count(*) FROM t` streams
 one column of `t` (the narrowest fixed-width column) over HTTP and counts
@@ -130,7 +133,7 @@ SQL).
 | Pipeline | Parameters | Description |
 |----------|------------|-------------|
 | `query_user_by_id` | `user_id` | Point lookup by primary key |
-| `list_all_users` | `limit` | Full scan, `LIMIT` pushed down |
+| `list_all_users` | `limit` | Full scan; the `ORDER BY` + `LIMIT` run in Skardi |
 | `products_by_category` | `category` | Filter on a `Nullable(String)` column |
 | `user_order_summary` | `min_total` | Join users ⨝ orders, aggregate spend per user |
 | `federated_stock_value` | `warehouse` | Join ClickHouse products with a CSV warehouse map |

--- a/docs/clickhouse/README.md
+++ b/docs/clickhouse/README.md
@@ -363,12 +363,20 @@ the following `options` keys:
 | `user_env` | for auth | **Name of an environment variable** holding the username. The out-of-the-box `default` user needs no credentials, so this is optional. |
 | `pass_env` | for auth | **Name of an environment variable** holding the password. |
 
+Option validation is strict and runs at registration (server and CLI alike):
+an unrecognised key — e.g. a misspelled `pass_env`, which would otherwise
+silently connect as the `default` user — is a hard error, as is an option
+that belongs to the other hierarchy mode (`table`/`database` in catalog mode,
+`allowed_schemas` in table mode) or an `allowed_schemas` with no non-empty
+entry.
+
 The native TCP protocol (port 9000) is not supported — registration rejects
 non-`http(s)` schemes. Credentials embedded in the URL
-(`http://user:pass@host`) are rejected outright — the connection pool would
-ignore them, and connection strings are logged and surfaced by the
-data-sources API. Use `user_env` / `pass_env` so secrets stay out of the YAML,
-the logs, and the API.
+(`http://user:pass@host`) are rejected outright, and so is any URL query
+string (ClickHouse accepts `?user=…&password=…` as HTTP auth) — the
+connection pool would ignore them, and connection strings are logged and
+surfaced by the data-sources API. Use `user_env` / `pass_env` so secrets stay
+out of the YAML, the logs, and the API.
 
 ## Access Mode
 

--- a/docs/clickhouse/README.md
+++ b/docs/clickhouse/README.md
@@ -381,7 +381,8 @@ out of the YAML, the logs, and the API.
 ## Access Mode
 
 This source is **read-only**. Declaring `access_mode: read_write` on a
-ClickHouse source fails config validation, and ClickHouse sources are rejected
-as job destinations. Ingest into ClickHouse should go through ClickHouse's own
+ClickHouse source is rejected at the provider boundary — the server config
+path and the CLI enforce the same contract — and ClickHouse sources are
+rejected as job destinations. Ingest into ClickHouse should go through ClickHouse's own
 INSERT pipelines (Kafka engine, `clickhouse-client`, HTTP inserts) — Skardi is
 the query side.

--- a/docs/clickhouse/README.md
+++ b/docs/clickhouse/README.md
@@ -97,10 +97,13 @@ option). To expose several tables, declare one data source per table — see
 [`ctx_clickhouse_demo.yaml`](ctx_clickhouse_demo.yaml) — or register the whole
 server at once with [catalog mode](#catalog-mode).
 
-The table's Arrow schema is inferred at server startup with `DESCRIBE TABLE`,
-so the ClickHouse endpoint must be reachable when Skardi loads its context
-(the same eager-connect behaviour as the Postgres/MySQL/Mongo providers). An
-empty table registers cleanly — the schema never depends on sampled rows.
+The table's Arrow schema is inferred at server startup with a
+`SELECT * … LIMIT 0` probe (via ClickHouse's ArrowStream output format, plus
+an engine lookup in `system.tables`), so the ClickHouse endpoint must be
+reachable when Skardi loads its context (the same eager-connect behaviour as
+the Postgres/MySQL/Mongo providers). An empty table registers cleanly — the
+schema never depends on sampled rows. Note this means a table whose engine
+refuses direct SELECT (e.g. `Kafka`) cannot be registered in table mode.
 
 ## Query Pushdown
 
@@ -110,6 +113,13 @@ projections, and `LIMIT`s run **inside ClickHouse**, so a
 `WHERE id = {user_id}` pipeline transfers one row, not the table. Joins and
 aggregations across sources execute in Skardi after the (already filtered)
 scans return.
+
+**Aggregates are not pushed down.** A bare `SELECT count(*) FROM t` streams
+one column of `t` (the narrowest fixed-width column) over HTTP and counts
+client-side, instead of letting ClickHouse answer from part metadata. On
+OLAP-sized tables, put a selective `WHERE` on such queries — or query a
+pre-aggregated table — until aggregate pushdown lands (upstream's
+`clickhouse-federation` feature).
 
 ## Available Pipelines
 
@@ -317,10 +327,16 @@ curl -X POST http://localhost:8080/clickhouse-catalog-cross-table-join/execute \
 }
 ```
 
-Catalog mode must not mix with per-table options — `table` / `schema` are
-rejected when `hierarchy_level: catalog` is set. Use `allowed_schemas` to
-restrict which databases are exposed; omit it to include every non-system
-database.
+Catalog mode must not mix with per-table options — `table` / `schema` /
+`database` are rejected when `hierarchy_level: catalog` is set. Use
+`allowed_schemas` to restrict which databases are exposed; omit it to include
+every non-system database.
+
+Catalog assembly is **best-effort**: a table whose schema can't be fetched
+(e.g. a view over a dropped table, or a permissions gap) is skipped with a
+warning instead of failing startup. Stream-like engine tables (`Kafka`,
+`RabbitMQ`, `NATS`, `FileLog` — engines that refuse direct SELECT) and
+materialized-view inner tables (`.inner…` names) are excluded up front.
 
 ---
 
@@ -349,8 +365,10 @@ the following `options` keys:
 
 The native TCP protocol (port 9000) is not supported — registration rejects
 non-`http(s)` schemes. Credentials embedded in the URL
-(`http://user:pass@host`) are ignored with a warning; use `user_env` /
-`pass_env` so secrets stay out of the YAML.
+(`http://user:pass@host`) are rejected outright — the connection pool would
+ignore them, and connection strings are logged and surfaced by the
+data-sources API. Use `user_env` / `pass_env` so secrets stay out of the YAML,
+the logs, and the API.
 
 ## Access Mode
 

--- a/docs/clickhouse/README.md
+++ b/docs/clickhouse/README.md
@@ -1,0 +1,361 @@
+# ClickHouse Integration
+
+This guide covers querying **ClickHouse** from Skardi.
+
+ClickHouse is a columnar OLAP database with an HTTP query interface. Skardi
+registers each ClickHouse table (or a whole server, in catalog mode) as a
+DataFusion table, so you can `SELECT`, aggregate, and **federate ClickHouse
+data with any other Skardi source** (CSV, Postgres, Lance, …) in a single
+query. Filters, projections, and `LIMIT`s are unparsed back to ClickHouse SQL
+and executed server-side, so scans stream only the rows a query actually
+needs.
+
+> **Access is read-only.** ClickHouse has no transactional UPDATE/DELETE —
+> mutations (`ALTER TABLE ... UPDATE/DELETE`) are asynchronous background
+> rewrites, and a mid-stream INSERT failure leaves partial parts visible.
+> `access_mode: read_write` is rejected for ClickHouse sources.
+
+## Quick Start
+
+```bash
+# 1. Start ClickHouse in Docker (same image + credentials as CI)
+docker run -d --name clickhouse-skardi \
+  -p 8123:8123 \
+  -e CLICKHOUSE_DB=mydb \
+  -e CLICKHOUSE_USER=skardi_user \
+  -e CLICKHOUSE_PASSWORD=skardi_pass \
+  clickhouse/clickhouse-server:24.8
+
+# 2. Seed sample data
+docker exec -i clickhouse-skardi clickhouse-client \
+  --user skardi_user --password skardi_pass --multiquery <<'EOF'
+CREATE TABLE mydb.users (
+    id UInt32,
+    name String,
+    email String
+) ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO mydb.users VALUES
+    (1, 'Alice Smith', 'alice@example.com'),
+    (2, 'Bob Johnson', 'bob@example.com'),
+    (3, 'Carol Williams', 'carol@example.com');
+
+CREATE TABLE mydb.orders (
+    id UInt32,
+    user_id UInt32,
+    product String,
+    amount Float64
+) ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO mydb.orders VALUES
+    (1, 1, 'Laptop', 999.99),
+    (2, 2, 'Keyboard', 79.99),
+    (3, 3, 'Monitor', 299.99);
+
+CREATE TABLE mydb.products (
+    product_id String,
+    name String,
+    category Nullable(String),
+    price Float64,
+    in_stock Bool
+) ENGINE = MergeTree ORDER BY product_id;
+
+INSERT INTO mydb.products VALUES
+    ('PROD001', 'Laptop', 'Electronics', 999.99, true),
+    ('PROD002', 'Keyboard', 'Electronics', 79.99, true),
+    ('PROD003', 'Monitor', 'Electronics', 299.99, false),
+    ('PROD004', 'Mouse', 'Electronics', 29.99, true),
+    ('PROD005', 'Desk Chair', NULL, 199.99, true);
+EOF
+
+# 3. Export the credentials the demo context reads via user_env / pass_env
+export CLICKHOUSE_USER=skardi_user
+export CLICKHOUSE_PASSWORD=skardi_pass
+
+# 4. Start the Skardi server against the demo context + pipelines
+cargo run --bin skardi-server -- \
+  --ctx docs/clickhouse/ctx_clickhouse_demo.yaml \
+  --pipeline docs/clickhouse/pipelines/ \
+  --port 8080
+```
+
+## Data Model
+
+A ClickHouse table maps 1:1 to a SQL table; column types map to Arrow:
+
+| ClickHouse type | Arrow / SQL projection |
+|-----------------|------------------------|
+| `UInt32` / `Int64` / … | corresponding integer column |
+| `String` | `Utf8` column |
+| `Float64` | `Float64` column |
+| `Nullable(T)` | nullable column of `T` |
+| `Bool` | `Boolean` column |
+| `DateTime` | `Timestamp` column |
+
+Each table-mode data source binds to **one** ClickHouse table (via the `table`
+option). To expose several tables, declare one data source per table — see
+[`ctx_clickhouse_demo.yaml`](ctx_clickhouse_demo.yaml) — or register the whole
+server at once with [catalog mode](#catalog-mode).
+
+The table's Arrow schema is inferred at server startup with `DESCRIBE TABLE`,
+so the ClickHouse endpoint must be reachable when Skardi loads its context
+(the same eager-connect behaviour as the Postgres/MySQL/Mongo providers). An
+empty table registers cleanly — the schema never depends on sampled rows.
+
+## Query Pushdown
+
+Pipeline SQL is planned by DataFusion, and the table scan underneath is
+unparsed back into ClickHouse SQL: predicates on the scanned table,
+projections, and `LIMIT`s run **inside ClickHouse**, so a
+`WHERE id = {user_id}` pipeline transfers one row, not the table. Joins and
+aggregations across sources execute in Skardi after the (already filtered)
+scans return.
+
+## Available Pipelines
+
+Every pipeline is **parameterised** — each `execute` call supplies its
+parameters in the JSON request body (the `{name}` placeholders in the pipeline
+SQL).
+
+| Pipeline | Parameters | Description |
+|----------|------------|-------------|
+| `query_user_by_id` | `user_id` | Point lookup by primary key |
+| `list_all_users` | `limit` | Full scan, `LIMIT` pushed down |
+| `products_by_category` | `category` | Filter on a `Nullable(String)` column |
+| `user_order_summary` | `min_total` | Join users ⨝ orders, aggregate spend per user |
+| `federated_stock_value` | `warehouse` | Join ClickHouse products with a CSV warehouse map |
+
+> The response bodies below are captured from a live run against
+> `clickhouse/clickhouse-server:24.8` with the seed data above, using the
+> parameter values shown in each request. `execution_time_ms` and the
+> `timestamp` field (elided from the examples) vary per run.
+
+---
+
+## 1. Point Lookup
+
+```bash
+curl -X POST http://localhost:8080/query_user_by_id/execute \
+  -H "Content-Type: application/json" \
+  -d '{"user_id": 1}' | jq .
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": [
+    {"id": 1, "name": "Alice Smith", "email": "alice@example.com"}
+  ],
+  "rows": 1,
+  "execution_time_ms": 80
+}
+```
+
+---
+
+## 2. Full Scan with Limit
+
+```bash
+curl -X POST http://localhost:8080/list_all_users/execute \
+  -H "Content-Type: application/json" \
+  -d '{"limit": 10}' | jq .
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": [
+    {"id": 1, "name": "Alice Smith", "email": "alice@example.com"},
+    {"id": 2, "name": "Bob Johnson", "email": "bob@example.com"},
+    {"id": 3, "name": "Carol Williams", "email": "carol@example.com"}
+  ],
+  "rows": 3,
+  "execution_time_ms": 12
+}
+```
+
+---
+
+## 3. Filter on a Nullable Column
+
+`PROD005` has a `NULL` category and is excluded by the equality filter, as SQL
+semantics demand.
+
+```bash
+curl -X POST http://localhost:8080/products_by_category/execute \
+  -H "Content-Type: application/json" \
+  -d '{"category": "Electronics"}' | jq .
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": [
+    {"product_id": "PROD001", "name": "Laptop", "price": 999.99, "in_stock": true},
+    {"product_id": "PROD003", "name": "Monitor", "price": 299.99, "in_stock": false},
+    {"product_id": "PROD002", "name": "Keyboard", "price": 79.99, "in_stock": true},
+    {"product_id": "PROD004", "name": "Mouse", "price": 29.99, "in_stock": true}
+  ],
+  "rows": 4,
+  "execution_time_ms": 14
+}
+```
+
+---
+
+## 4. Join + Aggregation
+
+```bash
+curl -X POST http://localhost:8080/user_order_summary/execute \
+  -H "Content-Type: application/json" \
+  -d '{"min_total": 100}' | jq .
+```
+
+**Response:** (Bob's 79.99 keyboard order is below the threshold)
+```json
+{
+  "success": true,
+  "data": [
+    {"name": "Alice Smith", "order_count": 1, "total_spent": 999.99},
+    {"name": "Carol Williams", "order_count": 1, "total_spent": 299.99}
+  ],
+  "rows": 2,
+  "execution_time_ms": 29
+}
+```
+
+---
+
+## 5. Federated Query: ClickHouse ⨝ CSV
+
+Join the ClickHouse `products` table with a CSV product → warehouse map and
+roll up the stock value per warehouse — a single SQL query spanning two
+backends.
+
+```
+ClickHouse (products)   CSV (product_inventory.csv)
+      │                          │
+      └────────────┬─────────────┘
+                   │
+              DataFusion
+            JOIN + Aggregate
+                   │
+                   ▼
+        per-warehouse stock value
+```
+
+```bash
+curl -X POST http://localhost:8080/federated_stock_value/execute \
+  -H "Content-Type: application/json" \
+  -d '{"warehouse": "us-west"}' | jq .
+```
+
+**Response:** (`PROD001`, `PROD002`, `PROD005` are stocked in `us-west`)
+```json
+{
+  "success": true,
+  "data": [
+    {"warehouse": "us-west", "skus": 3, "stock_value": 16999.39}
+  ],
+  "rows": 1,
+  "execution_time_ms": 16
+}
+```
+
+---
+
+## Catalog Mode
+
+Instead of declaring one data source per table, register the whole server as a
+DataFusion catalog. Every table in the allowed databases becomes addressable
+as `ch_catalog.<database>.<table>`:
+
+```bash
+cargo run --bin skardi-server -- \
+  --ctx docs/clickhouse/ctx_clickhouse_catalog_demo.yaml \
+  --pipeline docs/clickhouse/pipelines/catalog_demo/ \
+  --port 8080
+```
+
+```bash
+curl -X POST http://localhost:8080/clickhouse-catalog-list-users/execute \
+  -H "Content-Type: application/json" \
+  -d '{"limit": 2}' | jq .
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": [
+    {"id": 1, "name": "Alice Smith", "email": "alice@example.com"},
+    {"id": 2, "name": "Bob Johnson", "email": "bob@example.com"}
+  ],
+  "rows": 2,
+  "execution_time_ms": 236
+}
+```
+
+```bash
+curl -X POST http://localhost:8080/clickhouse-catalog-cross-table-join/execute \
+  -H "Content-Type: application/json" \
+  -d '{"user_id": 1}' | jq .
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": [
+    {"name": "Alice Smith", "product": "Laptop", "amount": 999.99}
+  ],
+  "rows": 1,
+  "execution_time_ms": 84
+}
+```
+
+Catalog mode must not mix with per-table options — `table` / `schema` are
+rejected when `hierarchy_level: catalog` is set. Use `allowed_schemas` to
+restrict which databases are exposed; omit it to include every non-system
+database.
+
+---
+
+## Cleanup
+
+```bash
+docker stop clickhouse-skardi && docker rm clickhouse-skardi
+pkill -f skardi-server
+```
+
+---
+
+## Connection Options
+
+ClickHouse sources use `connection_string` for the **HTTP interface** URL
+(e.g. `http://localhost:8123`, or `https://…` for TLS/ClickHouse Cloud) and
+the following `options` keys:
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `table` | table mode | ClickHouse table to register. |
+| `database` | no | Database holding the table (defaults to the server's default database, usually `default`). |
+| `allowed_schemas` | no (catalog mode) | Comma-separated database allow-list; omit to expose all non-system databases. |
+| `user_env` | for auth | **Name of an environment variable** holding the username. The out-of-the-box `default` user needs no credentials, so this is optional. |
+| `pass_env` | for auth | **Name of an environment variable** holding the password. |
+
+The native TCP protocol (port 9000) is not supported — registration rejects
+non-`http(s)` schemes. Credentials embedded in the URL
+(`http://user:pass@host`) are ignored with a warning; use `user_env` /
+`pass_env` so secrets stay out of the YAML.
+
+## Access Mode
+
+This source is **read-only**. Declaring `access_mode: read_write` on a
+ClickHouse source fails config validation, and ClickHouse sources are rejected
+as job destinations. Ingest into ClickHouse should go through ClickHouse's own
+INSERT pipelines (Kafka engine, `clickhouse-client`, HTTP inserts) — Skardi is
+the query side.

--- a/docs/clickhouse/ctx_clickhouse_catalog_demo.yaml
+++ b/docs/clickhouse/ctx_clickhouse_catalog_demo.yaml
@@ -1,0 +1,22 @@
+kind: context
+
+metadata:
+  name: ctx_clickhouse_catalog_demo
+  version: 1.0.0
+
+spec:
+  data_sources:
+    # Expose every table in the allowed ClickHouse databases as a DataFusion
+    # catalog. Query tables with the three-part reference:
+    #   ch_catalog.<database>.<table>
+    - name: "ch_catalog"
+      type: "clickhouse"
+      hierarchy_level: "catalog"
+      connection_string: "http://localhost:8123"
+      description: "ClickHouse server registered as a named DataFusion catalog"
+      options:
+        user_env: "CLICKHOUSE_USER"
+        pass_env: "CLICKHOUSE_PASSWORD"
+        # Restrict to specific databases (optional — omit to include all
+        # non-system databases):
+        allowed_schemas: "mydb"

--- a/docs/clickhouse/ctx_clickhouse_demo.yaml
+++ b/docs/clickhouse/ctx_clickhouse_demo.yaml
@@ -1,0 +1,47 @@
+kind: context
+
+metadata:
+  name: ctx_clickhouse_demo
+  version: 1.0.0
+
+spec:
+  data_sources:
+    # Each ClickHouse table is registered as its own read-only Skardi table.
+    # Credentials come from env vars (CLICKHOUSE_USER / CLICKHOUSE_PASSWORD);
+    # a plain local container's `default` user needs none — drop user_env /
+    # pass_env in that case.
+    - name: "users"
+      type: "clickhouse"
+      connection_string: "http://localhost:8123"
+      description: "Demo users table in ClickHouse"
+      options:
+        database: "mydb"
+        table: "users"
+        user_env: "CLICKHOUSE_USER"
+        pass_env: "CLICKHOUSE_PASSWORD"
+
+    - name: "orders"
+      type: "clickhouse"
+      connection_string: "http://localhost:8123"
+      description: "Demo orders table in ClickHouse"
+      options:
+        database: "mydb"
+        table: "orders"
+        user_env: "CLICKHOUSE_USER"
+        pass_env: "CLICKHOUSE_PASSWORD"
+
+    - name: "products"
+      type: "clickhouse"
+      connection_string: "http://localhost:8123"
+      description: "Demo products table in ClickHouse (category is Nullable)"
+      options:
+        database: "mydb"
+        table: "products"
+        user_env: "CLICKHOUSE_USER"
+        pass_env: "CLICKHOUSE_PASSWORD"
+
+    # CSV data source used by the federated-join example.
+    - name: "product_inventory"
+      type: "csv"
+      path: "docs/clickhouse/sample_data/product_inventory.csv"
+      description: "Static product → warehouse / quantity mapping"

--- a/docs/clickhouse/pipelines/catalog_demo/cross_table_join.yaml
+++ b/docs/clickhouse/pipelines/catalog_demo/cross_table_join.yaml
@@ -1,0 +1,19 @@
+kind: pipeline
+
+metadata:
+  name: "clickhouse-catalog-cross-table-join"
+  version: "1.0.0"
+  description: >
+    Join two ClickHouse tables through the catalog without declaring
+    per-table data sources.
+
+# Parameters:
+#   {user_id} - User whose orders to list
+
+spec:
+  query: |
+    SELECT u.name, o.product, o.amount
+    FROM ch_catalog.mydb.users u
+    JOIN ch_catalog.mydb.orders o ON u.id = o.user_id
+    WHERE u.id = {user_id}
+    ORDER BY o.amount DESC

--- a/docs/clickhouse/pipelines/catalog_demo/list_users.yaml
+++ b/docs/clickhouse/pipelines/catalog_demo/list_users.yaml
@@ -1,0 +1,18 @@
+kind: pipeline
+
+metadata:
+  name: "clickhouse-catalog-list-users"
+  version: "1.0.0"
+  description: >
+    Scan the users table via a three-part catalog reference.
+    Demonstrates catalog mode: tables are addressed as catalog.database.table.
+
+# Parameters:
+#   {limit} - Maximum number of rows to return
+
+spec:
+  query: |
+    SELECT id, name, email
+    FROM ch_catalog.mydb.users
+    ORDER BY id
+    LIMIT {limit}

--- a/docs/clickhouse/pipelines/federated_stock_value.yaml
+++ b/docs/clickhouse/pipelines/federated_stock_value.yaml
@@ -14,7 +14,7 @@ spec:
   query: |
     SELECT w.warehouse,
            count(*) AS skus,
-           sum(p.price * w.quantity) AS stock_value
+           round(sum(p.price * w.quantity), 2) AS stock_value
     FROM products p
     JOIN product_inventory w ON p.product_id = w.product_id
     WHERE w.warehouse = {warehouse}

--- a/docs/clickhouse/pipelines/federated_stock_value.yaml
+++ b/docs/clickhouse/pipelines/federated_stock_value.yaml
@@ -1,0 +1,21 @@
+kind: pipeline
+
+metadata:
+  name: "federated_stock_value"
+  version: "1.0"
+  description: >
+    Federated join: ClickHouse products x CSV warehouse inventory,
+    rolled up to total stock value per warehouse.
+
+# Parameters:
+#   {warehouse} - Warehouse to report on (e.g. "us-west")
+
+spec:
+  query: |
+    SELECT w.warehouse,
+           count(*) AS skus,
+           sum(p.price * w.quantity) AS stock_value
+    FROM products p
+    JOIN product_inventory w ON p.product_id = w.product_id
+    WHERE w.warehouse = {warehouse}
+    GROUP BY w.warehouse

--- a/docs/clickhouse/pipelines/list_all_users.yaml
+++ b/docs/clickhouse/pipelines/list_all_users.yaml
@@ -1,0 +1,12 @@
+kind: pipeline
+
+metadata:
+  name: "list_all_users"
+  version: "1.0"
+  description: "Full scan of the users table (LIMIT pushed down to ClickHouse)"
+
+# Parameters:
+#   {limit} - Maximum number of rows to return
+
+spec:
+  query: "SELECT id, name, email FROM users ORDER BY id LIMIT {limit}"

--- a/docs/clickhouse/pipelines/list_all_users.yaml
+++ b/docs/clickhouse/pipelines/list_all_users.yaml
@@ -3,7 +3,7 @@ kind: pipeline
 metadata:
   name: "list_all_users"
   version: "1.0"
-  description: "Full scan of the users table (LIMIT pushed down to ClickHouse)"
+  description: "Full scan of the users table (ORDER BY + LIMIT run in Skardi; a bare LIMIT would push down)"
 
 # Parameters:
 #   {limit} - Maximum number of rows to return

--- a/docs/clickhouse/pipelines/products_by_category.yaml
+++ b/docs/clickhouse/pipelines/products_by_category.yaml
@@ -1,0 +1,12 @@
+kind: pipeline
+
+metadata:
+  name: "products_by_category"
+  version: "1.0"
+  description: "Products in one category, priciest first (category is Nullable in ClickHouse)"
+
+# Parameters:
+#   {category} - Product category to filter on (e.g. "Electronics")
+
+spec:
+  query: "SELECT product_id, name, price, in_stock FROM products WHERE category = {category} ORDER BY price DESC"

--- a/docs/clickhouse/pipelines/query_user_by_id.yaml
+++ b/docs/clickhouse/pipelines/query_user_by_id.yaml
@@ -1,0 +1,12 @@
+kind: pipeline
+
+metadata:
+  name: "query_user_by_id"
+  version: "1.0"
+  description: "Point lookup of a user by primary key (filter pushed down to ClickHouse)"
+
+# Parameters:
+#   {user_id} - ID of the user to fetch (e.g. 1)
+
+spec:
+  query: "SELECT id, name, email FROM users WHERE id = {user_id}"

--- a/docs/clickhouse/pipelines/user_order_summary.yaml
+++ b/docs/clickhouse/pipelines/user_order_summary.yaml
@@ -1,0 +1,18 @@
+kind: pipeline
+
+metadata:
+  name: "user_order_summary"
+  version: "1.0"
+  description: "Join users with orders inside Skardi and aggregate spend per user"
+
+# Parameters:
+#   {min_total} - Only include users whose total spend is at least this amount
+
+spec:
+  query: |
+    SELECT u.name, count(o.id) AS order_count, sum(o.amount) AS total_spent
+    FROM users u
+    JOIN orders o ON u.id = o.user_id
+    GROUP BY u.name
+    HAVING sum(o.amount) >= {min_total}
+    ORDER BY total_spent DESC

--- a/docs/clickhouse/sample_data/product_inventory.csv
+++ b/docs/clickhouse/sample_data/product_inventory.csv
@@ -1,0 +1,6 @@
+product_id,warehouse,quantity
+PROD001,us-west,12
+PROD002,us-west,40
+PROD003,us-east,7
+PROD004,us-east,55
+PROD005,us-west,9


### PR DESCRIPTION
## Summary

Adds **ClickHouse** as a read-only data source, backed by the `clickhouse` feature of `datafusion-table-providers`. Filters, projections, and `LIMIT`s are unparsed back to ClickHouse SQL and executed server-side, so scans stream only the rows a query actually needs — and ClickHouse tables federate with any other Skardi source in a single query.

## Details

- **Two registration modes**, mirroring the other SQL providers:
  - **Table mode** (default): one ClickHouse table registered under the source name, with an optional `database` option.
  - **Catalog mode**: every table across the server's non-system databases registered as `name.<database>.<table>`, filtered by an optional `allowed_schemas` allow-list.
- **Credentials** come from environment variables via `user_env` / `pass_env` options and are never embedded in the connection URL.
- **Read-only by design**: ClickHouse mutations (`ALTER TABLE ... UPDATE/DELETE`) are asynchronous background rewrites and a mid-stream INSERT failure leaves partial parts visible, which doesn't match the semantics Skardi's write path promises. `access_mode: read_write` and job destinations are rejected for ClickHouse sources.
- **CI**: a `clickhouse/clickhouse-server:24.8` service container with seeded fixture tables (including a NULL-column and an empty table for schema-inference coverage); integration tests are `#[ignore]`-gated and run via the existing `--ignored` pass.
- **Robust catalog registration** (review follow-up): best-effort per-table assembly (one broken view or Kafka-engine table no longer aborts startup), with stream-like engines and materialized-view `.inner*` tables filtered up front, and introspection batched into a single `system.tables` query.
- **Validation at the provider boundary** (review follow-up): unknown options, mode-mismatched options, empty `allowed_schemas`, URL-embedded credentials, query strings, and `access_mode: read_write` are all hard errors in `register_clickhouse_tables` itself, so the CLI and public API enforce the same contract as server config validation — and secrets can't reach logs or the data-sources API.
- **Docs**: quick-start guide, table- and catalog-mode demo contexts, and federated demo pipelines (ClickHouse × CSV join) under `docs/clickhouse/`, plus a README source-matrix row.

## Test plan

- [ ] Unit tests: option parsing, URL validation, and `DataSourceType` roundtrip (`cargo nextest run`)
- [ ] `#[ignore]`-gated integration tests against the CI ClickHouse service container: registration, scans, filter/limit pushdown, NULL handling, empty-table schema inference, catalog mode
- [ ] `submit_rejects_clickhouse_destination_as_non_transactional` covers the job-destination rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)
