### PR TITLE
refactor(sources): share the UDTF string-argument extractor

### DIFF
--- a/crates/skardi/src/sources/providers/lance/fts_table_function.rs
+++ b/crates/skardi/src/sources/providers/lance/fts_table_function.rs
@@ -39,6 +39,7 @@ use std::sync::Arc;
 
 use super::fts_exec::LanceFtsExec;
 use super::utils::expr_to_lance_sql;
+use crate::sources::providers::udtf_args::{optional_string_arg, string_arg};
 use crate::sources::providers::{DatasetEntry, DatasetRegistry};
 
 /// Table function that creates full-text search on Lance tables
@@ -62,9 +63,9 @@ impl TableFunctionImpl for LanceFtsTableFunction {
             );
         }
 
-        let table_name = extract_string(&exprs[0], "table_name")?;
-        let text_column = extract_string(&exprs[1], "text_column")?;
-        let query = extract_string_or_null(&exprs[2], "query")?;
+        let table_name = string_arg(&exprs[0], "lance_fts", "table_name")?;
+        let text_column = string_arg(&exprs[1], "lance_fts", "text_column")?;
+        let query = optional_string_arg(&exprs[2], "lance_fts", "query")?;
         let limit = extract_int(&exprs[3], "limit")?;
 
         // Get dataset from registry
@@ -308,24 +309,6 @@ impl TableProvider for LanceFtsProvider {
 }
 
 // Helper functions for argument extraction
