### PR TITLE
feat(sources): Open Connector UDTFs, security policy, and observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ For end-to-end walkthroughs — RAG, recommendations, an agent-native wiki, a si
 | S3 / GCS / Azure | Read | No | CSV, Parquet, Lance from object stores | [docs/S3_USAGE.md](docs/S3_USAGE.md) |
 | Apache Iceberg | Read | No | Schema evolution, partition pruning | [docs/iceberg/](docs/iceberg/) |
 | InfluxDB 3 | Read | No | Time-series measurements over Arrow Flight SQL | [docs/influxdb/](docs/influxdb/) |
+| Open Connector | Read | Yes | SaaS resources as stable SQL tables via a self-hosted [Open Connector](https://github.com/oomol-lab/open-connector) gateway; `open_connector_query` / `open_connector_scan` UDTFs, filter + limit pushdown, bounded TTL cache (foundation + synthetic pack today; provider packs rolling out) | [docs/open-connector.md](docs/open-connector.md) |
 | Documents | Read | No | PDF/Office/ODF/image -> per-page markdown, tables, images (local directories; `documents` feature) | [docs/documents.md](docs/documents.md) |
 
 ---

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -51,7 +51,10 @@ use skardi::sources::providers::{
     lance::register_lance_table,
     mongo::register_mongo_tables,
     mysql::register_mysql_tables,
-    open_connector::{OpenConnectorConfig, register_open_connector_tables},
+    open_connector::{
+        OpenConnectorConfig, OpenConnectorGateways, register_open_connector_tables,
+        register_open_connector_udtfs,
+    },
     sqlite::{
         register_sqlite_fts_udtf, register_sqlite_knn_udtf, register_sqlite_tables,
         register_vec_to_binary_udf,
@@ -478,9 +481,10 @@ impl UrlTableFactory for SkardiUrlTableFactory {
 }
 
 /// Create a new SessionContext with custom URL table support (built-in files + Lance)
-/// and the `lance_knn` / `pg_knn` UDTFs registered.
-fn new_session_context() -> (SessionContext, DatasetRegistry) {
+/// and the `lance_knn` / `pg_knn` / Open Connector UDTFs registered.
+fn new_session_context() -> (SessionContext, DatasetRegistry, OpenConnectorGateways) {
     let dataset_registry: DatasetRegistry = Arc::new(RwLock::new(HashMap::new()));
+    let open_connector_gateways = OpenConnectorGateways::default();
     let session_store = SessionStore::new();
     let factory = Arc::new(SkardiUrlTableFactory::new(
         session_store,
@@ -515,6 +519,9 @@ fn new_session_context() -> (SessionContext, DatasetRegistry) {
     register_sqlite_knn_udtf(&ctx, Arc::clone(&dataset_registry));
     register_sqlite_fts_udtf(&ctx, Arc::clone(&dataset_registry));
     register_vec_to_binary_udf(&mut ctx);
+    // Open Connector UDTFs plan against the gateway state that
+    // register_open_connector_tables fills in during ctx registration.
+    register_open_connector_udtfs(&ctx, Arc::clone(&open_connector_gateways));
 
     // Embedding UDFs (gated by feature flags, lazy model loading on first call).
     #[cfg(feature = "onnx")]
@@ -543,7 +550,7 @@ fn new_session_context() -> (SessionContext, DatasetRegistry) {
         registry.register_chunk_udf(&mut ctx);
     }
 
-    (ctx, dataset_registry)
+    (ctx, dataset_registry, open_connector_gateways)
 }
 
 /// Resolve a path string: if relative (and not remote), resolve against cwd.
@@ -732,13 +739,19 @@ async fn load_and_register_all(
     ctx_path: &Path,
     session_ctx: &mut SessionContext,
     dataset_registry: &DatasetRegistry,
+    open_connector_gateways: &OpenConnectorGateways,
 ) -> Result<LocalContextConfig> {
     let config = read_context_file(ctx_path)?;
 
     for source in &config.data_sources {
-        register_source(session_ctx, source, dataset_registry)
-            .await
-            .with_context(|| format!("Failed to register data source '{}'", source.name))?;
+        register_source(
+            session_ctx,
+            source,
+            dataset_registry,
+            open_connector_gateways,
+        )
+        .await
+        .with_context(|| format!("Failed to register data source '{}'", source.name))?;
     }
 
     Ok(config)
@@ -773,6 +786,7 @@ async fn register_source(
     session_ctx: &mut SessionContext,
     source: &LocalDataSource,
     dataset_registry: &DatasetRegistry,
+    open_connector_gateways: &OpenConnectorGateways,
 ) -> Result<()> {
     let source_type = source.source_type.to_lowercase();
 
@@ -956,6 +970,7 @@ async fn register_source(
                 source.open_connector.as_ref(),
                 source.is_read_write(),
                 source.hierarchy_level,
+                Some(open_connector_gateways),
             )
             .await
             .with_context(|| format!("Failed to register Open Connector '{}'", source.name))?;
@@ -1203,8 +1218,9 @@ async fn show_schema(
     table_filter: Option<&str>,
     out: &mut dyn Write,
 ) -> Result<()> {
-    let (mut session_ctx, dataset_registry) = new_session_context();
-    let config = load_and_register_all(ctx_path, &mut session_ctx, &dataset_registry).await?;
+    let (mut session_ctx, dataset_registry, oc_gateways) = new_session_context();
+    let config =
+        load_and_register_all(ctx_path, &mut session_ctx, &dataset_registry, &oc_gateways).await?;
 
     // Build the semantics registry from the same inputs the server uses:
     //   - the ctx-inline `description` field on each data source (fallback), and
@@ -1349,12 +1365,13 @@ fn source_name_for<'a>(
 /// data sources first. If no context file is found, run the query in a bare session with
 /// URL table support (allowing direct file/lance paths in SQL).
 async fn run_query(ctx_override: Option<PathBuf>, sql: &str) -> Result<()> {
-    let (mut session_ctx, dataset_registry) = new_session_context();
+    let (mut session_ctx, dataset_registry, oc_gateways) = new_session_context();
 
     // Try to load context file, but don't fail if not found when no explicit --ctx was given
     match resolve_ctx_path(ctx_override.as_deref()) {
         Some(ctx_path) if ctx_path.exists() => {
-            load_and_register_all(&ctx_path, &mut session_ctx, &dataset_registry).await?;
+            load_and_register_all(&ctx_path, &mut session_ctx, &dataset_registry, &oc_gateways)
+                .await?;
         }
         Some(ctx_path) if ctx_override.is_some() => {
             anyhow::bail!("Context file not found: {}", ctx_path.display());
@@ -1506,9 +1523,9 @@ async fn run_pipeline_with_params(
         .with_context(|| format!("Failed to render SQL for pipeline '{}'", pipeline_name))?;
 
     // 3. Build a SessionContext with ctx data sources registered, then execute.
-    let (mut session_ctx, dataset_registry) = new_session_context();
+    let (mut session_ctx, dataset_registry, oc_gateways) = new_session_context();
     if let Some(p) = &ctx_path_for_load {
-        load_and_register_all(p, &mut session_ctx, &dataset_registry).await?;
+        load_and_register_all(p, &mut session_ctx, &dataset_registry, &oc_gateways).await?;
     }
 
     auto_register_object_stores_from_sql(&session_ctx, &sql)?;
@@ -2860,10 +2877,15 @@ spec:
 
         #[tokio::test]
         async fn errors_without_connection_string() {
-            let (mut session_ctx, registry) = new_session_context();
-            let err = register_source(&mut session_ctx, &dynamodb_source(None), &registry)
-                .await
-                .unwrap_err();
+            let (mut session_ctx, registry, oc_gateways) = new_session_context();
+            let err = register_source(
+                &mut session_ctx,
+                &dynamodb_source(None),
+                &registry,
+                &oc_gateways,
+            )
+            .await
+            .unwrap_err();
             let msg = format!("{err:?}");
             assert!(
                 msg.contains("connection_string (endpoint URL) required"),
@@ -2873,9 +2895,9 @@ spec:
 
         #[tokio::test]
         async fn errors_without_options() {
-            let (mut session_ctx, registry) = new_session_context();
+            let (mut session_ctx, registry, oc_gateways) = new_session_context();
             let source = dynamodb_source(Some("http://localhost:8000"));
-            let err = register_source(&mut session_ctx, &source, &registry)
+            let err = register_source(&mut session_ctx, &source, &registry, &oc_gateways)
                 .await
                 .unwrap_err();
             let msg = format!("{err:?}");
@@ -2921,9 +2943,9 @@ bindings:
 
         #[tokio::test]
         async fn errors_without_connection_string() {
-            let (mut session_ctx, registry) = new_session_context();
+            let (mut session_ctx, registry, oc_gateways) = new_session_context();
             let source = open_connector_source(None, Some(VALID_CONFIG));
-            let err = register_source(&mut session_ctx, &source, &registry)
+            let err = register_source(&mut session_ctx, &source, &registry, &oc_gateways)
                 .await
                 .unwrap_err();
             let msg = format!("{err:?}");
@@ -2937,11 +2959,11 @@ bindings:
         async fn errors_with_table_hierarchy() {
             // hierarchy_level defaults to Table; the CLI must reject it with
             // a clear message, not the provider's wrapped error.
-            let (mut session_ctx, registry) = new_session_context();
+            let (mut session_ctx, registry, oc_gateways) = new_session_context();
             let mut source =
                 open_connector_source(Some("http://localhost:3000"), Some(VALID_CONFIG));
             source.hierarchy_level = HierarchyLevel::Table;
-            let err = register_source(&mut session_ctx, &source, &registry)
+            let err = register_source(&mut session_ctx, &source, &registry, &oc_gateways)
                 .await
                 .unwrap_err();
             let msg = format!("{err:?}");
@@ -2953,9 +2975,9 @@ bindings:
 
         #[tokio::test]
         async fn errors_without_typed_config() {
-            let (mut session_ctx, registry) = new_session_context();
+            let (mut session_ctx, registry, oc_gateways) = new_session_context();
             let source = open_connector_source(Some("http://localhost:3000"), None);
-            let err = register_source(&mut session_ctx, &source, &registry)
+            let err = register_source(&mut session_ctx, &source, &registry, &oc_gateways)
                 .await
                 .unwrap_err();
             let msg = format!("{err:?}");
@@ -2971,11 +2993,11 @@ bindings:
             // The provider is the single enforcement point for the
             // read-only invariant — the CLI must reject read_write exactly
             // like the server's UnsupportedWriteMode.
-            let (mut session_ctx, registry) = new_session_context();
+            let (mut session_ctx, registry, oc_gateways) = new_session_context();
             let mut source =
                 open_connector_source(Some("http://localhost:3000"), Some(VALID_CONFIG));
             source.access_mode = Some("read_write".to_string());
-            let err = register_source(&mut session_ctx, &source, &registry)
+            let err = register_source(&mut session_ctx, &source, &registry, &oc_gateways)
                 .await
                 .unwrap_err();
             let msg = format!("{err:?}");
@@ -2984,11 +3006,11 @@ bindings:
 
         #[tokio::test]
         async fn errors_when_typed_config_on_wrong_type() {
-            let (mut session_ctx, registry) = new_session_context();
+            let (mut session_ctx, registry, oc_gateways) = new_session_context();
             let mut source =
                 open_connector_source(Some("http://localhost:3000"), Some(VALID_CONFIG));
             source.source_type = "csv".to_string();
-            let err = register_source(&mut session_ctx, &source, &registry)
+            let err = register_source(&mut session_ctx, &source, &registry, &oc_gateways)
                 .await
                 .unwrap_err();
             let msg = format!("{err:?}");
@@ -3002,11 +3024,11 @@ bindings:
         async fn errors_when_token_env_missing() {
             // With the config valid, the next failure is the unset runtime
             // token — before any network call to the (unroutable) gateway.
-            let (mut session_ctx, registry) = new_session_context();
+            let (mut session_ctx, registry, oc_gateways) = new_session_context();
             let config =
                 VALID_CONFIG.replace("OPEN_CONNECTOR_TOKEN", "SKARDI_CLI_TEST_OC_TOKEN_UNSET");
             let source = open_connector_source(Some("http://127.0.0.1:1"), Some(config.as_str()));
-            let err = register_source(&mut session_ctx, &source, &registry)
+            let err = register_source(&mut session_ctx, &source, &registry, &oc_gateways)
                 .await
                 .unwrap_err();
             let msg = format!("{err:?}");

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2949,10 +2949,15 @@ spec:
 
         #[tokio::test]
         async fn errors_without_connection_string() {
-            let (mut session_ctx, registry) = new_session_context();
-            let err = register_source(&mut session_ctx, &clickhouse_source(None), &registry)
-                .await
-                .unwrap_err();
+            let (mut session_ctx, registry, oc_gateways) = new_session_context();
+            let err = register_source(
+                &mut session_ctx,
+                &clickhouse_source(None),
+                &registry,
+                &oc_gateways,
+            )
+            .await
+            .unwrap_err();
             let msg = format!("{err:?}");
             assert!(
                 msg.contains("connection_string required"),
@@ -2965,10 +2970,10 @@ spec:
             // The provider is the single enforcement point for the read-only
             // invariant — the CLI must reject read_write exactly like the
             // server's UnsupportedWriteMode.
-            let (mut session_ctx, registry) = new_session_context();
+            let (mut session_ctx, registry, oc_gateways) = new_session_context();
             let mut source = clickhouse_source(Some("http://127.0.0.1:1"));
             source.access_mode = Some("read_write".to_string());
-            let err = register_source(&mut session_ctx, &source, &registry)
+            let err = register_source(&mut session_ctx, &source, &registry, &oc_gateways)
                 .await
                 .unwrap_err();
             let msg = format!("{err:?}");

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -1416,6 +1416,7 @@ async fn register_data_source(
             // `validate_data_sources` already guarantees the config block is
             // present and access is read-only; the provider re-checks both so
             // the CLI path (which has no such validation layer) is covered.
+            let oc_gateways = optimizer_registry.map(|r| r.open_connector_gateways());
             register_open_connector_tables(
                 session_ctx,
                 &source.name,
@@ -1423,6 +1424,7 @@ async fn register_data_source(
                 source.open_connector.as_ref(),
                 source.access_mode.is_read_write(),
                 source.hierarchy_level,
+                oc_gateways.as_ref(),
             )
             .await
             .map_err(|e| {

--- a/crates/server/src/optimizer_registry.rs
+++ b/crates/server/src/optimizer_registry.rs
@@ -13,6 +13,9 @@ use datafusion::prelude::SessionContext;
 use lance::dataset::Dataset;
 use skardi::sources::providers::lance::{register_lance_fts_udtf, register_lance_knn_udtf};
 use skardi::sources::providers::mongo::fts_table_function::register_mongo_fts_udtf;
+use skardi::sources::providers::open_connector::{
+    OpenConnectorGateways, register_open_connector_udtfs,
+};
 use skardi::sources::providers::seekdb::{register_seekdb_fts_udtf, register_seekdb_knn_udtf};
 use skardi::sources::providers::sqlite::{
     register_sqlite_fts_udtf, register_sqlite_knn_udtf, register_vec_to_binary_udf,
@@ -35,6 +38,10 @@ pub struct OptimizerRegistry {
     /// Stores both Lance datasets and Postgres entries, used by
     /// lance_knn, lance_fts, pg_knn, and pg_fts table functions.
     dataset_registry: DatasetRegistry,
+    /// Open Connector gateway state indexed by gateway (data source) name,
+    /// filled during data-source registration and used by the
+    /// open_connector_query / open_connector_scan table functions.
+    open_connector_gateways: OpenConnectorGateways,
 }
 
 impl OptimizerRegistry {
@@ -42,6 +49,7 @@ impl OptimizerRegistry {
     pub fn new() -> Self {
         Self {
             dataset_registry: Arc::new(RwLock::new(HashMap::new())),
+            open_connector_gateways: OpenConnectorGateways::default(),
         }
     }
 
@@ -107,6 +115,13 @@ impl OptimizerRegistry {
         // Register SeekDB-specific table functions
         if source_types.contains(&DataSourceType::Seekdb) {
             self.register_seekdb_functions(ctx)?;
+        }
+
+        // Register Open Connector table functions
+        if source_types.contains(&DataSourceType::OpenConnector) {
+            tracing::info!("Registering Open Connector table functions");
+            register_open_connector_udtfs(ctx, self.open_connector_gateways());
+            tracing::info!("✓ Registered open_connector_query and open_connector_scan");
         }
 
         Ok(())
@@ -204,6 +219,12 @@ impl OptimizerRegistry {
         Arc::clone(&self.dataset_registry)
     }
 
+    /// Get a clone of the Open Connector gateway map to share with
+    /// `register_open_connector_tables` and the Open Connector UDTFs.
+    pub fn open_connector_gateways(&self) -> OpenConnectorGateways {
+        Arc::clone(&self.open_connector_gateways)
+    }
+
     /// Alias for `datasets()` — used when passing to `register_postgres_tables`.
     pub fn pg_knn_pools(&self) -> DatasetRegistry {
         self.datasets()
@@ -254,6 +275,44 @@ mod tests {
 
         let result = registry.register_udfs(&mut ctx, &data_sources);
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_register_udfs_with_open_connector_source() {
+        use crate::config::DataSource;
+        use std::path::PathBuf;
+
+        let registry = OptimizerRegistry::new();
+        let mut ctx = SessionContext::new();
+        let data_sources = vec![DataSource {
+            name: "saas".to_string(),
+            source_type: DataSourceType::OpenConnector,
+            path: PathBuf::new(),
+            connection_string: Some("http://open-connector:3000".to_string()),
+            schema: None,
+            options: None,
+            access_mode: crate::config::AccessMode::default(),
+            enable_cache: false,
+            hierarchy_level: Default::default(),
+            description: None,
+            open_connector: None,
+        }];
+
+        registry
+            .register_udfs(&mut ctx, &data_sources)
+            .expect("register open connector UDTFs");
+
+        // The functions are registered; with no gateway handle published
+        // (this test never ran data-source registration) planning fails with
+        // the targeted gateway error rather than "function not found".
+        let err = ctx
+            .sql("SELECT * FROM open_connector_query('saas', 'mock.items', '{}')")
+            .await
+            .expect_err("no gateway state registered");
+        assert!(
+            err.to_string().contains("gateway 'saas' is not registered"),
+            "unexpected error: {err}"
+        );
     }
 
     #[tokio::test]

--- a/crates/skardi/src/sources/providers/open_connector/action_registry.rs
+++ b/crates/skardi/src/sources/providers/open_connector/action_registry.rs
@@ -30,6 +30,7 @@ pub struct ActionMetadata {
     action_id: String,
     input_schema: Option<Value>,
     output_schema: Option<Value>,
+    read_only: Option<bool>,
     connection_aliases: Vec<String>,
     fingerprint: String,
 }
@@ -43,6 +44,7 @@ impl ActionMetadata {
             action_id: action_id.to_string(),
             input_schema: discovered.input_schema,
             output_schema: discovered.output_schema,
+            read_only: discovered.read_only,
             connection_aliases: discovered.connection_aliases,
             fingerprint,
         }
@@ -61,6 +63,13 @@ impl ActionMetadata {
     /// Declared output JSON Schema, if the gateway provides one.
     pub fn output_schema(&self) -> Option<&Value> {
         self.output_schema.as_ref()
+    }
+
+    /// Whether the gateway classifies this action as a non-mutating read.
+    /// `None` means the gateway did not say — default-deny consumers (the
+    /// raw-action UDTF) must refuse to execute the action in that case.
+    pub fn read_only(&self) -> Option<bool> {
+        self.read_only
     }
 
     /// Connection aliases available for this action.
@@ -302,6 +311,26 @@ mod tests {
         );
         assert_eq!(meta.connection_aliases(), &["work".to_string()]);
         assert_eq!(meta.fingerprint().len(), 64, "BLAKE3 hash as hex");
+        assert_eq!(
+            meta.read_only(),
+            None,
+            "an absent read_only flag must stay absent (default-deny input)"
+        );
+    }
+
+    #[tokio::test]
+    async fn metadata_carries_explicit_read_only_classification() {
+        let gateway = MockGateway::start(|_| {
+            MockResponse::ok(
+                r#"{"input_schema": {}, "output_schema": {}, "locally_executable": true,
+                    "read_only": true, "connection_aliases": []}"#,
+            )
+        })
+        .await;
+        let registry = ActionRegistry::load(&client(&gateway), &["github.x".to_string()])
+            .await
+            .expect("load");
+        assert_eq!(registry.get("github.x").unwrap().read_only(), Some(true));
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/open_connector/client.rs
+++ b/crates/skardi/src/sources/providers/open_connector/client.rs
@@ -146,18 +146,28 @@ pub struct DiscoveredAction {
     /// "the gateway said yes" — default-deny consumers (the action registry)
     /// must treat `None` as not executable.
     pub locally_executable: Option<bool>,
+    /// Whether the gateway classifies the action as a non-mutating read.
+    ///
+    /// Same `Option` discipline as `locally_executable`: `None` means the
+    /// gateway did not classify the action, and default-deny consumers (the
+    /// raw-action UDTF) must refuse to execute it. Source-pack actions are
+    /// read-only by Skardi's own review instead, so packs do not consult
+    /// this flag.
+    pub read_only: Option<bool>,
     /// Connection aliases available for this action.
     pub connection_aliases: Vec<String>,
 }
 
 /// Wire shape of the action discovery response. Unknown fields are ignored
 /// so additive gateway changes don't break discovery. `locally_executable`
-/// deliberately has no default: a missing field must stay missing.
+/// and `read_only` deliberately have no default: a missing field must stay
+/// missing.
 #[derive(Debug, Deserialize)]
 struct RawDiscoveredAction {
     input_schema: Option<Value>,
     output_schema: Option<Value>,
     locally_executable: Option<bool>,
+    read_only: Option<bool>,
     #[serde(default)]
     connection_aliases: Vec<String>,
 }
@@ -367,6 +377,7 @@ impl OpenConnectorClient {
             input_schema: raw.input_schema,
             output_schema: raw.output_schema,
             locally_executable: raw.locally_executable,
+            read_only: raw.read_only,
             connection_aliases: raw.connection_aliases,
         })
     }
@@ -377,14 +388,10 @@ impl OpenConnectorClient {
     /// Crate-internal on purpose: execution is the *dangerous* half of the
     /// gateway contract (mutating actions exist upstream), and the
     /// default-deny gating lives one layer up — `ActionRegistry::load` admits
-    /// only explicitly allowlisted, locally-executable actions, and the
-    /// future scan engine / UDTFs must check membership before calling this.
-    /// Keeping the method `pub(crate)` makes that gating structurally
-    /// un-bypassable from outside the crate.
-    ///
-    /// Only exercised by tests until the scan engine wires the production
-    /// path (registration currently stops at `ExecutionNotImplemented`).
-    #[allow(dead_code)]
+    /// only explicitly allowlisted, locally-executable actions, and the scan
+    /// engine / UDTFs check membership before calling this. Keeping the
+    /// method `pub(crate)` makes that gating structurally un-bypassable from
+    /// outside the crate.
     pub(crate) async fn execute(
         &self,
         action_id: &str,

--- a/crates/skardi/src/sources/providers/open_connector/config.rs
+++ b/crates/skardi/src/sources/providers/open_connector/config.rs
@@ -646,6 +646,29 @@ bindings:
     }
 
     #[test]
+    fn parse_rejects_relational_contract_overrides_on_bindings() {
+        // The relational contract (action, row path, schema, pagination)
+        // belongs to the Skardi-maintained source pack. A binding that tries
+        // to swap any of it must fail loudly — accepting-and-ignoring would
+        // let a config claim a different action than the one that runs.
+        for (field, value) in [
+            ("action", "github.delete_repository"),
+            ("row_path", "$.other"),
+            ("pagination", "cursor"),
+            ("columns", "[]"),
+        ] {
+            let err = serde_yaml::from_str::<OpenConnectorConfig>(&format!(
+                "runtime_token_env: T\nbindings:\n  - name: b\n    source_pack: github\n    {field}: {value}\n    tables: [issues]",
+            ))
+            .unwrap_err();
+            assert!(
+                err.to_string().contains(field),
+                "override '{field}' should be rejected by name: {err}"
+            );
+        }
+    }
+
+    #[test]
     fn parse_rejects_misspelled_cache_field() {
         let err = serde_yaml::from_str::<OpenConnectorConfig>(
             "runtime_token_env: T\ncache_ttl_second: 60",

--- a/crates/skardi/src/sources/providers/open_connector/error.rs
+++ b/crates/skardi/src/sources/providers/open_connector/error.rs
@@ -336,4 +336,63 @@ pub enum OpenConnectorError {
     /// A response was not the JSON shape the client contract expects.
     #[error("Open Connector {operation} returned an invalid response: {reason}")]
     InvalidGatewayResponse { operation: String, reason: String },
+
+    /// A UDTF named a gateway that is not a registered `open_connector` data
+    /// source (or whose registration failed).
+    #[error(
+        "Open Connector gateway '{name}' is not registered; the first UDTF argument \
+         must name a 'type: open_connector' data source from the context configuration"
+    )]
+    UdtfGatewayNotRegistered { name: String },
+
+    /// A UDTF referenced an action whose metadata was never discovered.
+    /// Discovery happens only at registration (query planning performs no
+    /// network I/O), and only for bound source-pack tables and allowlisted
+    /// raw actions.
+    #[error(
+        "Open Connector action '{action_id}' was not discovered when gateway '{gateway}' \
+         was registered; bind its source-pack table in the context YAML or add the \
+         action to 'raw_action_allowlist' (query planning never contacts the gateway)"
+    )]
+    ActionNotDiscovered { gateway: String, action_id: String },
+
+    /// `open_connector_scan` was called with an action outside the gateway's
+    /// `raw_action_allowlist`. Raw-action access is default-deny.
+    #[error(
+        "Open Connector action '{action_id}' is not in the 'raw_action_allowlist' of \
+         gateway '{gateway}'; open_connector_scan executes explicitly allowlisted \
+         actions only (default-deny)"
+    )]
+    RawActionNotAllowlisted { gateway: String, action_id: String },
+
+    /// An allowlisted raw action's metadata classifies it as mutating.
+    /// The allowlist alone never grants execution.
+    #[error(
+        "Open Connector action '{action_id}' is classified as mutating by its gateway \
+         metadata; open_connector_scan executes non-mutating reads only"
+    )]
+    RawActionMutating { action_id: String },
+
+    /// An allowlisted raw action's metadata does not say whether it mutates;
+    /// default-deny refuses to execute it, naming the classification gap.
+    #[error(
+        "Open Connector action '{action_id}' does not declare a read-only \
+         classification in its gateway metadata; refusing to execute it \
+         (default-deny — the allowlist alone does not grant execution)"
+    )]
+    RawActionReadOnlyUnknown { action_id: String },
+
+    /// A raw scan's row path does not resolve to a deterministic object row
+    /// type in the discovered action output schema, so no stable Arrow
+    /// schema can be planned.
+    #[error(
+        "Open Connector raw scan of action '{action_id}' cannot derive a deterministic \
+         row type at '{row_path}': {reason}; use a built-in source-pack table \
+         (open_connector_query) or contribute a source-pack definition instead"
+    )]
+    RawRowTypeIndeterminate {
+        action_id: String,
+        row_path: String,
+        reason: String,
+    },
 }

--- a/crates/skardi/src/sources/providers/open_connector/exec.rs
+++ b/crates/skardi/src/sources/providers/open_connector/exec.rs
@@ -448,6 +448,11 @@ impl ScanState {
         )
         .await
         .map_err(|_| self.timeout_error())??;
+        // Counted at fetch time on purpose: `pages_fetched` measures gateway
+        // traffic (requests actually made, rate-limit budget actually spent),
+        // not pages emitted downstream. A page that lands right at the
+        // deadline — or fails extraction/conversion below — was still a real
+        // gateway call, and the failure event should say so.
         self.pages_fetched += 1;
         if Instant::now() >= self.deadline {
             return Err(self.timeout_error());

--- a/crates/skardi/src/sources/providers/open_connector/exec.rs
+++ b/crates/skardi/src/sources/providers/open_connector/exec.rs
@@ -31,18 +31,48 @@ use super::cache::{ScanCache, ScanKeyParts, scan_cache_key, schema_fingerprint};
 use super::client::OpenConnectorClient;
 use super::error::OpenConnectorError;
 use super::json_to_arrow::RowConverter;
-use super::pagination::Pagination;
+use super::pagination::{Pagination, PaginationStrategy};
 use super::row_path::RowPath;
 use super::source_pack::SourcePackTable;
+
+/// The scanned collection's identity and pagination contract — the shape
+/// shared by YAML-bound source-pack tables and `open_connector_scan` raw
+/// actions, which have no static [`SourcePackTable`] to point at.
+#[derive(Debug, Clone)]
+pub struct ScanTarget {
+    /// Stable table ID (`mock.items`) or a raw-action label, for errors and
+    /// tracing.
+    pub table_id: Arc<str>,
+    /// Open Connector action to execute.
+    pub action_id: Arc<str>,
+    /// Pagination contract.
+    pub pagination: PaginationStrategy,
+    /// Source-pack version, part of the cache key (0 for raw scans, which
+    /// have no pack and bypass the cache).
+    pub source_pack_version: u32,
+}
+
+impl ScanTarget {
+    /// The target of a bound source-pack table.
+    pub fn from_pack_table(table: &SourcePackTable, source_pack_version: u32) -> Self {
+        Self {
+            table_id: Arc::from(table.id),
+            action_id: Arc::from(table.action_id),
+            pagination: table.pagination,
+            source_pack_version,
+        }
+    }
+}
 
 /// Everything a scan needs, bound once at planning time.
 pub struct OpenConnectorExec {
     client: Arc<OpenConnectorClient>,
     cache: Option<Arc<ScanCache>>,
     gateway: String,
+    /// Binding (catalog schema) name for tracing; `None` for UDTF scans.
+    binding: Option<String>,
     connection_alias: Option<String>,
-    table: &'static SourcePackTable,
-    source_pack_version: u32,
+    target: ScanTarget,
     converter: Arc<RowConverter>,
     row_path: RowPath,
     resource: Value,
@@ -59,8 +89,8 @@ pub struct OpenConnectorExec {
 impl fmt::Debug for OpenConnectorExec {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("OpenConnectorExec")
-            .field("table", &self.table.id)
-            .field("action", &self.table.action_id)
+            .field("table", &self.target.table_id)
+            .field("action", &self.target.action_id)
             .field("limit", &self.limit)
             .field("projection", &self.projection)
             .finish()
@@ -76,9 +106,9 @@ impl OpenConnectorExec {
         client: Arc<OpenConnectorClient>,
         cache: Option<Arc<ScanCache>>,
         gateway: String,
+        binding: Option<String>,
         connection_alias: Option<String>,
-        table: &'static SourcePackTable,
-        source_pack_version: u32,
+        target: ScanTarget,
         converter: Arc<RowConverter>,
         row_path: RowPath,
         resource: Value,
@@ -104,9 +134,9 @@ impl OpenConnectorExec {
             client,
             cache,
             gateway,
+            binding,
             connection_alias,
-            table,
-            source_pack_version,
+            target,
             converter,
             row_path,
             resource,
@@ -127,7 +157,7 @@ impl DisplayAs for OpenConnectorExec {
         write!(
             f,
             "OpenConnectorExec: table={} action={} limit={:?}",
-            self.table.id, self.table.action_id, self.limit
+            self.target.table_id, self.target.action_id, self.limit
         )
     }
 }
@@ -190,7 +220,21 @@ impl ExecutionPlan for OpenConnectorExec {
             match state.next_page().await {
                 Ok(Some(batch)) => Ok(Some((batch, state))),
                 Ok(None) => Ok(None),
-                Err(e) => Err(DataFusionError::External(Box::new(e))),
+                Err(e) => {
+                    // The scan-failure counterpart of the completion event in
+                    // `next_page` — same identifying fields, never tokens or
+                    // response bodies (errors carry JSON *kinds* only).
+                    tracing::warn!(
+                        gateway = %state.gateway,
+                        binding = state.binding.as_deref().unwrap_or("<udtf>"),
+                        table = %state.target.table_id,
+                        action = %state.target.action_id,
+                        pages_fetched = state.pages_fetched,
+                        error = %e,
+                        "Open Connector scan failed"
+                    );
+                    Err(DataFusionError::External(Box::new(e)))
+                }
             }
         });
         Ok(Box::pin(RecordBatchStreamAdapter::new(
@@ -205,8 +249,10 @@ struct ScanState {
     client: Arc<OpenConnectorClient>,
     cache: Option<Arc<ScanCache>>,
     cache_key: String,
+    gateway: String,
+    binding: Option<String>,
     connection_alias: Option<String>,
-    table: &'static SourcePackTable,
+    target: ScanTarget,
     converter: Arc<RowConverter>,
     row_path: RowPath,
     resource: Value,
@@ -227,6 +273,12 @@ struct ScanState {
     /// Idempotence guard for the two store sites (LIMIT-satisfied and
     /// exhaustion), which can both fire on the same page.
     cache_stored: bool,
+    // Observability (see `log_completion`).
+    started: Instant,
+    cache_hit: bool,
+    pages_fetched: u32,
+    rows_returned: u64,
+    completion_logged: bool,
 }
 
 impl ScanState {
@@ -249,8 +301,8 @@ impl ScanState {
         let cache_key = scan_cache_key(&ScanKeyParts {
             gateway: &exec.gateway,
             connection_alias: exec.connection_alias.as_deref(),
-            action_id: exec.table.action_id,
-            source_pack_version: exec.source_pack_version,
+            action_id: &exec.target.action_id,
+            source_pack_version: exec.target.source_pack_version,
             resource: &exec.resource,
             filter_inputs: &exec.filter_inputs,
             projection: &projection_names,
@@ -274,8 +326,10 @@ impl ScanState {
             client: exec.client.clone(),
             cache: exec.cache.clone(),
             cache_key,
+            gateway: exec.gateway.clone(),
+            binding: exec.binding.clone(),
             connection_alias: exec.connection_alias.clone(),
-            table: exec.table,
+            target: exec.target.clone(),
             converter: exec.converter.clone(),
             row_path: exec.row_path.clone(),
             resource: exec.resource.clone(),
@@ -286,12 +340,17 @@ impl ScanState {
             max_rows: exec.max_rows,
             scan_timeout: exec.scan_timeout,
             deadline: Instant::now() + exec.scan_timeout,
-            pagination: Pagination::new(exec.table.pagination)?,
+            pagination: Pagination::new(exec.target.pagination)?,
             rows_emitted: 0,
             replay,
             fetched: Vec::new(),
             done,
             cache_stored: false,
+            started: Instant::now(),
+            cache_hit: done,
+            pages_fetched: 0,
+            rows_returned: 0,
+            completion_logged: false,
         })
     }
 
@@ -307,18 +366,40 @@ impl ScanState {
 
     fn timeout_error(&self) -> OpenConnectorError {
         OpenConnectorError::ScanTimeout {
-            table: self.table.id.to_string(),
+            table: self.target.table_id.to_string(),
             seconds: self.scan_timeout.as_secs(),
         }
+    }
+
+    /// Emit the scan-completion event exactly once. Identifying fields and
+    /// counters only — never tokens, headers, inputs, or row values.
+    fn log_completion(&mut self) {
+        if self.completion_logged {
+            return;
+        }
+        self.completion_logged = true;
+        tracing::info!(
+            gateway = %self.gateway,
+            binding = self.binding.as_deref().unwrap_or("<udtf>"),
+            table = %self.target.table_id,
+            action = %self.target.action_id,
+            cache_hit = self.cache_hit,
+            pages = self.pages_fetched,
+            rows = self.rows_returned,
+            duration_ms = self.started.elapsed().as_millis() as u64,
+            "Open Connector scan completed"
+        );
     }
 
     /// Fetch and convert one page; returns None when the scan is complete.
     async fn next_page(&mut self) -> Result<Option<RecordBatch>, OpenConnectorError> {
         if let Some(batch) = self.replay.pop_front() {
+            self.rows_returned += batch.num_rows() as u64;
             return Ok(Some(batch));
         }
         if self.done || self.limit_remaining == Some(0) {
             self.done = true;
+            self.log_completion();
             return Ok(None);
         }
         if Instant::now() >= self.deadline {
@@ -326,7 +407,7 @@ impl ScanState {
         }
         if self.pagination.page() > self.max_pages as usize {
             return Err(OpenConnectorError::ScanBoundsExceeded {
-                table: self.table.id.to_string(),
+                table: self.target.table_id.to_string(),
                 bound: "max_pages",
                 limit: u64::from(self.max_pages),
             });
@@ -349,13 +430,14 @@ impl ScanState {
         let envelope = tokio::time::timeout_at(
             tokio::time::Instant::from_std(self.deadline),
             self.client.execute(
-                self.table.action_id,
+                &self.target.action_id,
                 &Value::Object(input),
                 self.connection_alias.as_deref(),
             ),
         )
         .await
         .map_err(|_| self.timeout_error())??;
+        self.pages_fetched += 1;
         if Instant::now() >= self.deadline {
             return Err(self.timeout_error());
         }
@@ -395,7 +477,7 @@ impl ScanState {
         self.rows_emitted += batch.num_rows() as u64;
         if self.rows_emitted > self.max_rows {
             return Err(OpenConnectorError::ScanBoundsExceeded {
-                table: self.table.id.to_string(),
+                table: self.target.table_id.to_string(),
                 bound: "max_rows",
                 limit: self.max_rows,
             });
@@ -422,8 +504,10 @@ impl ScanState {
 
         // A terminal empty page is completion, not output.
         if batch.num_rows() == 0 && self.done {
+            self.log_completion();
             return Ok(None);
         }
+        self.rows_returned += batch.num_rows() as u64;
         Ok(Some(batch))
     }
 }
@@ -445,8 +529,8 @@ mod tests {
             None,
             "saas".to_string(),
             None,
-            table,
-            source_pack_version,
+            None,
+            ScanTarget::from_pack_table(table, source_pack_version),
             Arc::new(RowConverter::new(table.fields).expect("converter")),
             RowPath::parse(table.row_path).expect("row path"),
             json!({}),

--- a/crates/skardi/src/sources/providers/open_connector/exec.rs
+++ b/crates/skardi/src/sources/providers/open_connector/exec.rs
@@ -395,6 +395,12 @@ impl ScanState {
     async fn next_page(&mut self) -> Result<Option<RecordBatch>, OpenConnectorError> {
         if let Some(batch) = self.replay.pop_front() {
             self.rows_returned += batch.num_rows() as u64;
+            // The last replayed batch may satisfy a downstream LIMIT, which
+            // drops this stream without ever polling again — log with the
+            // final batch, not on a poll that may never come.
+            if self.replay.is_empty() {
+                self.log_completion();
+            }
             return Ok(Some(batch));
         }
         if self.done || self.limit_remaining == Some(0) {
@@ -508,6 +514,15 @@ impl ScanState {
             return Ok(None);
         }
         self.rows_returned += batch.num_rows() as u64;
+        // A completing scan must log with its final batch: a satisfied
+        // downstream LIMIT drops this stream immediately (DataFusion's
+        // LimitStream clears its input), so the `self.done` early return
+        // above may never run — the same reason the LIMIT-satisfied cache
+        // store is eager. Logged after the row count so the event carries
+        // the full total.
+        if self.done {
+            self.log_completion();
+        }
         Ok(Some(batch))
     }
 }
@@ -516,19 +531,23 @@ impl ScanState {
 mod tests {
     use super::*;
     use crate::sources::providers::open_connector::packs::mock::MOCK_PACK;
+    use crate::sources::providers::open_connector::testutil::{
+        MockGateway, MockResponse, RecordedRequest,
+    };
     use serde_json::json;
 
-    fn exec_with_version(source_pack_version: u32) -> OpenConnectorExec {
+    fn build_exec(
+        client: Arc<OpenConnectorClient>,
+        cache: Option<Arc<ScanCache>>,
+        limit: Option<usize>,
+        source_pack_version: u32,
+    ) -> OpenConnectorExec {
         let table = &MOCK_PACK.tables[0];
-        let client = Arc::new(
-            OpenConnectorClient::new("http://127.0.0.1:1", "t", Duration::from_secs(1))
-                .expect("build client"),
-        );
         OpenConnectorExec::new(
             client,
-            None,
+            cache,
             "saas".to_string(),
-            None,
+            Some("ws".to_string()),
             None,
             ScanTarget::from_pack_table(table, source_pack_version),
             Arc::new(RowConverter::new(table.fields).expect("converter")),
@@ -536,12 +555,128 @@ mod tests {
             json!({}),
             vec![],
             None,
-            None,
+            limit,
             10,
             1000,
             Duration::from_secs(30),
         )
         .expect("build exec")
+    }
+
+    fn exec_with_version(source_pack_version: u32) -> OpenConnectorExec {
+        let client = Arc::new(
+            OpenConnectorClient::new("http://127.0.0.1:1", "t", Duration::from_secs(1))
+                .expect("build client"),
+        );
+        build_exec(client, None, None, source_pack_version)
+    }
+
+    /// Execute-only mock gateway for `mock.list_items` (per_page = 2), the
+    /// only call `ScanState` makes (discovery/health happen at registration).
+    fn items_handler(req: &RecordedRequest, total: usize) -> MockResponse {
+        if req.method == "POST" && req.path == "/v1/actions/mock.list_items/execute" {
+            let body: serde_json::Value = serde_json::from_str(&req.body).unwrap_or_default();
+            let page = body
+                .get("input")
+                .and_then(|input| input.get("page"))
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(1) as usize;
+            let items: Vec<_> = (1..=total)
+                .map(|id| json!({"id": id, "name": format!("item-{id}")}))
+                .skip((page - 1) * 2)
+                .take(2)
+                .collect();
+            return MockResponse::ok(&json!({"output": {"items": items}}).to_string());
+        }
+        MockResponse::new(404, "{}")
+    }
+
+    async fn online_client(gateway: &MockGateway) -> Arc<OpenConnectorClient> {
+        Arc::new(
+            OpenConnectorClient::new(&gateway.url, "t", Duration::from_secs(5))
+                .expect("build client"),
+        )
+    }
+
+    #[tokio::test]
+    async fn limit_satisfied_scan_logs_completion_with_the_final_batch() {
+        // A satisfied downstream LIMIT drops the stream without another poll
+        // (DataFusion's LimitStream clears its input), so the completion
+        // event must be emitted together with the final batch — the
+        // early-return branch at the top of next_page is never reached.
+        let gateway = MockGateway::start(|req| items_handler(req, 5)).await;
+        let exec = build_exec(online_client(&gateway).await, None, Some(1), 1);
+
+        let mut state = ScanState::new(&exec).expect("state");
+        let batch = state.next_page().await.expect("page").expect("batch");
+        assert_eq!(batch.num_rows(), 1);
+        assert!(
+            state.completion_logged,
+            "LIMIT-satisfied scan must log completion on its final batch, \
+             not on a poll that never comes"
+        );
+        assert_eq!(
+            state.rows_returned, 1,
+            "the event must count the final batch"
+        );
+    }
+
+    #[tokio::test]
+    async fn exhausted_scan_logs_completion_with_a_nonempty_final_page() {
+        // 3 items at per_page = 2: page 2 is short (1 row), so the scan
+        // completes while still returning a batch — the event must not
+        // depend on the consumer polling once more for the None.
+        let gateway = MockGateway::start(|req| items_handler(req, 3)).await;
+        let exec = build_exec(online_client(&gateway).await, None, None, 1);
+
+        let mut state = ScanState::new(&exec).expect("state");
+        state.next_page().await.expect("page 1").expect("full page");
+        assert!(
+            !state.completion_logged,
+            "scan is still running after page 1"
+        );
+        state
+            .next_page()
+            .await
+            .expect("page 2")
+            .expect("short page");
+        assert!(
+            state.completion_logged,
+            "exhaustion must log with the final batch"
+        );
+        assert_eq!(state.rows_returned, 3);
+    }
+
+    #[tokio::test]
+    async fn cached_replay_logs_completion_with_the_last_replayed_batch() {
+        let gateway = MockGateway::start(|req| items_handler(req, 3)).await;
+        let cache = Arc::new(ScanCache::new(Duration::from_secs(60), usize::MAX));
+        let exec = build_exec(online_client(&gateway).await, Some(cache), None, 1);
+
+        // Live scan to completion populates the cache.
+        let mut state = ScanState::new(&exec).expect("live state");
+        while state.next_page().await.expect("live page").is_some() {}
+
+        // The replayed scan must log once its queue drains — a satisfied
+        // downstream LIMIT would never poll again, exactly as in the live
+        // case (LIMIT queries are cached; LIMIT is part of the key).
+        let mut state = ScanState::new(&exec).expect("replay state");
+        assert!(state.cache_hit, "second identical scan replays from cache");
+        let batches = state.replay.len();
+        assert!(batches > 0);
+        for index in 1..=batches {
+            state
+                .next_page()
+                .await
+                .expect("replayed page")
+                .expect("batch");
+            assert_eq!(
+                state.completion_logged,
+                index == batches,
+                "completion logs exactly when the replay queue drains"
+            );
+        }
+        assert_eq!(state.rows_returned, 3);
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/open_connector/exec.rs
+++ b/crates/skardi/src/sources/providers/open_connector/exec.rs
@@ -537,9 +537,11 @@ mod tests {
     use super::*;
     use crate::sources::providers::open_connector::packs::mock::MOCK_PACK;
     use crate::sources::providers::open_connector::testutil::{
-        MockGateway, MockResponse, RecordedRequest,
+        CapturedEvent, MockGateway, MockResponse, RecordedRequest, capture_events,
     };
+    use futures::StreamExt;
     use serde_json::json;
+    use std::sync::Mutex;
 
     fn build_exec(
         client: Arc<OpenConnectorClient>,
@@ -682,6 +684,151 @@ mod tests {
             );
         }
         assert_eq!(state.rows_returned, 3);
+    }
+
+    // ── Emitted-event assertions ─────────────────────────────────────────
+    // The flag tests above pin the state machine; these pin the actual
+    // tracing output — exactly one event per scan, with the documented
+    // fields — by consuming the real `execute()` stream.
+
+    const COMPLETED: &str = "Open Connector scan completed";
+    const FAILED: &str = "Open Connector scan failed";
+
+    /// Captured events with the given message, in emission order.
+    fn events_with_message(
+        events: &Arc<Mutex<Vec<CapturedEvent>>>,
+        message: &str,
+    ) -> Vec<CapturedEvent> {
+        events
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .iter()
+            .filter(|event| event.message == message)
+            .cloned()
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn limit_satisfied_stream_emits_exactly_one_completion_event() {
+        let gateway = MockGateway::start(|req| items_handler(req, 5)).await;
+        let exec = build_exec(online_client(&gateway).await, None, Some(1), 1);
+        let (_guard, events) = capture_events();
+
+        let mut stream = exec
+            .execute(0, Arc::new(TaskContext::default()))
+            .expect("stream");
+        let batch = stream.next().await.expect("a batch").expect("no error");
+        assert_eq!(batch.num_rows(), 1);
+        // A satisfied LimitStream drops its input without polling again.
+        drop(stream);
+
+        let completed = events_with_message(&events, COMPLETED);
+        assert_eq!(completed.len(), 1, "exactly one completion event");
+        let event = &completed[0];
+        assert_eq!(event.level, tracing::Level::INFO);
+        assert_eq!(event.field("gateway"), Some("saas"));
+        assert_eq!(event.field("binding"), Some("ws"));
+        assert_eq!(event.field("table"), Some("mock.items"));
+        assert_eq!(event.field("action"), Some("mock.list_items"));
+        assert_eq!(event.field("cache_hit"), Some("false"));
+        assert_eq!(event.field("pages"), Some("1"));
+        assert_eq!(event.field("rows"), Some("1"));
+        assert!(event.fields.contains_key("duration_ms"));
+        assert!(events_with_message(&events, FAILED).is_empty());
+    }
+
+    #[tokio::test]
+    async fn empty_scan_emits_exactly_one_completion_event() {
+        let gateway = MockGateway::start(|req| items_handler(req, 0)).await;
+        let exec = build_exec(online_client(&gateway).await, None, None, 1);
+        let (_guard, events) = capture_events();
+
+        let mut stream = exec
+            .execute(0, Arc::new(TaskContext::default()))
+            .expect("stream");
+        assert!(
+            stream.next().await.is_none(),
+            "empty scan yields no batches"
+        );
+        assert!(stream.next().await.is_none(), "stream stays terminated");
+
+        let completed = events_with_message(&events, COMPLETED);
+        assert_eq!(completed.len(), 1, "exactly one completion event");
+        assert_eq!(completed[0].field("rows"), Some("0"));
+        assert_eq!(completed[0].field("pages"), Some("1"));
+        assert_eq!(completed[0].field("cache_hit"), Some("false"));
+    }
+
+    #[tokio::test]
+    async fn cache_replay_emits_exactly_one_completion_event_marked_cache_hit() {
+        let gateway = MockGateway::start(|req| items_handler(req, 3)).await;
+        let cache = Arc::new(ScanCache::new(Duration::from_secs(60), usize::MAX));
+        let exec = build_exec(online_client(&gateway).await, Some(cache), None, 1);
+        let (_guard, events) = capture_events();
+
+        for round in 1..=2 {
+            let mut stream = exec
+                .execute(0, Arc::new(TaskContext::default()))
+                .expect("stream");
+            let mut rows = 0;
+            while let Some(batch) = stream.next().await {
+                rows += batch.expect("no error").num_rows();
+            }
+            assert_eq!(rows, 3, "round {round}");
+        }
+
+        let completed = events_with_message(&events, COMPLETED);
+        assert_eq!(
+            completed.len(),
+            2,
+            "one completion event per scan, replay included"
+        );
+        assert_eq!(completed[0].field("cache_hit"), Some("false"));
+        assert_eq!(completed[0].field("pages"), Some("2"));
+        assert_eq!(completed[1].field("cache_hit"), Some("true"));
+        assert_eq!(
+            completed[1].field("pages"),
+            Some("0"),
+            "a replay fetches no live pages"
+        );
+        assert_eq!(completed[1].field("rows"), Some("3"));
+    }
+
+    #[tokio::test]
+    async fn failed_scan_emits_one_failure_event_and_no_completion() {
+        let gateway = MockGateway::start(|req| {
+            if req.method == "POST" {
+                // 5xx is terminal for the non-idempotent execute: no retry.
+                MockResponse::new(500, r#"{"message":"boom"}"#)
+            } else {
+                MockResponse::new(404, "{}")
+            }
+        })
+        .await;
+        let exec = build_exec(online_client(&gateway).await, None, None, 1);
+        let (_guard, events) = capture_events();
+
+        let mut stream = exec
+            .execute(0, Arc::new(TaskContext::default()))
+            .expect("stream");
+        let result = stream.next().await.expect("one item");
+        assert!(result.is_err(), "scan must fail");
+
+        let failed = events_with_message(&events, FAILED);
+        assert_eq!(failed.len(), 1, "exactly one failure event");
+        let event = &failed[0];
+        assert_eq!(event.level, tracing::Level::WARN);
+        assert_eq!(event.field("gateway"), Some("saas"));
+        assert_eq!(event.field("binding"), Some("ws"));
+        assert_eq!(event.field("table"), Some("mock.items"));
+        assert_eq!(event.field("action"), Some("mock.list_items"));
+        assert_eq!(event.field("pages_fetched"), Some("0"));
+        let error = event.field("error").expect("error field");
+        assert!(
+            error.contains("HTTP 500"),
+            "error carries the terminal status: {error}"
+        );
+        assert!(events_with_message(&events, COMPLETED).is_empty());
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/open_connector/exec.rs
+++ b/crates/skardi/src/sources/providers/open_connector/exec.rs
@@ -222,8 +222,13 @@ impl ExecutionPlan for OpenConnectorExec {
                 Ok(None) => Ok(None),
                 Err(e) => {
                     // The scan-failure counterpart of the completion event in
-                    // `next_page` — same identifying fields, never tokens or
-                    // response bodies (errors carry JSON *kinds* only).
+                    // `next_page` — same identifying fields plus the error.
+                    // The error display may quote a bounded (≤512-char)
+                    // snippet of the gateway's *error* response and a
+                    // pagination cursor; it never carries tokens,
+                    // authorization headers, successful-response bodies, or
+                    // row data (conversion and row-path failures report JSON
+                    // *kinds* only).
                     tracing::warn!(
                         gateway = %state.gateway,
                         binding = state.binding.as_deref().unwrap_or("<udtf>"),

--- a/crates/skardi/src/sources/providers/open_connector/json_to_arrow.rs
+++ b/crates/skardi/src/sources/providers/open_connector/json_to_arrow.rs
@@ -38,7 +38,9 @@ pub enum FieldType {
     /// JSON array of strings ↔ Arrow List\<Utf8\>.
     Utf8List,
     /// Any JSON value serialized to a JSON string ↔ Arrow Utf8. For
-    /// intentionally opaque fields (arbitrary maps, unstable unions).
+    /// intentionally opaque fields (arbitrary maps, unstable unions). A
+    /// present JSON null is SQL NULL (per the shared null rules), not the
+    /// string `"null"`.
     Json,
 }
 
@@ -243,13 +245,17 @@ impl RowConverter {
                 |v| v.as_str().map(str::to_string),
                 fail,
             )?))),
-            FieldType::Json => {
-                let values: Vec<Option<String>> = cells
-                    .iter()
-                    .map(|cell| cell.map(|v| v.to_string()))
-                    .collect();
-                Ok(Arc::new(StringArray::from(values)))
-            }
+            // Opaque values serialize to canonical JSON text, but a present
+            // JSON null is SQL NULL like everywhere else — never the 4-char
+            // string "null", which would break `IS NULL` and match
+            // `= 'null'`. Routing through collect_cells also makes a null in
+            // a non-nullable Json column a targeted per-column failure.
+            FieldType::Json => Ok(Arc::new(StringArray::from(collect_cells(
+                &cells,
+                spec,
+                |v| Some(v.to_string()),
+                fail,
+            )?))),
             FieldType::TimestampMillisUtc => Ok(Arc::new(
                 TimestampMillisecondArray::from(collect_cells(
                     &cells,
@@ -583,6 +589,48 @@ mod tests {
             .downcast_ref::<StringArray>()
             .unwrap();
         assert!(raw.value(0).contains("nested"));
+    }
+
+    #[test]
+    fn json_null_becomes_arrow_null_not_the_string_null() {
+        // A present JSON null in a nullable Json column is SQL NULL — never
+        // the 4-char string "null", which would make `IS NULL` miss and
+        // `= 'null'` match. Raw scans type every object/array field as Json,
+        // so nullable nested SaaS fields (assignee: null) hit this arm.
+        let mut with_null = row(1, "a");
+        with_null["raw"] = Value::Null;
+        let mut absent = row(2, "b");
+        absent.as_object_mut().unwrap().remove("raw");
+
+        let batch = converter().convert(&[with_null, absent], 1).unwrap();
+        let raw = batch
+            .column(6)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert!(raw.is_null(0), "present JSON null must be Arrow null");
+        assert!(raw.is_null(1), "absent key stays Arrow null");
+    }
+
+    #[test]
+    fn json_null_fails_for_non_nullable_json_column() {
+        // Same null discipline as every other type: a required opaque field
+        // fails with a targeted per-column error, not a batch-level one.
+        let converter = RowConverter::new(&[FieldMapping {
+            name: "raw",
+            path: "raw",
+            field_type: FieldType::Json,
+            nullable: false,
+        }])
+        .unwrap();
+        let err = converter
+            .convert(&[serde_json::json!({"raw": null})], 3)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            OpenConnectorError::ConversionFailed { ref column, page: 3, row: 0, ref found, .. }
+                if column == "raw" && found == "null"
+        ));
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/open_connector/json_to_arrow.rs
+++ b/crates/skardi/src/sources/providers/open_connector/json_to_arrow.rs
@@ -87,10 +87,37 @@ pub struct FieldMapping {
     pub nullable: bool,
 }
 
-/// A field mapping with its path pre-parsed.
+/// An owned [`FieldMapping`]. Source packs declare columns statically; raw
+/// scans (`open_connector_scan`) derive them at planning time from discovered
+/// action metadata, so their names cannot be `&'static str`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ColumnSpec {
+    /// Arrow column name.
+    pub name: String,
+    /// Row-relative dotted path (see [`FieldMapping::path`]).
+    pub path: String,
+    /// Column type.
+    pub field_type: FieldType,
+    /// Whether missing keys / JSON nulls become Arrow nulls (true) or fail
+    /// conversion (false).
+    pub nullable: bool,
+}
+
+impl From<&FieldMapping> for ColumnSpec {
+    fn from(mapping: &FieldMapping) -> Self {
+        Self {
+            name: mapping.name.to_string(),
+            path: mapping.path.to_string(),
+            field_type: mapping.field_type,
+            nullable: mapping.nullable,
+        }
+    }
+}
+
+/// A column spec with its path pre-parsed.
 #[derive(Debug)]
 struct CompiledField {
-    mapping: FieldMapping,
+    spec: ColumnSpec,
     path: RowPath,
 }
 
@@ -109,19 +136,21 @@ impl RowConverter {
     /// Returns [`OpenConnectorError::InvalidRowPath`] if any mapping path is
     /// not a dotted object-key path.
     pub fn new(mappings: &[FieldMapping]) -> Result<Self, OpenConnectorError> {
-        let mut fields = Vec::with_capacity(mappings.len());
-        let mut arrow_fields = Vec::with_capacity(mappings.len());
-        for mapping in mappings {
-            let path = RowPath::parse(&format!("$.{}", mapping.path))?;
+        Self::from_columns(mappings.iter().map(ColumnSpec::from).collect())
+    }
+
+    /// Compile a converter from owned column specs (the raw-scan path).
+    pub fn from_columns(columns: Vec<ColumnSpec>) -> Result<Self, OpenConnectorError> {
+        let mut fields = Vec::with_capacity(columns.len());
+        let mut arrow_fields = Vec::with_capacity(columns.len());
+        for spec in columns {
+            let path = RowPath::parse(&format!("$.{}", spec.path))?;
             arrow_fields.push(Field::new(
-                mapping.name,
-                mapping.field_type.arrow_type(),
-                mapping.nullable,
+                &spec.name,
+                spec.field_type.arrow_type(),
+                spec.nullable,
             ));
-            fields.push(CompiledField {
-                mapping: *mapping,
-                path,
-            });
+            fields.push(CompiledField { spec, path });
         }
         Ok(Self {
             fields,
@@ -160,7 +189,7 @@ impl RowConverter {
         rows: &[Value],
         page: usize,
     ) -> Result<ArrayRef, OpenConnectorError> {
-        let mapping = &field.mapping;
+        let spec = &field.spec;
         let mut cells: Vec<Option<&Value>> = Vec::with_capacity(rows.len());
         for (row_index, row) in rows.iter().enumerate() {
             match field.path.extract(row, page) {
@@ -169,7 +198,7 @@ impl RowConverter {
                 // column. A present-but-wrong-shape value mid-path (e.g.
                 // `user` changed from object to string) is an upstream
                 // *breaking* change and must fail, per this module's contract.
-                Err(OpenConnectorError::RowPathNotFound { .. }) if mapping.nullable => {
+                Err(OpenConnectorError::RowPathNotFound { .. }) if spec.nullable => {
                     cells.push(None)
                 }
                 Err(OpenConnectorError::RowPathNotFound { .. }) => {
@@ -183,34 +212,34 @@ impl RowConverter {
         }
 
         let fail = |index: usize, found: &str| self.failure(field, page, index, found);
-        match mapping.field_type {
+        match spec.field_type {
             FieldType::Boolean => Ok(Arc::new(BooleanArray::from(collect_cells(
                 &cells,
-                mapping,
+                spec,
                 |v| v.as_bool(),
                 fail,
             )?))),
             FieldType::Int64 => Ok(Arc::new(Int64Array::from(collect_cells(
                 &cells,
-                mapping,
+                spec,
                 |v| v.as_i64(),
                 fail,
             )?))),
             FieldType::UInt64 => Ok(Arc::new(UInt64Array::from(collect_cells(
                 &cells,
-                mapping,
+                spec,
                 |v| v.as_u64(),
                 fail,
             )?))),
             FieldType::Float64 => Ok(Arc::new(Float64Array::from(collect_cells(
                 &cells,
-                mapping,
+                spec,
                 |v| v.as_f64(),
                 fail,
             )?))),
             FieldType::Utf8 => Ok(Arc::new(StringArray::from(collect_cells(
                 &cells,
-                mapping,
+                spec,
                 |v| v.as_str().map(str::to_string),
                 fail,
             )?))),
@@ -224,7 +253,7 @@ impl RowConverter {
             FieldType::TimestampMillisUtc => Ok(Arc::new(
                 TimestampMillisecondArray::from(collect_cells(
                     &cells,
-                    mapping,
+                    spec,
                     parse_timestamp,
                     fail,
                 )?)
@@ -247,7 +276,7 @@ impl RowConverter {
                 continue;
             };
             if value.is_null() {
-                if field.mapping.nullable {
+                if field.spec.nullable {
                     builder.append(false);
                     continue;
                 }
@@ -276,10 +305,10 @@ impl RowConverter {
     ) -> OpenConnectorError {
         OpenConnectorError::ConversionFailed {
             path: field.path.as_str().to_string(),
-            column: field.mapping.name.to_string(),
+            column: field.spec.name.clone(),
             page,
             row,
-            expected: field.mapping.field_type.label().to_string(),
+            expected: field.spec.field_type.label().to_string(),
             found: found.to_string(),
         }
     }
@@ -289,7 +318,7 @@ impl RowConverter {
 /// nullable fields and failing otherwise.
 fn collect_cells<T, F, E>(
     cells: &[Option<&Value>],
-    mapping: &FieldMapping,
+    spec: &ColumnSpec,
     convert: F,
     fail: E,
 ) -> Result<Vec<Option<T>>, OpenConnectorError>
@@ -302,7 +331,7 @@ where
         match cell {
             None => out.push(None),
             Some(value) if value.is_null() => {
-                if mapping.nullable {
+                if spec.nullable {
                     out.push(None);
                 } else {
                     return Err(fail(index, "null"));
@@ -562,6 +591,23 @@ mod tests {
         let batch = converter.convert(&[], 1).unwrap();
         assert_eq!(batch.num_rows(), 0);
         assert_eq!(batch.schema().fields().len(), 7);
+    }
+
+    #[test]
+    fn owned_columns_build_the_same_converter_as_static_mappings() {
+        // The raw-scan path derives ColumnSpecs at planning time; they must
+        // produce exactly the schema and conversion the static path does.
+        let owned = RowConverter::from_columns(FIELDS.iter().map(ColumnSpec::from).collect())
+            .expect("owned converter");
+        assert_eq!(owned.schema(), converter().schema());
+
+        let batch = owned.convert(&[row(7, "seven")], 1).unwrap();
+        let ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .unwrap();
+        assert_eq!(ids.value(0), 7);
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/open_connector/mod.rs
+++ b/crates/skardi/src/sources/providers/open_connector/mod.rs
@@ -6,11 +6,11 @@
 //! (stable table definitions, JSON-to-Arrow conversion, pagination, filter
 //! and limit pushdown, DataFusion registration) on top.
 //!
-//! **Status: typed config, HTTP client, action registry, source packs, and
-//! the scan engine have landed.** A configured gateway registers as a real
-//! catalog (`<gateway>.<binding>.<table>`) and is queryable today — with the
-//! synthetic `mock` source pack. Real provider packs (GitHub, Slack, Notion)
-//! and the raw-action UDTF land next.
+//! **Status: typed config, HTTP client, action registry, source packs, the
+//! scan engine, and the two UDTFs have landed.** A configured gateway
+//! registers as a real catalog (`<gateway>.<binding>.<table>`) and is
+//! queryable today — with the synthetic `mock` source pack. Real provider
+//! packs (GitHub, Slack, Notion) land next.
 //!
 //! - [`OpenConnectorConfig`] / [`OpenConnectorBinding`] — the typed
 //!   `open_connector:` block of a `type: open_connector` data source, shared
@@ -22,7 +22,10 @@
 //!   fingerprints, so query planning never performs network I/O;
 //! - [`SourcePackRegistry`] — built-in stable table definitions;
 //! - [`register_open_connector_tables`] — the registration entry point both
-//!   front-ends wire to.
+//!   front-ends wire to;
+//! - [`register_open_connector_udtfs`] — the `open_connector_query` /
+//!   `open_connector_scan` table functions, planning against the
+//!   [`OpenConnectorGateways`] state captured at registration.
 //!
 //! See `docs/superpowers/specs/2026-07-11-open-connector-integration-design.md`.
 
@@ -36,9 +39,11 @@ pub mod filters;
 pub mod json_to_arrow;
 pub mod packs;
 pub mod pagination;
+mod raw_schema;
 pub mod row_path;
 pub mod source_pack;
 pub mod table;
+pub mod table_functions;
 
 #[cfg(test)]
 pub(crate) mod testutil;
@@ -49,6 +54,7 @@ pub use config::{OpenConnectorBinding, OpenConnectorConfig};
 pub use error::OpenConnectorError;
 pub use source_pack::{SourcePack, SourcePackRegistry, SourcePackTable};
 pub use table::OpenConnectorTableProvider;
+pub use table_functions::{GatewayHandle, OpenConnectorGateways, register_open_connector_udtfs};
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -81,7 +87,11 @@ use anyhow::Result;
 ///    into an [`ActionRegistry`], enforcing version pins, required
 ///    resources, and action-contract fingerprints;
 /// 5. builds one [`OpenConnectorTableProvider`] per bound table and
-///    registers the catalog.
+///    registers the catalog;
+/// 6. when `udtf_gateways` is provided, publishes the gateway's
+///    planning-time state ([`GatewayHandle`]) so the `open_connector_query`
+///    / `open_connector_scan` UDTFs (see [`register_open_connector_udtfs`])
+///    can plan against it without network I/O.
 ///
 /// # Example
 /// ```no_run
@@ -111,6 +121,7 @@ use anyhow::Result;
 ///     Some(&config),
 ///     false,
 ///     HierarchyLevel::Catalog,
+///     None,
 /// )
 /// .await?;
 ///
@@ -118,6 +129,7 @@ use anyhow::Result;
 /// # Ok(())
 /// # }
 /// ```
+#[allow(clippy::too_many_arguments)]
 pub async fn register_open_connector_tables(
     session_ctx: &mut SessionContext,
     name: &str,
@@ -125,6 +137,7 @@ pub async fn register_open_connector_tables(
     config: Option<&OpenConnectorConfig>,
     read_write: bool,
     hierarchy_level: HierarchyLevel,
+    udtf_gateways: Option<&OpenConnectorGateways>,
 ) -> Result<()> {
     // All invariant checks live here so both front-ends (server and CLI)
     // get identical behavior; front-ends may add earlier typed errors, but
@@ -176,7 +189,7 @@ pub async fn register_open_connector_tables(
             }
         }
     }
-    let registry = ActionRegistry::load(&client, &action_ids).await?;
+    let registry = Arc::new(ActionRegistry::load(&client, &action_ids).await?);
 
     let catalog = Arc::new(MemoryCatalogProvider::new());
     let cache = Arc::new(cache::ScanCache::new(
@@ -215,6 +228,7 @@ pub async fn register_open_connector_tables(
                 Arc::clone(&client),
                 Some(Arc::clone(&cache)),
                 name.to_string(),
+                Some(binding.name.clone()),
                 binding.connection_alias.clone(),
                 table,
                 pack.version,
@@ -247,6 +261,21 @@ pub async fn register_open_connector_tables(
     }
 
     session_ctx.register_catalog(name, catalog);
+
+    // Publish the gateway's planning-time state for the UDTFs only after
+    // every gate above has passed — a failed registration must not leave a
+    // queryable handle behind.
+    if let Some(gateways) = udtf_gateways {
+        gateways.write().unwrap_or_else(|p| p.into_inner()).insert(
+            name.to_string(),
+            Arc::new(GatewayHandle::new(
+                Arc::clone(&client),
+                Arc::clone(&cache),
+                Arc::clone(&registry),
+                config,
+            )),
+        );
+    }
 
     tracing::info!(
         gateway = %name,
@@ -295,6 +324,7 @@ bindings:
             Some(&valid_config("UNUSED_ENV")),
             false,
             HierarchyLevel::Table,
+            None,
         )
         .await
         .unwrap_err();
@@ -315,6 +345,7 @@ bindings:
             Some(&valid_config("UNUSED_ENV")),
             false,
             HierarchyLevel::Catalog,
+            None,
         )
         .await
         .unwrap_err();
@@ -337,6 +368,7 @@ bindings:
             Some(&valid_config("UNUSED_ENV")),
             true,
             HierarchyLevel::Catalog,
+            None,
         )
         .await
         .unwrap_err();
@@ -357,6 +389,7 @@ bindings:
             None,
             false,
             HierarchyLevel::Catalog,
+            None,
         )
         .await
         .unwrap_err();
@@ -381,6 +414,7 @@ bindings:
             Some(&invalid),
             false,
             HierarchyLevel::Catalog,
+            None,
         )
         .await
         .unwrap_err();
@@ -398,6 +432,7 @@ bindings:
             Some(&valid_config("SKARDI_TEST_OC_TOKEN_DEFINITELY_UNSET")),
             false,
             HierarchyLevel::Catalog,
+            None,
         )
         .await
         .unwrap_err();
@@ -427,6 +462,7 @@ bindings:
             Some(&valid_config(TOKEN_ENV_HEALTH_FAIL)),
             false,
             HierarchyLevel::Catalog,
+            None,
         )
         .await;
         unsafe {
@@ -465,6 +501,7 @@ bindings:
             Some(&mock_config(TOKEN_ENV_CATALOG_BASIC, 0)),
             false,
             HierarchyLevel::Catalog,
+            None,
         )
         .await
         .expect("catalog registration succeeds");
@@ -503,6 +540,7 @@ bindings:
             Some(&mock_config(TOKEN_ENV_CATALOG_FILTER, 0)),
             false,
             HierarchyLevel::Catalog,
+            None,
         )
         .await
         .expect("catalog registration succeeds");
@@ -540,6 +578,7 @@ bindings:
             Some(&mock_config(TOKEN_ENV_CATALOG_FILTER, 0)),
             false,
             HierarchyLevel::Catalog,
+            None,
         )
         .await
         .expect("catalog registration succeeds");
@@ -595,6 +634,7 @@ bindings:
             Some(&config),
             false,
             HierarchyLevel::Catalog,
+            None,
         )
         .await
         .expect("catalog registration succeeds");
@@ -630,6 +670,7 @@ bindings:
             Some(&mock_config(TOKEN_ENV_CATALOG_FILTER, 0)),
             false,
             HierarchyLevel::Catalog,
+            None,
         )
         .await
         .expect("catalog registration succeeds");
@@ -669,6 +710,7 @@ bindings:
             Some(&mock_config(TOKEN_ENV_CATALOG_CACHE, 60)),
             false,
             HierarchyLevel::Catalog,
+            None,
         )
         .await
         .expect("catalog registration succeeds");
@@ -712,6 +754,7 @@ bindings:
             Some(&mock_config(TOKEN_ENV_CATALOG_CACHE, 60)),
             false,
             HierarchyLevel::Catalog,
+            None,
         )
         .await
         .expect("catalog registration succeeds");
@@ -753,6 +796,7 @@ bindings:
             Some(&mock_config(TOKEN_ENV_CATALOG_EMPTY_CACHE, 60)),
             false,
             HierarchyLevel::Catalog,
+            None,
         )
         .await
         .expect("catalog registration succeeds");
@@ -793,6 +837,7 @@ bindings:
             Some(&mock_config(TOKEN_ENV_CATALOG_SELFJOIN, 60)),
             false,
             HierarchyLevel::Catalog,
+            None,
         )
         .await
         .expect("catalog registration succeeds");

--- a/crates/skardi/src/sources/providers/open_connector/pagination.rs
+++ b/crates/skardi/src/sources/providers/open_connector/pagination.rs
@@ -39,6 +39,11 @@ pub enum PaginationStrategy {
         /// Page size to request (ignored when `page_size_param` is None).
         page_size: u32,
     },
+    /// One request, one page: no pagination inputs are injected and the scan
+    /// completes after the first response. Used by `open_connector_scan`,
+    /// whose raw actions declare no pagination contract — callers pass any
+    /// paging inputs explicitly in the action input JSON.
+    SinglePage,
 }
 
 /// Mutable pagination state for one scan.
@@ -79,13 +84,13 @@ impl Pagination {
     pub fn new(strategy: PaginationStrategy) -> Result<Self, OpenConnectorError> {
         let next_token = match &strategy {
             PaginationStrategy::PageNumber { .. } => Some("1".to_string()),
-            PaginationStrategy::Cursor { .. } => None,
+            PaginationStrategy::Cursor { .. } | PaginationStrategy::SinglePage => None,
         };
         let cursor_path = match &strategy {
             PaginationStrategy::Cursor {
                 next_cursor_path, ..
             } => Some(RowPath::parse(next_cursor_path)?),
-            PaginationStrategy::PageNumber { .. } => None,
+            PaginationStrategy::PageNumber { .. } | PaginationStrategy::SinglePage => None,
         };
         Ok(Self {
             strategy,
@@ -130,6 +135,7 @@ impl Pagination {
                     input.insert((*param).to_string(), Value::from(*page_size));
                 }
             }
+            PaginationStrategy::SinglePage => {}
         }
     }
 
@@ -177,6 +183,7 @@ impl Pagination {
                 self.next_token = Some(next);
                 Ok(true)
             }
+            PaginationStrategy::SinglePage => Ok(false),
         }
     }
 }
@@ -299,6 +306,27 @@ mod tests {
             err,
             OpenConnectorError::PaginationLoop { ref token } if token == "same"
         ));
+    }
+
+    #[test]
+    fn single_page_injects_nothing_and_never_advances() {
+        let mut pagination = Pagination::new(PaginationStrategy::SinglePage).unwrap();
+        assert_eq!(pagination.page(), 1);
+
+        let mut input = Map::new();
+        pagination.apply(&mut input);
+        assert!(input.is_empty(), "no pagination inputs for a raw scan");
+
+        // Even a "full-looking" page ends the scan: raw actions declare no
+        // pagination contract, so there is nothing to advance.
+        assert!(
+            !pagination
+                .advance(&json!({"next_cursor": "c2"}), 100)
+                .unwrap()
+        );
+        PaginationStrategy::SinglePage
+            .validate()
+            .expect("nothing to validate");
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/open_connector/raw_schema.rs
+++ b/crates/skardi/src/sources/providers/open_connector/raw_schema.rs
@@ -1,0 +1,321 @@
+//! Deterministic row types for raw-action scans.
+//!
+//! `open_connector_scan` has no source pack to declare its Arrow schema, so
+//! the schema is derived at planning time from the *discovered* action
+//! output JSON Schema (in-memory — planning never contacts the gateway).
+//! The derivation is deliberately conservative:
+//!
+//! - the row-path target must be an array of objects with declared
+//!   properties — otherwise planning fails with a message recommending a
+//!   built-in source-pack table or a new source-pack contribution;
+//! - stable primitives (`string`, `integer`, `number`, `boolean`) become
+//!   typed nullable columns, including the `["T", "null"]` union spelling;
+//! - everything else (objects, arrays, unions, undeclared types) becomes an
+//!   opaque JSON-string column rather than a guess.
+
+use serde_json::Value;
+
+use super::error::OpenConnectorError;
+use super::json_to_arrow::{ColumnSpec, FieldType};
+use super::row_path::RowPath;
+
+/// Derive the raw-scan columns for `action_id` from its discovered output
+/// schema, at the row array located by `row_path`.
+///
+/// Columns are sorted by name so the derived Arrow schema does not depend on
+/// the gateway's property serialization order.
+pub(crate) fn derive_raw_columns(
+    action_id: &str,
+    output_schema: Option<&Value>,
+    row_path: &RowPath,
+) -> Result<Vec<ColumnSpec>, OpenConnectorError> {
+    let fail = |reason: String| OpenConnectorError::RawRowTypeIndeterminate {
+        action_id: action_id.to_string(),
+        row_path: row_path.as_str().to_string(),
+        reason,
+    };
+
+    let mut node =
+        output_schema.ok_or_else(|| fail("the action declares no output schema".to_string()))?;
+
+    // Walk the row path through nested `properties` declarations.
+    for segment in row_path.segments() {
+        let properties = node
+            .get("properties")
+            .and_then(Value::as_object)
+            .ok_or_else(|| {
+                fail(format!(
+                    "the schema containing segment '{segment}' declares no object properties"
+                ))
+            })?;
+        node = properties.get(segment).ok_or_else(|| {
+            fail(format!(
+                "segment '{segment}' is not declared in the output schema"
+            ))
+        })?;
+    }
+
+    if schema_type(node) != Some("array") {
+        return Err(fail(format!(
+            "the row-path target is declared as {}, not an array of row objects",
+            schema_type(node).unwrap_or("an undeclared type")
+        )));
+    }
+    let items = node
+        .get("items")
+        .filter(|items| items.is_object())
+        .ok_or_else(|| fail("the row array declares no single item schema".to_string()))?;
+    if schema_type(items) != Some("object") {
+        return Err(fail(format!(
+            "the row items are declared as {}, not objects",
+            schema_type(items).unwrap_or("an undeclared type")
+        )));
+    }
+    let properties = items
+        .get("properties")
+        .and_then(Value::as_object)
+        .filter(|properties| !properties.is_empty())
+        .ok_or_else(|| fail("the row object schema declares no properties".to_string()))?;
+
+    let mut columns = Vec::with_capacity(properties.len());
+    for (name, property) in properties {
+        // A column's path round-trips through the converter's dotted-path
+        // parser, so a dotted property name would silently address a nested
+        // key instead of itself.
+        if name.is_empty() || name.contains('.') {
+            return Err(fail(format!(
+                "property '{name}' cannot be exposed as a column (empty or dotted name)"
+            )));
+        }
+        let (field_type, nullable) = column_type(property);
+        columns.push(ColumnSpec {
+            name: name.clone(),
+            path: name.clone(),
+            field_type,
+            nullable,
+        });
+    }
+    columns.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(columns)
+}
+
+/// The declared `type` of a schema node, collapsing the `["T", "null"]`
+/// union spelling to `T`. `None` for undeclared or wider unions.
+fn schema_type(node: &Value) -> Option<&str> {
+    match node.get("type") {
+        Some(Value::String(t)) => Some(t.as_str()),
+        Some(Value::Array(types)) => {
+            let mut non_null = types
+                .iter()
+                .filter_map(Value::as_str)
+                .filter(|t| *t != "null");
+            match (non_null.next(), non_null.next()) {
+                (Some(t), None) => Some(t),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Map one property schema to a column type. All raw-scan columns are
+/// nullable: a discovered `required` list is provider-authored metadata, and
+/// trusting it would turn a provider omission into a failed scan.
+fn column_type(property: &Value) -> (FieldType, bool) {
+    let field_type = match schema_type(property) {
+        Some("string") => FieldType::Utf8,
+        Some("integer") => FieldType::Int64,
+        Some("number") => FieldType::Float64,
+        Some("boolean") => FieldType::Boolean,
+        // Objects, arrays, wide unions, undeclared types: opaque JSON.
+        _ => FieldType::Json,
+    };
+    (field_type, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn path(raw: &str) -> RowPath {
+        RowPath::parse(raw).expect("valid path")
+    }
+
+    fn issues_schema() -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "issues": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "number": {"type": "integer"},
+                            "title": {"type": "string"},
+                            "score": {"type": "number"},
+                            "open": {"type": "boolean"},
+                            "body": {"type": ["string", "null"]},
+                            "user": {"type": "object", "properties": {"login": {"type": "string"}}},
+                            "labels": {"type": "array", "items": {"type": "string"}},
+                            "meta": {}
+                        }
+                    }
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn derives_sorted_typed_columns_with_json_fallback() {
+        let columns =
+            derive_raw_columns("github.x", Some(&issues_schema()), &path("$.issues")).unwrap();
+        let summary: Vec<(&str, FieldType)> = columns
+            .iter()
+            .map(|c| (c.name.as_str(), c.field_type))
+            .collect();
+        assert_eq!(
+            summary,
+            vec![
+                ("body", FieldType::Utf8),   // ["string","null"] union
+                ("labels", FieldType::Json), // array → opaque JSON
+                ("meta", FieldType::Json),   // undeclared type → opaque JSON
+                ("number", FieldType::Int64),
+                ("open", FieldType::Boolean),
+                ("score", FieldType::Float64),
+                ("title", FieldType::Utf8),
+                ("user", FieldType::Json), // object → opaque JSON
+            ],
+            "columns are sorted by name and typed conservatively"
+        );
+        assert!(
+            columns.iter().all(|c| c.nullable),
+            "raw columns are nullable"
+        );
+        assert!(
+            columns.iter().all(|c| c.name == c.path),
+            "raw columns read top-level row keys"
+        );
+    }
+
+    #[test]
+    fn nested_row_paths_descend_through_properties() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "object",
+                    "properties": {
+                        "items": {
+                            "type": "array",
+                            "items": {"type": "object", "properties": {"id": {"type": "integer"}}}
+                        }
+                    }
+                }
+            }
+        });
+        let columns = derive_raw_columns("a.b", Some(&schema), &path("$.data.items")).unwrap();
+        assert_eq!(columns.len(), 1);
+        assert_eq!(columns[0].name, "id");
+        assert_eq!(columns[0].field_type, FieldType::Int64);
+    }
+
+    #[test]
+    fn missing_output_schema_is_indeterminate() {
+        let err = derive_raw_columns("a.b", None, &path("$.items")).unwrap_err();
+        assert!(matches!(
+            err,
+            OpenConnectorError::RawRowTypeIndeterminate { ref reason, .. }
+                if reason.contains("no output schema")
+        ));
+    }
+
+    #[test]
+    fn unknown_segment_is_indeterminate() {
+        let err = derive_raw_columns("a.b", Some(&issues_schema()), &path("$.rows")).unwrap_err();
+        assert!(matches!(
+            err,
+            OpenConnectorError::RawRowTypeIndeterminate { ref reason, .. }
+                if reason.contains("segment 'rows'")
+        ));
+    }
+
+    #[test]
+    fn non_array_target_is_indeterminate() {
+        let schema = json!({
+            "type": "object",
+            "properties": {"total": {"type": "integer"}}
+        });
+        let err = derive_raw_columns("a.b", Some(&schema), &path("$.total")).unwrap_err();
+        assert!(matches!(
+            err,
+            OpenConnectorError::RawRowTypeIndeterminate { ref reason, .. }
+                if reason.contains("not an array")
+        ));
+    }
+
+    #[test]
+    fn array_of_non_objects_is_indeterminate() {
+        let schema = json!({
+            "type": "object",
+            "properties": {"ids": {"type": "array", "items": {"type": "integer"}}}
+        });
+        let err = derive_raw_columns("a.b", Some(&schema), &path("$.ids")).unwrap_err();
+        assert!(matches!(
+            err,
+            OpenConnectorError::RawRowTypeIndeterminate { ref reason, .. }
+                if reason.contains("not objects")
+        ));
+    }
+
+    #[test]
+    fn propertyless_row_objects_are_indeterminate() {
+        // An object with no declared properties has no deterministic
+        // relational shape — the error must point at the source-pack road.
+        let schema = json!({
+            "type": "object",
+            "properties": {"items": {"type": "array", "items": {"type": "object"}}}
+        });
+        let err = derive_raw_columns("a.b", Some(&schema), &path("$.items")).unwrap_err();
+        assert!(err.to_string().contains("source-pack"), "got: {err}");
+    }
+
+    #[test]
+    fn dotted_property_names_are_rejected() {
+        // "a.b" as a column name would be parsed as a nested path by the
+        // converter and silently read the wrong key.
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {"type": "object", "properties": {"a.b": {"type": "string"}}}
+                }
+            }
+        });
+        let err = derive_raw_columns("a.b", Some(&schema), &path("$.items")).unwrap_err();
+        assert!(matches!(
+            err,
+            OpenConnectorError::RawRowTypeIndeterminate { ref reason, .. }
+                if reason.contains("'a.b'")
+        ));
+    }
+
+    #[test]
+    fn wide_unions_fall_back_to_json() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {"value": {"type": ["string", "integer"]}}
+                    }
+                }
+            }
+        });
+        let columns = derive_raw_columns("a.b", Some(&schema), &path("$.items")).unwrap();
+        assert_eq!(columns[0].field_type, FieldType::Json);
+    }
+}

--- a/crates/skardi/src/sources/providers/open_connector/row_path.rs
+++ b/crates/skardi/src/sources/providers/open_connector/row_path.rs
@@ -57,6 +57,11 @@ impl RowPath {
         &self.raw
     }
 
+    /// The object-key segments, in traversal order.
+    pub fn segments(&self) -> impl Iterator<Item = &str> {
+        self.segments.iter().map(String::as_str)
+    }
+
     /// Walk the path inside `value`. A key absent from an object fails with
     /// [`OpenConnectorError::RowPathNotFound`]; a present non-object where
     /// the path must descend fails with

--- a/crates/skardi/src/sources/providers/open_connector/table.rs
+++ b/crates/skardi/src/sources/providers/open_connector/table.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 
 use super::cache::ScanCache;
 use super::client::OpenConnectorClient;
-use super::exec::OpenConnectorExec;
+use super::exec::{OpenConnectorExec, ScanTarget};
 use super::filters::translate_filters;
 use super::json_to_arrow::RowConverter;
 use super::row_path::RowPath;
@@ -29,6 +29,9 @@ pub struct OpenConnectorTableProvider {
     client: Arc<OpenConnectorClient>,
     cache: Option<Arc<ScanCache>>,
     gateway: String,
+    /// Binding (catalog schema) name for tracing; `None` for UDTF-planned
+    /// tables, which have no persistent binding.
+    binding: Option<String>,
     connection_alias: Option<String>,
     table: &'static SourcePackTable,
     source_pack_version: u32,
@@ -62,6 +65,7 @@ impl OpenConnectorTableProvider {
         client: Arc<OpenConnectorClient>,
         cache: Option<Arc<ScanCache>>,
         gateway: String,
+        binding: Option<String>,
         connection_alias: Option<String>,
         table: &'static SourcePackTable,
         source_pack_version: u32,
@@ -79,6 +83,7 @@ impl OpenConnectorTableProvider {
             client,
             cache,
             gateway,
+            binding,
             connection_alias,
             table,
             source_pack_version,
@@ -129,9 +134,9 @@ impl TableProvider for OpenConnectorTableProvider {
             Arc::clone(&self.client),
             self.cache.clone(),
             self.gateway.clone(),
+            self.binding.clone(),
             self.connection_alias.clone(),
-            self.table,
-            self.source_pack_version,
+            ScanTarget::from_pack_table(self.table, self.source_pack_version),
             Arc::clone(&self.converter),
             self.row_path.clone(),
             self.resource.clone(),
@@ -203,6 +208,7 @@ mod tests {
             None,
             "saas".to_string(),
             None,
+            None,
             table,
             1,
             serde_json::json!({}),
@@ -229,6 +235,7 @@ mod tests {
             offline_client(),
             None,
             "saas".to_string(),
+            None,
             None,
             table,
             1,

--- a/crates/skardi/src/sources/providers/open_connector/table_functions.rs
+++ b/crates/skardi/src/sources/providers/open_connector/table_functions.rs
@@ -1,0 +1,973 @@
+//! The two Open Connector UDTFs — the ad-hoc SQL surface of the gateway.
+//!
+//! - `open_connector_query(gateway, table_id, resource_json[, alias])` runs
+//!   a **built-in source-pack table** without a persistent YAML binding. It
+//!   compiles into exactly the scan a YAML-bound table uses: same stable
+//!   schema, filter allowlist, pagination, safety bounds, and shared cache.
+//! - `open_connector_scan(gateway, action_id, input_json, row_path[, alias])`
+//!   invokes an **explicitly allowlisted raw read action** once (no
+//!   pagination contract), deriving a deterministic row type from the
+//!   discovered action output schema or failing at planning time.
+//!
+//! Both resolve against planning-time state captured when the gateway was
+//! registered ([`GatewayHandle`]) — query planning never performs network
+//! I/O, so an action that was not discovered at registration is a targeted
+//! planning error, not a hidden gateway call.
+//!
+//! Security is default-deny and enforced here, before any HTTP request:
+//! `open_connector_query` accepts only built-in pack definitions (their
+//! read actions are hard-coded in Skardi), and `open_connector_scan`
+//! requires the action to be allowlisted **and** classified as a
+//! non-mutating read by its discovered gateway metadata — absent or
+//! ambiguous classification is refused, naming the gap.
+
+use std::any::Any;
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+use arrow::datatypes::SchemaRef;
+use async_trait::async_trait;
+use datafusion::catalog::{Session, TableFunctionImpl, TableProvider};
+use datafusion::common::{ScalarValue, plan_err};
+use datafusion::datasource::TableType;
+use datafusion::error::{DataFusionError, Result as DFResult};
+use datafusion::logical_expr::Expr;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::prelude::SessionContext;
+use serde_json::Value;
+
+use super::action_registry::{ActionMetadata, ActionRegistry};
+use super::cache::ScanCache;
+use super::client::OpenConnectorClient;
+use super::config::OpenConnectorConfig;
+use super::error::OpenConnectorError;
+use super::exec::{OpenConnectorExec, ScanTarget};
+use super::json_to_arrow::RowConverter;
+use super::pagination::PaginationStrategy;
+use super::raw_schema::derive_raw_columns;
+use super::row_path::RowPath;
+use super::source_pack::SourcePackRegistry;
+use super::table::OpenConnectorTableProvider;
+
+/// Planning-time state of one registered gateway, captured by
+/// `register_open_connector_tables` and shared with both UDTFs.
+pub struct GatewayHandle {
+    client: Arc<OpenConnectorClient>,
+    cache: Arc<ScanCache>,
+    actions: Arc<ActionRegistry>,
+    raw_action_allowlist: HashSet<String>,
+    max_pages: u32,
+    max_rows: u64,
+    scan_timeout: Duration,
+}
+
+impl std::fmt::Debug for GatewayHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GatewayHandle")
+            .field("actions", &self.actions.len())
+            .field("raw_action_allowlist", &self.raw_action_allowlist)
+            .finish()
+    }
+}
+
+impl GatewayHandle {
+    /// Capture one registered gateway's planning-time state.
+    pub(crate) fn new(
+        client: Arc<OpenConnectorClient>,
+        cache: Arc<ScanCache>,
+        actions: Arc<ActionRegistry>,
+        config: &OpenConnectorConfig,
+    ) -> Self {
+        Self {
+            client,
+            cache,
+            actions,
+            raw_action_allowlist: config.raw_action_allowlist.iter().cloned().collect(),
+            max_pages: config.max_pages,
+            max_rows: config.max_rows,
+            scan_timeout: Duration::from_secs(config.scan_timeout_seconds),
+        }
+    }
+}
+
+/// Shared map of gateway (data source) name → [`GatewayHandle`]. Owned by
+/// the front-end (server `OptimizerRegistry` / CLI main) the way the KNN/FTS
+/// `DatasetRegistry` is, filled by `register_open_connector_tables`, and
+/// read by both UDTFs at planning time.
+pub type OpenConnectorGateways = Arc<RwLock<HashMap<String, Arc<GatewayHandle>>>>;
+
+/// Register `open_connector_query` and `open_connector_scan` on a session.
+pub fn register_open_connector_udtfs(ctx: &SessionContext, gateways: OpenConnectorGateways) {
+    ctx.register_udtf(
+        "open_connector_query",
+        Arc::new(OpenConnectorQueryFunction::new(Arc::clone(&gateways))),
+    );
+    ctx.register_udtf(
+        "open_connector_scan",
+        Arc::new(OpenConnectorScanFunction::new(gateways)),
+    );
+}
+
+/// `open_connector_query('gateway', 'pack.table', '{resource json}'[, 'alias'])`.
+#[derive(Debug)]
+pub struct OpenConnectorQueryFunction {
+    gateways: OpenConnectorGateways,
+    packs: SourcePackRegistry,
+}
+
+impl OpenConnectorQueryFunction {
+    /// Build the function over the shared gateway map.
+    pub fn new(gateways: OpenConnectorGateways) -> Self {
+        Self {
+            gateways,
+            packs: SourcePackRegistry::builtins(),
+        }
+    }
+}
+
+impl TableFunctionImpl for OpenConnectorQueryFunction {
+    fn call(&self, exprs: &[Expr]) -> DFResult<Arc<dyn TableProvider>> {
+        if exprs.len() < 3 || exprs.len() > 4 {
+            return plan_err!(
+                "open_connector_query(gateway, table_id, resource_json, [connection_alias]) \
+                 expects 3-4 arguments, got {}",
+                exprs.len()
+            );
+        }
+        let gateway = literal_string("open_connector_query", &exprs[0], "gateway")?;
+        let table_id = literal_string("open_connector_query", &exprs[1], "table_id")?;
+        let resource_json = literal_string("open_connector_query", &exprs[2], "resource_json")?;
+        let alias = exprs
+            .get(3)
+            .map(|expr| literal_string("open_connector_query", expr, "connection_alias"))
+            .transpose()?;
+
+        let handle = lookup_gateway(&self.gateways, &gateway)?;
+
+        // `pack.table` resolves against the built-in pack registry only —
+        // there is no way to name an action here, so the function can execute
+        // nothing but the read actions hard-coded in Skardi's packs.
+        let Some((pack_name, table_name)) = table_id.split_once('.') else {
+            return plan_err!(
+                "open_connector_query: table_id '{table_id}' must be '<pack>.<table>', \
+                 e.g. 'github.issues'"
+            );
+        };
+        let pack = self.packs.require(pack_name).map_err(plan_error)?;
+        let table = self.packs.table(pack, table_name).map_err(plan_error)?;
+
+        let resource: Value = serde_json::from_str(&resource_json).map_err(|e| {
+            DataFusionError::Plan(format!(
+                "open_connector_query: resource_json is not valid JSON: {e}"
+            ))
+        })?;
+        if !resource.is_object() {
+            return plan_err!(
+                "open_connector_query: resource_json must be a JSON object of resource \
+                 inputs, e.g. '{{\"owner\":\"SkardiLabs\",\"repo\":\"skardi\"}}'"
+            );
+        }
+        for key in table.required_resources {
+            if resource.get(*key).is_none() {
+                return Err(plan_error(OpenConnectorError::MissingResourceInput {
+                    binding: format!("open_connector_query('{gateway}', '{table_id}')"),
+                    key: (*key).to_string(),
+                }));
+            }
+        }
+
+        // Same discovery and compatibility gates as YAML registration: the
+        // action must have been discovered when the gateway registered, and
+        // must still match the pack's expected contract fingerprint.
+        let meta = discovered_action(&handle, &gateway, table.action_id)?;
+        if let Some(expected) = table.expected_fingerprint
+            && meta.fingerprint() != expected
+        {
+            return Err(plan_error(OpenConnectorError::ActionContractMismatch {
+                table: table.id.to_string(),
+                reason: format!(
+                    "action '{}' fingerprint mismatch (expected {expected}, discovered {})",
+                    table.action_id,
+                    meta.fingerprint()
+                ),
+            }));
+        }
+
+        let provider = OpenConnectorTableProvider::new(
+            Arc::clone(&handle.client),
+            Some(Arc::clone(&handle.cache)),
+            gateway,
+            None,
+            alias,
+            table,
+            pack.version,
+            resource,
+            handle.max_pages,
+            handle.max_rows,
+            handle.scan_timeout,
+        )
+        .map_err(plan_error)?;
+        Ok(Arc::new(provider))
+    }
+}
+
+/// `open_connector_scan('gateway', 'action.id', '{input json}', '$.rows'[, 'alias'])`.
+#[derive(Debug)]
+pub struct OpenConnectorScanFunction {
+    gateways: OpenConnectorGateways,
+}
+
+impl OpenConnectorScanFunction {
+    /// Build the function over the shared gateway map.
+    pub fn new(gateways: OpenConnectorGateways) -> Self {
+        Self { gateways }
+    }
+}
+
+impl TableFunctionImpl for OpenConnectorScanFunction {
+    fn call(&self, exprs: &[Expr]) -> DFResult<Arc<dyn TableProvider>> {
+        if exprs.len() < 4 || exprs.len() > 5 {
+            return plan_err!(
+                "open_connector_scan(gateway, action_id, input_json, row_path, \
+                 [connection_alias]) expects 4-5 arguments, got {}",
+                exprs.len()
+            );
+        }
+        let gateway = literal_string("open_connector_scan", &exprs[0], "gateway")?;
+        let action_id = literal_string("open_connector_scan", &exprs[1], "action_id")?;
+        let input_json = literal_string("open_connector_scan", &exprs[2], "input_json")?;
+        let row_path = literal_string("open_connector_scan", &exprs[3], "row_path")?;
+        let alias = exprs
+            .get(4)
+            .map(|expr| literal_string("open_connector_scan", expr, "connection_alias"))
+            .transpose()?;
+
+        let handle = lookup_gateway(&self.gateways, &gateway)?;
+
+        // Default-deny, before anything else: only explicitly allowlisted
+        // actions are even looked up.
+        if !handle.raw_action_allowlist.contains(&action_id) {
+            return Err(plan_error(OpenConnectorError::RawActionNotAllowlisted {
+                gateway,
+                action_id,
+            }));
+        }
+        // The allowlist alone does not grant execution: the discovered
+        // metadata must classify the action as a non-mutating read. Both
+        // rejections fire at planning time, before any HTTP request.
+        let meta = discovered_action(&handle, &gateway, &action_id)?;
+        match meta.read_only() {
+            Some(true) => {}
+            Some(false) => {
+                return Err(plan_error(OpenConnectorError::RawActionMutating {
+                    action_id,
+                }));
+            }
+            None => {
+                return Err(plan_error(OpenConnectorError::RawActionReadOnlyUnknown {
+                    action_id,
+                }));
+            }
+        }
+
+        let input: Value = serde_json::from_str(&input_json).map_err(|e| {
+            DataFusionError::Plan(format!(
+                "open_connector_scan: input_json is not valid JSON: {e}"
+            ))
+        })?;
+        if !input.is_object() {
+            return plan_err!(
+                "open_connector_scan: input_json must be a JSON object of action inputs, \
+                 e.g. '{{\"owner\":\"SkardiLabs\",\"repo\":\"skardi\"}}'"
+            );
+        }
+
+        let row_path = RowPath::parse(&row_path).map_err(plan_error)?;
+        // Deterministic row type or planning error — derived purely from the
+        // in-memory discovered output schema.
+        let columns =
+            derive_raw_columns(&action_id, meta.output_schema(), &row_path).map_err(plan_error)?;
+        let converter = Arc::new(RowConverter::from_columns(columns).map_err(plan_error)?);
+
+        Ok(Arc::new(RawScanProvider {
+            client: Arc::clone(&handle.client),
+            gateway,
+            connection_alias: alias,
+            target: ScanTarget {
+                table_id: Arc::from(format!("raw:{action_id}")),
+                action_id: Arc::from(action_id),
+                pagination: PaginationStrategy::SinglePage,
+                source_pack_version: 0,
+            },
+            converter,
+            row_path,
+            input,
+            max_pages: handle.max_pages,
+            max_rows: handle.max_rows,
+            scan_timeout: handle.scan_timeout,
+        }))
+    }
+}
+
+/// One planned raw-action scan: a single live execution of an allowlisted
+/// read action, converted through the planning-time derived schema.
+///
+/// No cache (raw scans are always live reads — with no pagination contract
+/// there is no "complete result" to store) and no filter pushdown (raw
+/// actions declare no filter allowlist; callers pass provider filters in the
+/// input JSON, and SQL predicates stay in DataFusion).
+struct RawScanProvider {
+    client: Arc<OpenConnectorClient>,
+    gateway: String,
+    connection_alias: Option<String>,
+    target: ScanTarget,
+    converter: Arc<RowConverter>,
+    row_path: RowPath,
+    input: Value,
+    max_pages: u32,
+    max_rows: u64,
+    scan_timeout: Duration,
+}
+
+impl std::fmt::Debug for RawScanProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RawScanProvider")
+            .field("action", &self.target.action_id)
+            .field("gateway", &self.gateway)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl TableProvider for RawScanProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(self.converter.schema())
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        _filters: &[Expr],
+        limit: Option<usize>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        let exec = OpenConnectorExec::new(
+            Arc::clone(&self.client),
+            None,
+            self.gateway.clone(),
+            None,
+            self.connection_alias.clone(),
+            self.target.clone(),
+            Arc::clone(&self.converter),
+            self.row_path.clone(),
+            self.input.clone(),
+            Vec::new(),
+            projection.cloned(),
+            limit,
+            self.max_pages,
+            self.max_rows,
+            self.scan_timeout,
+        )?;
+        Ok(Arc::new(exec))
+    }
+}
+
+/// Resolve a gateway name against the shared map.
+fn lookup_gateway(gateways: &OpenConnectorGateways, name: &str) -> DFResult<Arc<GatewayHandle>> {
+    gateways
+        .read()
+        .unwrap_or_else(|p| p.into_inner())
+        .get(name)
+        .cloned()
+        .ok_or_else(|| {
+            plan_error(OpenConnectorError::UdtfGatewayNotRegistered {
+                name: name.to_string(),
+            })
+        })
+}
+
+/// Look up one discovered action's metadata, cloning it out of the handle.
+fn discovered_action(
+    handle: &GatewayHandle,
+    gateway: &str,
+    action_id: &str,
+) -> DFResult<ActionMetadata> {
+    handle.actions.get(action_id).cloned().ok_or_else(|| {
+        plan_error(OpenConnectorError::ActionNotDiscovered {
+            gateway: gateway.to_string(),
+            action_id: action_id.to_string(),
+        })
+    })
+}
+
+/// UDTF failures surface as planning errors; the typed error's message is
+/// the user-facing diagnostic.
+fn plan_error(e: OpenConnectorError) -> DataFusionError {
+    DataFusionError::Plan(e.to_string())
+}
+
+/// Extract one string-literal argument.
+fn literal_string(function: &str, expr: &Expr, name: &str) -> DFResult<String> {
+    match expr {
+        Expr::Literal(ScalarValue::Utf8(Some(s)), _)
+        | Expr::Literal(ScalarValue::LargeUtf8(Some(s)), _) => Ok(s.clone()),
+        _ => plan_err!("{function}: {name} must be a string literal"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sources::hierarchy::HierarchyLevel;
+    use crate::sources::providers::open_connector::register_open_connector_tables;
+    use crate::sources::providers::open_connector::testutil::{
+        MockGateway, MockResponse, RecordedRequest,
+    };
+    use arrow::util::pretty::pretty_format_batches;
+    use datafusion::prelude::CsvReadOptions;
+    use std::io::Write;
+
+    /// Discovery metadata for `mock.list_items`, with a controllable
+    /// read-only classification and an output schema matching the items the
+    /// mock gateway serves.
+    fn discovery_response(read_only: Option<bool>, output_schema: &str) -> String {
+        let read_only = match read_only {
+            Some(flag) => format!(r#""read_only": {flag},"#),
+            None => String::new(),
+        };
+        format!(
+            r#"{{"input_schema": {{}}, "output_schema": {output_schema},
+                "locally_executable": true, {read_only} "connection_aliases": ["work"]}}"#
+        )
+    }
+
+    /// Output schema describing the mock item rows.
+    const ITEMS_OUTPUT_SCHEMA: &str = r#"{
+        "type": "object",
+        "properties": {
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "integer"},
+                        "name": {"type": "string"},
+                        "value": {"type": "number"},
+                        "tags": {"type": "array", "items": {"type": "string"}},
+                        "created_at": {"type": "string"}
+                    }
+                }
+            }
+        }
+    }"#;
+
+    /// All items the mock gateway serves, 1-based ids.
+    fn mock_items() -> Vec<serde_json::Value> {
+        (1..=5)
+            .map(|id| {
+                serde_json::json!({
+                    "id": id,
+                    "name": format!("item-{id}"),
+                    "value": id as f64,
+                    "tags": ["t1", "t2"],
+                    "created_at": "2026-01-01T00:00:00Z"
+                })
+            })
+            .collect()
+    }
+
+    /// Mock gateway: health, discovery (with the given read-only flag), and
+    /// page-number `mock.list_items` execution (2 items per page).
+    fn gateway_handler(
+        req: &RecordedRequest,
+        total: usize,
+        read_only: Option<bool>,
+        output_schema: &str,
+    ) -> MockResponse {
+        if req.method == "GET" && req.path == "/v1/health" {
+            return MockResponse::ok("{}");
+        }
+        if req.method == "GET" && req.path == "/v1/actions/mock.list_items" {
+            return MockResponse::ok(&discovery_response(read_only, output_schema));
+        }
+        if req.method == "POST" && req.path == "/v1/actions/mock.list_items/execute" {
+            let body: serde_json::Value = serde_json::from_str(&req.body).unwrap_or_default();
+            let input = body.get("input").cloned().unwrap_or_default();
+            let page = input
+                .get("page")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(1) as usize;
+            let min_value = input.get("min_value").and_then(serde_json::Value::as_f64);
+            let slice: Vec<_> = mock_items()
+                .into_iter()
+                .take(total)
+                .filter(|item| {
+                    min_value.is_none_or(|min| {
+                        item.get("value").and_then(serde_json::Value::as_f64) > Some(min)
+                    })
+                })
+                .skip((page - 1) * 2)
+                .take(2)
+                .collect();
+            return MockResponse::ok(
+                &serde_json::json!({ "output": { "items": slice } }).to_string(),
+            );
+        }
+        MockResponse::new(404, "{}")
+    }
+
+    const BOUND_CONFIG: &str = "
+runtime_token_env: {env}
+cache_ttl_seconds: {ttl}
+bindings:
+  - name: ws
+    source_pack: mock
+    resource: { workspace: demo }
+    tables: [items]
+";
+
+    const ALLOWLIST_CONFIG: &str = "
+runtime_token_env: {env}
+raw_action_allowlist:
+  - mock.list_items
+";
+
+    fn parse_config(
+        template: &str,
+        token_env: &str,
+        cache_ttl_seconds: u64,
+    ) -> OpenConnectorConfig {
+        let yaml = template
+            .replace("{env}", token_env)
+            .replace("{ttl}", &cache_ttl_seconds.to_string());
+        serde_yaml::from_str(&yaml).expect("parse config")
+    }
+
+    /// Register the gateway (tables + UDTF state) and both UDTFs.
+    async fn setup(
+        gateway: &MockGateway,
+        config: &OpenConnectorConfig,
+        token_env: &str,
+    ) -> SessionContext {
+        unsafe {
+            std::env::set_var(token_env, "test-token");
+        }
+        let gateways = OpenConnectorGateways::default();
+        let mut ctx = SessionContext::new();
+        register_open_connector_tables(
+            &mut ctx,
+            "saas",
+            &gateway.url,
+            Some(config),
+            false,
+            HierarchyLevel::Catalog,
+            Some(&gateways),
+        )
+        .await
+        .expect("gateway registration succeeds");
+        unsafe {
+            std::env::remove_var(token_env);
+        }
+        register_open_connector_udtfs(&ctx, gateways);
+        ctx
+    }
+
+    async fn collect(ctx: &SessionContext, sql: &str) -> Vec<arrow::record_batch::RecordBatch> {
+        ctx.sql(sql)
+            .await
+            .expect("plan")
+            .collect()
+            .await
+            .expect("collect")
+    }
+
+    /// Planning must fail and the error must carry the given fragment.
+    async fn expect_plan_error(ctx: &SessionContext, sql: &str, fragment: &str) {
+        let err = match ctx.sql(sql).await {
+            Err(e) => e.to_string(),
+            Ok(df) => df.collect().await.expect_err("query must fail").to_string(),
+        };
+        assert!(err.contains(fragment), "expected '{fragment}' in: {err}");
+    }
+
+    fn execute_requests(gateway: &MockGateway) -> Vec<RecordedRequest> {
+        gateway
+            .requests()
+            .into_iter()
+            .filter(|r| r.method == "POST")
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn query_udtf_matches_yaml_registered_table() {
+        let gateway =
+            MockGateway::start(|req| gateway_handler(req, 5, None, ITEMS_OUTPUT_SCHEMA)).await;
+        let config = parse_config(BOUND_CONFIG, "SKARDI_TEST_OC_UDTF_QUERY_PARITY", 0);
+        let ctx = setup(&gateway, &config, "SKARDI_TEST_OC_UDTF_QUERY_PARITY").await;
+
+        let from_table = collect(&ctx, "SELECT * FROM saas.ws.items ORDER BY id").await;
+        let from_udtf = collect(
+            &ctx,
+            r#"SELECT * FROM open_connector_query('saas', 'mock.items', '{"workspace":"demo"}')
+               ORDER BY id"#,
+        )
+        .await;
+
+        // Same stable Arrow schema and same values as the YAML-bound table.
+        assert_eq!(from_table[0].schema(), from_udtf[0].schema());
+        assert_eq!(
+            pretty_format_batches(&from_table).unwrap().to_string(),
+            pretty_format_batches(&from_udtf).unwrap().to_string()
+        );
+        let rows: usize = from_udtf.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(rows, 5);
+    }
+
+    #[tokio::test]
+    async fn query_udtf_pushes_filters_and_sends_alias() {
+        let gateway =
+            MockGateway::start(|req| gateway_handler(req, 5, None, ITEMS_OUTPUT_SCHEMA)).await;
+        let config = parse_config(BOUND_CONFIG, "SKARDI_TEST_OC_UDTF_QUERY_FILTER", 0);
+        let ctx = setup(&gateway, &config, "SKARDI_TEST_OC_UDTF_QUERY_FILTER").await;
+
+        let batches = collect(
+            &ctx,
+            r#"SELECT id, value
+               FROM open_connector_query('saas', 'mock.items', '{"workspace":"demo"}', 'work')
+               WHERE value > 3.0"#,
+        )
+        .await;
+        let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(rows, 2, "values 4.0 and 5.0");
+
+        // The UDTF goes through the same filter allowlist and connection
+        // alias plumbing as the stable table.
+        let executes = execute_requests(&gateway);
+        assert!(!executes.is_empty());
+        assert!(
+            executes.iter().all(|r| r.body.contains(r#""min_value":3"#)),
+            "Exact filter pushed on every page"
+        );
+        assert!(
+            executes
+                .iter()
+                .all(|r| r.header("x-openconnector-connection-alias").as_deref() == Some("work")),
+            "explicit connection alias sent on every execute"
+        );
+    }
+
+    #[tokio::test]
+    async fn query_udtf_shares_the_gateway_scan_cache() {
+        let gateway =
+            MockGateway::start(|req| gateway_handler(req, 3, None, ITEMS_OUTPUT_SCHEMA)).await;
+        let config = parse_config(BOUND_CONFIG, "SKARDI_TEST_OC_UDTF_QUERY_CACHE", 60);
+        let ctx = setup(&gateway, &config, "SKARDI_TEST_OC_UDTF_QUERY_CACHE").await;
+
+        // Warm the cache through the YAML-bound table…
+        let batches = collect(&ctx, "SELECT id, name FROM saas.ws.items ORDER BY id").await;
+        assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 3);
+        let live_pages = execute_requests(&gateway).len();
+        assert_eq!(live_pages, 2, "3 items at per_page=2");
+
+        // …and replay it through the UDTF: identical scan spec → same key.
+        let batches = collect(
+            &ctx,
+            r#"SELECT id, name
+               FROM open_connector_query('saas', 'mock.items', '{"workspace":"demo"}')
+               ORDER BY id"#,
+        )
+        .await;
+        assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 3);
+        assert_eq!(
+            execute_requests(&gateway).len(),
+            live_pages,
+            "the UDTF scan replays from the shared cache with zero new requests"
+        );
+    }
+
+    #[tokio::test]
+    async fn query_udtf_rejects_bad_arguments_and_unknown_names() {
+        let gateway =
+            MockGateway::start(|req| gateway_handler(req, 5, None, ITEMS_OUTPUT_SCHEMA)).await;
+        let config = parse_config(BOUND_CONFIG, "SKARDI_TEST_OC_UDTF_QUERY_ERRORS", 0);
+        let ctx = setup(&gateway, &config, "SKARDI_TEST_OC_UDTF_QUERY_ERRORS").await;
+        let live = execute_requests(&gateway).len();
+
+        expect_plan_error(
+            &ctx,
+            "SELECT * FROM open_connector_query('nope', 'mock.items', '{}')",
+            "gateway 'nope' is not registered",
+        )
+        .await;
+        expect_plan_error(
+            &ctx,
+            "SELECT * FROM open_connector_query('saas', 'github.issues', '{}')",
+            "unknown source pack 'github'",
+        )
+        .await;
+        expect_plan_error(
+            &ctx,
+            "SELECT * FROM open_connector_query('saas', 'mock.users', '{}')",
+            "has no table 'users'",
+        )
+        .await;
+        expect_plan_error(
+            &ctx,
+            "SELECT * FROM open_connector_query('saas', 'mock-items', '{}')",
+            "must be '<pack>.<table>'",
+        )
+        .await;
+        expect_plan_error(
+            &ctx,
+            "SELECT * FROM open_connector_query('saas', 'mock.items', '{}')",
+            "missing required resource input 'workspace'",
+        )
+        .await;
+        expect_plan_error(
+            &ctx,
+            "SELECT * FROM open_connector_query('saas', 'mock.items', 'not json')",
+            "resource_json is not valid JSON",
+        )
+        .await;
+        expect_plan_error(
+            &ctx,
+            "SELECT * FROM open_connector_query('saas', 'mock.items')",
+            "expects 3-4 arguments",
+        )
+        .await;
+        expect_plan_error(
+            &ctx,
+            "SELECT * FROM open_connector_query(1, 'mock.items', '{}')",
+            "gateway must be a string literal",
+        )
+        .await;
+
+        assert_eq!(
+            execute_requests(&gateway).len(),
+            live,
+            "every rejection fires at planning time, before any HTTP execute"
+        );
+    }
+
+    #[tokio::test]
+    async fn query_udtf_requires_registration_time_discovery() {
+        // No binding and no allowlist entry → mock.list_items was never
+        // discovered, and planning (which performs no network I/O) must say
+        // how to fix that rather than silently contacting the gateway.
+        let gateway =
+            MockGateway::start(|req| gateway_handler(req, 5, None, ITEMS_OUTPUT_SCHEMA)).await;
+        let config = parse_config(
+            "runtime_token_env: {env}\ncache_ttl_seconds: {ttl}\n",
+            "SKARDI_TEST_OC_UDTF_QUERY_UNDISCOVERED",
+            0,
+        );
+        let ctx = setup(&gateway, &config, "SKARDI_TEST_OC_UDTF_QUERY_UNDISCOVERED").await;
+
+        expect_plan_error(
+            &ctx,
+            r#"SELECT * FROM open_connector_query('saas', 'mock.items', '{"workspace":"demo"}')"#,
+            "was not discovered when gateway 'saas' was registered",
+        )
+        .await;
+        assert!(
+            execute_requests(&gateway).is_empty(),
+            "no execute call may be attempted"
+        );
+    }
+
+    #[tokio::test]
+    async fn scan_udtf_executes_allowlisted_read_action_once() {
+        let gateway =
+            MockGateway::start(|req| gateway_handler(req, 5, Some(true), ITEMS_OUTPUT_SCHEMA))
+                .await;
+        let config = parse_config(ALLOWLIST_CONFIG, "SKARDI_TEST_OC_UDTF_SCAN_OK", 0);
+        let ctx = setup(&gateway, &config, "SKARDI_TEST_OC_UDTF_SCAN_OK").await;
+
+        let batches = collect(
+            &ctx,
+            r#"SELECT id, name, value
+               FROM open_connector_scan('saas', 'mock.list_items',
+                                        '{"workspace":"demo"}', '$.items')
+               ORDER BY id"#,
+        )
+        .await;
+        // A raw action has no pagination contract: exactly one execution,
+        // returning the gateway's first page (2 of 5 items).
+        let rendered = pretty_format_batches(&batches).unwrap().to_string();
+        assert_eq!(
+            batches.iter().map(|b| b.num_rows()).sum::<usize>(),
+            2,
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("item-1") && rendered.contains("item-2"),
+            "{rendered}"
+        );
+        assert_eq!(
+            execute_requests(&gateway).len(),
+            1,
+            "single page, single POST"
+        );
+
+        // The derived schema is deterministic: sorted, conservatively typed.
+        let schema = batches[0].schema();
+        let names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+        assert_eq!(names, vec!["id", "name", "value"]);
+        assert_eq!(
+            schema.field(0).data_type(),
+            &arrow::datatypes::DataType::Int64
+        );
+    }
+
+    #[tokio::test]
+    async fn scan_udtf_exposes_complex_fields_as_json_and_honors_limit() {
+        let gateway =
+            MockGateway::start(|req| gateway_handler(req, 5, Some(true), ITEMS_OUTPUT_SCHEMA))
+                .await;
+        let config = parse_config(ALLOWLIST_CONFIG, "SKARDI_TEST_OC_UDTF_SCAN_JSON", 0);
+        let ctx = setup(&gateway, &config, "SKARDI_TEST_OC_UDTF_SCAN_JSON").await;
+
+        let batches = collect(
+            &ctx,
+            r#"SELECT tags
+               FROM open_connector_scan('saas', 'mock.list_items',
+                                        '{"workspace":"demo"}', '$.items')
+               LIMIT 1"#,
+        )
+        .await;
+        assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 1);
+        let tags = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .expect("tags is an opaque JSON string column");
+        assert_eq!(tags.value(0), r#"["t1","t2"]"#);
+    }
+
+    #[tokio::test]
+    async fn scan_udtf_denies_unallowlisted_actions_before_http() {
+        // mock.list_items IS discovered (the binding uses it) — but raw
+        // access is a separate, default-deny grant.
+        let gateway =
+            MockGateway::start(|req| gateway_handler(req, 5, Some(true), ITEMS_OUTPUT_SCHEMA))
+                .await;
+        let config = parse_config(BOUND_CONFIG, "SKARDI_TEST_OC_UDTF_SCAN_DENY", 0);
+        let ctx = setup(&gateway, &config, "SKARDI_TEST_OC_UDTF_SCAN_DENY").await;
+
+        expect_plan_error(
+            &ctx,
+            r#"SELECT * FROM open_connector_scan('saas', 'mock.list_items',
+                                                 '{"workspace":"demo"}', '$.items')"#,
+            "is not in the 'raw_action_allowlist'",
+        )
+        .await;
+        assert!(execute_requests(&gateway).is_empty(), "rejected pre-HTTP");
+    }
+
+    #[tokio::test]
+    async fn scan_udtf_rejects_unclassified_and_mutating_actions_before_http() {
+        // No read_only flag at all → classification gap, named as such.
+        let gateway =
+            MockGateway::start(|req| gateway_handler(req, 5, None, ITEMS_OUTPUT_SCHEMA)).await;
+        let config = parse_config(ALLOWLIST_CONFIG, "SKARDI_TEST_OC_UDTF_SCAN_UNCLASSIFIED", 0);
+        let ctx = setup(&gateway, &config, "SKARDI_TEST_OC_UDTF_SCAN_UNCLASSIFIED").await;
+        expect_plan_error(
+            &ctx,
+            r#"SELECT * FROM open_connector_scan('saas', 'mock.list_items',
+                                                 '{"workspace":"demo"}', '$.items')"#,
+            "does not declare a read-only classification",
+        )
+        .await;
+        assert!(execute_requests(&gateway).is_empty(), "rejected pre-HTTP");
+
+        // Explicitly mutating → rejected with the other targeted error.
+        let gateway =
+            MockGateway::start(|req| gateway_handler(req, 5, Some(false), ITEMS_OUTPUT_SCHEMA))
+                .await;
+        let config = parse_config(ALLOWLIST_CONFIG, "SKARDI_TEST_OC_UDTF_SCAN_MUTATING", 0);
+        let ctx = setup(&gateway, &config, "SKARDI_TEST_OC_UDTF_SCAN_MUTATING").await;
+        expect_plan_error(
+            &ctx,
+            r#"SELECT * FROM open_connector_scan('saas', 'mock.list_items',
+                                                 '{"workspace":"demo"}', '$.items')"#,
+            "is classified as mutating",
+        )
+        .await;
+        assert!(execute_requests(&gateway).is_empty(), "rejected pre-HTTP");
+    }
+
+    #[tokio::test]
+    async fn scan_udtf_requires_a_deterministic_row_type_at_planning() {
+        // The action is allowlisted and read-only, but its output schema
+        // gives the row path no deterministic object rows.
+        let gateway =
+            MockGateway::start(|req| gateway_handler(req, 5, Some(true), r#"{"type": "object"}"#))
+                .await;
+        let config = parse_config(ALLOWLIST_CONFIG, "SKARDI_TEST_OC_UDTF_SCAN_NOSCHEMA", 0);
+        let ctx = setup(&gateway, &config, "SKARDI_TEST_OC_UDTF_SCAN_NOSCHEMA").await;
+
+        expect_plan_error(
+            &ctx,
+            r#"SELECT * FROM open_connector_scan('saas', 'mock.list_items',
+                                                 '{"workspace":"demo"}', '$.items')"#,
+            "cannot derive a deterministic row type",
+        )
+        .await;
+        expect_plan_error(
+            &ctx,
+            r#"SELECT * FROM open_connector_scan('saas', 'mock.list_items',
+                                                 '{"workspace":"demo"}', 'items')"#,
+            "must start with '$.'",
+        )
+        .await;
+        assert!(execute_requests(&gateway).is_empty(), "rejected pre-HTTP");
+    }
+
+    #[tokio::test]
+    async fn udtf_joins_the_mock_pack_with_a_local_csv() {
+        let gateway =
+            MockGateway::start(|req| gateway_handler(req, 5, None, ITEMS_OUTPUT_SCHEMA)).await;
+        let config = parse_config(BOUND_CONFIG, "SKARDI_TEST_OC_UDTF_JOIN", 0);
+        let ctx = setup(&gateway, &config, "SKARDI_TEST_OC_UDTF_JOIN").await;
+
+        // A local CSV source to federate with.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let csv_path = dir.path().join("labels.csv");
+        let mut file = std::fs::File::create(&csv_path).expect("create csv");
+        writeln!(file, "id,label").unwrap();
+        writeln!(file, "1,alpha").unwrap();
+        writeln!(file, "3,gamma").unwrap();
+        drop(file);
+        ctx.register_csv("labels", csv_path.to_str().unwrap(), CsvReadOptions::new())
+            .await
+            .expect("register csv");
+
+        let batches = collect(
+            &ctx,
+            r#"SELECT i.id, i.name, l.label
+               FROM open_connector_query('saas', 'mock.items', '{"workspace":"demo"}') i
+               JOIN labels l ON i.id = l.id
+               ORDER BY i.id"#,
+        )
+        .await;
+        let rendered = pretty_format_batches(&batches).unwrap().to_string();
+        assert_eq!(
+            batches.iter().map(|b| b.num_rows()).sum::<usize>(),
+            2,
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("alpha") && rendered.contains("gamma"),
+            "{rendered}"
+        );
+    }
+}

--- a/crates/skardi/src/sources/providers/open_connector/table_functions.rs
+++ b/crates/skardi/src/sources/providers/open_connector/table_functions.rs
@@ -854,6 +854,67 @@ raw_action_allowlist:
     }
 
     #[tokio::test]
+    async fn scan_udtf_treats_json_null_fields_as_sql_null() {
+        // Raw scans type nested fields as opaque Json; a provider null
+        // (assignee: null and friends) must behave as SQL NULL — `IS NULL`
+        // matches it, `= 'null'` does not.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path == "/v1/actions/mock.list_items" {
+                return MockResponse::ok(&discovery_response(Some(true), ITEMS_OUTPUT_SCHEMA));
+            }
+            if req.method == "POST" && req.path == "/v1/actions/mock.list_items/execute" {
+                return MockResponse::ok(
+                    &serde_json::json!({"output": {"items": [
+                        {"id": 1, "name": "tagged", "tags": ["t1"]},
+                        {"id": 2, "name": "untagged", "tags": null}
+                    ]}})
+                    .to_string(),
+                );
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let config = parse_config(ALLOWLIST_CONFIG, "SKARDI_TEST_OC_UDTF_SCAN_JSON_NULL", 0);
+        let ctx = setup(&gateway, &config, "SKARDI_TEST_OC_UDTF_SCAN_JSON_NULL").await;
+
+        let batches = collect(
+            &ctx,
+            r#"SELECT id
+               FROM open_connector_scan('saas', 'mock.list_items',
+                                        '{"workspace":"demo"}', '$.items')
+               WHERE tags IS NULL"#,
+        )
+        .await;
+        let rendered = pretty_format_batches(&batches).unwrap().to_string();
+        assert_eq!(
+            batches.iter().map(|b| b.num_rows()).sum::<usize>(),
+            1,
+            "IS NULL must match the provider null: {rendered}"
+        );
+        assert!(
+            rendered.contains('2'),
+            "row id=2 is the null-tagged one: {rendered}"
+        );
+
+        let batches = collect(
+            &ctx,
+            r#"SELECT id
+               FROM open_connector_scan('saas', 'mock.list_items',
+                                        '{"workspace":"demo"}', '$.items')
+               WHERE tags = 'null'"#,
+        )
+        .await;
+        assert_eq!(
+            batches.iter().map(|b| b.num_rows()).sum::<usize>(),
+            0,
+            "the string 'null' must not match a provider null"
+        );
+    }
+
+    #[tokio::test]
     async fn scan_udtf_denies_unallowlisted_actions_before_http() {
         // mock.list_items IS discovered (the binding uses it) — but raw
         // access is a separate, default-deny grant.

--- a/crates/skardi/src/sources/providers/open_connector/table_functions.rs
+++ b/crates/skardi/src/sources/providers/open_connector/table_functions.rs
@@ -20,6 +20,14 @@
 //! requires the action to be allowlisted **and** classified as a
 //! non-mutating read by its discovered gateway metadata — absent or
 //! ambiguous classification is refused, naming the gap.
+//!
+//! Staleness boundary: because planning never re-discovers, the metadata
+//! these gates read (read-only classification, executability, contract
+//! fingerprints) is a snapshot from registration. An upstream action that
+//! turns mutating *after* registration keeps passing the Skardi-side gate
+//! until the next restart or configuration reload; Open Connector's own
+//! action policies are the live, independent enforcement boundary for that
+//! window.
 
 use std::any::Any;
 use std::collections::{HashMap, HashSet};

--- a/crates/skardi/src/sources/providers/open_connector/testutil.rs
+++ b/crates/skardi/src/sources/providers/open_connector/testutil.rs
@@ -1,16 +1,20 @@
-//! A minimal mock Open Connector gateway for tests.
+//! A minimal mock Open Connector gateway for tests, plus a tracing capture
+//! for asserting on emitted events.
 //!
-//! Hand-rolled over `tokio::net::TcpListener` so the test suite needs no mock
-//! HTTP crate. It speaks just enough HTTP/1.1 for `reqwest`: read the request
-//! head, consume the declared body, answer from a user-supplied handler, and
-//! close the connection (which tells reqwest to open a fresh one next time).
+//! The gateway is hand-rolled over `tokio::net::TcpListener` so the test
+//! suite needs no mock HTTP crate. It speaks just enough HTTP/1.1 for
+//! `reqwest`: read the request head, consume the declared body, answer from
+//! a user-supplied handler, and close the connection (which tells reqwest to
+//! open a fresh one next time).
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
+use tracing::field::{Field, Visit};
 
 /// One request observed by the mock gateway.
 #[derive(Debug, Clone)]
@@ -222,4 +226,115 @@ fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
     haystack
         .windows(needle.len())
         .position(|window| window == needle)
+}
+
+/// One tracing event captured by [`capture_events`].
+#[derive(Debug, Clone)]
+pub(crate) struct CapturedEvent {
+    pub(crate) level: tracing::Level,
+    /// The event's format-string message (e.g. "Open Connector scan completed").
+    pub(crate) message: String,
+    /// Structured fields, rendered to strings.
+    pub(crate) fields: HashMap<String, String>,
+}
+
+impl CapturedEvent {
+    /// Look up one structured field by name.
+    pub(crate) fn field(&self, name: &str) -> Option<&str> {
+        self.fields.get(name).map(String::as_str)
+    }
+}
+
+/// Renders an event's fields into owned strings. Typed values keep their
+/// plain rendering (`true`, `3`); everything else (including `%`-Display
+/// arguments and the message) comes through `record_debug`.
+#[derive(Default)]
+struct FieldRecorder {
+    message: String,
+    fields: HashMap<String, String>,
+}
+
+impl Visit for FieldRecorder {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        let rendered = format!("{value:?}");
+        if field.name() == "message" {
+            self.message = rendered;
+        } else {
+            self.fields.insert(field.name().to_string(), rendered);
+        }
+    }
+}
+
+/// Minimal subscriber that records every event into a shared vector.
+struct CaptureSubscriber {
+    events: Arc<Mutex<Vec<CapturedEvent>>>,
+    next_span_id: AtomicU64,
+}
+
+impl tracing::Subscriber for CaptureSubscriber {
+    fn enabled(&self, _metadata: &tracing::Metadata<'_>) -> bool {
+        true
+    }
+
+    fn new_span(&self, _attrs: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+        // Span IDs must be non-zero; the counter starts at 1.
+        tracing::span::Id::from_u64(self.next_span_id.fetch_add(1, Ordering::Relaxed))
+    }
+
+    fn record(&self, _span: &tracing::span::Id, _values: &tracing::span::Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &tracing::span::Id, _follows: &tracing::span::Id) {}
+
+    fn event(&self, event: &tracing::Event<'_>) {
+        let mut recorder = FieldRecorder::default();
+        event.record(&mut recorder);
+        self.events
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .push(CapturedEvent {
+                level: *event.metadata().level(),
+                message: recorder.message,
+                fields: recorder.fields,
+            });
+    }
+
+    fn enter(&self, _span: &tracing::span::Id) {}
+
+    fn exit(&self, _span: &tracing::span::Id) {}
+}
+
+/// Capture every tracing event emitted on the current thread while the
+/// returned guard lives. `#[tokio::test]` bodies run on a single-threaded
+/// runtime, so scan events land on the test thread and parallel tests stay
+/// isolated (the subscriber is a thread-local default, never global).
+pub(crate) fn capture_events() -> (
+    tracing::subscriber::DefaultGuard,
+    Arc<Mutex<Vec<CapturedEvent>>>,
+) {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = CaptureSubscriber {
+        events: Arc::clone(&events),
+        next_span_id: AtomicU64::new(1),
+    };
+    (tracing::subscriber::set_default(subscriber), events)
 }

--- a/docs/open-connector.md
+++ b/docs/open-connector.md
@@ -204,8 +204,15 @@ JOIN 'labels.csv' l ON i.id = l.id;
   unclassified actions are rejected before any HTTP request.
 - The integration registers no DML: `INSERT`/`UPDATE`/`DELETE` and
   read-write access modes fail with targeted errors.
+- The metadata these gates read (read-only classification, executability,
+  action-contract fingerprints) is discovered at registration and holds
+  until the next restart or configuration reload — query planning never
+  re-contacts the gateway. An action whose upstream definition turns
+  mutating after registration is therefore not re-checked by Skardi inside
+  that window.
 - Open Connector's own action policies remain a second, independent
-  enforcement boundary.
+  enforcement boundary — and the live one during the staleness window
+  above.
 
 ## Caching and freshness
 

--- a/docs/open-connector.md
+++ b/docs/open-connector.md
@@ -1,0 +1,253 @@
+# Open Connector Integration
+
+[Open Connector](https://github.com/oomol-lab/open-connector) is a separate,
+self-hosted SaaS gateway: it owns provider credentials, OAuth flows, token
+refresh, action policies, and provider-specific HTTP execution for 1,000+
+SaaS providers. Skardi adds the relational layer on top — stable table
+definitions, JSON-to-Arrow conversion, pagination, safe filter and limit
+pushdown, optional caching, and DataFusion registration — so selected SaaS
+resources become ordinary SQL tables that can join against every other
+Skardi source.
+
+Provider credentials never enter Skardi. Skardi is configured with only two
+things: the gateway URL and the name of an environment variable holding the
+gateway **runtime token**.
+
+> **Status:** the shared foundation is complete and queryable end to end
+> with the synthetic `mock` source pack (used by the test suite and local
+> stub gateways). Real provider packs (GitHub, Slack, Notion, …) ship one
+> pack per release per the
+> [design spec](superpowers/specs/2026-07-11-open-connector-integration-design.md);
+> a source is advertised as supported only once its pack passes the
+> admission gate there.
+
+## Configuration
+
+An Open Connector gateway is a `type: open_connector` data source with
+`hierarchy_level: catalog` and a typed `open_connector:` block:
+
+```yaml
+kind: context
+
+metadata:
+  name: saas-example
+  version: 1.0.0
+
+spec:
+  data_sources:
+    - name: saas                                  # catalog name in SQL
+      type: open_connector
+      connection_string: http://open-connector:3000
+      hierarchy_level: catalog
+
+      open_connector:
+        # Environment variable holding the gateway runtime token.
+        # The token value itself never appears in YAML.
+        runtime_token_env: OPEN_CONNECTOR_TOKEN
+
+        # Safety bounds (defaults shown).
+        request_timeout_seconds: 30      # one gateway HTTP request
+        scan_timeout_seconds: 300        # one whole scan, all pages
+        max_pages: 100                   # pages per scan
+        max_rows: 100000                 # rows per scan
+        max_response_bytes: 16777216     # decoded bytes per response
+        max_attempts: 3                  # attempts per gateway call
+
+        # Caching: live reads by default; > 0 enables the bounded
+        # in-memory TTL cache shared by all scans of this gateway.
+        cache_ttl_seconds: 0
+        cache_max_bytes: 268435456
+
+        # Actions open_connector_scan may invoke. Empty by default —
+        # raw-action access is default-deny.
+        raw_action_allowlist:
+          - github.list_repository_issues
+
+        # Persistent stable tables: each binding becomes a schema in the
+        # gateway catalog, each listed source-pack table becomes a table.
+        bindings:
+          - name: github_skardi          # schema name in SQL
+            source_pack: github          # built-in pack
+            source_pack_version: 1       # optional pin (schema stability)
+            connection_alias: work       # optional Open Connector alias
+            resource:                    # inputs the pack requires
+              owner: SkardiLabs
+              repo: skardi
+            tables:
+              - issues
+              - pull_requests
+```
+
+Notes:
+
+- Unknown keys anywhere in the block are rejected at load time — a
+  misspelled `source_pack_versions` fails loudly instead of silently
+  disabling the pin it was meant to set.
+- The gateway URL must be plain `http(s)://` with no embedded credentials,
+  query string, or fragment; the runtime token travels only as a Bearer
+  header.
+- The source is read-only by construction. `access_mode: read_write`, SQL
+  DML, and job destinations are all rejected.
+- Registration is a configuration action, not a SQL action: bindings change
+  only through reviewed context YAML, never through DDL.
+
+At startup Skardi validates the config, health-checks the gateway,
+discovers the metadata of every referenced action (bound pack tables plus
+the raw-action allowlist), verifies pack version pins, required resource
+inputs, and action-contract fingerprints, and only then registers the
+catalog. Query planning never performs network I/O.
+
+## Three SQL interfaces
+
+### 1. Stable catalog tables
+
+Each binding is a schema under the gateway catalog:
+`<gateway>.<binding>.<table>`. This is the interface for repeatedly queried
+resources and federated joins:
+
+```sql
+SELECT number, title, author_login
+FROM saas.github_skardi.issues
+WHERE state = 'open'
+LIMIT 50;
+```
+
+Filters that the source pack maps faithfully (`Exact`) are pushed into the
+provider API call; everything else stays in DataFusion. `LIMIT` stops
+pagination as soon as enough rows have been emitted.
+
+### 2. `open_connector_query` — built-in pack tables, ad hoc
+
+Runs a **built-in source-pack table** without a persistent binding.
+Arguments: gateway, stable table ID, resource JSON, optional connection
+alias.
+
+```sql
+SELECT number, title, author_login
+FROM open_connector_query(
+  'saas',
+  'github.issues',
+  '{"owner":"SkardiLabs","repo":"skardi"}',
+  'work'                    -- optional; defaults to the gateway default
+)
+WHERE state = 'open'
+LIMIT 50;
+```
+
+It compiles into exactly the scan the YAML-bound table uses: same stable
+Arrow schema, filter allowlist, pagination, safety bounds, and shared
+cache. The table's action must have been discovered when the gateway was
+registered — bind the table in YAML or add its action to
+`raw_action_allowlist`; otherwise planning fails with an error saying so
+(planning never contacts the gateway).
+
+### 3. `open_connector_scan` — allowlisted raw read actions
+
+The escape hatch for actions no pack covers yet. Arguments: gateway, action
+ID, input JSON, row path, optional connection alias.
+
+```sql
+SELECT number, title
+FROM open_connector_scan(
+  'saas',
+  'github.list_repository_issues',
+  '{"owner":"SkardiLabs","repo":"skardi","state":"open"}',
+  '$.issues'
+)
+LIMIT 50;
+```
+
+Raw scans are deliberately narrow:
+
+- **Default-deny.** The action must be in the gateway's
+  `raw_action_allowlist`, *and* its discovered metadata must classify it as
+  a non-mutating read (`read_only: true`). A missing or ambiguous
+  classification is refused with an error naming the gap — the allowlist
+  alone never grants execution. Both checks fire at planning time, before
+  any HTTP request.
+- **Deterministic row type or planning error.** The Arrow schema is derived
+  from the discovered action output schema at the row path: declared
+  primitives (`string`, `integer`, `number`, `boolean`, including
+  `["T","null"]` unions) become typed nullable columns; objects, arrays,
+  wider unions, and undeclared types become JSON-string columns. If the row
+  path does not resolve to an array of objects with declared properties,
+  planning fails and recommends a built-in pack table or a source-pack
+  contribution.
+- **One request, one page.** Raw actions declare no pagination contract, so
+  the action executes exactly once; pass any paging inputs explicitly in
+  the input JSON. Raw scans are always live (never cached) and support no
+  filter pushdown — provider-side filters go in the input JSON, SQL
+  predicates are evaluated by DataFusion.
+
+## Federated joins
+
+Open Connector tables join like any other source:
+
+```sql
+SELECT i.id, i.name, l.label
+FROM open_connector_query('saas', 'mock.items', '{"workspace":"demo"}') i
+JOIN 'labels.csv' l ON i.id = l.id;
+```
+
+## Security model
+
+- Provider credentials stay in Open Connector; Skardi holds only the
+  gateway runtime token, read from the environment at registration.
+- Tokens never appear in YAML, logs, `Debug` output, error messages, or
+  the data-sources API.
+- Stable tables and `open_connector_query` can execute only the read
+  actions hard-coded in Skardi's source packs; bindings cannot override the
+  pack's action, row path, pagination, or schema (unknown keys are rejected
+  at parse time).
+- `open_connector_scan` requires an explicit allowlist entry **and** a
+  read-only classification in the discovered metadata; mutating and
+  unclassified actions are rejected before any HTTP request.
+- The integration registers no DML: `INSERT`/`UPDATE`/`DELETE` and
+  read-write access modes fail with targeted errors.
+- Open Connector's own action policies remain a second, independent
+  enforcement boundary.
+
+## Caching and freshness
+
+Live reads are the default (`cache_ttl_seconds: 0`). With a positive TTL,
+completed scans are cached in a bounded in-memory LRU (byte- and
+entry-capped) keyed by gateway, connection alias, action, source-pack
+version, resource inputs, translated filters, projection, LIMIT, and the
+Arrow schema fingerprint. Only completed scans are stored, so a truncated
+result can never serve a fuller query. Both stable tables and
+`open_connector_query` share one cache per gateway; raw scans bypass it.
+
+Caching claims no transactional consistency: a live multi-page scan can
+observe upstream changes between pages, subject to the provider's own
+pagination guarantees.
+
+## Bounds, retries, and errors
+
+Every scan is bounded by `max_pages`, `max_rows`, `request_timeout_seconds`,
+`scan_timeout_seconds`, and `max_response_bytes`; hitting a bound fails the
+scan rather than returning a partial result as success. Idempotent gateway
+calls (health, discovery) retry `429`/transient `5xx` with capped
+exponential backoff honoring `Retry-After`; non-idempotent execute calls
+retry only a pre-execution `429` and never re-send a request that may have
+already run. Cursor pagination that stops advancing fails as a detected
+loop instead of spinning forever. Conversion errors report the action, row
+path, page, row, column, and expected type — with the offending JSON
+*kind*, never the value.
+
+## Compatibility and schema drift
+
+Each pack table pins the full relational contract and an expected
+action-contract fingerprint (a canonicalized hash of the discovered output
+schema). An Open Connector upgrade that changes an action incompatibly
+fails registration with a targeted error instead of silently changing a
+table's schema; additive upstream fields are ignored. Bindings may pin
+`source_pack_version` so a Skardi upgrade cannot silently change a bound
+table's schema either.
+
+## Observability
+
+Every scan completion emits a structured tracing event with the gateway,
+binding, table, action, cache hit/miss, pages fetched, rows returned, and
+duration; scan failures emit the same identity plus the error. The client
+logs each retry with the operation and status. Tokens, headers, request
+inputs, and response bodies are never logged.

--- a/docs/open-connector.md
+++ b/docs/open-connector.md
@@ -248,6 +248,12 @@ table's schema either.
 
 Every scan completion emits a structured tracing event with the gateway,
 binding, table, action, cache hit/miss, pages fetched, rows returned, and
-duration; scan failures emit the same identity plus the error. The client
-logs each retry with the operation and status. Tokens, headers, request
-inputs, and response bodies are never logged.
+duration — identifying fields and counters only. Scan failures emit the
+same identity plus the error; for failure diagnosability the error message
+may quote a bounded (at most 512-character) snippet of the gateway's
+*error* response — which can echo request identifiers such as an owner or
+repo name — and, on pagination-loop detection, the offending cursor. The
+client logs each retry with the operation and status. Tokens,
+authorization headers, provider credentials, successful-response bodies,
+and row data are never logged; conversion and row-path failures report
+JSON *kinds*, never values.

--- a/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
+++ b/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
@@ -98,8 +98,12 @@ do not reintroduce it here.
       action/row_path/pagination/columns rejected by `deny_unknown_fields` (tests pin it);
       default-deny allowlist unchanged
 - [x] 4.4 Observability: scan completion/failure tracing events (gateway, binding, table,
-      action, cache hit, pages, rows, duration) without tokens, inputs, or bodies; client
-      retry warns already carried operation + status
+      action, cache hit, pages, rows, duration); completion events carry identity and
+      counters only, failure events add the error — whose message may quote a bounded
+      (≤512-char) snippet of the gateway's *error* response and a pagination cursor for
+      diagnosability, per the design's "no tokens / credentials / authorization headers /
+      full sensitive inputs" wording — never tokens, successful-response bodies, or row
+      data; client retry warns already carried operation + status
 - [x] 4.5 Docs: `docs/open-connector.md` (config reference, three SQL interfaces, security
       model, caching, bounds, observability), ctx/UDTF examples inside it, README
       supported-sources entry (first time the source is actually queryable)

--- a/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
+++ b/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
@@ -108,7 +108,7 @@ do not reintroduce it here.
       model, caching, bounds, observability), ctx/UDTF examples inside it, README
       supported-sources entry (first time the source is actually queryable)
 
-**Verification**: 154 open_connector tests. `open_connector_query` asserted to return the
+**Verification**: 157 open_connector tests. `open_connector_query` asserted to return the
 same schema and values as `saas.ws.items`, replay from the table's cache entry with zero
 new gateway requests, and push the same `min_value` filter and connection alias;
 `open_connector_scan` asserted to execute exactly one POST, expose derived typed/JSON

--- a/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
+++ b/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
@@ -83,15 +83,34 @@ intact. `CREATE EXTERNAL TABLE ... STORED AS OPEN_CONNECTOR` is a
 documented future extension only, gated on a DDL authorization design —
 do not reintroduce it here.
 
-- [ ] 4.1 `open_connector_query` UDTF (built-in pack definitions only)
-- [ ] 4.2 `open_connector_scan` UDTF (allowlisted raw actions only; deterministic row type or planning error)
-- [ ] 4.3 Security policy enforcement: mutating actions rejected pre-HTTP; YAML overrides cannot swap actions/row paths; default-deny allowlist
-- [ ] 4.4 Observability: scan spans/metrics (gateway, binding, action, cache hit, pages, rows, retries) without tokens or bodies
-- [ ] 4.5 Docs: `docs/open-connector.md`, ctx/UDTF examples, README supported-sources entry (first time the source is actually queryable)
+- [x] 4.1 `open_connector_query` UDTF (built-in pack definitions only): compiles into the same
+      provider/scan/cache path as the YAML-bound table (identical schema, filter allowlist,
+      fingerprint gate, shared per-gateway cache); plans against registration-time discovery,
+      so an undiscovered action is a targeted planning error, never a hidden gateway call
+- [x] 4.2 `open_connector_scan` UDTF (allowlisted raw actions only): deterministic row type
+      derived from the discovered output schema at the row path (primitives typed,
+      `["T","null"]` unions nullable, everything else opaque JSON) or a planning error
+      recommending a source pack; single-page live execution (`PaginationStrategy::SinglePage`,
+      no cache, no filter pushdown)
+- [x] 4.3 Security policy enforcement: raw actions require allowlist membership **and** an
+      explicit `read_only: true` in discovered metadata (mutating and unclassified actions
+      rejected at planning, pre-HTTP, with distinct errors); YAML overrides of pack
+      action/row_path/pagination/columns rejected by `deny_unknown_fields` (tests pin it);
+      default-deny allowlist unchanged
+- [x] 4.4 Observability: scan completion/failure tracing events (gateway, binding, table,
+      action, cache hit, pages, rows, duration) without tokens, inputs, or bodies; client
+      retry warns already carried operation + status
+- [x] 4.5 Docs: `docs/open-connector.md` (config reference, three SQL interfaces, security
+      model, caching, bounds, observability), ctx/UDTF examples inside it, README
+      supported-sources entry (first time the source is actually queryable)
 
-**Verification**: both UDTFs return the stable schema and values of their
-corresponding YAML-registered tables; federated join of the mock pack
-against a local CSV.
+**Verification**: 147 open_connector tests. `open_connector_query` asserted to return the
+same schema and values as `saas.ws.items`, replay from the table's cache entry with zero
+new gateway requests, and push the same `min_value` filter and connection alias;
+`open_connector_scan` asserted to execute exactly one POST, expose derived typed/JSON
+columns, and reject unallowlisted, mutating, unclassified, and schema-indeterminate
+actions before any HTTP execute; federated join of the mock pack (via the UDTF) against a
+local CSV.
 
 ## Milestone 5+ — Real source packs (one PR each, per design rollout)
 
@@ -108,9 +127,12 @@ bounded safety defaults, null/empty/nested fixtures, docs.
 
 ## Review notes
 
-- **Current PR**: milestones 1–3 (`feature/open-connector-integration-task-3`).
-  Registration builds a queryable catalog after gateway health, action
-  discovery, source-pack validation, and fingerprint checks.
+- **Current PR**: milestone 4 (UDTFs + security/observability + docs).
+  Milestones 1–3 are merged; registration builds a queryable catalog after
+  gateway health, action discovery, source-pack validation, and fingerprint
+  checks, and now also publishes per-gateway planning state for the two
+  UDTFs (shared with the server `OptimizerRegistry` / CLI the way the
+  KNN/FTS `DatasetRegistry` is).
 - **Invariants to hold in review**: no provider credentials in Skardi;
   read-only until explicitly designed otherwise; pure validation shared by
   CLI and server; no network I/O at query-planning time; no `.unwrap()` in

--- a/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
+++ b/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
@@ -108,7 +108,7 @@ do not reintroduce it here.
       model, caching, bounds, observability), ctx/UDTF examples inside it, README
       supported-sources entry (first time the source is actually queryable)
 
-**Verification**: 150 open_connector tests. `open_connector_query` asserted to return the
+**Verification**: 154 open_connector tests. `open_connector_query` asserted to return the
 same schema and values as `saas.ws.items`, replay from the table's cache entry with zero
 new gateway requests, and push the same `min_value` filter and connection alias;
 `open_connector_scan` asserted to execute exactly one POST, expose derived typed/JSON
@@ -116,7 +116,11 @@ columns, and reject unallowlisted, mutating, unclassified, and schema-indetermin
 actions before any HTTP execute; federated join of the mock pack (via the UDTF) against a
 local CSV. Scan-completion events are emitted with the final batch (LIMIT-satisfied,
 short-final-page exhaustion, and cache-replay scans included), since a satisfied
-downstream LIMIT drops the stream without another poll.
+downstream LIMIT drops the stream without another poll; a test-only tracing capture
+(`testutil::capture_events`) pins the emitted events themselves — exactly one
+completion per scan (LIMIT-terminated stream dropped without a further poll, empty
+scan, cache replay) with the documented field values, and exactly one WARN failure
+event carrying the scan identity and error.
 
 ## Milestone 5+ — Real source packs (one PR each, per design rollout)
 

--- a/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
+++ b/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
@@ -104,13 +104,15 @@ do not reintroduce it here.
       model, caching, bounds, observability), ctx/UDTF examples inside it, README
       supported-sources entry (first time the source is actually queryable)
 
-**Verification**: 147 open_connector tests. `open_connector_query` asserted to return the
+**Verification**: 150 open_connector tests. `open_connector_query` asserted to return the
 same schema and values as `saas.ws.items`, replay from the table's cache entry with zero
 new gateway requests, and push the same `min_value` filter and connection alias;
 `open_connector_scan` asserted to execute exactly one POST, expose derived typed/JSON
 columns, and reject unallowlisted, mutating, unclassified, and schema-indeterminate
 actions before any HTTP execute; federated join of the mock pack (via the UDTF) against a
-local CSV.
+local CSV. Scan-completion events are emitted with the final batch (LIMIT-satisfied,
+short-final-page exhaustion, and cache-replay scans included), since a satisfied
+downstream LIMIT drops the stream without another poll.
 
 ## Milestone 5+ — Real source packs (one PR each, per design rollout)
 


### PR DESCRIPTION
## Summary

This PR implements the fourth milestone of the [Open Connector integration design](https://github.com/SkardiLabs/skardi/blob/main/docs/superpowers/specs/2026-07-11-open-connector-integration-design.md), following #159 (milestones 1–2) and #162 (milestone 3): the interactive SQL surface (`open_connector_query` / `open_connector_scan` UDTFs), default-deny security policy enforcement, scan observability, and the first user-facing documentation — the point at which the source is advertised in the README.

**No SQL DDL**, per the approved design: stable tables register exclusively through context YAML ("registration is a configuration action, not a SQL action"). Both UDTFs are plain `SELECT` table functions, so the SQL validator's no-DDL invariant and shared-`SessionContext` semantics are untouched.

## Milestone 4 — UDTFs + Security/Observability

### 4.1 `open_connector_query` — built-in pack tables, ad hoc

- **`table_functions.rs` (new)** — `open_connector_query(gateway, 'pack.table', resource_json[, connection_alias])` runs a built-in source-pack table without a persistent YAML binding. It resolves the table against `SourcePackRegistry::builtins()` only — there is no way to name an action through this function, so it can execute nothing but the read actions hard-coded in Skardi's packs.

- **Identical scan path as YAML tables** — The function constructs the same `OpenConnectorTableProvider` a binding does: same stable Arrow schema, same `FilterMapping` allowlist and pushdown classification, same pagination strategy, same `max_pages`/`max_rows`/`scan_timeout` bounds, and the **same per-gateway `ScanCache` instance** — a UDTF invocation with the same resource/filters/projection/LIMIT replays a YAML table's cache entry (and vice versa) with zero new gateway requests, verified in tests.

- **Planning-time gates, no network I/O** — `GatewayHandle` captures each gateway's planning-time state (client, `Arc<ActionRegistry>`, cache, allowlist, bounds) when `register_open_connector_tables` succeeds. Planning re-runs the registration gates in memory: required resource inputs present, action discovered, action-contract fingerprint matches the pack's pin. An action that was never discovered (its table not bound, its action not allowlisted) is a targeted planning error telling the operator to bind the table or allowlist the action — never a hidden gateway call.

- **`OpenConnectorGateways`** — `Arc<RwLock<HashMap<String, Arc<GatewayHandle>>>>`, the shared map both UDTFs plan against, owned by the front-end exactly the way the KNN/FTS `DatasetRegistry` is. Handles are published only after every registration gate passes, so a failed registration never leaves a queryable handle behind.

### 4.2 `open_connector_scan` — allowlisted raw actions

- **`open_connector_scan(gateway, action_id, input_json, row_path[, connection_alias])`** invokes an explicitly allowlisted raw read action. Raw actions declare no pagination contract, so the scan is one request, one page (new `PaginationStrategy::SinglePage` — injects nothing, never advances); callers pass any paging inputs explicitly in the input JSON.

- **`raw_schema.rs` (new)** — Deterministic row type or planning error, derived purely from the discovered action output JSON Schema at the row path (in-memory; planning never contacts the gateway):
  - the row-path target must be an array of objects with declared properties, walked through nested `properties` declarations;
  - declared primitives (`string`, `integer`, `number`, `boolean`), including the `["T","null"]` union spelling, become typed nullable columns;
  - objects, arrays, wider unions, and undeclared types become opaque JSON-string columns rather than guesses;
  - columns are sorted by name so the derived schema doesn't depend on the gateway's property serialization order; dotted property names are rejected (they would silently address a nested key through the converter's path parser);
  - anything else fails with `RawRowTypeIndeterminate`, whose message recommends a built-in pack table or a source-pack contribution.

- **Deliberately narrow execution** — `RawScanProvider` uses the shared `OpenConnectorExec` with no cache (raw scans are always live: with no pagination contract there is no "complete result" to store) and no filter pushdown (no allowlist to translate against; provider-side filters go in the input JSON, SQL predicates stay in DataFusion). LIMIT and all safety bounds still apply.

### 4.3 Security policy enforcement — default-deny, pre-HTTP

- **`read_only` classification in discovery** — `DiscoveredAction`/`ActionMetadata` gain `read_only: Option<bool>` with the same `Option` discipline as `locally_executable`: a missing field stays missing and is never read as "yes".

- **The allowlist alone does not grant execution** — a raw scan requires allowlist membership **and** `read_only: Some(true)` in the discovered metadata. `Some(false)` fails as `RawActionMutating`; `None` fails as `RawActionReadOnlyUnknown`, naming the classification gap — two distinct errors so operators can tell an explicit refusal from a metadata gap. Both fire at planning time; tests assert zero gateway POSTs were recorded.

- **Deny-by-order** — the allowlist check runs before any metadata lookup, so an unallowlisted action is rejected without leaking whether it exists.

- **YAML cannot swap the relational contract** — new config tests pin that a binding declaring `action`, `row_path`, `pagination`, or `columns` fails loudly at parse time (`deny_unknown_fields`), rather than being accepted-and-ignored while the config claims a different action than the one that runs.

- **Structural guarantees unchanged** — `OpenConnectorClient::execute` stays `pub(crate)`, so allowlist/classification gating remains un-bypassable from outside the crate; pack tables continue to vouch read-only by Skardi review (they do not consult `read_only`, so gateways that don't emit the flag yet still serve stable tables — only raw scans refuse).

### 4.4 Observability

- **Scan completion event** (once per scan, in `exec.rs`): gateway, binding (or `<udtf>` for ad-hoc scans), table, action, cache hit/miss, pages fetched, rows returned, duration — emitted for live, cached, and empty scans alike.
- **Scan failure event** with the same identity fields, pages fetched, and the error display.
- Tokens, headers, request inputs, and response bodies are never logged; conversion errors already carry JSON *kinds*, not values. Client retry warns (operation, attempt, status) from milestone 2 are unchanged.
- To carry the binding name, `OpenConnectorTableProvider`/`OpenConnectorExec` thread an optional `binding` through from registration.

### 4.5 Docs — the source becomes advertised

- **`docs/open-connector.md` (new)** — configuration reference with every field and default, catalog naming, all three SQL interfaces with runnable examples, federated-join example, security model, caching/freshness semantics, bounds/retries/error behavior, compatibility & schema drift, observability. Status wording is honest per the design's marketing rule: foundation + synthetic mock pack today, provider packs one PR each behind the admission gate.
- **README supported-sources entry** — first added now that the source is actually queryable, linking the new guide.
- **Tasks spec** — milestone 4 items checked off with implementation notes; review-notes section updated to point at this PR.

## Enabling Engine Refactor

The raw UDTF derives its schema at planning time, so the scan engine could no longer require `&'static` pack definitions:

- **`exec.rs`** — `OpenConnectorExec` takes an owned `ScanTarget { table_id, action_id, pagination, source_pack_version }` instead of `&'static SourcePackTable`; `ScanTarget::from_pack_table` keeps the stable-table path a one-liner. Cache-key composition is unchanged (verified by the existing pack-version key test).
- **`json_to_arrow.rs`** — new owned `ColumnSpec` (+ `RowConverter::from_columns`); `RowConverter::new(&[FieldMapping])` keeps its signature and now delegates. A test pins that both constructors produce identical schemas and conversions.
- **`pagination.rs`** — `SinglePage` variant wired through `new`/`apply`/`advance`/`validate`.
- **`row_path.rs`** — `segments()` accessor for the schema walk.

No leaked statics, no per-query allocation tricks: UDTF invocations build ordinary owned providers.

## Front-end Wiring

- **`mod.rs`** — `register_open_connector_tables` gains `udtf_gateways: Option<&OpenConnectorGateways>`; the `ActionRegistry` is now `Arc`-shared between registration and the handle. Module docs updated; stale "execute() unused until the scan engine lands" comment removed.
- **Server** — `OptimizerRegistry` owns the `OpenConnectorGateways` map (accessor + `register_udfs` arm for `DataSourceType::OpenConnector`); the registration arm in `config.rs` passes it through. A new test proves the UDTFs are registered and fail with the targeted "gateway not registered" error rather than "function not found" when no handle exists.
- **CLI** — `new_session_context()` creates the map and registers both UDTFs alongside the existing KNN/FTS functions; `load_and_register_all`/`register_source` thread it to the `open_connector` arm.

## New Error Variants

`UdtfGatewayNotRegistered`, `ActionNotDiscovered` (names the fix: bind the table or allowlist the action), `RawActionNotAllowlisted`, `RawActionMutating`, `RawActionReadOnlyUnknown`, `RawRowTypeIndeterminate` — all surfaced as planning errors with the typed message as the user-facing diagnostic. Argument-shape problems (wrong arity, non-literal args, invalid JSON, non-object input) use `plan_err!` in the established `lance_knn` style.

## Test Coverage

147 `skardi` open_connector tests (was 125), all passing. New coverage:

- **UDTF/YAML parity** — `open_connector_query` returns the same Arrow schema and the same rendered values as `saas.ws.items`; pushes the same `min_value` Exact filter into gateway request bodies; sends the explicit connection alias header on every execute.
- **Shared cache** — a YAML-table scan's cache entry is replayed by an identical UDTF scan with zero new gateway requests.
- **Raw scan** — exactly one POST per scan; derived columns sorted and conservatively typed (`Int64` id, JSON-string `tags`); LIMIT honored; complex fields render as canonical JSON text.
- **Security, asserted via recorded gateway traffic** — unallowlisted (even though discovered via a binding), mutating (`read_only: false`), unclassified (flag absent), and schema-indeterminate actions are all rejected with their distinct messages **before any HTTP execute**; row-path syntax errors too.
- **Planning-time discovery rule** — a pack table whose action was never discovered fails with the bind-or-allowlist error and no gateway traffic.
- **Federated join** — the mock pack, through the UDTF, joined against a local CSV (tempfile + `register_csv`).
- **Argument validation** — arity, non-literal arguments, malformed JSON, malformed table IDs, unknown gateway/pack/table, missing required resource.
- **Engine refactor** — `SinglePage` injects nothing and never advances; owned-`ColumnSpec` converter equivalence; `raw_schema` unit tests for every indeterminate case (no output schema, unknown segment, non-array target, non-object items, propertyless rows, dotted property names, wide unions).
- **Registry/client** — `read_only` passthrough (absent stays absent; explicit `true` carried).
- **Config** — relational-contract override rejection (`action`/`row_path`/`pagination`/`columns`).

Plus 1 new server test (UDTF registration path). Full suites green: `skardi` 646 lib tests, server 134 lib + integration, CLI 61, doc tests; `cargo fmt` applied; `cargo clippy` clean in all touched files.

## Invariants Held (from the tasks-spec review notes)

No provider credentials in Skardi; read-only by construction (execute stays `pub(crate)`, no DML registered); pure validation shared by CLI and server; **no network I/O at query-planning time**; no `.unwrap()` in production paths.

## Out of Scope (Later Milestones)

Real provider packs — GitHub (5.1), Slack (5.2), Notion (5.3), and later waves — land one PR each through the source-pack admission gate. `CREATE EXTERNAL TABLE ... STORED AS OPEN_CONNECTOR` remains a documented future extension gated on a DDL authorization design. Registration-time read-only gating of allowlisted actions (as opposed to scan-planning-time) was deliberately not added, so gateways that don't emit `read_only` metadata yet can still register and serve stable pack tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