-
-fn extract_string(expr: &Expr, name: &str) -> DFResult<String> {
-    match expr {
-        Expr::Literal(ScalarValue::Utf8(Some(s)), _) => Ok(s.clone()),
-        Expr::Literal(ScalarValue::LargeUtf8(Some(s)), _) => Ok(s.clone()),
-        // Accept NULL as placeholder during pipeline validation/schema inference.
-        // The inferencer replaces {param} with NULL before plan creation.
-        Expr::Literal(ScalarValue::Null, _) => Ok(String::new()),
-        _ => plan_err!("lance_fts: {} must be a string literal", name),
-    }
-}
-
-fn extract_string_or_null(expr: &Expr, name: &str) -> DFResult<Option<String>> {
-    match expr {
-        Expr::Literal(ScalarValue::Null, _) => Ok(None),
-        other => extract_string(other, name).map(Some),
-    }
-}
 
 fn extract_int(expr: &Expr, name: &str) -> DFResult<usize> {
     match expr {

--- a/crates/skardi/src/sources/providers/lance/knn_table_function.rs
+++ b/crates/skardi/src/sources/providers/lance/knn_table_function.rs
@@ -30,6 +30,7 @@ use std::sync::Arc;
 use super::knn_exec::LanceKnnExec;
 use super::utils::expr_to_lance_sql;
 use crate::sources::providers::knn_utils::extract_k;
+use crate::sources::providers::udtf_args::strict_string_arg;
 use crate::sources::providers::{DatasetEntry, DatasetRegistry};
 
 /// Table function that creates KNN search on Lance tables
@@ -54,11 +55,11 @@ impl TableFunctionImpl for LanceKnnTableFunction {
         }
 
         // Extract string arguments
-        let table_name = extract_string(&exprs[0], "table_name")?;
-        let vector_column = extract_string(&exprs[1], "vector_column")?;
+        let table_name = strict_string_arg(&exprs[0], "lance_knn", "table_name")?;
+        let vector_column = strict_string_arg(&exprs[1], "lance_knn", "vector_column")?;
         let k = extract_k(&exprs[3], "lance_knn")?;
         let filter = if exprs.len() == 5 {
-            Some(extract_string(&exprs[4], "filter")?)
+            Some(strict_string_arg(&exprs[4], "lance_knn", "filter")?)
         } else {
             None
         };
@@ -229,14 +230,6 @@ impl TableProvider for LanceKnnProvider {
 }
 
 // Helper functions for argument extraction
-
-fn extract_string(expr: &Expr, name: &str) -> DFResult<String> {
-    match expr {
-        Expr::Literal(ScalarValue::Utf8(Some(s)), _) => Ok(s.clone()),
-        Expr::Literal(ScalarValue::LargeUtf8(Some(s)), _) => Ok(s.clone()),
-        _ => plan_err!("lance_knn: {} must be a string literal", name),
-    }
-}
 
 fn try_extract_vector(expr: &Expr) -> DFResult<Option<ArrayRef>> {
     match expr {

--- a/crates/skardi/src/sources/providers/mod.rs
+++ b/crates/skardi/src/sources/providers/mod.rs
@@ -14,6 +14,7 @@ pub mod redis;
 pub mod seekdb;
 pub mod sqlite;
 pub mod sqlx;
+pub(crate) mod udtf_args;
 
 use ::lance::dataset::Dataset;
 use datafusion::datasource::TableProvider;

--- a/crates/skardi/src/sources/providers/mongo/fts_table_function.rs
+++ b/crates/skardi/src/sources/providers/mongo/fts_table_function.rs
@@ -29,6 +29,7 @@ use std::sync::Arc;
 
 use super::fts_exec::MongoFtsExec;
 use super::{binary_expr_to_mongo, is_pushable_binary_filter};
+use crate::sources::providers::udtf_args::string_arg;
 use crate::sources::providers::{DatasetEntry, DatasetRegistry};
 
 /// Maximum allowed FTS result limit (matches MAX_KNN_K).
@@ -65,8 +66,8 @@ impl TableFunctionImpl for MongoFtsTableFunction {
             );
         }
 
-        let collection_name = extract_string(&exprs[0], "collection")?;
-        let query = extract_string(&exprs[1], "query")?;
+        let collection_name = string_arg(&exprs[0], "mongo_fts", "collection")?;
+        let query = string_arg(&exprs[1], "mongo_fts", "query")?;
         let limit = extract_int(&exprs[2], "limit")?;
 
         // The inferencer replaces {param} with NULL, yielding empty string for
@@ -235,21 +236,6 @@ fn expr_to_mongo_filter_entry(expr: &Expr, primary_key: &str) -> Option<Document
 }
 
 // ─── Argument extraction helpers ─────────────────────────────────────────────
-
-fn extract_string(expr: &Expr, name: &str) -> DFResult<String> {
-    match expr {
-        Expr::Literal(ScalarValue::Utf8(Some(s)), _)
-        | Expr::Literal(ScalarValue::LargeUtf8(Some(s)), _) => Ok(s.clone()),
-        // Accept NULL as placeholder during pipeline validation/schema inference.
-        // The inferencer replaces {param} with NULL before plan creation.
-        Expr::Literal(ScalarValue::Null, _) => Ok(String::new()),
-        _ => plan_err!(
-            "mongo_fts: '{}' must be a string literal, got {:?}",
-            name,
-            expr
-        ),
-    }
-}
 
 fn extract_int(expr: &Expr, name: &str) -> DFResult<usize> {
     match expr {

--- a/crates/skardi/src/sources/providers/open_connector/table_functions.rs
+++ b/crates/skardi/src/sources/providers/open_connector/table_functions.rs
@@ -37,7 +37,7 @@ use std::time::Duration;
 use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
 use datafusion::catalog::{Session, TableFunctionImpl, TableProvider};
-use datafusion::common::plan_err;
+use datafusion::common::{plan_datafusion_err, plan_err};
 use datafusion::datasource::TableType;
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::logical_expr::Expr;
@@ -420,7 +420,7 @@ fn plan_error(e: OpenConnectorError) -> DataFusionError {
 /// inputs"), so sharing the implementation doesn't flatten the context.
 fn parse_json_object(fn_name: &str, arg: &str, raw: &str, noun: &str) -> DFResult<Value> {
     let value: Value = serde_json::from_str(raw)
-        .map_err(|e| DataFusionError::Plan(format!("{fn_name}: {arg} is not valid JSON: {e}")))?;
+        .map_err(|e| plan_datafusion_err!("{fn_name}: {arg} is not valid JSON: {e}"))?;
     if !value.is_object() {
         return plan_err!(
             "{fn_name}: {arg} must be a JSON object of {noun}, \

--- a/crates/skardi/src/sources/providers/open_connector/table_functions.rs
+++ b/crates/skardi/src/sources/providers/open_connector/table_functions.rs
@@ -762,6 +762,26 @@ raw_action_allowlist:
             "'gateway' must be a string literal",
         )
         .await;
+        // NULL is rejected outright for schema-determining arguments — a
+        // placeholder cannot produce a plan (strict_string_arg semantics).
+        expect_plan_error(
+            &ctx,
+            "SELECT * FROM open_connector_query(NULL, 'mock.items', '{}')",
+            "'gateway' must be a string literal, not NULL",
+        )
+        .await;
+        expect_plan_error(
+            &ctx,
+            "SELECT * FROM open_connector_query('saas', NULL, '{}')",
+            "'table_id' must be a string literal, not NULL",
+        )
+        .await;
+        expect_plan_error(
+            &ctx,
+            "SELECT * FROM open_connector_query('saas', 'mock.items', NULL)",
+            "'resource_json' must be a string literal, not NULL",
+        )
+        .await;
 
         assert_eq!(
             execute_requests(&gateway).len(),

--- a/crates/skardi/src/sources/providers/open_connector/table_functions.rs
+++ b/crates/skardi/src/sources/providers/open_connector/table_functions.rs
@@ -37,7 +37,7 @@ use std::time::Duration;
 use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
 use datafusion::catalog::{Session, TableFunctionImpl, TableProvider};
-use datafusion::common::{ScalarValue, plan_err};
+use datafusion::common::plan_err;
 use datafusion::datasource::TableType;
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::logical_expr::Expr;
@@ -57,6 +57,7 @@ use super::raw_schema::derive_raw_columns;
 use super::row_path::RowPath;
 use super::source_pack::SourcePackRegistry;
 use super::table::OpenConnectorTableProvider;
+use crate::sources::providers::udtf_args::strict_string_arg;
 
 /// Planning-time state of one registered gateway, captured by
 /// `register_open_connector_tables` and shared with both UDTFs.
@@ -143,12 +144,12 @@ impl TableFunctionImpl for OpenConnectorQueryFunction {
                 exprs.len()
             );
         }
-        let gateway = literal_string("open_connector_query", &exprs[0], "gateway")?;
-        let table_id = literal_string("open_connector_query", &exprs[1], "table_id")?;
-        let resource_json = literal_string("open_connector_query", &exprs[2], "resource_json")?;
+        let gateway = strict_string_arg(&exprs[0], "open_connector_query", "gateway")?;
+        let table_id = strict_string_arg(&exprs[1], "open_connector_query", "table_id")?;
+        let resource_json = strict_string_arg(&exprs[2], "open_connector_query", "resource_json")?;
         let alias = exprs
             .get(3)
-            .map(|expr| literal_string("open_connector_query", expr, "connection_alias"))
+            .map(|expr| strict_string_arg(expr, "open_connector_query", "connection_alias"))
             .transpose()?;
 
         let handle = lookup_gateway(&self.gateways, &gateway)?;
@@ -242,13 +243,13 @@ impl TableFunctionImpl for OpenConnectorScanFunction {
                 exprs.len()
             );
         }
-        let gateway = literal_string("open_connector_scan", &exprs[0], "gateway")?;
-        let action_id = literal_string("open_connector_scan", &exprs[1], "action_id")?;
-        let input_json = literal_string("open_connector_scan", &exprs[2], "input_json")?;
-        let row_path = literal_string("open_connector_scan", &exprs[3], "row_path")?;
+        let gateway = strict_string_arg(&exprs[0], "open_connector_scan", "gateway")?;
+        let action_id = strict_string_arg(&exprs[1], "open_connector_scan", "action_id")?;
+        let input_json = strict_string_arg(&exprs[2], "open_connector_scan", "input_json")?;
+        let row_path = strict_string_arg(&exprs[3], "open_connector_scan", "row_path")?;
         let alias = exprs
             .get(4)
-            .map(|expr| literal_string("open_connector_scan", expr, "connection_alias"))
+            .map(|expr| strict_string_arg(expr, "open_connector_scan", "connection_alias"))
             .transpose()?;
 
         let handle = lookup_gateway(&self.gateways, &gateway)?;
@@ -421,15 +422,6 @@ fn discovered_action(
 /// the user-facing diagnostic.
 fn plan_error(e: OpenConnectorError) -> DataFusionError {
     DataFusionError::Plan(e.to_string())
-}
-
-/// Extract one string-literal argument.
-fn literal_string(function: &str, expr: &Expr, name: &str) -> DFResult<String> {
-    match expr {
-        Expr::Literal(ScalarValue::Utf8(Some(s)), _)
-        | Expr::Literal(ScalarValue::LargeUtf8(Some(s)), _) => Ok(s.clone()),
-        _ => plan_err!("{function}: {name} must be a string literal"),
-    }
 }
 
 #[cfg(test)]
@@ -755,7 +747,7 @@ raw_action_allowlist:
         expect_plan_error(
             &ctx,
             "SELECT * FROM open_connector_query(1, 'mock.items', '{}')",
-            "gateway must be a string literal",
+            "'gateway' must be a string literal",
         )
         .await;
 

--- a/crates/skardi/src/sources/providers/open_connector/table_functions.rs
+++ b/crates/skardi/src/sources/providers/open_connector/table_functions.rs
@@ -166,17 +166,7 @@ impl TableFunctionImpl for OpenConnectorQueryFunction {
         let pack = self.packs.require(pack_name).map_err(plan_error)?;
         let table = self.packs.table(pack, table_name).map_err(plan_error)?;
 
-        let resource: Value = serde_json::from_str(&resource_json).map_err(|e| {
-            DataFusionError::Plan(format!(
-                "open_connector_query: resource_json is not valid JSON: {e}"
-            ))
-        })?;
-        if !resource.is_object() {
-            return plan_err!(
-                "open_connector_query: resource_json must be a JSON object of resource \
-                 inputs, e.g. '{{\"owner\":\"SkardiLabs\",\"repo\":\"skardi\"}}'"
-            );
-        }
+        let resource = parse_json_object("open_connector_query", "resource_json", &resource_json)?;
         for key in table.required_resources {
             if resource.get(*key).is_none() {
                 return Err(plan_error(OpenConnectorError::MissingResourceInput {
@@ -280,17 +270,7 @@ impl TableFunctionImpl for OpenConnectorScanFunction {
             }
         }
 
-        let input: Value = serde_json::from_str(&input_json).map_err(|e| {
-            DataFusionError::Plan(format!(
-                "open_connector_scan: input_json is not valid JSON: {e}"
-            ))
-        })?;
-        if !input.is_object() {
-            return plan_err!(
-                "open_connector_scan: input_json must be a JSON object of action inputs, \
-                 e.g. '{{\"owner\":\"SkardiLabs\",\"repo\":\"skardi\"}}'"
-            );
-        }
+        let input = parse_json_object("open_connector_scan", "input_json", &input_json)?;
 
         let row_path = RowPath::parse(&row_path).map_err(plan_error)?;
         // Deterministic row type or planning error — derived purely from the
@@ -422,6 +402,21 @@ fn discovered_action(
 /// the user-facing diagnostic.
 fn plan_error(e: OpenConnectorError) -> DataFusionError {
     DataFusionError::Plan(e.to_string())
+}
+
+/// Parse a UDTF argument that must carry a JSON object (resource / action
+/// inputs), shared by both functions so the two diagnostics stay in
+/// lockstep.
+fn parse_json_object(fn_name: &str, arg: &str, raw: &str) -> DFResult<Value> {
+    let value: Value = serde_json::from_str(raw)
+        .map_err(|e| DataFusionError::Plan(format!("{fn_name}: {arg} is not valid JSON: {e}")))?;
+    if !value.is_object() {
+        return plan_err!(
+            "{fn_name}: {arg} must be a JSON object of input fields, \
+             e.g. '{{\"owner\":\"SkardiLabs\",\"repo\":\"skardi\"}}'"
+        );
+    }
+    Ok(value)
 }
 
 #[cfg(test)]
@@ -740,6 +735,12 @@ raw_action_allowlist:
         .await;
         expect_plan_error(
             &ctx,
+            "SELECT * FROM open_connector_query('saas', 'mock.items', '[1, 2]')",
+            "resource_json must be a JSON object",
+        )
+        .await;
+        expect_plan_error(
+            &ctx,
             "SELECT * FROM open_connector_query('saas', 'mock.items')",
             "expects 3-4 arguments",
         )
@@ -988,6 +989,13 @@ raw_action_allowlist:
             r#"SELECT * FROM open_connector_scan('saas', 'mock.list_items',
                                                  '{"workspace":"demo"}', 'items')"#,
             "must start with '$.'",
+        )
+        .await;
+        expect_plan_error(
+            &ctx,
+            r#"SELECT * FROM open_connector_scan('saas', 'mock.list_items',
+                                                 '[1, 2]', '$.items')"#,
+            "input_json must be a JSON object",
         )
         .await;
         assert!(execute_requests(&gateway).is_empty(), "rejected pre-HTTP");

--- a/crates/skardi/src/sources/providers/open_connector/table_functions.rs
+++ b/crates/skardi/src/sources/providers/open_connector/table_functions.rs
@@ -166,7 +166,12 @@ impl TableFunctionImpl for OpenConnectorQueryFunction {
         let pack = self.packs.require(pack_name).map_err(plan_error)?;
         let table = self.packs.table(pack, table_name).map_err(plan_error)?;
 
-        let resource = parse_json_object("open_connector_query", "resource_json", &resource_json)?;
+        let resource = parse_json_object(
+            "open_connector_query",
+            "resource_json",
+            &resource_json,
+            "resource inputs",
+        )?;
         for key in table.required_resources {
             if resource.get(*key).is_none() {
                 return Err(plan_error(OpenConnectorError::MissingResourceInput {
@@ -270,7 +275,12 @@ impl TableFunctionImpl for OpenConnectorScanFunction {
             }
         }
 
-        let input = parse_json_object("open_connector_scan", "input_json", &input_json)?;
+        let input = parse_json_object(
+            "open_connector_scan",
+            "input_json",
+            &input_json,
+            "action inputs",
+        )?;
 
         let row_path = RowPath::parse(&row_path).map_err(plan_error)?;
         // Deterministic row type or planning error — derived purely from the
@@ -404,15 +414,16 @@ fn plan_error(e: OpenConnectorError) -> DataFusionError {
     DataFusionError::Plan(e.to_string())
 }
 
-/// Parse a UDTF argument that must carry a JSON object (resource / action
-/// inputs), shared by both functions so the two diagnostics stay in
-/// lockstep.
-fn parse_json_object(fn_name: &str, arg: &str, raw: &str) -> DFResult<Value> {
+/// Parse a UDTF argument that must carry a JSON object, shared by both
+/// functions so the two diagnostics stay in lockstep. `noun` names what the
+/// object holds in the caller's vocabulary ("resource inputs" / "action
+/// inputs"), so sharing the implementation doesn't flatten the context.
+fn parse_json_object(fn_name: &str, arg: &str, raw: &str, noun: &str) -> DFResult<Value> {
     let value: Value = serde_json::from_str(raw)
         .map_err(|e| DataFusionError::Plan(format!("{fn_name}: {arg} is not valid JSON: {e}")))?;
     if !value.is_object() {
         return plan_err!(
-            "{fn_name}: {arg} must be a JSON object of input fields, \
+            "{fn_name}: {arg} must be a JSON object of {noun}, \
              e.g. '{{\"owner\":\"SkardiLabs\",\"repo\":\"skardi\"}}'"
         );
     }
@@ -736,7 +747,7 @@ raw_action_allowlist:
         expect_plan_error(
             &ctx,
             "SELECT * FROM open_connector_query('saas', 'mock.items', '[1, 2]')",
-            "resource_json must be a JSON object",
+            "resource_json must be a JSON object of resource inputs",
         )
         .await;
         expect_plan_error(
@@ -995,7 +1006,7 @@ raw_action_allowlist:
             &ctx,
             r#"SELECT * FROM open_connector_scan('saas', 'mock.list_items',
                                                  '[1, 2]', '$.items')"#,
-            "input_json must be a JSON object",
+            "input_json must be a JSON object of action inputs",
         )
         .await;
         assert!(execute_requests(&gateway).is_empty(), "rejected pre-HTTP");

--- a/crates/skardi/src/sources/providers/seekdb/fts_table_function.rs
+++ b/crates/skardi/src/sources/providers/seekdb/fts_table_function.rs
@@ -36,8 +36,9 @@ use datafusion_table_providers::sql::db_connection_pool::mysqlpool::MySQLConnect
 use std::any::Any;
 use std::sync::Arc;
 
+use super::expr_to_seekdb_sql;
 use super::fts_exec::SeekDbFtsExec;
-use super::{expr_to_seekdb_sql, extract_string_arg};
+use crate::sources::providers::udtf_args::string_arg;
 use crate::sources::providers::{DatasetEntry, DatasetRegistry};
 
 /// Maximum allowed FTS result limit.
@@ -66,9 +67,9 @@ impl TableFunctionImpl for SeekDbFtsTableFunction {
             );
         }
 
-        let table_name = extract_string_arg(&exprs[0], "seekdb_fts", "table")?;
-        let text_col = extract_string_arg(&exprs[1], "seekdb_fts", "text_col")?;
-        let query = extract_string_arg(&exprs[2], "seekdb_fts", "query")?;
+        let table_name = string_arg(&exprs[0], "seekdb_fts", "table")?;
+        let text_col = string_arg(&exprs[1], "seekdb_fts", "text_col")?;
+        let query = string_arg(&exprs[2], "seekdb_fts", "query")?;
         let limit = match extract_int(&exprs[3], "limit")? {
             None => 1,
             Some(v) if v > MAX_FTS_LIMIT => {

--- a/crates/skardi/src/sources/providers/seekdb/knn_table_function.rs
+++ b/crates/skardi/src/sources/providers/seekdb/knn_table_function.rs
@@ -52,9 +52,10 @@ use datafusion_table_providers::sql::db_connection_pool::mysqlpool::MySQLConnect
 use std::any::Any;
 use std::sync::Arc;
 
+use super::expr_to_seekdb_sql;
 use super::knn_exec::{DistanceMetric, SeekDbKnnExec};
-use super::{expr_to_seekdb_sql, extract_string_arg};
 use crate::sources::providers::knn_utils::{extract_k, extract_literal_vector};
+use crate::sources::providers::udtf_args::string_arg;
 use crate::sources::providers::{DatasetEntry, DatasetRegistry};
 
 /// Entry stored in the registry for each registered SeekDB table.
@@ -92,10 +93,10 @@ impl TableFunctionImpl for SeekDbKnnTableFunction {
             );
         }
 
-        let table_name = extract_string_arg(&exprs[0], "seekdb_knn", "table")?;
-        let vector_col = extract_string_arg(&exprs[1], "seekdb_knn", "vector_col")?;
+        let table_name = string_arg(&exprs[0], "seekdb_knn", "table")?;
+        let vector_col = string_arg(&exprs[1], "seekdb_knn", "vector_col")?;
 
-        let metric_str = extract_string_arg(&exprs[3], "seekdb_knn", "metric")?;
+        let metric_str = string_arg(&exprs[3], "seekdb_knn", "metric")?;
         let metric = if metric_str.is_empty() {
             // NULL placeholder during schema inference — default to L2.
             DistanceMetric::default()

--- a/crates/skardi/src/sources/providers/seekdb/mod.rs
+++ b/crates/skardi/src/sources/providers/seekdb/mod.rs
@@ -39,7 +39,7 @@ use arrow::array::{RecordBatch, UInt64Array};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
 use async_trait::async_trait;
 use datafusion::catalog::Session;
-use datafusion::common::{Constraints, ScalarValue, plan_err};
+use datafusion::common::Constraints;
 use datafusion::datasource::{TableProvider, TableType};
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
@@ -791,23 +791,6 @@ pub(crate) fn quote_seekdb_table(tbl: &TableReference) -> String {
 pub(crate) fn expr_to_seekdb_sql(expr: &Expr) -> Option<String> {
     let unparser = Unparser::new(&MySqlDialect {});
     unparser.expr_to_sql(expr).ok().map(|ast| ast.to_string())
-}
-
-/// Extract a string-literal argument from a table-function `Expr`. Shared by
-/// `seekdb_fts` and `seekdb_knn` so they can emit consistent error messages
-/// prefixed with the caller's UDTF name (`fn_name`). NULL is accepted as a
-/// placeholder during pipeline schema inference and returns the empty string.
-pub(crate) fn extract_string_arg(
-    expr: &Expr,
-    fn_name: &str,
-    arg: &str,
-) -> DataFusionResult<String> {
-    match expr {
-        Expr::Literal(ScalarValue::Utf8(Some(s)), _)
-        | Expr::Literal(ScalarValue::LargeUtf8(Some(s)), _) => Ok(s.clone()),
-        Expr::Literal(ScalarValue::Null, _) => Ok(String::new()),
-        _ => plan_err!("{fn_name}: '{arg}' must be a string literal"),
-    }
 }
 
 // ─── Execution plan for DELETE / UPDATE results ─────────────────────────────

--- a/crates/skardi/src/sources/providers/sqlite/fts_table_function.rs
+++ b/crates/skardi/src/sources/providers/sqlite/fts_table_function.rs
@@ -29,8 +29,9 @@ use std::any::Any;
 use std::sync::Arc;
 use tokio_rusqlite::Connection;
 
+use super::expr_to_sqlite_sql;
 use super::fts_exec::SqliteFtsExec;
-use super::{expr_to_sqlite_sql, extract_string};
+use crate::sources::providers::udtf_args::string_arg;
 use crate::sources::providers::{DatasetEntry, DatasetRegistry};
 
 /// Maximum allowed FTS result limit.
@@ -59,9 +60,9 @@ impl TableFunctionImpl for SqliteFtsTableFunction {
             );
         }
 
-        let table_name = extract_string(&exprs[0], "table")?;
-        let text_col = extract_string(&exprs[1], "text_col")?;
-        let query = extract_string(&exprs[2], "query")?;
+        let table_name = string_arg(&exprs[0], "sqlite_fts", "table")?;
+        let text_col = string_arg(&exprs[1], "sqlite_fts", "text_col")?;
+        let query = string_arg(&exprs[2], "sqlite_fts", "query")?;
         // `extract_int` returns `None` for NULL literals (placeholder mode used
         // by pipeline validation) and `Some(v)` for a real value, which is
         // already guaranteed positive. In placeholder mode, substitute a stub

--- a/crates/skardi/src/sources/providers/sqlite/knn_table_function.rs
+++ b/crates/skardi/src/sources/providers/sqlite/knn_table_function.rs
@@ -33,9 +33,10 @@ use std::any::Any;
 use std::sync::Arc;
 use tokio_rusqlite::Connection;
 
+use super::expr_to_sqlite_sql;
 use super::knn_exec::SqliteKnnExec;
-use super::{expr_to_sqlite_sql, extract_string};
 use crate::sources::providers::knn_utils::{extract_k, extract_literal_vector};
+use crate::sources::providers::udtf_args::string_arg;
 use crate::sources::providers::{DatasetEntry, DatasetRegistry};
 
 /// Entry stored in the registry for each registered SQLite table.
@@ -73,8 +74,8 @@ impl TableFunctionImpl for SqliteKnnTableFunction {
             );
         }
 
-        let table_name = extract_string(&exprs[0], "table")?;
-        let vector_col = extract_string(&exprs[1], "vector_col")?;
+        let table_name = string_arg(&exprs[0], "sqlite_knn", "table")?;
+        let vector_col = string_arg(&exprs[1], "sqlite_knn", "vector_col")?;
         let k = extract_k(&exprs[3], "sqlite_knn")?;
 
         // Try to extract a literal vector.

--- a/crates/skardi/src/sources/providers/sqlite/mod.rs
+++ b/crates/skardi/src/sources/providers/sqlite/mod.rs
@@ -1549,8 +1549,6 @@ pub(crate) fn expr_to_sqlite_sql(expr: &Expr) -> Option<String> {
     unparser.expr_to_sql(expr).ok().map(|ast| ast.to_string())
 }
 
-/// Extract a string literal from a DataFusion `Expr`.
-/// Returns an empty string for NULL placeholders (schema inference).
 /// Produces a properly quoted table reference string for SQLite.
 fn quote_sqlite_table(tbl: &TableReference) -> String {
     quote_sqlite_ident(tbl.table())

--- a/crates/skardi/src/sources/providers/sqlite/mod.rs
+++ b/crates/skardi/src/sources/providers/sqlite/mod.rs
@@ -16,7 +16,7 @@ use arrow::array::{
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use async_trait::async_trait;
 use datafusion::catalog::Session;
-use datafusion::common::{Constraints, ScalarValue};
+use datafusion::common::Constraints;
 use datafusion::datasource::{TableProvider, TableType};
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
@@ -1551,18 +1551,6 @@ pub(crate) fn expr_to_sqlite_sql(expr: &Expr) -> Option<String> {
 
 /// Extract a string literal from a DataFusion `Expr`.
 /// Returns an empty string for NULL placeholders (schema inference).
-pub(crate) fn extract_string(expr: &Expr, name: &str) -> DataFusionResult<String> {
-    match expr {
-        Expr::Literal(ScalarValue::Utf8(Some(s)), _)
-        | Expr::Literal(ScalarValue::LargeUtf8(Some(s)), _) => Ok(s.clone()),
-        Expr::Literal(ScalarValue::Null, _) => Ok(String::new()),
-        _ => Err(DataFusionError::Plan(format!(
-            "sqlite: '{}' must be a string literal",
-            name
-        ))),
-    }
-}
-
 /// Produces a properly quoted table reference string for SQLite.
 fn quote_sqlite_table(tbl: &TableReference) -> String {
     quote_sqlite_ident(tbl.table())

--- a/crates/skardi/src/sources/providers/sqlx/pg/fts_table_function.rs
+++ b/crates/skardi/src/sources/providers/sqlx/pg/fts_table_function.rs
@@ -38,6 +38,7 @@ use std::sync::Arc;
 
 use super::fts_exec::PgFtsExec;
 use super::utils::expr_to_pg_sql;
+use crate::sources::providers::udtf_args::string_arg;
 use crate::sources::providers::{DatasetEntry, DatasetRegistry};
 
 /// Maximum allowed FTS result limit.
@@ -66,13 +67,13 @@ impl TableFunctionImpl for PgFtsTableFunction {
             );
         }
 
-        let table_name = extract_string(&exprs[0], "table")?;
-        let text_col = extract_string(&exprs[1], "text_col")?;
-        let query = extract_string(&exprs[2], "query")?;
+        let table_name = string_arg(&exprs[0], "pg_fts", "table")?;
+        let text_col = string_arg(&exprs[1], "pg_fts", "text_col")?;
+        let query = string_arg(&exprs[2], "pg_fts", "query")?;
         let limit = extract_int(&exprs[3], "limit")?;
 
         let language = if exprs.len() == 5 {
-            let lang = extract_string(&exprs[4], "language")?;
+            let lang = string_arg(&exprs[4], "pg_fts", "language")?;
             if lang.is_empty() {
                 "english".to_string()
             } else {
@@ -240,16 +241,6 @@ impl TableProvider for PgFtsProvider {
 }
 
 // ─── Argument extraction helpers ─────────────────────────────────────────────
-
-fn extract_string(expr: &Expr, name: &str) -> DFResult<String> {
-    match expr {
-        Expr::Literal(ScalarValue::Utf8(Some(s)), _)
-        | Expr::Literal(ScalarValue::LargeUtf8(Some(s)), _) => Ok(s.clone()),
-        // Accept NULL as placeholder during pipeline validation/schema inference.
-        Expr::Literal(ScalarValue::Null, _) => Ok(String::new()),
-        _ => plan_err!("pg_fts: '{}' must be a string literal", name),
-    }
-}
 
 fn extract_int(expr: &Expr, name: &str) -> DFResult<usize> {
     match expr {

--- a/crates/skardi/src/sources/providers/sqlx/pg/knn_table_function.rs
+++ b/crates/skardi/src/sources/providers/sqlx/pg/knn_table_function.rs
@@ -41,7 +41,7 @@ use std::sync::Arc;
 use super::knn_exec::{DistanceMetric, PgKnnExec, PgVectorFetchExec};
 use super::utils::expr_to_pg_sql;
 use crate::sources::providers::knn_utils::{extract_k, extract_literal_vector};
-use crate::sources::providers::udtf_args::strict_string_arg;
+use crate::sources::providers::udtf_args::{optional_string_arg, strict_string_arg};
 use crate::sources::providers::{DatasetEntry, DatasetRegistry};
 
 /// Entry stored in the registry for each registered Postgres table.
@@ -91,8 +91,11 @@ impl TableFunctionImpl for PgKnnTableFunction {
 
         let k = extract_k(&exprs[4], "pg_knn")?;
 
+        // NULL means "no filter" (the pipeline placeholder); anything else
+        // that isn't a string literal is an error — the previous `.ok()`
+        // silently dropped a malformed filter, returning unfiltered rows.
         let inline_filter = if exprs.len() == 6 {
-            strict_string_arg(&exprs[5], "pg_knn", "filter").ok()
+            optional_string_arg(&exprs[5], "pg_knn", "filter")?
         } else {
             None
         };
@@ -433,6 +436,54 @@ mod tests {
             "not_a_subquery",
         ));
         assert!(build_vector_fetch_sql(&expr).is_err());
+    }
+
+    fn knn_args(filter: Expr) -> Vec<Expr> {
+        use datafusion::logical_expr::lit;
+        vec![
+            lit("items"),
+            lit("embedding"),
+            lit("placeholder"), // vector arg is resolved after the filter
+            lit("<->"),
+            lit(5i64),
+            filter,
+        ]
+    }
+
+    #[test]
+    fn malformed_inline_filter_is_an_error_not_silently_dropped() {
+        // A filter the planner can't read must fail the query — the old
+        // `.ok()` swallowed it and returned unfiltered rows.
+        use datafusion::logical_expr::lit;
+        let function = PgKnnTableFunction::new(Arc::new(std::sync::RwLock::new(
+            std::collections::HashMap::new(),
+        )));
+        let err = function.call(&knn_args(lit(42i64))).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("pg_knn: 'filter' must be a string literal"),
+            "got {err}"
+        );
+    }
+
+    #[test]
+    fn null_inline_filter_means_no_filter() {
+        // NULL is the pipeline placeholder for "not provided": argument
+        // extraction passes and planning proceeds to the registry lookup
+        // (which fails here only because the test registry is empty).
+        let function = PgKnnTableFunction::new(Arc::new(std::sync::RwLock::new(
+            std::collections::HashMap::new(),
+        )));
+        let err = function
+            .call(&knn_args(Expr::Literal(
+                datafusion::common::ScalarValue::Null,
+                None,
+            )))
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("not found in registry"),
+            "NULL filter must not fail extraction; got {err}"
+        );
     }
 }
 

--- a/crates/skardi/src/sources/providers/sqlx/pg/knn_table_function.rs
+++ b/crates/skardi/src/sources/providers/sqlx/pg/knn_table_function.rs
@@ -27,7 +27,7 @@
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use async_trait::async_trait;
 use datafusion::catalog::{Session, TableFunctionImpl, TableProvider};
-use datafusion::common::{Result as DFResult, ScalarValue, plan_err};
+use datafusion::common::{Result as DFResult, plan_err};
 use datafusion::datasource::TableType;
 use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
 use datafusion::physical_plan::ExecutionPlan;
@@ -41,6 +41,7 @@ use std::sync::Arc;
 use super::knn_exec::{DistanceMetric, PgKnnExec, PgVectorFetchExec};
 use super::utils::expr_to_pg_sql;
 use crate::sources::providers::knn_utils::{extract_k, extract_literal_vector};
+use crate::sources::providers::udtf_args::strict_string_arg;
 use crate::sources::providers::{DatasetEntry, DatasetRegistry};
 
 /// Entry stored in the registry for each registered Postgres table.
@@ -79,11 +80,11 @@ impl TableFunctionImpl for PgKnnTableFunction {
             );
         }
 
-        let table_name = extract_string(&exprs[0], "table")?;
-        let vector_col = extract_string(&exprs[1], "vector_col")?;
+        let table_name = strict_string_arg(&exprs[0], "pg_knn", "table")?;
+        let vector_col = strict_string_arg(&exprs[1], "pg_knn", "vector_col")?;
 
         let metric = {
-            let s = extract_string(&exprs[3], "metric")?;
+            let s = strict_string_arg(&exprs[3], "pg_knn", "metric")?;
             s.parse::<DistanceMetric>()
                 .map_err(datafusion::error::DataFusionError::Plan)?
         };
@@ -91,7 +92,7 @@ impl TableFunctionImpl for PgKnnTableFunction {
         let k = extract_k(&exprs[4], "pg_knn")?;
 
         let inline_filter = if exprs.len() == 6 {
-            extract_string(&exprs[5], "filter").ok()
+            strict_string_arg(&exprs[5], "pg_knn", "filter").ok()
         } else {
             None
         };
@@ -461,15 +462,5 @@ fn pg_type_to_arrow(
         "boolean" => DataType::Boolean,
         // Everything else (text, varchar, uuid, json, jsonb, timestamp, date, …)
         _ => DataType::Utf8,
-    }
-}
-
-// ─── Argument extraction helpers ─────────────────────────────────────────────
-
-fn extract_string(expr: &Expr, name: &str) -> DFResult<String> {
-    match expr {
-        Expr::Literal(ScalarValue::Utf8(Some(s)), _) => Ok(s.clone()),
-        Expr::Literal(ScalarValue::LargeUtf8(Some(s)), _) => Ok(s.clone()),
-        _ => plan_err!("pg_knn: '{}' must be a string literal", name),
     }
 }

--- a/crates/skardi/src/sources/providers/udtf_args.rs
+++ b/crates/skardi/src/sources/providers/udtf_args.rs
@@ -1,0 +1,106 @@
+//! Planning-time argument extraction shared by every table function.
+//!
+//! Each UDTF used to re-implement its own `Expr` → string-literal extractor
+//! with drifting error wording and NULL handling. These helpers keep the
+//! wording uniform and make the three deliberate NULL semantics explicit at
+//! each call site:
+//!
+//! - [`string_arg`] — NULL is accepted as a placeholder during pipeline
+//!   schema inference (the inferencer replaces `{param}` with NULL before
+//!   plan creation) and yields the empty string; the real value is
+//!   substituted textually at request time before re-planning, so the
+//!   placeholder never executes.
+//! - [`optional_string_arg`] — NULL means "argument not provided".
+//! - [`strict_string_arg`] — NULL is rejected: for arguments that determine
+//!   the planned schema (a table, gateway, or column name), where a
+//!   placeholder cannot produce a plan and accepting one would only trade
+//!   this targeted error for a confusing lookup failure.
+
+use datafusion::common::{ScalarValue, plan_err};
+use datafusion::error::Result as DFResult;
+use datafusion::logical_expr::Expr;
+
+/// Extract a string-literal argument; NULL is a pipeline schema-inference
+/// placeholder and yields the empty string. `fn_name` prefixes the error
+/// (e.g. `"sqlite_fts"`), `arg` names the argument.
+pub(crate) fn string_arg(expr: &Expr, fn_name: &str, arg: &str) -> DFResult<String> {
+    match expr {
+        Expr::Literal(ScalarValue::Utf8(Some(s)), _)
+        | Expr::Literal(ScalarValue::LargeUtf8(Some(s)), _) => Ok(s.clone()),
+        Expr::Literal(ScalarValue::Null, _) => Ok(String::new()),
+        _ => plan_err!("{fn_name}: '{arg}' must be a string literal"),
+    }
+}
+
+/// Extract an optional string-literal argument; NULL means "not provided".
+pub(crate) fn optional_string_arg(
+    expr: &Expr,
+    fn_name: &str,
+    arg: &str,
+) -> DFResult<Option<String>> {
+    match expr {
+        Expr::Literal(ScalarValue::Null, _) => Ok(None),
+        other => string_arg(other, fn_name, arg).map(Some),
+    }
+}
+
+/// Extract a string-literal argument, rejecting NULL — for arguments that
+/// determine the planned schema, where a placeholder cannot work.
+pub(crate) fn strict_string_arg(expr: &Expr, fn_name: &str, arg: &str) -> DFResult<String> {
+    match expr {
+        Expr::Literal(ScalarValue::Null, _) => {
+            plan_err!("{fn_name}: '{arg}' must be a string literal, not NULL")
+        }
+        other => string_arg(other, fn_name, arg),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::logical_expr::{col, lit};
+
+    fn null_expr() -> Expr {
+        Expr::Literal(ScalarValue::Null, None)
+    }
+
+    #[test]
+    fn string_arg_accepts_literals_and_placeholder_null() {
+        assert_eq!(string_arg(&lit("wiki"), "f", "table").unwrap(), "wiki");
+        assert_eq!(
+            string_arg(
+                &Expr::Literal(ScalarValue::LargeUtf8(Some("wiki".into())), None),
+                "f",
+                "table"
+            )
+            .unwrap(),
+            "wiki"
+        );
+        // Pipeline schema inference passes NULL for {param} placeholders.
+        assert_eq!(string_arg(&null_expr(), "f", "table").unwrap(), "");
+    }
+
+    #[test]
+    fn non_literals_fail_with_uniform_wording() {
+        for helper in [string_arg, strict_string_arg] {
+            let err = helper(&col("x"), "my_fn", "query").unwrap_err();
+            assert!(
+                err.to_string()
+                    .contains("my_fn: 'query' must be a string literal"),
+                "got {err}"
+            );
+        }
+        let err = optional_string_arg(&lit(42), "my_fn", "alias").unwrap_err();
+        assert!(err.to_string().contains("'alias' must be a string literal"));
+    }
+
+    #[test]
+    fn null_semantics_differ_by_variant() {
+        assert_eq!(
+            optional_string_arg(&null_expr(), "f", "alias").unwrap(),
+            None
+        );
+        let err = strict_string_arg(&null_expr(), "f", "gateway").unwrap_err();
+        assert!(err.to_string().contains("not NULL"), "got {err}");
+    }
+}

--- a/crates/skardi/src/sources/providers/udtf_args.rs
+++ b/crates/skardi/src/sources/providers/udtf_args.rs
@@ -100,7 +100,35 @@ mod tests {
             optional_string_arg(&null_expr(), "f", "alias").unwrap(),
             None
         );
+        assert_eq!(
+            optional_string_arg(&lit("work"), "f", "alias").unwrap(),
+            Some("work".to_string())
+        );
         let err = strict_string_arg(&null_expr(), "f", "gateway").unwrap_err();
         assert!(err.to_string().contains("not NULL"), "got {err}");
+    }
+
+    #[test]
+    fn typed_null_strings_are_rejected_not_read_as_empty() {
+        // Utf8(None) / LargeUtf8(None) are typed NULLs (e.g. from
+        // CAST(NULL AS VARCHAR)), not string literals: no variant may read
+        // them as a valid "" — and only the untyped ScalarValue::Null gets
+        // the placeholder treatment, matching every provider's
+        // pre-refactor behavior.
+        for scalar in [ScalarValue::Utf8(None), ScalarValue::LargeUtf8(None)] {
+            let expr = Expr::Literal(scalar, None);
+            for helper in [string_arg, strict_string_arg] {
+                let err = helper(&expr, "f", "arg").unwrap_err();
+                assert!(
+                    err.to_string().contains("'arg' must be a string literal"),
+                    "got {err}"
+                );
+            }
+            let err = optional_string_arg(&expr, "f", "arg").unwrap_err();
+            assert!(
+                err.to_string().contains("'arg' must be a string literal"),
+                "got {err}"
+            );
+        }
     }
 }


### PR DESCRIPTION
Nine per-provider Expr-to-string extractors (lance knn/fts, sqlite, seekdb, pg fts/knn, mongo, open_connector) had drifted in both error wording ("sqlite: 'x'", "lance_knn: x", "mongo_fts: 'x' ... got {:?}") and NULL handling — some accepted NULL as the pipeline schema-inference placeholder, others rejected it, with the difference nowhere stated.

One shared module (providers/udtf_args.rs) now carries the three deliberate semantics, named at each call site:

- string_arg: NULL is the pipeline {param} placeholder, yields "" (the prior behavior of lance_fts / sqlite / seekdb / pg_fts / mongo);
- optional_string_arg: NULL means "argument not provided" (lance_fts's or-null variant);
- strict_string_arg: NULL rejected, for arguments that determine the planned schema where a placeholder cannot produce a plan (lance_knn, pg_knn, and the open_connector UDTFs keep their prior strictness).

Error wording is uniform ("{fn}: '{arg}' must be a string literal"); each provider keeps its exact prior NULL semantics, so this changes no behavior beyond message text. Addresses the non-blocking cleanup note from the #165 review. The ColumnarValue-based extractors in model/ (scalar-UDF context, different signature) are out of scope.

Second cleanup from the same review: open_connector_query's resource_json and open_connector_scan's input_json duplicated the serde_json::from_str + is_object() validation with already-diverging messages. A shared parse_json_object(fn_name, arg, raw) helper keeps the two diagnostics in lockstep, and new tests pin the non-object rejection ('[1, 2]') for both functions.