### PR TITLE
feat(documents): S3 / object-store support for source path and image_store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -557,6 +557,62 @@ jobs:
       - name: Execute Integration tests
         run: cargo llvm-cov --no-report nextest --all-features -- --ignored
 
+      # MinIO gives the `documents` connector's object-store path real S3
+      # coverage without needing an AWS account or credentials in CI. Started
+      # with `docker run` rather than a `services:` entry because service
+      # containers cannot override the image command, and the MinIO image needs
+      # `server /data`.
+      - name: Start MinIO for documents S3 tests
+        run: |
+          docker run -d --name skardi-minio \
+            -p 127.0.0.1:9000:9000 \
+            -e MINIO_ROOT_USER=skardiminio \
+            -e MINIO_ROOT_PASSWORD=skardiminio123 \
+            quay.io/minio/minio server /data
+          # The image has no shell tooling for a container healthcheck, so poll
+          # readiness from the runner (same approach as DynamoDB Local above).
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:9000/minio/health/live >/dev/null 2>&1; then
+              echo "minio ready after ${i}s"
+              break
+            fi
+            if [ "$i" = "30" ]; then
+              echo "minio failed to become ready"
+              docker logs skardi-minio
+              exit 1
+            fi
+            sleep 1
+          done
+          AWS_ACCESS_KEY_ID=skardiminio AWS_SECRET_ACCESS_KEY=skardiminio123 \
+            aws --endpoint-url http://127.0.0.1:9000 s3 mb s3://skardi-ci-documents
+
+      # These are `#[ignore]`d and skip themselves unless DOCUMENTS_S3_LIVE=1, so
+      # the step above's credentials are what actually arms them. Set at step
+      # scope, not job scope: the job-level AWS_* values are the `dummy`
+      # placeholders DynamoDB Local expects, and MinIO rejects a root password
+      # shorter than 8 characters.
+      - name: Execute documents S3 live tests against MinIO
+        env:
+          DOCUMENTS_S3_LIVE: "1"
+          DOCUMENTS_S3_BUCKET: skardi-ci-documents
+          # `AmazonS3Builder::from_env()` honours both of these, so the real S3
+          # HTTP client path is exercised, not a stub.
+          AWS_ENDPOINT: http://127.0.0.1:9000
+          AWS_ALLOW_HTTP: "true"
+          AWS_REGION: us-east-1
+          AWS_ACCESS_KEY_ID: skardiminio
+          AWS_SECRET_ACCESS_KEY: skardiminio123
+        # `--no-tests=fail` is explicit rather than relying on the current
+        # default: if these tests are ever renamed out of the filter's reach, the
+        # step must fail loudly instead of reporting success having run nothing.
+        run: |
+          cargo llvm-cov --no-report nextest --all-features \
+            -E 'test(/live_s3_/)' --no-tests=fail -- --ignored
+
+      - name: Stop MinIO
+        if: always()
+        run: docker rm -f skardi-minio || true
+
       - name: Generate coverage report (lcov)
         run: cargo llvm-cov report --lcov --output-path lcov.info
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9350,6 +9350,7 @@ dependencies = [
  "mysql_async",
  "ndarray 0.17.2",
  "num_cpus",
+ "object_store",
  "ort",
  "percent-encoding",
  "pgvector",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9418,6 +9418,7 @@ dependencies = [
  "datafusion-federation",
  "datafusion-tracing",
  "dirs 5.0.1",
+ "futures",
  "http-body-util",
  "lance",
  "object_store",

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ For end-to-end walkthroughs — RAG, recommendations, an agent-native wiki, a si
 | Apache Iceberg | Read | No | Schema evolution, partition pruning | [docs/iceberg/](docs/iceberg/) |
 | InfluxDB 3 | Read | No | Time-series measurements over Arrow Flight SQL | [docs/influxdb/](docs/influxdb/) |
 | Open Connector | Read | Yes | SaaS resources as stable SQL tables via a self-hosted [Open Connector](https://github.com/oomol-lab/open-connector) gateway; GitHub pack (repos, issues, PRs, reviews, commits, workflow runs, releases — [guide](docs/open-connector-github.md)), Slack pack (conversations, users, files — [guide](docs/open-connector-slack.md)), `open_connector_query` / `open_connector_scan` UDTFs, filter + limit pushdown, bounded TTL cache (more provider packs rolling out) | [docs/open-connector.md](docs/open-connector.md), [demo](docs/open-connector/) |
-| Documents | Read | No | PDF/Office/ODF/image -> per-page markdown, tables, images (local directories; `documents` feature) | [docs/documents.md](docs/documents.md) |
+| Documents | Read | No | PDF/Office/ODF/image -> per-page markdown, tables, images (local directories or S3 prefixes; `documents` feature) | [docs/documents.md](docs/documents.md) |
 
 ---
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -40,6 +40,7 @@ dirs = "5.0"
 datafusion = { workspace = true }
 datafusion-federation = { workspace = true }
 datafusion-tracing = "52.0.0"
+futures = { workspace = true }
 lance = { workspace = true }
 object_store = { workspace = true }
 serde = { workspace = true }

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -1619,6 +1619,29 @@ async fn register_data_source(
                         path: source.path.clone(),
                     })?;
 
+                // S3 registration checks (no-op when both `path` and
+                // `image_store` are local): reject credentials in config, enforce
+                // the same-bucket constraint, then verify read connectivity and
+                // image_store writability up front.
+                let image_store = source
+                    .options
+                    .as_ref()
+                    .and_then(|o| o.get("image_store"))
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty());
+                let s3 = crate::remote_storage::S3Storage::new();
+                s3.validate_documents_configuration(path_str, image_store.as_deref(), source)
+                    .map_err(|e| ConfigError::DataSourceRegistrationFailed {
+                        name: source.name.clone(),
+                        error: e.to_string(),
+                    })?;
+                s3.preflight_documents_s3(path_str, image_store.as_deref(), &source.name)
+                    .await
+                    .map_err(|e| ConfigError::DataSourceRegistrationFailed {
+                        name: source.name.clone(),
+                        error: e.to_string(),
+                    })?;
+
                 skardi::sources::providers::documents::register_documents_tables(
                     session_ctx,
                     &source.name,

--- a/crates/server/src/remote_storage.rs
+++ b/crates/server/src/remote_storage.rs
@@ -249,7 +249,10 @@ fn build_bucket_store(
         .build()
         .map_err(|e| ConfigError::S3ObjectStoreRegistrationFailed {
             name: source_name.to_string(),
-            error: format!("Failed to build S3 object store for bucket '{}': {}", bucket, e),
+            error: format!(
+                "Failed to build S3 object store for bucket '{}': {}",
+                bucket, e
+            ),
         })?;
     Ok((Arc::new(store), region))
 }
@@ -676,10 +679,7 @@ path: "s3://corpus-bucket/in/"
                 &src,
             )
             .unwrap_err();
-        assert!(
-            err.to_string().contains("same bucket"),
-            "unexpected: {err}"
-        );
+        assert!(err.to_string().contains("same bucket"), "unexpected: {err}");
     }
 
     #[test]
@@ -698,14 +698,11 @@ options:
 "#,
         );
         let err = s3
-            .validate_documents_configuration(
-                "/data/corpus",
-                Some("s3://crops-bucket/out/"),
-                &src,
-            )
+            .validate_documents_configuration("/data/corpus", Some("s3://crops-bucket/out/"), &src)
             .unwrap_err();
         assert!(
-            err.to_string().contains("must not be stored in configuration files"),
+            err.to_string()
+                .contains("must not be stored in configuration files"),
             "unexpected: {err}"
         );
     }
@@ -725,7 +722,10 @@ options:
         let err = s3
             .validate_documents_configuration("s3://corpus-bucket/in/", None, &src)
             .unwrap_err();
-        assert!(err.to_string().contains("AWS configuration"), "unexpected: {err}");
+        assert!(
+            err.to_string().contains("AWS configuration"),
+            "unexpected: {err}"
+        );
     }
 
     #[test]

--- a/crates/server/src/remote_storage.rs
+++ b/crates/server/src/remote_storage.rs
@@ -91,6 +91,28 @@ impl S3Storage {
         image_store: Option<&str>,
         source: &DataSource,
     ) -> Result<()> {
+        // Reject an `image_store` that equals or is an ancestor of the source
+        // `path`. `list_docs` excludes everything under `image_store` as a
+        // self-ingestion guard, so such overlap silently drops every source
+        // document and the scan returns an empty-but-successful result. Applies
+        // to any backend (local or s3://); `image_store` nested *inside* the
+        // source is still allowed — that's the guard's intended use.
+        if let Some(img) = image_store {
+            if loc_is_under_or_equal(path, img) {
+                return Err(ConfigError::DataSourceRegistrationFailed {
+                    name: source.name.clone(),
+                    error: format!(
+                        "documents: `image_store` ('{img}') equals or is an ancestor of the \
+                         source `path` ('{path}'). Every source document lives under `image_store` \
+                         and would be excluded from the scan (self-ingestion guard), yielding an \
+                         empty result. Point `image_store` at a location nested inside or disjoint \
+                         from `path`.",
+                    ),
+                }
+                .into());
+            }
+        }
+
         let path_is_s3 = path.starts_with("s3://");
         let image_is_s3 = image_store.is_some_and(|s| s.starts_with("s3://"));
 
@@ -134,7 +156,9 @@ impl S3Storage {
     ///
     /// - **Read connectivity** — a *prefix-aware* `list` of the source `path`
     ///   (the object `head` used for CSV/Parquet returns `NotFound` for a
-    ///   prefix). An empty-but-reachable prefix is OK; auth/network errors fail.
+    ///   prefix). Only the stream's first item is polled — a full top-level
+    ///   inventory of a large prefix is never drained at startup — so an
+    ///   empty-but-reachable prefix is OK while auth/network errors still surface.
     /// - **Write preflight** — put+delete a probe object under `image_store` so a
     ///   missing `s3:PutObject` fails loudly here rather than silently dropping
     ///   crops mid-scan.
@@ -144,6 +168,7 @@ impl S3Storage {
         image_store: Option<&str>,
         source_name: &str,
     ) -> Result<()> {
+        use futures::StreamExt;
         use object_store::PutPayload;
         use object_store::path::Path as ObjectPath;
 
@@ -152,8 +177,11 @@ impl S3Storage {
             let (store, region) = build_bucket_store(&bucket, source_name)?;
             let prefix = s3_key_prefix(path);
             let op = (!prefix.is_empty()).then(|| ObjectPath::from(prefix.as_str()));
-            store.list_with_delimiter(op.as_ref()).await.map_err(|e| {
-                ConfigError::S3ObjectStoreRegistrationFailed {
+            // Poll only the first stream item: this proves auth/network/prefix
+            // reachability without draining a full inventory of a large prefix.
+            // `None` (empty but reachable) is a pass; a first-item error fails.
+            if let Some(res) = store.list(op.as_ref()).next().await {
+                res.map_err(|e| ConfigError::S3ObjectStoreRegistrationFailed {
                     name: source_name.to_string(),
                     error: format!(
                         "documents: S3 read connectivity check failed for '{}' (region '{}'): {}\n\
@@ -161,8 +189,8 @@ impl S3Storage {
                          credentials/region are configured via the environment.",
                         path, region, e
                     ),
-                }
-            })?;
+                })?;
+            }
         }
 
         if let Some(img) = image_store.filter(|s| s.starts_with("s3://")) {
@@ -214,6 +242,17 @@ fn write_probe_key(base: &str) -> String {
     } else {
         format!("{}/.skardi-write-probe", base.trim_end_matches('/'))
     }
+}
+
+/// Whether `inner` is the same location as, or nested under, `outer`
+/// (path-segment aware, trailing slashes ignored). Used at registration to
+/// detect a documents `image_store` that would swallow the source `path`.
+/// Cross-backend pairs (local vs `s3://`) never match, mirroring `list_docs`'s
+/// `loc_is_under`.
+fn loc_is_under_or_equal(inner: &str, outer: &str) -> bool {
+    let inner = inner.trim_end_matches('/');
+    let outer = outer.trim_end_matches('/');
+    inner == outer || inner.starts_with(&format!("{outer}/"))
 }
 
 /// The key/prefix portion of an `s3://bucket/key` URI (no leading `/`).
@@ -767,6 +806,63 @@ path: "s3://corpus-bucket/in/"
             )
             .unwrap_err();
         assert!(err.to_string().contains("same bucket"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn documents_rejects_image_store_equal_or_ancestor_of_path() {
+        let s3 = S3Storage::new();
+        let src = documents_source(
+            r#"
+name: "docs"
+type: "documents"
+path: "/data/corpus"
+"#,
+        );
+
+        // Local: image_store == path → rejected (all docs excluded → empty scan).
+        let err = s3
+            .validate_documents_configuration("/data/corpus", Some("/data/corpus"), &src)
+            .unwrap_err();
+        assert!(err.to_string().contains("ancestor"), "unexpected: {err}");
+        // Local: image_store is an ancestor of path → rejected.
+        let err = s3
+            .validate_documents_configuration("/data/corpus", Some("/data"), &src)
+            .unwrap_err();
+        assert!(err.to_string().contains("ancestor"), "unexpected: {err}");
+        // Local: image_store nested inside path → allowed (self-ingestion guard).
+        assert!(
+            s3.validate_documents_configuration("/data/corpus", Some("/data/corpus/crops"), &src)
+                .is_ok()
+        );
+        // A sibling that shares a name prefix but not a path segment is disjoint.
+        assert!(
+            s3.validate_documents_configuration("/data/corpus", Some("/data/corpus-2"), &src)
+                .is_ok()
+        );
+
+        // S3: image_store == path → rejected.
+        let err = s3
+            .validate_documents_configuration(
+                "s3://bucket/corpus/",
+                Some("s3://bucket/corpus/"),
+                &src,
+            )
+            .unwrap_err();
+        assert!(err.to_string().contains("ancestor"), "unexpected: {err}");
+        // S3: image_store is the bucket root (ancestor of every key) → rejected.
+        let err = s3
+            .validate_documents_configuration("s3://bucket/corpus/", Some("s3://bucket"), &src)
+            .unwrap_err();
+        assert!(err.to_string().contains("ancestor"), "unexpected: {err}");
+        // S3: image_store nested inside path → allowed.
+        assert!(
+            s3.validate_documents_configuration(
+                "s3://bucket/corpus/",
+                Some("s3://bucket/corpus/crops/"),
+                &src
+            )
+            .is_ok()
+        );
     }
 
     #[test]

--- a/crates/server/src/remote_storage.rs
+++ b/crates/server/src/remote_storage.rs
@@ -169,12 +169,7 @@ impl S3Storage {
             let bucket = parse_bucket(img, source_name)?;
             let (store, region) = build_bucket_store(&bucket, source_name)?;
             let base = s3_key_prefix(img);
-            let probe_key = if base.is_empty() {
-                ".skardi-write-probe".to_string()
-            } else {
-                format!("{}/.skardi-write-probe", base.trim_end_matches('/'))
-            };
-            let probe = ObjectPath::from(probe_key);
+            let probe = ObjectPath::from(write_probe_key(&base));
             store
                 .put(&probe, PutPayload::from_static(b"skardi-write-probe"))
                 .await
@@ -210,12 +205,47 @@ fn parse_bucket(s3_uri: &str, source_name: &str) -> Result<String> {
         })
 }
 
+/// Build the write-probe object key placed under an `image_store` prefix during
+/// the write preflight. An empty prefix probes the bucket root; otherwise the
+/// probe sits directly under the (single-slash-normalized) prefix.
+fn write_probe_key(base: &str) -> String {
+    if base.is_empty() {
+        ".skardi-write-probe".to_string()
+    } else {
+        format!("{}/.skardi-write-probe", base.trim_end_matches('/'))
+    }
+}
+
 /// The key/prefix portion of an `s3://bucket/key` URI (no leading `/`).
 fn s3_key_prefix(s3_uri: &str) -> String {
     url::Url::parse(s3_uri)
         .ok()
         .map(|u| u.path().trim_start_matches('/').to_string())
         .unwrap_or_default()
+}
+
+/// Validate that a region and some credential source are present, returning the
+/// resolved region. Pure over its inputs (the caller reads the env), so the
+/// missing-config branches are unit-testable without mutating process-global
+/// env vars.
+fn require_s3_region_and_creds(
+    region: Option<String>,
+    has_access_key: bool,
+    has_profile: bool,
+    source_name: &str,
+) -> Result<String> {
+    let region = region.ok_or_else(|| ConfigError::MissingAwsConfig {
+        name: source_name.to_string(),
+        field: "AWS_REGION or AWS_DEFAULT_REGION environment variable".to_string(),
+    })?;
+    if !has_access_key && !has_profile {
+        return Err(ConfigError::MissingAwsConfig {
+            name: source_name.to_string(),
+            field: "AWS_ACCESS_KEY_ID environment variable or AWS_PROFILE".to_string(),
+        }
+        .into());
+    }
+    Ok(region)
 }
 
 /// Build an S3 object store for `bucket` using env/IAM credentials and the
@@ -229,19 +259,11 @@ fn build_bucket_store(
     use object_store::aws::AmazonS3Builder;
 
     let region = std::env::var("AWS_REGION")
-        .or_else(|_| std::env::var("AWS_DEFAULT_REGION"))
-        .map_err(|_| ConfigError::MissingAwsConfig {
-            name: source_name.to_string(),
-            field: "AWS_REGION or AWS_DEFAULT_REGION environment variable".to_string(),
-        })?;
-
-    if std::env::var("AWS_ACCESS_KEY_ID").is_err() && std::env::var("AWS_PROFILE").is_err() {
-        return Err(ConfigError::MissingAwsConfig {
-            name: source_name.to_string(),
-            field: "AWS_ACCESS_KEY_ID environment variable or AWS_PROFILE".to_string(),
-        }
-        .into());
-    }
+        .ok()
+        .or_else(|| std::env::var("AWS_DEFAULT_REGION").ok());
+    let has_access_key = std::env::var("AWS_ACCESS_KEY_ID").is_ok();
+    let has_profile = std::env::var("AWS_PROFILE").is_ok();
+    let region = require_s3_region_and_creds(region, has_access_key, has_profile, source_name)?;
 
     let store = AmazonS3Builder::from_env()
         .with_bucket_name(bucket)
@@ -634,6 +656,63 @@ options:
 
     fn documents_source(yaml: &str) -> DataSource {
         serde_yaml::from_str(yaml).unwrap()
+    }
+
+    #[test]
+    fn s3_key_prefix_extracts_path_without_leading_slash() {
+        assert_eq!(s3_key_prefix("s3://bucket/in/corpus"), "in/corpus");
+        assert_eq!(s3_key_prefix("s3://bucket/in/corpus/"), "in/corpus/");
+        assert_eq!(s3_key_prefix("s3://bucket"), "");
+        assert_eq!(s3_key_prefix("s3://bucket/"), "");
+    }
+
+    #[test]
+    fn parse_bucket_extracts_bucket_or_errors() {
+        assert_eq!(
+            parse_bucket("s3://my-bucket/key", "src").unwrap(),
+            "my-bucket"
+        );
+        assert_eq!(parse_bucket("s3://my-bucket", "src").unwrap(), "my-bucket");
+        // No host → bucketless → error.
+        assert!(parse_bucket("s3:///key-only", "src").is_err());
+    }
+
+    #[test]
+    fn write_probe_key_scopes_under_prefix_or_bucket_root() {
+        // Empty prefix probes the bucket root.
+        assert_eq!(write_probe_key(""), ".skardi-write-probe");
+        // A prefix (with or without trailing slash) sits the probe directly
+        // under it, never doubling the separator.
+        assert_eq!(write_probe_key("crops"), "crops/.skardi-write-probe");
+        assert_eq!(
+            write_probe_key("out/crops/"),
+            "out/crops/.skardi-write-probe"
+        );
+    }
+
+    #[test]
+    fn require_s3_region_and_creds_branches() {
+        // Missing region → error names the region env vars.
+        let err = require_s3_region_and_creds(None, true, false, "src").unwrap_err();
+        assert!(err.to_string().contains("AWS_REGION"), "unexpected: {err}");
+
+        // Region present but neither access key nor profile → credential error.
+        let err =
+            require_s3_region_and_creds(Some("us-east-1".into()), false, false, "src").unwrap_err();
+        assert!(
+            err.to_string().contains("AWS_ACCESS_KEY_ID"),
+            "unexpected: {err}"
+        );
+
+        // Region + access key, or region + profile → ok, returns the region.
+        assert_eq!(
+            require_s3_region_and_creds(Some("us-east-1".into()), true, false, "src").unwrap(),
+            "us-east-1"
+        );
+        assert_eq!(
+            require_s3_region_and_creds(Some("eu-west-2".into()), false, true, "src").unwrap(),
+            "eu-west-2"
+        );
     }
 
     #[test]

--- a/crates/server/src/remote_storage.rs
+++ b/crates/server/src/remote_storage.rs
@@ -39,6 +39,219 @@ impl S3Storage {
     pub fn new() -> Self {
         Self
     }
+
+    /// Reject `aws_*` credential/region keys in a source's `options` — these must
+    /// come from the environment / IAM, never from a config file.
+    fn reject_credential_options(source: &DataSource) -> Result<()> {
+        let Some(options) = &source.options else {
+            return Ok(());
+        };
+        let forbidden_keys = [
+            "aws_access_key_id",
+            "aws_secret_access_key",
+            "aws_session_token",
+            "aws_region", // Also reject aws_region since it should come from env vars
+        ];
+        for key in &forbidden_keys {
+            if options.contains_key(*key) {
+                return Err(ConfigError::S3ObjectStoreRegistrationFailed {
+                    name: source.name.clone(),
+                    error: format!(
+                        "AWS configuration ('{}') must not be stored in configuration files. \
+                         Please use environment variables instead:\n\
+                         - Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY for credentials\n\
+                         - Set AWS_REGION or AWS_DEFAULT_REGION for region configuration\n\
+                         - Or use AWS_PROFILE to specify an AWS credentials profile\n\
+                         - Or use IAM roles/instance profiles on AWS infrastructure",
+                        key
+                    ),
+                }
+                .into());
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate S3 configuration for a `documents` source, where the source
+    /// `path` and the `image_store` option may **each independently** be a local
+    /// directory or an `s3://` prefix.
+    ///
+    /// - Rejects `aws_*` credential keys in `options` when *either* side is
+    ///   `s3://` (closing the gap where [`validate_configuration`] only fires for
+    ///   an `s3://` `path`, letting a local-`path` + `s3://`-`image_store` source
+    ///   smuggle credentials into `options`).
+    /// - When **both** are `s3://`, requires the **same bucket**: a single
+    ///   registered store / region / credential set cannot serve two buckets
+    ///   (see design doc §4). Cross-bucket support is a tracked follow-up.
+    ///
+    /// [`validate_configuration`]: RemoteStorage::validate_configuration
+    pub fn validate_documents_configuration(
+        &self,
+        path: &str,
+        image_store: Option<&str>,
+        source: &DataSource,
+    ) -> Result<()> {
+        let path_is_s3 = path.starts_with("s3://");
+        let image_is_s3 = image_store.is_some_and(|s| s.starts_with("s3://"));
+
+        if !path_is_s3 && !image_is_s3 {
+            return Ok(()); // fully local — nothing S3 to validate
+        }
+
+        // Once any side is S3, credentials must not live in config.
+        Self::reject_credential_options(source)?;
+
+        let path_bucket = if path_is_s3 {
+            Some(parse_bucket(path, &source.name)?)
+        } else {
+            None
+        };
+        let image_bucket = if image_is_s3 {
+            Some(parse_bucket(image_store.unwrap(), &source.name)?)
+        } else {
+            None
+        };
+
+        if let (Some(pb), Some(ib)) = (&path_bucket, &image_bucket) {
+            if pb != ib {
+                return Err(ConfigError::S3ObjectStoreRegistrationFailed {
+                    name: source.name.clone(),
+                    error: format!(
+                        "documents: `path` bucket '{pb}' and `image_store` bucket '{ib}' differ. \
+                         When both are s3://, they must be in the same bucket — a single object \
+                         store / region / credential set cannot serve two buckets. Cross-bucket \
+                         (cross-region/account) support is a tracked follow-up."
+                    ),
+                }
+                .into());
+            }
+        }
+        Ok(())
+    }
+
+    /// Registration-time reachability checks for a `documents` source's S3
+    /// endpoints (no-op for local paths):
+    ///
+    /// - **Read connectivity** — a *prefix-aware* `list` of the source `path`
+    ///   (the object `head` used for CSV/Parquet returns `NotFound` for a
+    ///   prefix). An empty-but-reachable prefix is OK; auth/network errors fail.
+    /// - **Write preflight** — put+delete a probe object under `image_store` so a
+    ///   missing `s3:PutObject` fails loudly here rather than silently dropping
+    ///   crops mid-scan.
+    pub async fn preflight_documents_s3(
+        &self,
+        path: &str,
+        image_store: Option<&str>,
+        source_name: &str,
+    ) -> Result<()> {
+        use object_store::PutPayload;
+        use object_store::path::Path as ObjectPath;
+
+        if path.starts_with("s3://") {
+            let bucket = parse_bucket(path, source_name)?;
+            let (store, region) = build_bucket_store(&bucket, source_name)?;
+            let prefix = s3_key_prefix(path);
+            let op = (!prefix.is_empty()).then(|| ObjectPath::from(prefix.as_str()));
+            store.list_with_delimiter(op.as_ref()).await.map_err(|e| {
+                ConfigError::S3ObjectStoreRegistrationFailed {
+                    name: source_name.to_string(),
+                    error: format!(
+                        "documents: S3 read connectivity check failed for '{}' (region '{}'): {}\n\
+                         Ensure s3:ListBucket + s3:GetObject on the bucket/prefix and that \
+                         credentials/region are configured via the environment.",
+                        path, region, e
+                    ),
+                }
+            })?;
+        }
+
+        if let Some(img) = image_store.filter(|s| s.starts_with("s3://")) {
+            let bucket = parse_bucket(img, source_name)?;
+            let (store, region) = build_bucket_store(&bucket, source_name)?;
+            let base = s3_key_prefix(img);
+            let probe_key = if base.is_empty() {
+                ".skardi-write-probe".to_string()
+            } else {
+                format!("{}/.skardi-write-probe", base.trim_end_matches('/'))
+            };
+            let probe = ObjectPath::from(probe_key);
+            store
+                .put(&probe, PutPayload::from_static(b"skardi-write-probe"))
+                .await
+                .map_err(|e| ConfigError::S3ObjectStoreRegistrationFailed {
+                    name: source_name.to_string(),
+                    error: format!(
+                        "documents: image_store write preflight failed for '{}' (region '{}'): {}\n\
+                         Ensure s3:PutObject on the image_store bucket/prefix.",
+                        img, region, e
+                    ),
+                })?;
+            // Best-effort cleanup — a leftover probe object is harmless.
+            let _ = store.delete(&probe).await;
+        }
+        Ok(())
+    }
+}
+
+/// Extract the bucket name from an `s3://bucket/key` URI.
+fn parse_bucket(s3_uri: &str, source_name: &str) -> Result<String> {
+    let url = url::Url::parse(s3_uri).map_err(|e| ConfigError::InvalidS3Path {
+        path: format!("Invalid S3 URL '{}': {}", s3_uri, e),
+    })?;
+    url.host_str()
+        .map(|h| h.to_string())
+        .filter(|h| !h.is_empty())
+        .ok_or_else(|| {
+            ConfigError::S3ObjectStoreRegistrationFailed {
+                name: source_name.to_string(),
+                error: format!("No bucket name found in S3 URL: {}", s3_uri),
+            }
+            .into()
+        })
+}
+
+/// The key/prefix portion of an `s3://bucket/key` URI (no leading `/`).
+fn s3_key_prefix(s3_uri: &str) -> String {
+    url::Url::parse(s3_uri)
+        .ok()
+        .map(|u| u.path().trim_start_matches('/').to_string())
+        .unwrap_or_default()
+}
+
+/// Build an S3 object store for `bucket` using env/IAM credentials and the
+/// `AWS_REGION`/`AWS_DEFAULT_REGION` region. Returns the store and the region
+/// (for error messages). Mirrors the credential contract of
+/// [`S3Storage::setup_object_store`].
+fn build_bucket_store(
+    bucket: &str,
+    source_name: &str,
+) -> Result<(Arc<dyn object_store::ObjectStore>, String)> {
+    use object_store::aws::AmazonS3Builder;
+
+    let region = std::env::var("AWS_REGION")
+        .or_else(|_| std::env::var("AWS_DEFAULT_REGION"))
+        .map_err(|_| ConfigError::MissingAwsConfig {
+            name: source_name.to_string(),
+            field: "AWS_REGION or AWS_DEFAULT_REGION environment variable".to_string(),
+        })?;
+
+    if std::env::var("AWS_ACCESS_KEY_ID").is_err() && std::env::var("AWS_PROFILE").is_err() {
+        return Err(ConfigError::MissingAwsConfig {
+            name: source_name.to_string(),
+            field: "AWS_ACCESS_KEY_ID environment variable or AWS_PROFILE".to_string(),
+        }
+        .into());
+    }
+
+    let store = AmazonS3Builder::from_env()
+        .with_bucket_name(bucket)
+        .with_region(&region)
+        .build()
+        .map_err(|e| ConfigError::S3ObjectStoreRegistrationFailed {
+            name: source_name.to_string(),
+            error: format!("Failed to build S3 object store for bucket '{}': {}", bucket, e),
+        })?;
+    Ok((Arc::new(store), region))
 }
 
 #[async_trait::async_trait]
@@ -63,32 +276,7 @@ impl RemoteStorage for S3Storage {
         }
 
         // Security check: Reject credentials in configuration file if options exist
-        if let Some(options) = &source.options {
-            let forbidden_keys = [
-                "aws_access_key_id",
-                "aws_secret_access_key",
-                "aws_session_token",
-                "aws_region", // Also reject aws_region since it should come from env vars
-            ];
-
-            for key in &forbidden_keys {
-                if options.contains_key(*key) {
-                    return Err(ConfigError::S3ObjectStoreRegistrationFailed {
-                        name: source.name.clone(),
-                        error: format!(
-                            "AWS configuration ('{}') must not be stored in configuration files. \
-                             Please use environment variables instead:\n\
-                             - Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY for credentials\n\
-                             - Set AWS_REGION or AWS_DEFAULT_REGION for region configuration\n\
-                             - Or use AWS_PROFILE to specify an AWS credentials profile\n\
-                             - Or use IAM roles/instance profiles on AWS infrastructure",
-                            key
-                        ),
-                    }
-                    .into());
-                }
-            }
-        }
+        Self::reject_credential_options(source)?;
 
         tracing::debug!(
             "S3 configuration validated for data source: {}",
@@ -439,6 +627,105 @@ options:
         assert!(error.to_string().contains("AWS configuration"));
         assert!(error.to_string().contains("aws_region"));
         assert!(error.to_string().contains("environment variables"));
+    }
+
+    fn documents_source(yaml: &str) -> DataSource {
+        serde_yaml::from_str(yaml).unwrap()
+    }
+
+    #[test]
+    fn documents_fully_local_needs_no_s3_validation() {
+        let s3 = S3Storage::new();
+        let src = documents_source(
+            r#"
+name: "docs"
+type: "documents"
+path: "/data/corpus"
+"#,
+        );
+        assert!(
+            s3.validate_documents_configuration("/data/corpus", Some("/data/crops"), &src)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn documents_same_bucket_ok_different_bucket_rejected() {
+        let s3 = S3Storage::new();
+        let src = documents_source(
+            r#"
+name: "docs"
+type: "documents"
+path: "s3://corpus-bucket/in/"
+"#,
+        );
+        // Same bucket for path + image_store → ok.
+        assert!(
+            s3.validate_documents_configuration(
+                "s3://corpus-bucket/in/",
+                Some("s3://corpus-bucket/crops/"),
+                &src
+            )
+            .is_ok()
+        );
+        // Different buckets → rejected with a clear message.
+        let err = s3
+            .validate_documents_configuration(
+                "s3://corpus-bucket/in/",
+                Some("s3://other-bucket/crops/"),
+                &src,
+            )
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("same bucket"),
+            "unexpected: {err}"
+        );
+    }
+
+    #[test]
+    fn documents_rejects_credentials_when_only_image_store_is_s3() {
+        // The gap-closer: local `path` + s3 `image_store` must still reject
+        // aws_* keys in options (validate_configuration alone would skip this).
+        let s3 = S3Storage::new();
+        let src = documents_source(
+            r#"
+name: "docs"
+type: "documents"
+path: "/data/corpus"
+options:
+  image_store: "s3://crops-bucket/out/"
+  aws_secret_access_key: "should_be_rejected"
+"#,
+        );
+        let err = s3
+            .validate_documents_configuration(
+                "/data/corpus",
+                Some("s3://crops-bucket/out/"),
+                &src,
+            )
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("must not be stored in configuration files"),
+            "unexpected: {err}"
+        );
+    }
+
+    #[test]
+    fn documents_rejects_credentials_when_path_is_s3() {
+        let s3 = S3Storage::new();
+        let src = documents_source(
+            r#"
+name: "docs"
+type: "documents"
+path: "s3://corpus-bucket/in/"
+options:
+  aws_access_key_id: "nope"
+"#,
+        );
+        let err = s3
+            .validate_documents_configuration("s3://corpus-bucket/in/", None, &src)
+            .unwrap_err();
+        assert!(err.to_string().contains("AWS configuration"), "unexpected: {err}");
     }
 
     #[test]

--- a/crates/server/src/remote_storage.rs
+++ b/crates/server/src/remote_storage.rs
@@ -228,6 +228,14 @@ fn s3_key_prefix(s3_uri: &str) -> String {
 /// resolved region. Pure over its inputs (the caller reads the env), so the
 /// missing-config branches are unit-testable without mutating process-global
 /// env vars.
+///
+/// `AWS_PROFILE` satisfies this check for parity with
+/// [`S3Storage::setup_object_store`], but `object_store` never reads `~/.aws/`
+/// profiles — with only `AWS_PROFILE` set, request signing has no credentials
+/// and the preflight list/put in [`S3Storage::preflight_documents_s3`] fails at
+/// startup with the underlying S3 error. Exporting real env credentials
+/// (`aws configure export-credentials --format env`) is the working path; see
+/// docs/documents.md § "S3 / object store".
 fn require_s3_region_and_creds(
     region: Option<String>,
     has_access_key: bool,

--- a/crates/skardi/Cargo.toml
+++ b/crates/skardi/Cargo.toml
@@ -28,7 +28,7 @@ chunking = ["dep:text-splitter"]
 # RAG umbrella: chunk → embed → write loop in one feature.
 rag = ["embedding", "chunking"]
 # documents source connector: parse a folder of files into queryable (file, page) rows.
-documents = ["dep:liteparse", "dep:glob"]
+documents = ["dep:liteparse", "dep:glob", "dep:object_store"]
 
 [dependencies]
 # engine
@@ -89,6 +89,9 @@ liteparse = { version = "2.4.0", default-features = false, optional = true }
 blake3 = "1"
 # include_globs matching for the documents connector.
 glob = { version = "0.3", optional = true }
+# object-store (S3/GCS/Azure) backend for the documents connector's source `path`
+# and `image_store`. Only the `aws` scheme is wired in v1 (see blob.rs).
+object_store = { workspace = true, optional = true }
 secrecy = "0.10"
 pgvector = { version = "0.4", features = ["sqlx"] }
 sqlx = { workspace = true }

--- a/crates/skardi/Cargo.toml
+++ b/crates/skardi/Cargo.toml
@@ -105,3 +105,7 @@ tokio-test = "0.4"
 tempfile = { workspace = true }
 redis-test = "0.13.0"
 gguf-rs-lib = "0.2"
+# Seeding / cleaning object-store fixtures in the opt-in `documents_s3_live`
+# integration test (it drives S3 directly, not through the connector).
+object_store = { workspace = true }
+futures = { workspace = true }

--- a/crates/skardi/src/model/llm_extract/mod.rs
+++ b/crates/skardi/src/model/llm_extract/mod.rs
@@ -505,6 +505,17 @@ fn fetch_image(image_ref: &str) -> anyhow::Result<provider::ImageInput> {
     fetch_image_with_policy(image_ref, image_fetch_allowed())
 }
 
+/// Test-only entry point into the real [`fetch_image_with_policy`], so the
+/// opt-in integration tests exercise the shipped resolution path rather than a
+/// reimplementation of it. Not part of the public API.
+#[doc(hidden)]
+pub fn fetch_image_for_test(
+    image_ref: &str,
+    allow_fetch: bool,
+) -> anyhow::Result<provider::ImageInput> {
+    fetch_image_with_policy(image_ref, allow_fetch)
+}
+
 /// Whether http(s)/file `image_ref` fetching is opted in via
 /// `LLM_EXTRACT_IMAGE_FETCH` (`1`/`true`/`yes`). Default-deny.
 fn image_fetch_allowed() -> bool {
@@ -517,6 +528,35 @@ fn image_fetch_allowed() -> bool {
     )
 }
 
+/// How an `image_ref` should be resolved. Kept separate from
+/// [`fetch_image_with_policy`] so the routing decision is unit-testable without
+/// performing any I/O — the `s3://`-misrouted-as-a-file bug this guards against
+/// was only observable at runtime before.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RefKind {
+    /// Inline `data:` URI — no I/O.
+    Data,
+    /// `http://` / `https://`.
+    Http,
+    /// `s3://bucket/key`.
+    S3,
+    /// `file://` URL or a bare filesystem path.
+    File,
+}
+
+/// Classify an `image_ref` by scheme. Pure; performs no I/O.
+fn classify_ref(image_ref: &str) -> RefKind {
+    if image_ref.starts_with("data:") {
+        RefKind::Data
+    } else if image_ref.starts_with("http://") || image_ref.starts_with("https://") {
+        RefKind::Http
+    } else if image_ref.starts_with("s3://") {
+        RefKind::S3
+    } else {
+        RefKind::File
+    }
+}
+
 /// Fetch an image referenced by `image_ref` and return it as base64 + mime.
 ///
 /// **Security — `image_ref` is data-derived (a column value), so fetching it is
@@ -524,6 +564,12 @@ fn image_fetch_allowed() -> bool {
 /// - `data:<mime>;base64,<payload>` — always allowed (no I/O; payload is inline).
 /// - `http://` / `https://` — only when `allow_fetch` is `true`
 ///   (`LLM_EXTRACT_IMAGE_FETCH=1`); otherwise refused. Can reach internal hosts.
+/// - `s3://bucket/key` — only when `allow_fetch` is `true`; otherwise refused.
+///   Gated identically to http(s) because the bucket/key are data-derived: with
+///   the process's ambient AWS credentials this is a read primitive over every
+///   object those credentials can reach, not just the configured `image_store`.
+///   Requires the `documents` feature (which owns the S3 client); without it the
+///   ref is refused with a build hint rather than being read off the filesystem.
 /// - any other scheme / bare path — treated as a local file, only when
 ///   `allow_fetch` is `true`; otherwise refused. Can read arbitrary files.
 fn fetch_image_with_policy(
@@ -532,8 +578,11 @@ fn fetch_image_with_policy(
 ) -> anyhow::Result<provider::ImageInput> {
     use anyhow::Context;
 
-    if let Some(rest) = image_ref.strip_prefix("data:") {
+    let kind = classify_ref(image_ref);
+
+    if kind == RefKind::Data {
         // data:<mime>;base64,<payload>
+        let rest = image_ref.strip_prefix("data:").unwrap_or(image_ref);
         let (meta, payload) = rest
             .split_once(',')
             .ok_or_else(|| anyhow::anyhow!("malformed data URI"))?;
@@ -554,14 +603,14 @@ fn fetch_image_with_policy(
         return Err(anyhow::anyhow!(
             "refusing to fetch image_ref '{image_ref}': only data: URIs are allowed by \
              default (SSRF / path-traversal guard). Set LLM_EXTRACT_IMAGE_FETCH=1 to \
-             enable http(s)/file fetching"
+             enable http(s)/s3/file fetching"
         ));
     }
 
     use base64::Engine;
     let engine = base64::engine::general_purpose::STANDARD;
 
-    if image_ref.starts_with("http://") || image_ref.starts_with("https://") {
+    if kind == RefKind::Http {
         let handle = tokio::runtime::Handle::current();
         let (bytes, mime) = tokio::task::block_in_place(|| {
             handle.block_on(async {
@@ -583,6 +632,40 @@ fn fetch_image_with_policy(
             base64: engine.encode(&bytes),
             mime,
         });
+    }
+
+    // Object store. `page_image_ref` / `image_refs` are `s3://…` whenever the
+    // documents connector runs with an `s3://` `image_store`, so without this
+    // branch such a ref would fall through to `std::fs::read("s3://…")` and fail
+    // with a misleading "No such file or directory".
+    if kind == RefKind::S3 {
+        #[cfg(feature = "documents")]
+        {
+            use crate::sources::providers::documents::blob::BlobStore;
+
+            let handle = tokio::runtime::Handle::current();
+            let bytes = tokio::task::block_in_place(|| {
+                handle.block_on(async {
+                    // Build the store inside this runtime: the underlying reqwest
+                    // client must not outlive / cross runtimes (see blob.rs).
+                    let (store, loc) = BlobStore::resolve(image_ref)?;
+                    store.get(&loc).await
+                })
+            })
+            .with_context(|| format!("reading s3 image_ref '{image_ref}'"))?;
+            return Ok(provider::ImageInput {
+                base64: engine.encode(&bytes),
+                mime: mime_from_path(image_ref),
+            });
+        }
+        #[cfg(not(feature = "documents"))]
+        {
+            return Err(anyhow::anyhow!(
+                "cannot fetch image_ref '{image_ref}': s3:// refs require the `documents` \
+                 Cargo feature (which provides the S3 client). Rebuild with \
+                 --features documents, or use a local image_store."
+            ));
+        }
     }
 
     // Local file path.
@@ -1498,6 +1581,51 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err3.contains("refusing to fetch"), "got: {err3}");
+
+        // s3:// is gated by the same opt-in: the bucket/key are data-derived, so
+        // with ambient AWS credentials an un-gated fetch would be a read
+        // primitive over every object those credentials can reach.
+        let err4 = fetch_image_with_policy("s3://some-bucket/secret/key.png", false)
+            .unwrap_err()
+            .to_string();
+        assert!(err4.contains("refusing to fetch"), "got: {err4}");
+        assert!(err4.contains("LLM_EXTRACT_IMAGE_FETCH"), "got: {err4}");
+    }
+
+    #[test]
+    fn classify_ref_routes_s3_away_from_the_filesystem() {
+        // The regression this guards: an `s3://` ref used to fall through to the
+        // local-file branch and fail with a misleading
+        // "reading image file 's3://…': No such file or directory".
+        assert_eq!(
+            classify_ref("s3://bucket/extracted/report.pdf_page_1.png"),
+            RefKind::S3
+        );
+        assert_eq!(classify_ref("s3://bucket"), RefKind::S3);
+
+        // Neighbouring schemes keep their existing routing.
+        assert_eq!(classify_ref("data:image/png;base64,aGk="), RefKind::Data);
+        assert_eq!(classify_ref("http://example.com/a.png"), RefKind::Http);
+        assert_eq!(classify_ref("https://example.com/a.png"), RefKind::Http);
+        assert_eq!(classify_ref("file:///tmp/a.png"), RefKind::File);
+        assert_eq!(classify_ref("/tmp/a.png"), RefKind::File);
+        assert_eq!(classify_ref("relative/a.png"), RefKind::File);
+
+        // Not S3: a lookalike prefix must not be routed to the object store.
+        assert_eq!(classify_ref("s3:/bucket/key.png"), RefKind::File);
+        assert_eq!(classify_ref("s3x://bucket/key.png"), RefKind::File);
+        assert_eq!(classify_ref("/data/s3://weird.png"), RefKind::File);
+    }
+
+    #[test]
+    fn mime_inferred_from_s3_key_extension() {
+        // The documents connector always writes `.png` crops/page renders, and
+        // the S3 branch infers the MIME from the key alone (no HEAD request).
+        assert_eq!(
+            mime_from_path("s3://bucket/extracted/a.pdf_page_1.png"),
+            "image/png"
+        );
+        assert_eq!(mime_from_path("s3://bucket/scan.jpg"), "image/jpeg");
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/documents/blob.rs
+++ b/crates/skardi/src/sources/providers/documents/blob.rs
@@ -18,7 +18,10 @@ use object_store::{Attribute, Attributes, ObjectStore, PutOptions, PutPayload};
 pub enum Loc {
     Local(PathBuf),
     /// `key` never has a leading `/`.
-    S3 { bucket: String, key: String },
+    S3 {
+        bucket: String,
+        key: String,
+    },
 }
 
 impl Loc {
@@ -116,7 +119,10 @@ impl BlobStore {
                     .get(&OsPath::from(key.as_str()))
                     .await
                     .with_context(|| format!("s3 get {key}"))?;
-                let bytes = res.bytes().await.with_context(|| format!("s3 read body {key}"))?;
+                let bytes = res
+                    .bytes()
+                    .await
+                    .with_context(|| format!("s3 read body {key}"))?;
                 Ok(bytes.to_vec())
             }
             _ => anyhow::bail!("documents: BlobStore/Loc backend mismatch in get()"),
@@ -143,7 +149,11 @@ impl BlobStore {
                     ..Default::default()
                 };
                 store
-                    .put_opts(&OsPath::from(key.as_str()), PutPayload::from(bytes.to_vec()), opts)
+                    .put_opts(
+                        &OsPath::from(key.as_str()),
+                        PutPayload::from(bytes.to_vec()),
+                        opts,
+                    )
                     .await
                     .with_context(|| format!("s3 put {key}"))?;
                 Ok(())

--- a/crates/skardi/src/sources/providers/documents/blob.rs
+++ b/crates/skardi/src/sources/providers/documents/blob.rs
@@ -1,0 +1,448 @@
+//! Local-vs-object-store I/O for the `documents` connector.
+//!
+//! All filesystem / S3 access the connector performs goes through [`BlobStore`],
+//! so the source `path` and `image_store` can each independently be a local
+//! directory or an `s3://` prefix. See the design doc
+//! `docs/superpowers/specs/2026-07-23-documents-s3-object-store-support-design.md`.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use futures::StreamExt;
+use object_store::path::Path as OsPath;
+use object_store::{Attribute, Attributes, ObjectStore, PutOptions, PutPayload};
+
+/// A parsed source/target location: either a local path or an S3 object.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Loc {
+    Local(PathBuf),
+    /// `key` never has a leading `/`.
+    S3 { bucket: String, key: String },
+}
+
+impl Loc {
+    /// Parse a URI into a [`Loc`]. A bare path or a `file:` URL is [`Loc::Local`];
+    /// an `s3://bucket/key` URL is [`Loc::S3`].
+    pub fn parse(uri: &str) -> Result<Loc> {
+        if let Some(rest) = uri.strip_prefix("s3://") {
+            let (bucket, key) = match rest.split_once('/') {
+                Some((b, k)) => (b, k),
+                None => (rest, ""),
+            };
+            if bucket.is_empty() {
+                anyhow::bail!("invalid s3 uri (no bucket): {uri}");
+            }
+            return Ok(Loc::S3 {
+                bucket: bucket.to_string(),
+                key: key.to_string(),
+            });
+        }
+        if let Some(path) = uri.strip_prefix("file://") {
+            return Ok(Loc::Local(PathBuf::from(path)));
+        }
+        Ok(Loc::Local(PathBuf::from(uri)))
+    }
+}
+
+/// Normalize an S3 prefix key so it is empty or ends with exactly one `/`.
+/// This makes object listing directory-scoped: `corpus` becomes `corpus/`, so
+/// it never spuriously matches sibling keys like `corpus-2/…`.
+fn normalize_prefix(key: &str) -> String {
+    let trimmed = key.trim_end_matches('/');
+    if trimmed.is_empty() {
+        String::new()
+    } else {
+        format!("{trimmed}/")
+    }
+}
+
+/// The `Content-Type` to stamp on a written object, inferred from its key's
+/// extension. Returns `None` when unknown (the store then applies its default).
+fn content_type_for_key(key: &str) -> Option<&'static str> {
+    let ext = Path::new(key)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase());
+    match ext.as_deref() {
+        Some("png") => Some("image/png"),
+        Some("jpg") | Some("jpeg") => Some("image/jpeg"),
+        Some("gif") => Some("image/gif"),
+        Some("tif") | Some("tiff") => Some("image/tiff"),
+        Some("bmp") => Some("image/bmp"),
+        _ => None,
+    }
+}
+
+/// Local-vs-object-store I/O backend for the documents connector.
+#[derive(Clone)]
+pub enum BlobStore {
+    Local,
+    Remote(Arc<dyn ObjectStore>),
+}
+
+impl std::fmt::Debug for BlobStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BlobStore::Local => write!(f, "BlobStore::Local"),
+            BlobStore::Remote(_) => write!(f, "BlobStore::Remote(..)"),
+        }
+    }
+}
+
+impl BlobStore {
+    /// List every object/file under `prefix`, honoring `recursive`, returning
+    /// `(loc, rel_key)` pairs. `rel_key` is relative to `prefix` and uses `/`
+    /// separators — identical across backends so `doc_id`/`path` stay stable.
+    /// No glob filtering happens here (callers filter by basename).
+    pub async fn list(&self, prefix: &Loc, recursive: bool) -> Result<Vec<(Loc, String)>> {
+        match (self, prefix) {
+            (BlobStore::Local, Loc::Local(root)) => list_local(root, recursive),
+            (BlobStore::Remote(store), Loc::S3 { bucket, key }) => {
+                list_remote(store, bucket, key, recursive).await
+            }
+            _ => anyhow::bail!("documents: BlobStore/Loc backend mismatch in list()"),
+        }
+    }
+
+    /// Fetch the full bytes of one object/file.
+    pub async fn get(&self, loc: &Loc) -> Result<Vec<u8>> {
+        match (self, loc) {
+            (BlobStore::Local, Loc::Local(path)) => {
+                std::fs::read(path).with_context(|| format!("reading {}", path.display()))
+            }
+            (BlobStore::Remote(store), Loc::S3 { key, .. }) => {
+                let res = store
+                    .get(&OsPath::from(key.as_str()))
+                    .await
+                    .with_context(|| format!("s3 get {key}"))?;
+                let bytes = res.bytes().await.with_context(|| format!("s3 read body {key}"))?;
+                Ok(bytes.to_vec())
+            }
+            _ => anyhow::bail!("documents: BlobStore/Loc backend mismatch in get()"),
+        }
+    }
+
+    /// Write bytes to one object/file (image crops / page renders).
+    pub async fn put(&self, loc: &Loc, bytes: &[u8]) -> Result<()> {
+        match (self, loc) {
+            (BlobStore::Local, Loc::Local(path)) => {
+                if let Some(parent) = path.parent() {
+                    std::fs::create_dir_all(parent)
+                        .with_context(|| format!("creating dir {}", parent.display()))?;
+                }
+                std::fs::write(path, bytes).with_context(|| format!("writing {}", path.display()))
+            }
+            (BlobStore::Remote(store), Loc::S3 { key, .. }) => {
+                let mut attributes = Attributes::new();
+                if let Some(ct) = content_type_for_key(key) {
+                    attributes.insert(Attribute::ContentType, ct.into());
+                }
+                let opts = PutOptions {
+                    attributes,
+                    ..Default::default()
+                };
+                store
+                    .put_opts(&OsPath::from(key.as_str()), PutPayload::from(bytes.to_vec()), opts)
+                    .await
+                    .with_context(|| format!("s3 put {key}"))?;
+                Ok(())
+            }
+            _ => anyhow::bail!("documents: BlobStore/Loc backend mismatch in put()"),
+        }
+    }
+
+    /// Build the backend + parsed location for a URI. For S3 this constructs the
+    /// `object_store` client **on the calling thread's runtime** (call from the
+    /// documents parse thread) to avoid reqwest connection-pool cross-runtime
+    /// hazards; credentials/region come from the environment.
+    pub fn resolve(uri: &str) -> Result<(BlobStore, Loc)> {
+        let loc = Loc::parse(uri)?;
+        let store = match &loc {
+            Loc::Local(_) => BlobStore::Local,
+            Loc::S3 { bucket, .. } => BlobStore::Remote(build_s3_store(bucket)?),
+        };
+        Ok((store, loc))
+    }
+}
+
+/// Build an S3 object store for `bucket`, reading credentials/region from the
+/// environment (never from config — see `remote_storage.rs`).
+pub fn build_s3_store(bucket: &str) -> Result<Arc<dyn ObjectStore>> {
+    use object_store::aws::AmazonS3Builder;
+    let store = AmazonS3Builder::from_env()
+        .with_bucket_name(bucket)
+        .build()
+        .with_context(|| format!("building S3 object store for bucket '{bucket}'"))?;
+    Ok(Arc::new(store))
+}
+
+/// Walk a local directory, returning `(Loc::Local(abs), rel_key)` for every
+/// file. A missing/unreadable root is a hard error (matching the pre-S3
+/// behavior); subdirectory read errors are logged and skipped.
+fn list_local(root: &Path, recursive: bool) -> Result<Vec<(Loc, String)>> {
+    std::fs::read_dir(root)
+        .with_context(|| format!("documents: cannot read root directory {}", root.display()))?;
+
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(e) => {
+                tracing::warn!("documents: cannot read dir {}: {}", dir.display(), e);
+                continue;
+            }
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if recursive {
+                    stack.push(path);
+                }
+                continue;
+            }
+            let rel = path
+                .strip_prefix(root)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .replace('\\', "/");
+            out.push((Loc::Local(path), rel));
+        }
+    }
+    out.sort_by(|a, b| a.1.cmp(&b.1));
+    Ok(out)
+}
+
+/// List objects under an S3 prefix. Recursive uses a flat `list`; non-recursive
+/// uses a delimiter-scoped listing (one level).
+async fn list_remote(
+    store: &Arc<dyn ObjectStore>,
+    bucket: &str,
+    prefix_key: &str,
+    recursive: bool,
+) -> Result<Vec<(Loc, String)>> {
+    let norm = normalize_prefix(prefix_key);
+    let os_prefix = (!norm.is_empty()).then(|| OsPath::from(norm.as_str()));
+
+    let mut out: Vec<(Loc, String)> = Vec::new();
+    if recursive {
+        let mut stream = store.list(os_prefix.as_ref());
+        while let Some(meta) = stream.next().await {
+            let meta = meta.context("s3 list")?;
+            push_remote_entry(&mut out, bucket, &norm, meta.location.as_ref(), false);
+        }
+    } else {
+        let res = store
+            .list_with_delimiter(os_prefix.as_ref())
+            .await
+            .context("s3 list_with_delimiter")?;
+        for meta in res.objects {
+            push_remote_entry(&mut out, bucket, &norm, meta.location.as_ref(), true);
+        }
+    }
+    out.sort_by(|a, b| a.1.cmp(&b.1));
+    Ok(out)
+}
+
+/// Append one S3 object to the accumulator, stripping `norm` to the rel key.
+/// Skips the zero-length "folder marker" (rel == "") and, when `single_level`,
+/// any nested key that slipped through.
+fn push_remote_entry(
+    out: &mut Vec<(Loc, String)>,
+    bucket: &str,
+    norm: &str,
+    full_key: &str,
+    single_level: bool,
+) {
+    let rel = full_key.strip_prefix(norm).unwrap_or(full_key).to_string();
+    if rel.is_empty() || (single_level && rel.contains('/')) {
+        return;
+    }
+    out.push((
+        Loc::S3 {
+            bucket: bucket.to_string(),
+            key: full_key.to_string(),
+        },
+        rel,
+    ));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loc_parse_detects_local_and_s3() {
+        assert_eq!(
+            Loc::parse("/tmp/corpus").unwrap(),
+            Loc::Local(PathBuf::from("/tmp/corpus"))
+        );
+        assert_eq!(
+            Loc::parse("file:///tmp/corpus").unwrap(),
+            Loc::Local(PathBuf::from("/tmp/corpus"))
+        );
+        assert_eq!(
+            Loc::parse("s3://my-bucket/corpus/a.pdf").unwrap(),
+            Loc::S3 {
+                bucket: "my-bucket".to_string(),
+                key: "corpus/a.pdf".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn loc_parse_s3_prefix_without_key() {
+        assert_eq!(
+            Loc::parse("s3://my-bucket").unwrap(),
+            Loc::S3 {
+                bucket: "my-bucket".to_string(),
+                key: String::new(),
+            }
+        );
+        assert_eq!(
+            Loc::parse("s3://my-bucket/").unwrap(),
+            Loc::S3 {
+                bucket: "my-bucket".to_string(),
+                key: String::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn loc_parse_rejects_bucketless_s3() {
+        assert!(Loc::parse("s3://").is_err());
+        assert!(Loc::parse("s3:///key-only").is_err());
+    }
+
+    #[test]
+    fn normalize_prefix_forces_single_trailing_slash() {
+        assert_eq!(normalize_prefix("corpus"), "corpus/");
+        assert_eq!(normalize_prefix("corpus/"), "corpus/");
+        assert_eq!(normalize_prefix("a/b/c"), "a/b/c/");
+        assert_eq!(normalize_prefix(""), "");
+        assert_eq!(normalize_prefix("/"), "");
+    }
+
+    #[test]
+    fn content_type_inferred_from_extension() {
+        assert_eq!(content_type_for_key("x/y_0.png"), Some("image/png"));
+        assert_eq!(content_type_for_key("a.JPG"), Some("image/jpeg"));
+        assert_eq!(content_type_for_key("a.tiff"), Some("image/tiff"));
+        assert_eq!(content_type_for_key("a.pdf"), None);
+        assert_eq!(content_type_for_key("noext"), None);
+    }
+
+    #[tokio::test]
+    async fn local_backend_list_get_put_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("top.pdf"), b"TOP").unwrap();
+        let sub = dir.path().join("sub");
+        std::fs::create_dir(&sub).unwrap();
+        std::fs::write(sub.join("nested.pdf"), b"NESTED").unwrap();
+
+        let store = BlobStore::Local;
+        let prefix = Loc::Local(dir.path().to_path_buf());
+
+        // Recursive lists both, with '/'-separated rel keys, sorted.
+        let listed = store.list(&prefix, true).await.unwrap();
+        let rels: Vec<&str> = listed.iter().map(|(_, r)| r.as_str()).collect();
+        assert_eq!(rels, vec!["sub/nested.pdf", "top.pdf"]);
+
+        // Non-recursive lists only the top level.
+        let flat = store.list(&prefix, false).await.unwrap();
+        let flat_rels: Vec<&str> = flat.iter().map(|(_, r)| r.as_str()).collect();
+        assert_eq!(flat_rels, vec!["top.pdf"]);
+
+        // get returns the file bytes.
+        let (top_loc, _) = listed.iter().find(|(_, r)| r == "top.pdf").unwrap();
+        assert_eq!(store.get(top_loc).await.unwrap(), b"TOP");
+
+        // put creates parent dirs and writes bytes.
+        let out = Loc::Local(dir.path().join("crops/a_0.png"));
+        store.put(&out, b"\x89PNG").await.unwrap();
+        assert_eq!(
+            std::fs::read(dir.path().join("crops/a_0.png")).unwrap(),
+            b"\x89PNG"
+        );
+    }
+
+    #[tokio::test]
+    async fn local_backend_missing_root_errors() {
+        let store = BlobStore::Local;
+        let prefix = Loc::Local(PathBuf::from("/no/such/documents/root"));
+        let err = store.list(&prefix, true).await.unwrap_err();
+        assert!(
+            format!("{err:#}").contains("cannot read root directory"),
+            "unexpected: {err:#}"
+        );
+    }
+
+    async fn seed_inmemory(pairs: &[(&str, &[u8])]) -> Arc<dyn ObjectStore> {
+        let store = Arc::new(object_store::memory::InMemory::new());
+        for (key, bytes) in pairs {
+            store
+                .put(&OsPath::from(*key), PutPayload::from(bytes.to_vec()))
+                .await
+                .unwrap();
+        }
+        store
+    }
+
+    #[tokio::test]
+    async fn remote_backend_prefix_is_directory_scoped() {
+        // `corpus` must not match the sibling `corpus-2/` prefix.
+        let store = seed_inmemory(&[
+            ("corpus/a.pdf", b"A"),
+            ("corpus/sub/b.pdf", b"B"),
+            ("corpus-2/c.pdf", b"C"),
+        ])
+        .await;
+        let blob = BlobStore::Remote(store);
+        let prefix = Loc::S3 {
+            bucket: "bk".into(),
+            key: "corpus".into(), // no trailing slash on purpose
+        };
+
+        let listed = blob.list(&prefix, true).await.unwrap();
+        let rels: Vec<&str> = listed.iter().map(|(_, r)| r.as_str()).collect();
+        assert_eq!(rels, vec!["a.pdf", "sub/b.pdf"]);
+
+        // Loc carries the full key.
+        assert!(matches!(
+            &listed[0].0,
+            Loc::S3 { bucket, key } if bucket == "bk" && key == "corpus/a.pdf"
+        ));
+
+        // Non-recursive drops the nested entry.
+        let flat = blob.list(&prefix, false).await.unwrap();
+        let flat_rels: Vec<&str> = flat.iter().map(|(_, r)| r.as_str()).collect();
+        assert_eq!(flat_rels, vec!["a.pdf"]);
+    }
+
+    #[tokio::test]
+    async fn remote_backend_get_put_roundtrip() {
+        let store = seed_inmemory(&[("corpus/a.pdf", b"HELLO")]).await;
+        let blob = BlobStore::Remote(store);
+
+        let src = Loc::S3 {
+            bucket: "bk".into(),
+            key: "corpus/a.pdf".into(),
+        };
+        assert_eq!(blob.get(&src).await.unwrap(), b"HELLO");
+
+        let dst = Loc::S3 {
+            bucket: "bk".into(),
+            key: "crops/a.pdf_img0.png".into(),
+        };
+        blob.put(&dst, b"\x89PNGcrop").await.unwrap();
+        assert_eq!(blob.get(&dst).await.unwrap(), b"\x89PNGcrop");
+    }
+
+    #[test]
+    fn resolve_local_uri_yields_local_backend() {
+        let (store, loc) = BlobStore::resolve("/tmp/corpus").unwrap();
+        assert!(matches!(store, BlobStore::Local));
+        assert_eq!(loc, Loc::Local(PathBuf::from("/tmp/corpus")));
+    }
+}

--- a/crates/skardi/src/sources/providers/documents/mod.rs
+++ b/crates/skardi/src/sources/providers/documents/mod.rs
@@ -4,6 +4,7 @@
 //! into queryable `(file, page)` rows via the pure-Rust `liteparse` crate.
 //! Everything here is behind the `documents` Cargo feature.
 
+mod blob;
 mod parse;
 mod table;
 

--- a/crates/skardi/src/sources/providers/documents/mod.rs
+++ b/crates/skardi/src/sources/providers/documents/mod.rs
@@ -4,7 +4,10 @@
 //! into queryable `(file, page)` rows via the pure-Rust `liteparse` crate.
 //! Everything here is behind the `documents` Cargo feature.
 
-mod blob;
+// `pub(crate)` rather than private: `llm_extract`'s image fetch reuses
+// [`blob::BlobStore`] to read `s3://` `image_ref`s, so that S3 client
+// construction and the env-only credential contract live in exactly one place.
+pub(crate) mod blob;
 mod parse;
 mod table;
 

--- a/crates/skardi/src/sources/providers/documents/parse.rs
+++ b/crates/skardi/src/sources/providers/documents/parse.rs
@@ -306,10 +306,39 @@ fn build_config(opts: &ParseOptions) -> LiteParseConfig {
     cfg
 }
 
+/// Running tally of `image_store` write attempts across a scan.
+///
+/// An individual failed write is not fatal — the affected row simply carries no
+/// `page_image_ref` / crop ref. But that degradation is invisible in the result
+/// set, so the counts are aggregated here and inspected once at the end of the
+/// scan (see [`parse_source_blocking`]) rather than only appearing as one
+/// `warn!` per object.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct WriteTally {
+    attempted: usize,
+    failed: usize,
+}
+
+impl WriteTally {
+    fn record(&mut self, ok: bool) {
+        self.attempted += 1;
+        if !ok {
+            self.failed += 1;
+        }
+    }
+
+    /// Every attempted write failed — indistinguishable, from the rows alone,
+    /// from `image_store` never having been configured.
+    fn all_failed(&self) -> bool {
+        self.attempted > 0 && self.failed == self.attempted
+    }
+}
+
 /// Parse a single file (given its raw bytes) into its pages. Errors propagate to
 /// the caller, which isolates them per-file. `write_store` is the resolved
 /// `image_store` backend (present when `image_store` is configured); crops/page
-/// renders are written through it for both local and S3 targets.
+/// renders are written through it for both local and S3 targets, and each
+/// attempt is recorded in `writes`.
 ///
 /// Inputs are fed to liteparse as `PdfInput::Bytes`, so routing to LibreOffice
 /// for non-PDF inputs is by content sniff (see the design doc), not extension.
@@ -318,6 +347,7 @@ async fn parse_file(
     rel_path: &str,
     opts: &ParseOptions,
     write_store: Option<&BlobStore>,
+    writes: &mut WriteTally,
 ) -> Result<Vec<ParsedPage>> {
     let mut cfg = build_config(opts);
 
@@ -362,7 +392,9 @@ async fn parse_file(
                 for shot in shots {
                     let uri = page_image_uri(opts.image_store.as_deref(), rel_path, shot.page_num);
                     if let Some(store) = write_store {
-                        if let Err(e) = write_crop(store, &uri, &shot.image_bytes).await {
+                        let res = write_crop(store, &uri, &shot.image_bytes).await;
+                        writes.record(res.is_ok());
+                        if let Err(e) = res {
                             tracing::warn!(
                                 "documents: failed to write page image {}: {:#}",
                                 uri,
@@ -411,7 +443,9 @@ async fn parse_file(
                 let uri =
                     image_ref_uri(opts.image_store.as_deref(), rel_path, &img.id, &img.format);
                 if let Some(store) = write_store {
-                    if let Err(e) = write_crop(store, &uri, &img.bytes).await {
+                    let res = write_crop(store, &uri, &img.bytes).await;
+                    writes.record(res.is_ok());
+                    if let Err(e) = res {
                         tracing::warn!("documents: failed to write image crop {}: {:#}", uri, e);
                         continue;
                     }
@@ -582,6 +616,7 @@ fn parse_source_blocking(root: &str, opts: &ParseOptions) -> Result<Vec<ParsedPa
 
     let mut rows = Vec::new();
     let mut ok_files = 0usize;
+    let mut writes = WriteTally::default();
     for (loc, rel_path) in entries {
         let bytes = match runtime.block_on(read_store.get(&loc)) {
             Ok(b) => b,
@@ -590,7 +625,13 @@ fn parse_source_blocking(root: &str, opts: &ParseOptions) -> Result<Vec<ParsedPa
                 continue;
             }
         };
-        match runtime.block_on(parse_file(&bytes, &rel_path, opts, write_store.as_ref())) {
+        match runtime.block_on(parse_file(
+            &bytes,
+            &rel_path,
+            opts,
+            write_store.as_ref(),
+            &mut writes,
+        )) {
             Ok(mut page_rows) => {
                 ok_files += 1;
                 rows.append(&mut page_rows);
@@ -609,6 +650,30 @@ fn parse_source_blocking(root: &str, opts: &ParseOptions) -> Result<Vec<ParsedPa
         anyhow::bail!(
             "documents: all {total} matched object(s) failed to fetch/parse — treating as a \
              hard error rather than an empty result (check credentials/permissions)"
+        );
+    }
+
+    // Same reasoning applied to the write side. Individual crop/page-image write
+    // failures only `warn!` and drop the ref, which is invisible in the result
+    // set: rows come back with `page_image_ref = NULL` exactly as if
+    // `render_page_images` were off. The registration preflight covers `s3://`
+    // targets at startup, but not credentials that expire mid-scan, and not a
+    // local `image_store` at all — so a wholesale write failure is escalated
+    // here rather than silently degrading every row.
+    if writes.all_failed() {
+        anyhow::bail!(
+            "documents: all {} image_store write(s) failed — refusing to return rows whose \
+             page_image_ref/image_refs would silently be empty (check write permissions on \
+             image_store: s3:PutObject for s3://, filesystem permissions for a local path)",
+            writes.attempted
+        );
+    }
+    if writes.failed > 0 {
+        tracing::warn!(
+            "documents: {}/{} image_store write(s) failed; the affected rows carry no \
+             page_image_ref/image_refs (individual failures logged above)",
+            writes.failed,
+            writes.attempted
         );
     }
 
@@ -859,6 +924,81 @@ mod tests {
             image_ref_uri(Some("/tmp/out/"), "a.pdf", "img0", "png"),
             "/tmp/out/a.pdf_img0.png"
         );
+    }
+
+    #[test]
+    fn write_tally_only_escalates_on_wholesale_failure() {
+        // Nothing attempted (no image_store, or nothing to write) is not a failure.
+        let empty = WriteTally::default();
+        assert!(!empty.all_failed());
+
+        // Partial failure degrades those rows but must not fail the scan.
+        let mut partial = WriteTally::default();
+        partial.record(true);
+        partial.record(false);
+        assert_eq!((partial.attempted, partial.failed), (2, 1));
+        assert!(
+            !partial.all_failed(),
+            "a partial write failure must not fail the whole scan"
+        );
+
+        // Every write failing is indistinguishable from an unconfigured
+        // image_store in the rows, so it escalates.
+        let mut total = WriteTally::default();
+        total.record(false);
+        total.record(false);
+        assert!(total.all_failed());
+    }
+
+    #[tokio::test]
+    async fn wholesale_image_store_write_failure_is_an_error() {
+        // A read-only local `image_store` gets no preflight at all (that only
+        // covers `s3://`), so this guard is the only thing standing between a
+        // permission problem and every row silently losing its image refs.
+        let src = tempfile::tempdir().unwrap();
+        std::fs::copy(
+            "tests/fixtures/documents/two_pages.pdf",
+            src.path().join("a.pdf"),
+        )
+        .unwrap();
+
+        let store_dir = tempfile::tempdir().unwrap();
+        let store_path = store_dir.path().join("readonly");
+        std::fs::create_dir(&store_path).unwrap();
+        // Drop write permission so every `write_crop` fails.
+        let mut perms = std::fs::metadata(&store_path).unwrap().permissions();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            perms.set_mode(0o500);
+        }
+        std::fs::set_permissions(&store_path, perms).unwrap();
+
+        let opts = ParseOptions {
+            recursive: false,
+            include_globs: vec!["*.pdf".into()],
+            image_store: Some(store_path.to_string_lossy().into_owned()),
+            render_page_images: true,
+            ocr: OcrMode::Off,
+            ..ParseOptions::default()
+        };
+
+        let err = parse_source(src.path().to_str().unwrap(), &opts)
+            .expect_err("every image_store write failing must be a hard error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("image_store write(s) failed"),
+            "unexpected error: {msg}"
+        );
+
+        // Restore permissions so the tempdir can be cleaned up.
+        let mut perms = std::fs::metadata(&store_path).unwrap().permissions();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            perms.set_mode(0o700);
+        }
+        std::fs::set_permissions(&store_path, perms).unwrap();
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/documents/parse.rs
+++ b/crates/skardi/src/sources/providers/documents/parse.rs
@@ -861,6 +861,50 @@ mod tests {
         );
     }
 
+    #[test]
+    fn s3_image_refs_round_trip_back_into_a_loc() {
+        // The refs this module *writes* into `page_image_ref` / `image_refs` are
+        // the same strings `llm_extract`'s image fetch later resolves. If the two
+        // ever disagree, multimodal escalation silently breaks on S3 — so pin the
+        // round-trip here rather than only asserting the string shape.
+        let store = "s3://my-bucket/extracted";
+
+        let page_uri = page_image_uri(Some(store), "nested/sub/report.pdf", 2);
+        assert_eq!(
+            page_uri,
+            "s3://my-bucket/extracted/nested_sub_report.pdf_page_2.png"
+        );
+        assert_eq!(
+            Loc::parse(&page_uri).unwrap(),
+            Loc::S3 {
+                bucket: "my-bucket".into(),
+                key: "extracted/nested_sub_report.pdf_page_2.png".into(),
+            },
+            "page_image_ref must parse back to the object it was written to"
+        );
+
+        let crop_uri = image_ref_uri(Some(store), "nested/sub/report.pdf", "img0", "png");
+        assert_eq!(
+            Loc::parse(&crop_uri).unwrap(),
+            Loc::S3 {
+                bucket: "my-bucket".into(),
+                key: "extracted/nested_sub_report.pdf_img0.png".into(),
+            },
+            "image_refs entries must parse back to the object they were written to"
+        );
+
+        // A trailing slash on the configured store must not produce a `//` key,
+        // which S3 treats as a distinct (empty-named) path segment.
+        let slashed = page_image_uri(Some("s3://my-bucket/extracted/"), "a.pdf", 1);
+        assert_eq!(
+            Loc::parse(&slashed).unwrap(),
+            Loc::S3 {
+                bucket: "my-bucket".into(),
+                key: "extracted/a.pdf_page_1.png".into(),
+            }
+        );
+    }
+
     #[tokio::test]
     async fn list_docs_filters_by_glob_and_respects_recursive() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/skardi/src/sources/providers/documents/parse.rs
+++ b/crates/skardi/src/sources/providers/documents/parse.rs
@@ -555,8 +555,8 @@ pub fn parse_source(root: &str, opts: &ParseOptions) -> Result<Vec<ParsedPage>> 
 /// this thread, so any S3 `object_store` client is built on the same runtime it
 /// is polled from (avoids reqwest connection-pool cross-runtime hazards).
 fn parse_source_blocking(root: &str, opts: &ParseOptions) -> Result<Vec<ParsedPage>> {
-    let (read_store, prefix_loc) =
-        BlobStore::resolve(root).with_context(|| format!("documents: resolving source path {root}"))?;
+    let (read_store, prefix_loc) = BlobStore::resolve(root)
+        .with_context(|| format!("documents: resolving source path {root}"))?;
 
     let (write_store, image_base) = match opts.image_store.as_deref() {
         Some(s) => {
@@ -572,8 +572,12 @@ fn parse_source_blocking(root: &str, opts: &ParseOptions) -> Result<Vec<ParsedPa
         .build()
         .context("failed to build tokio runtime for documents parse")?;
 
-    let entries =
-        runtime.block_on(list_docs(&read_store, &prefix_loc, opts, image_base.as_ref()))?;
+    let entries = runtime.block_on(list_docs(
+        &read_store,
+        &prefix_loc,
+        opts,
+        image_base.as_ref(),
+    ))?;
     let total = entries.len();
 
     let mut rows = Vec::new();
@@ -938,10 +942,7 @@ mod tests {
                 key: "k".into()
             }
         ));
-        assert!(!loc_is_under(
-            &Loc::Local("/x".into()),
-            &e("corpus")
-        ));
+        assert!(!loc_is_under(&Loc::Local("/x".into()), &e("corpus")));
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/documents/parse.rs
+++ b/crates/skardi/src/sources/providers/documents/parse.rs
@@ -6,11 +6,14 @@
 //! consumes the source's output through SQL, not this module.
 
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::{Context, Result};
 use liteparse::config::ImageMode as LpImageMode;
+use liteparse::types::PdfInput;
 use liteparse::{LiteParse, LiteParseConfig, OutputFormat};
+
+use super::blob::{BlobStore, Loc};
 
 /// How raster images on a page are surfaced.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -225,46 +228,60 @@ fn glob_match(pattern: &str, name: &str) -> bool {
     }
 }
 
-/// Collect candidate files under `root`, honoring `recursive` + `include_globs`.
+/// List the documents to parse under `prefix`, honoring `recursive` +
+/// `include_globs`, and excluding anything under the `image_store` location so
+/// crops written by a prior scan are never re-ingested (self-ingestion guard).
 ///
-/// A missing/unreadable *root* is a configuration error (typo'd path, bad
-/// permissions) and fails the scan loudly rather than silently returning an
-/// empty corpus. Subdirectories hit during the recursive descent are more
-/// lenient (existing behavior): a permission error on one subdirectory logs
-/// a warning and is skipped rather than failing the whole scan.
-fn collect_files(root: &Path, opts: &ParseOptions) -> Result<Vec<PathBuf>> {
-    std::fs::read_dir(root)
-        .with_context(|| format!("documents: cannot read root directory {}", root.display()))?;
-
-    let mut out = Vec::new();
-    let mut stack = vec![root.to_path_buf()];
-    while let Some(dir) = stack.pop() {
-        let entries = match std::fs::read_dir(&dir) {
-            Ok(e) => e,
-            Err(e) => {
-                tracing::warn!("documents: cannot read dir {}: {}", dir.display(), e);
-                continue;
+/// Backed by [`BlobStore::list`]; a missing/unreadable local root fails the scan
+/// loudly (see `list_local`). Glob matching is on the entry's basename.
+async fn list_docs(
+    store: &BlobStore,
+    prefix: &Loc,
+    opts: &ParseOptions,
+    image_store: Option<&Loc>,
+) -> Result<Vec<(Loc, String)>> {
+    let entries = store.list(prefix, opts.recursive).await?;
+    Ok(entries
+        .into_iter()
+        .filter(|(loc, rel)| {
+            let name = rel.rsplit('/').next().unwrap_or(rel);
+            if !matches_globs(name, &opts.include_globs) {
+                return false;
             }
-        };
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_dir() {
-                if opts.recursive {
-                    stack.push(path);
+            if let Some(base) = image_store {
+                if loc_is_under(loc, base) {
+                    return false;
                 }
-                continue;
             }
-            let file_name = match path.file_name().and_then(|n| n.to_str()) {
-                Some(n) => n,
-                None => continue,
-            };
-            if matches_globs(file_name, &opts.include_globs) {
-                out.push(path);
+            true
+        })
+        .collect())
+}
+
+/// Whether `entry` lives under the `base` location — used to exclude the
+/// `image_store` prefix from listing when it overlaps the source. Cross-backend
+/// (local vs S3) or cross-bucket pairs never overlap.
+fn loc_is_under(entry: &Loc, base: &Loc) -> bool {
+    match (entry, base) {
+        (Loc::Local(e), Loc::Local(b)) => e.starts_with(b),
+        (
+            Loc::S3 {
+                bucket: eb,
+                key: ek,
+            },
+            Loc::S3 {
+                bucket: bb,
+                key: bk,
+            },
+        ) => {
+            if eb != bb {
+                return false;
             }
+            let trimmed = bk.trim_end_matches('/');
+            trimmed.is_empty() || ek == trimmed || ek.starts_with(&format!("{trimmed}/"))
         }
+        _ => false,
     }
-    out.sort();
-    Ok(out)
 }
 
 /// Build the liteparse config for a parse run.
@@ -289,17 +306,19 @@ fn build_config(opts: &ParseOptions) -> LiteParseConfig {
     cfg
 }
 
-/// Parse a single file into its pages. Errors propagate to the caller, which
-/// isolates them per-file.
+/// Parse a single file (given its raw bytes) into its pages. Errors propagate to
+/// the caller, which isolates them per-file. `write_store` is the resolved
+/// `image_store` backend (present when `image_store` is configured); crops/page
+/// renders are written through it for both local and S3 targets.
+///
+/// Inputs are fed to liteparse as `PdfInput::Bytes`, so routing to LibreOffice
+/// for non-PDF inputs is by content sniff (see the design doc), not extension.
 async fn parse_file(
-    abs_path: &Path,
+    bytes: &[u8],
     rel_path: &str,
     opts: &ParseOptions,
+    write_store: Option<&BlobStore>,
 ) -> Result<Vec<ParsedPage>> {
-    let path_str = abs_path
-        .to_str()
-        .with_context(|| format!("non-UTF-8 path: {}", abs_path.display()))?;
-
     let mut cfg = build_config(opts);
 
     // OCR Auto: ask liteparse which pages need OCR and only enable it when at
@@ -308,10 +327,7 @@ async fn parse_file(
     // when no OCR engine is reachable — enabling OCR would hard-fail the parse.
     if matches!(opts.ocr, OcrMode::Auto) && ocr_engine_available(opts) {
         let probe = LiteParse::new(cfg.clone());
-        match probe
-            .is_complex(liteparse::types::PdfInput::Path(path_str.to_string()))
-            .await
-        {
+        match probe.is_complex(PdfInput::Bytes(bytes.to_vec())).await {
             Ok(stats) => {
                 if stats.iter().any(|s| s.needs_ocr) {
                     cfg.ocr_enabled = true;
@@ -325,11 +341,11 @@ async fn parse_file(
 
     let parser = LiteParse::new(cfg.clone());
     let result = parser
-        .parse(path_str)
+        .parse_input(PdfInput::Bytes(bytes.to_vec()))
         .await
         .with_context(|| format!("liteparse failed for {}", rel_path))?;
 
-    let file_type = file_type_for(abs_path);
+    let file_type = file_type_for(Path::new(rel_path));
     let doc_id = doc_id_for(rel_path);
 
     // Optionally render full-page images for `page_image_ref` (multimodal use,
@@ -338,12 +354,15 @@ async fn parse_file(
     // non-PDF inputs, same as parsing. Map page_num -> written/ref URI.
     let mut page_image_refs: HashMap<u32, String> = HashMap::new();
     if opts.render_page_images {
-        match parser.screenshot(path_str, None).await {
+        match parser
+            .screenshot_input(PdfInput::Bytes(bytes.to_vec()), None)
+            .await
+        {
             Ok(shots) => {
                 for shot in shots {
                     let uri = page_image_uri(opts.image_store.as_deref(), rel_path, shot.page_num);
-                    if let Some(store) = opts.image_store.as_deref() {
-                        if let Err(e) = write_image_crop(store, &uri, &shot.image_bytes) {
+                    if let Some(store) = write_store {
+                        if let Err(e) = write_crop(store, &uri, &shot.image_bytes).await {
                             tracing::warn!(
                                 "documents: failed to write page image {}: {:#}",
                                 uri,
@@ -383,26 +402,23 @@ async fn parse_file(
         // `image_store` is configured we also write the crop bytes there and
         // record only the refs for crops we could materialize.
         let image_refs: Vec<String> = if opts.image_mode == ImageMode::Embedded {
-            result
+            let mut refs = Vec::new();
+            for img in result
                 .images
                 .iter()
                 .filter(|img| img.page as usize == page.page_number)
-                .filter_map(|img| {
-                    let uri =
-                        image_ref_uri(opts.image_store.as_deref(), rel_path, &img.id, &img.format);
-                    if let Some(store) = opts.image_store.as_deref() {
-                        if let Err(e) = write_image_crop(store, &uri, &img.bytes) {
-                            tracing::warn!(
-                                "documents: failed to write image crop {}: {:#}",
-                                uri,
-                                e
-                            );
-                            return None;
-                        }
+            {
+                let uri =
+                    image_ref_uri(opts.image_store.as_deref(), rel_path, &img.id, &img.format);
+                if let Some(store) = write_store {
+                    if let Err(e) = write_crop(store, &uri, &img.bytes).await {
+                        tracing::warn!("documents: failed to write image crop {}: {:#}", uri, e);
+                        continue;
                     }
-                    Some(uri)
-                })
-                .collect()
+                }
+                refs.push(uri);
+            }
+            refs
         } else {
             Vec::new()
         };
@@ -450,22 +466,12 @@ fn page_image_uri(store: Option<&str>, rel_path: &str, page: u32) -> String {
     }
 }
 
-/// Write an extracted image crop to a local `image_store`. Remote stores
-/// (`s3://…`, etc.) are not written here in v1 — the ref is still recorded so a
-/// later object-store pass can upload (spec §7 open item). Returns `Ok` for the
-/// remote-store no-op so the ref is kept.
-fn write_image_crop(store: &str, uri: &str, bytes: &[u8]) -> Result<()> {
-    if store.contains("://") {
-        // Remote object store: defer the actual upload.
-        return Ok(());
-    }
-    let path = Path::new(uri);
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("creating image_store dir {}", parent.display()))?;
-    }
-    std::fs::write(path, bytes).with_context(|| format!("writing image crop {}", uri))?;
-    Ok(())
+/// Write an extracted image crop / page render to the resolved `image_store`
+/// backend. The ref URI is parsed into a [`Loc`] and handed to
+/// [`BlobStore::put`], so both local and S3 targets perform a real write.
+async fn write_crop(store: &BlobStore, uri: &str, bytes: &[u8]) -> Result<()> {
+    let loc = Loc::parse(uri).with_context(|| format!("parsing image_store uri {uri}"))?;
+    store.put(&loc, bytes).await
 }
 
 /// Lift GFM pipe tables out of page markdown into a JSON array. Each table is
@@ -544,29 +550,62 @@ pub fn parse_source(root: &str, opts: &ParseOptions) -> Result<Vec<ParsedPage>> 
 }
 
 /// The actual blocking parse loop, run on a thread that owns a tokio runtime.
+///
+/// The read `path` and write `image_store` backends are resolved **here**, on
+/// this thread, so any S3 `object_store` client is built on the same runtime it
+/// is polled from (avoids reqwest connection-pool cross-runtime hazards).
 fn parse_source_blocking(root: &str, opts: &ParseOptions) -> Result<Vec<ParsedPage>> {
-    let root_path = Path::new(root);
-    let files = collect_files(root_path, opts)?;
+    let (read_store, prefix_loc) =
+        BlobStore::resolve(root).with_context(|| format!("documents: resolving source path {root}"))?;
+
+    let (write_store, image_base) = match opts.image_store.as_deref() {
+        Some(s) => {
+            let (ws, loc) = BlobStore::resolve(s)
+                .with_context(|| format!("documents: resolving image_store {s}"))?;
+            (Some(ws), Some(loc))
+        }
+        None => (None, None),
+    };
 
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .context("failed to build tokio runtime for documents parse")?;
 
-    let mut rows = Vec::new();
-    for file in files {
-        let rel_path = file
-            .strip_prefix(root_path)
-            .unwrap_or(&file)
-            .to_string_lossy()
-            .replace('\\', "/");
+    let entries =
+        runtime.block_on(list_docs(&read_store, &prefix_loc, opts, image_base.as_ref()))?;
+    let total = entries.len();
 
-        match runtime.block_on(parse_file(&file, &rel_path, opts)) {
-            Ok(mut page_rows) => rows.append(&mut page_rows),
+    let mut rows = Vec::new();
+    let mut ok_files = 0usize;
+    for (loc, rel_path) in entries {
+        let bytes = match runtime.block_on(read_store.get(&loc)) {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!("documents: fetch failed for {}: {:#}", rel_path, e);
+                continue;
+            }
+        };
+        match runtime.block_on(parse_file(&bytes, &rel_path, opts, write_store.as_ref())) {
+            Ok(mut page_rows) => {
+                ok_files += 1;
+                rows.append(&mut page_rows);
+            }
             Err(e) => {
                 tracing::warn!("documents: skipping {}: {:#}", rel_path, e);
             }
         }
+    }
+
+    // Wholesale-failure guard: a non-empty listing where *every* object failed to
+    // fetch/parse (e.g. credentials expired after listing) is a hard error, not a
+    // silent empty result that looks like an empty corpus. An empty listing
+    // (total == 0) stays a valid, currently-empty corpus.
+    if total > 0 && ok_files == 0 {
+        anyhow::bail!(
+            "documents: all {total} matched object(s) failed to fetch/parse — treating as a \
+             hard error rather than an empty result (check credentials/permissions)"
+        );
     }
 
     Ok(rows)
@@ -796,30 +835,113 @@ mod tests {
         );
     }
 
-    #[test]
-    fn collect_files_recurses_into_subdirectories_when_enabled() {
+    #[tokio::test]
+    async fn list_docs_filters_by_glob_and_respects_recursive() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("top.pdf"), b"x").unwrap();
+        std::fs::write(dir.path().join("skip.txt"), b"x").unwrap();
         let sub = dir.path().join("sub");
         std::fs::create_dir(&sub).unwrap();
         std::fs::write(sub.join("nested.pdf"), b"x").unwrap();
+
+        let store = BlobStore::Local;
+        let prefix = Loc::Local(dir.path().to_path_buf());
 
         let opts = ParseOptions {
             recursive: true,
             include_globs: vec!["*.pdf".into()],
             ..ParseOptions::default()
         };
-        let files = collect_files(dir.path(), &opts).unwrap();
-        assert_eq!(files.len(), 2);
+        let rels: Vec<String> = list_docs(&store, &prefix, &opts, None)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|(_, r)| r)
+            .collect();
+        assert_eq!(rels, vec!["sub/nested.pdf", "top.pdf"]); // .txt filtered out
 
-        let opts_non_recursive = ParseOptions {
+        let opts_flat = ParseOptions {
             recursive: false,
-            include_globs: vec!["*.pdf".into()],
+            ..opts.clone()
+        };
+        let rels: Vec<String> = list_docs(&store, &prefix, &opts_flat, None)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|(_, r)| r)
+            .collect();
+        assert_eq!(rels, vec!["top.pdf"]);
+    }
+
+    #[tokio::test]
+    async fn list_docs_excludes_image_store_prefix() {
+        // A crop written under a nested image_store must not be re-ingested.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.pdf"), b"x").unwrap();
+        let crops = dir.path().join("crops");
+        std::fs::create_dir(&crops).unwrap();
+        std::fs::write(crops.join("a.pdf_img0.png"), b"x").unwrap();
+
+        let store = BlobStore::Local;
+        let prefix = Loc::Local(dir.path().to_path_buf());
+        let image_store = Loc::Local(crops.clone());
+        let opts = ParseOptions {
+            recursive: true,
+            include_globs: vec!["*.pdf".into(), "*.png".into()],
             ..ParseOptions::default()
         };
-        let files = collect_files(dir.path(), &opts_non_recursive).unwrap();
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0].file_name().unwrap(), "top.pdf");
+
+        // Without exclusion the crop would appear; with it, only the source doc.
+        let with_excl: Vec<String> = list_docs(&store, &prefix, &opts, Some(&image_store))
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|(_, r)| r)
+            .collect();
+        assert_eq!(with_excl, vec!["a.pdf"]);
+
+        let without_excl: Vec<String> = list_docs(&store, &prefix, &opts, None)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|(_, r)| r)
+            .collect();
+        assert_eq!(without_excl, vec!["a.pdf", "crops/a.pdf_img0.png"]);
+    }
+
+    #[test]
+    fn loc_is_under_matches_backends() {
+        // Local nesting.
+        assert!(loc_is_under(
+            &Loc::Local("/root/crops/x.png".into()),
+            &Loc::Local("/root/crops".into())
+        ));
+        assert!(!loc_is_under(
+            &Loc::Local("/root/a.pdf".into()),
+            &Loc::Local("/root/crops".into())
+        ));
+        // S3 same bucket, prefix-scoped.
+        let e = |k: &str| Loc::S3 {
+            bucket: "b".into(),
+            key: k.into(),
+        };
+        assert!(loc_is_under(&e("corpus/crops/x.png"), &e("corpus/crops")));
+        assert!(!loc_is_under(&e("corpus/a.pdf"), &e("corpus/crops")));
+        // Different bucket / backend never overlap.
+        assert!(!loc_is_under(
+            &Loc::S3 {
+                bucket: "b1".into(),
+                key: "k".into()
+            },
+            &Loc::S3 {
+                bucket: "b2".into(),
+                key: "k".into()
+            }
+        ));
+        assert!(!loc_is_under(
+            &Loc::Local("/x".into()),
+            &e("corpus")
+        ));
     }
 
     #[test]
@@ -855,19 +977,14 @@ mod tests {
         );
     }
 
-    #[test]
-    fn write_image_crop_writes_local_file() {
+    #[tokio::test]
+    async fn write_crop_writes_local_file() {
         let dir = tempfile::tempdir().unwrap();
         let uri = format!("{}/sub/crop_p1_0.png", dir.path().display());
-        write_image_crop(dir.path().to_str().unwrap(), &uri, b"\x89PNGfake").unwrap();
-        let written = std::fs::read(&uri).unwrap();
-        assert_eq!(written, b"\x89PNGfake");
-    }
-
-    #[test]
-    fn write_image_crop_skips_remote_store() {
-        // Remote stores are a no-op (deferred upload) but must not error.
-        write_image_crop("s3://bucket/prefix", "s3://bucket/prefix/x.png", b"data").unwrap();
+        write_crop(&BlobStore::Local, &uri, b"\x89PNGfake")
+            .await
+            .unwrap();
+        assert_eq!(std::fs::read(&uri).unwrap(), b"\x89PNGfake");
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/documents/parse.rs
+++ b/crates/skardi/src/sources/providers/documents/parse.rs
@@ -728,6 +728,28 @@ mod tests {
     }
 
     #[test]
+    fn all_files_failing_to_parse_is_a_hard_error() {
+        // Wholesale-failure guard: a non-empty listing where *every* matched file
+        // fails to parse must be a hard error, not a silent empty result (which
+        // would masquerade as an empty corpus). Two `.pdf` files of non-PDF
+        // garbage make liteparse error on each, so total>0 && ok_files==0.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.pdf"), b"not a real pdf at all").unwrap();
+        std::fs::write(dir.path().join("b.pdf"), b"also garbage bytes").unwrap();
+        let opts = ParseOptions {
+            include_globs: vec!["*.pdf".into()],
+            ocr: OcrMode::Off,
+            ..ParseOptions::default()
+        };
+        let err = parse_source(dir.path().to_str().unwrap(), &opts).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("failed to fetch/parse"),
+            "expected wholesale-failure hard error, got: {msg}"
+        );
+    }
+
+    #[test]
     fn glob_match_basics() {
         assert!(glob_match("*.pdf", "a.pdf"));
         assert!(glob_match("*.pdf", "DIR.PDF"));

--- a/crates/skardi/tests/documents_s3_live.rs
+++ b/crates/skardi/tests/documents_s3_live.rs
@@ -1,0 +1,322 @@
+//! Opt-in live tests for the `documents` connector's object-store backend.
+//!
+//! Disabled by default (`#[ignore]`) so the default suite stays offline and
+//! deterministic. These are the only tests that exercise the real S3 code path —
+//! everything else stubs at [`Loc`]/`BlobStore` level — so run them whenever the
+//! object-store code changes.
+//!
+//! Against real AWS S3:
+//!   DOCUMENTS_S3_LIVE=1 DOCUMENTS_S3_BUCKET=my-bucket \
+//!     AWS_REGION=us-east-1 AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... \
+//!     cargo test -p skardi --test documents_s3_live \
+//!       --features documents,llm-extract -- --ignored
+//!
+//! Against MinIO (no AWS account needed):
+//!   docker run -d -p 127.0.0.1:9000:9000 -e MINIO_ROOT_USER=minioadmin \
+//!     -e MINIO_ROOT_PASSWORD=minioadmin quay.io/minio/minio server /data
+//!   aws --endpoint-url http://127.0.0.1:9000 s3 mb s3://skardi-test
+//!   DOCUMENTS_S3_LIVE=1 DOCUMENTS_S3_BUCKET=skardi-test \
+//!     AWS_ENDPOINT=http://127.0.0.1:9000 AWS_ALLOW_HTTP=true \
+//!     AWS_REGION=us-east-1 AWS_ACCESS_KEY_ID=minioadmin \
+//!     AWS_SECRET_ACCESS_KEY=minioadmin \
+//!     cargo test -p skardi --test documents_s3_live \
+//!       --features documents,llm-extract -- --ignored
+//!
+//! The bucket must already exist; each test writes under a distinct prefix and
+//! cleans up after itself.
+
+#![cfg(feature = "documents")]
+
+use std::sync::Arc;
+
+use object_store::aws::AmazonS3Builder;
+use object_store::path::Path as OsPath;
+use object_store::{ObjectStore, PutPayload};
+
+/// Fixture PDF shipped with the crate — a real 2-page PDF liteparse can parse
+/// without LibreOffice or ImageMagick installed.
+const FIXTURE_PDF: &str = "tests/fixtures/documents/two_pages.pdf";
+
+fn live_enabled() -> bool {
+    std::env::var("DOCUMENTS_S3_LIVE").ok().as_deref() == Some("1")
+}
+
+fn bucket() -> String {
+    std::env::var("DOCUMENTS_S3_BUCKET")
+        .expect("DOCUMENTS_S3_BUCKET must be set when DOCUMENTS_S3_LIVE=1")
+}
+
+fn store(bucket: &str) -> Arc<dyn ObjectStore> {
+    Arc::new(
+        AmazonS3Builder::from_env()
+            .with_bucket_name(bucket)
+            .build()
+            .expect("build S3 store from environment"),
+    )
+}
+
+/// Upload the fixture PDF at `key`, returning its bytes.
+async fn seed(store: &Arc<dyn ObjectStore>, key: &str) -> Vec<u8> {
+    let bytes = std::fs::read(FIXTURE_PDF).expect("read fixture pdf");
+    store
+        .put(&OsPath::from(key), PutPayload::from(bytes.clone()))
+        .await
+        .expect("seed object");
+    bytes
+}
+
+async fn purge(store: &Arc<dyn ObjectStore>, prefix: &str) {
+    use futures::StreamExt;
+    let mut listing = store.list(Some(&OsPath::from(prefix)));
+    while let Some(Ok(meta)) = listing.next().await {
+        let _ = store.delete(&meta.location).await;
+    }
+}
+
+/// End-to-end: list + fetch + parse from S3, and write page renders / crops back
+/// to an S3 `image_store`. Covers the whole object-store round trip that only
+/// manual testing exercised before.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "live: requires DOCUMENTS_S3_LIVE=1, DOCUMENTS_S3_BUCKET and AWS credentials"]
+async fn live_s3_scan_reads_objects_and_writes_image_store() {
+    if !live_enabled() {
+        eprintln!("skipping live S3 test: set DOCUMENTS_S3_LIVE=1 to run");
+        return;
+    }
+    let bucket = bucket();
+    let st = store(&bucket);
+    let base = "skardi-live/scan";
+    purge(&st, base).await;
+
+    // Two objects, one nested, to cover recursive listing and '/'-separated keys.
+    seed(&st, &format!("{base}/docs/flat.pdf")).await;
+    seed(&st, &format!("{base}/docs/nested/sub/deep.pdf")).await;
+
+    let opts = skardi::sources::providers::documents::ParseOptions {
+        recursive: true,
+        include_globs: vec!["*.pdf".into()],
+        image_mode: skardi::sources::providers::documents::ImageMode::Embedded,
+        image_store: Some(format!("s3://{bucket}/{base}/extracted")),
+        render_page_images: true,
+        ocr: skardi::sources::providers::documents::OcrMode::Off,
+        ocr_server_url: None,
+    };
+
+    let root = format!("s3://{bucket}/{base}/docs");
+    let rows = skardi::sources::providers::documents::parse_source(&root, &opts)
+        .expect("parse_source over s3");
+
+    // Both files, both pages each.
+    assert_eq!(rows.len(), 4, "expected 2 files x 2 pages, got {rows:?}");
+
+    let mut paths: Vec<&str> = rows.iter().map(|r| r.path.as_str()).collect();
+    paths.sort();
+    paths.dedup();
+    assert_eq!(
+        paths,
+        vec!["flat.pdf", "nested/sub/deep.pdf"],
+        "prefix-relative paths must use '/' separators, identical to the local backend"
+    );
+
+    // Every row got a page render, and each ref is an s3:// URI under image_store.
+    assert!(
+        rows.iter().all(|r| r.page_image_ref.is_some()),
+        "render_page_images=true must set page_image_ref on every row"
+    );
+    let refs: Vec<&String> = rows
+        .iter()
+        .filter_map(|r| r.page_image_ref.as_ref())
+        .collect();
+    assert!(
+        refs.iter()
+            .all(|r| r.starts_with(&format!("s3://{bucket}/{base}/extracted/"))),
+        "page_image_ref must point into the configured s3 image_store: {refs:?}"
+    );
+
+    // The referenced objects must actually exist and be non-empty — the write
+    // path only `warn!`s on failure, so a silent drop would otherwise pass.
+    for r in &refs {
+        let key = r
+            .strip_prefix(&format!("s3://{bucket}/"))
+            .expect("ref has bucket prefix");
+        let meta = st
+            .head(&OsPath::from(key))
+            .await
+            .unwrap_or_else(|e| panic!("page image {key} missing from S3: {e}"));
+        assert!(meta.size > 0, "page image {key} is empty");
+    }
+
+    purge(&st, base).await;
+}
+
+/// The scan must not re-ingest its own output when `image_store` nests inside
+/// the source prefix and matches `include_globs` (self-ingestion guard).
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "live: requires DOCUMENTS_S3_LIVE=1, DOCUMENTS_S3_BUCKET and AWS credentials"]
+async fn live_s3_self_ingestion_guard_holds_across_scans() {
+    if !live_enabled() {
+        eprintln!("skipping live S3 test: set DOCUMENTS_S3_LIVE=1 to run");
+        return;
+    }
+    let bucket = bucket();
+    let st = store(&bucket);
+    let base = "skardi-live/selfingest";
+    purge(&st, base).await;
+    seed(&st, &format!("{base}/docs/report.pdf")).await;
+
+    let opts = skardi::sources::providers::documents::ParseOptions {
+        recursive: true,
+        // *.png matches the crops/page renders the scan itself writes.
+        include_globs: vec!["*.pdf".into(), "*.png".into()],
+        image_mode: skardi::sources::providers::documents::ImageMode::Embedded,
+        image_store: Some(format!("s3://{bucket}/{base}/docs/crops")),
+        render_page_images: true,
+        ocr: skardi::sources::providers::documents::OcrMode::Off,
+        ocr_server_url: None,
+    };
+    let root = format!("s3://{bucket}/{base}/docs");
+
+    let first = skardi::sources::providers::documents::parse_source(&root, &opts).expect("scan 1");
+    // Crops now exist inside the scanned prefix.
+    let second = skardi::sources::providers::documents::parse_source(&root, &opts).expect("scan 2");
+
+    assert_eq!(
+        first.len(),
+        second.len(),
+        "row count must be stable across scans; the guard failed to exclude image_store output"
+    );
+    assert!(
+        second.iter().all(|r| !r.path.starts_with("crops/")),
+        "no row may originate from inside image_store: {:?}",
+        second.iter().map(|r| &r.path).collect::<Vec<_>>()
+    );
+
+    purge(&st, base).await;
+}
+
+/// A listing that is non-empty but whose every object fails to parse must be a
+/// hard error, not a silently-empty result (the credentials-expired-after-list
+/// scenario).
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "live: requires DOCUMENTS_S3_LIVE=1, DOCUMENTS_S3_BUCKET and AWS credentials"]
+async fn live_s3_wholesale_parse_failure_is_an_error() {
+    if !live_enabled() {
+        eprintln!("skipping live S3 test: set DOCUMENTS_S3_LIVE=1 to run");
+        return;
+    }
+    let bucket = bucket();
+    let st = store(&bucket);
+    let base = "skardi-live/allfail";
+    purge(&st, base).await;
+
+    // Valid extension, garbage bytes — matches the glob, fails to parse.
+    for name in ["a.pdf", "b.pdf"] {
+        st.put(
+            &OsPath::from(format!("{base}/docs/{name}")),
+            PutPayload::from_static(b"not a pdf at all"),
+        )
+        .await
+        .expect("seed junk object");
+    }
+
+    let opts = skardi::sources::providers::documents::ParseOptions {
+        recursive: true,
+        include_globs: vec!["*.pdf".into()],
+        ocr: skardi::sources::providers::documents::OcrMode::Off,
+        ..Default::default()
+    };
+    let err = skardi::sources::providers::documents::parse_source(
+        &format!("s3://{bucket}/{base}/docs"),
+        &opts,
+    )
+    .expect_err("all-fail listing must be a hard error, not zero rows");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("failed to fetch/parse"),
+        "unexpected error text: {msg}"
+    );
+
+    purge(&st, base).await;
+}
+
+/// An empty-but-reachable prefix is a valid, currently-empty corpus — zero rows,
+/// no error. Distinguishes "nothing there" from "cannot read".
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "live: requires DOCUMENTS_S3_LIVE=1, DOCUMENTS_S3_BUCKET and AWS credentials"]
+async fn live_s3_empty_prefix_yields_no_rows_without_error() {
+    if !live_enabled() {
+        eprintln!("skipping live S3 test: set DOCUMENTS_S3_LIVE=1 to run");
+        return;
+    }
+    let bucket = bucket();
+    let opts = skardi::sources::providers::documents::ParseOptions {
+        recursive: true,
+        include_globs: vec!["*.pdf".into()],
+        ocr: skardi::sources::providers::documents::OcrMode::Off,
+        ..Default::default()
+    };
+    let rows = skardi::sources::providers::documents::parse_source(
+        &format!("s3://{bucket}/skardi-live/definitely-empty-prefix"),
+        &opts,
+    )
+    .expect("an empty but reachable prefix must not error");
+    assert!(rows.is_empty(), "expected zero rows, got {}", rows.len());
+}
+
+/// `llm_extract` must be able to read an `s3://` `image_ref` — the refs the
+/// connector writes when `image_store` is `s3://`. Regression test: this used to
+/// fall through to `std::fs::read("s3://…")` and fail with a filesystem error,
+/// silently breaking multimodal escalation on S3.
+#[cfg(feature = "llm-extract")]
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "live: requires DOCUMENTS_S3_LIVE=1, DOCUMENTS_S3_BUCKET and AWS credentials"]
+async fn live_s3_image_ref_is_readable_by_llm_extract() {
+    if !live_enabled() {
+        eprintln!("skipping live S3 test: set DOCUMENTS_S3_LIVE=1 to run");
+        return;
+    }
+    let bucket = bucket();
+    let st = store(&bucket);
+    let base = "skardi-live/imageref";
+    purge(&st, base).await;
+    seed(&st, &format!("{base}/docs/report.pdf")).await;
+
+    let opts = skardi::sources::providers::documents::ParseOptions {
+        recursive: true,
+        include_globs: vec!["*.pdf".into()],
+        image_store: Some(format!("s3://{bucket}/{base}/extracted")),
+        render_page_images: true,
+        ocr: skardi::sources::providers::documents::OcrMode::Off,
+        ..Default::default()
+    };
+    let rows = skardi::sources::providers::documents::parse_source(
+        &format!("s3://{bucket}/{base}/docs"),
+        &opts,
+    )
+    .expect("scan");
+
+    let image_ref = rows
+        .iter()
+        .find_map(|r| r.page_image_ref.clone())
+        .expect("a page_image_ref");
+    assert!(image_ref.starts_with("s3://"), "got {image_ref}");
+
+    // Fetching is default-deny for data-derived refs; the opt-in gates s3:// too.
+    let img = skardi::model::llm_extract::fetch_image_for_test(&image_ref, true)
+        .unwrap_or_else(|e| panic!("llm_extract could not read {image_ref}: {e:#}"));
+    assert_eq!(
+        img.mime, "image/png",
+        "mime inferred from the key extension"
+    );
+    assert!(!img.base64.is_empty(), "decoded image must be non-empty");
+
+    // Without the opt-in it must be refused, not fetched.
+    let err = skardi::model::llm_extract::fetch_image_for_test(&image_ref, false)
+        .expect_err("s3:// must be refused when the fetch opt-in is off");
+    assert!(
+        err.to_string().contains("refusing to fetch"),
+        "unexpected error: {err}"
+    );
+
+    purge(&st, base).await;
+}

--- a/docs/S3_USAGE.md
+++ b/docs/S3_USAGE.md
@@ -16,8 +16,9 @@ export AWS_ACCESS_KEY_ID="your_access_key_id"
 export AWS_SECRET_ACCESS_KEY="your_secret_access_key"
 export AWS_SESSION_TOKEN="your_session_token"  # Optional for temporary credentials
 
-# Method 2: Use AWS CLI profile (recommended for local development)
-export AWS_PROFILE="your_profile_name"
+# Method 2: Convert an AWS CLI profile into env vars (AWS_PROFILE alone does
+# NOT work — the S3 client never reads ~/.aws/; see Authentication Methods)
+eval "$(aws configure export-credentials --profile your_profile_name --format env)"
 ```
 
 ### 2. Configure S3 Data Sources
@@ -67,36 +68,50 @@ The server automatically:
 
 ## Authentication Methods
 
-### 1. Environment Variables (Development/CI)
+> **⚠️ Environment variables are the only working method today.** The S3 client
+> is built from environment variables alone and never reads `~/.aws/`, and the
+> credential check requires `AWS_ACCESS_KEY_ID` (or `AWS_PROFILE`) to be present.
+> Profiles, SSO, and IAM roles therefore need the conversion step shown below.
+
+### 1. Environment Variables (Development/CI) — works
 ```bash
+export AWS_REGION="us-east-1"   # or AWS_DEFAULT_REGION; required, no default
 export AWS_ACCESS_KEY_ID="AKIAIOSFODNN7EXAMPLE"
 export AWS_SECRET_ACCESS_KEY="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+export AWS_SESSION_TOKEN="..."  # only for temporary credentials
 ```
 
-### 2. AWS CLI Profiles (Local Development)
+### 2. AWS CLI Profiles / SSO — export them first
+Setting `AWS_PROFILE` alone passes the credential check but contributes **no
+credentials to request signing**, so requests then fail with an S3 auth error.
+Convert the profile into environment variables instead:
+
 ```bash
-# Configure profile
-aws configure --profile myprofile
-
-# Use profile
-export AWS_PROFILE="myprofile"
+eval "$(aws configure export-credentials --profile myprofile --format env)"
+export AWS_REGION="us-east-1"
 ```
 
-### 3. IAM Roles (Production - AWS Infrastructure)
-No explicit credentials needed. Perfect for:
-- EC2 instances with IAM instance profiles
-- ECS tasks with IAM task roles
-- Lambda functions with IAM execution roles
-- EKS pods with IAM roles for service accounts
+The same applies to SSO / Identity Center profiles (`aws configure sso`) — log
+in, then export.
 
-### 4. AWS SSO/Identity Center
+### 3. IAM Roles (EC2 / ECS / Lambda / EKS) — not supported yet
+The underlying `object_store` client can source credentials from instance
+metadata, ECS task endpoints, and EKS web-identity tokens, but skardi's
+credential check rejects those setups before they are reached: it requires
+`AWS_ACCESS_KEY_ID` or `AWS_PROFILE`, neither of which is set under an instance
+profile or IRSA. Assume the role explicitly and export the result:
+
 ```bash
-# Configure SSO
-aws configure sso
-
-# Use SSO profile
-export AWS_PROFILE="sso-profile-name"
+CREDS=$(aws sts assume-role --role-arn "$ROLE_ARN" --role-session-name skardi)
+export AWS_ACCESS_KEY_ID=$(jq -r .Credentials.AccessKeyId <<<"$CREDS")
+export AWS_SECRET_ACCESS_KEY=$(jq -r .Credentials.SecretAccessKey <<<"$CREDS")
+export AWS_SESSION_TOKEN=$(jq -r .Credentials.SessionToken <<<"$CREDS")
+export AWS_REGION="us-east-1"
 ```
+
+Note that assumed-role credentials expire (1h by default), and the server reads
+the environment at registration *and* on each scan — so a long-running server
+needs re-exported credentials, or a restart, before they lapse.
 
 ## Required IAM Permissions
 

--- a/docs/documents.md
+++ b/docs/documents.md
@@ -24,18 +24,17 @@
 > When both are set, `pdfium-sys` links the provided library instead of
 > downloading one.
 
-`documents` is a read-only skardi data source that turns a **local directory**
-of files — PDF, Office (`.docx/.xlsx/.pptx`), ODF, and images — into queryable
-rows. Each row is one parsed **(file, page)** carrying reconstructed markdown,
-tables, and references to extracted images. It is backed by the pure-Rust
-[`liteparse`](https://github.com/run-llama/liteparse) crate.
+`documents` is a read-only skardi data source that turns a **local directory
+or `s3://` prefix** of files — PDF, Office (`.docx/.xlsx/.pptx`), ODF, and
+images — into queryable rows. Each row is one parsed **(file, page)** carrying
+reconstructed markdown, tables, and references to extracted images. It is
+backed by the pure-Rust [`liteparse`](https://github.com/run-llama/liteparse)
+crate.
 
-> **`path` is local-filesystem only in v1.** File discovery walks `path` with
-> `std::fs::read_dir`; there is no object-store listing/read path yet, so an
-> `s3://…` (or `gs://`/`az://`) `path` will register successfully but scan
-> zero files. `image_store` (below) accepts `s3://…` today only in the sense
-> that it *records* the ref — see that row for what "later upload pass" means
-> in practice.
+> **S3 support.** `path` and `image_store` may **each independently** be a
+> local directory or an `s3://bucket/prefix` URI; see [S3 / object
+> store](#s3--object-store) for the credential contract and constraints.
+> Other object-store schemes (`gs://`, `az://`) are not wired yet.
 
 Once registered, `SELECT * FROM documents` behaves like any other table: it is
 joinable in SQL and can be fed to the `llm_extract` UDF over its `markdown`
@@ -47,14 +46,14 @@ shared Rust between the two, only SQL.
 ```yaml
 - name: documents
   type: documents
-  path: /data/pp/inbound         # local directory (the root); recurses by default
+  path: /data/pp/inbound         # local directory or s3://bucket/prefix (the root); recurses by default
   access_mode: read_only
   description: "Supplier source documents"
   options:
     recursive: "true"            # descend subdirectories (default: true)
     include_globs: "*.pdf,*.docx,*.xlsx,*.png,*.jpg"  # default: all supported types
     image_mode: "embedded"       # embedded | placeholder | off (default: off)
-    image_store: "/data/pp/extracted"  # where cropped images are written; s3://… records refs only, see below
+    image_store: "/data/pp/extracted"  # where cropped images are written; local path or s3://bucket/prefix
     ocr: "auto"                  # auto | on | off (default: auto)
     render_page_images: "true"   # render full-page images for page_image_ref
     ocr_server_url: "http://ocr:8080/ocr"  # HTTP OCR engine (see OCR below)
@@ -67,7 +66,7 @@ All keys are optional except `path`.
 | `recursive` | `true` | Descend into subdirectories. |
 | `include_globs` | all supported | Comma-separated `*.ext` globs; only matching files are parsed. |
 | `image_mode` | `off` | `embedded` extracts image bytes; `placeholder` keeps refs only; `off` strips images. |
-| `image_store` | — | Destination for extracted image crops. Local paths are written immediately and are safe to use as-is (including as `llm_extract`'s `image_ref`). Remote (`s3://…`) refs are recorded but **bytes are not uploaded** — no upload pass exists yet — so a remote `image_store` currently produces refs nothing can read. Use a local path until that lands. |
+| `image_store` | — | Destination for extracted image crops — a local path or an `s3://bucket/prefix`. Both backends perform a real write (S3 objects get a `Content-Type` inferred from the extension), so refs are safe to use as-is (including as `llm_extract`'s `image_ref`). When both `path` and `image_store` are `s3://`, they must be in the **same bucket** (see [S3 / object store](#s3--object-store)). |
 | `ocr` | `auto` | `auto` OCRs only complex pages (needs `ocr_server_url`); `on` always (requires `ocr_server_url`, else hard error); `off` never. See OCR. |
 | `render_page_images` | `false` | Render each page to a PNG into `image_store` and set `page_image_ref` (needed for multimodal `llm_extract`). |
 | `ocr_server_url` | — | HTTP OCR engine URL. The only way to do OCR in this build (no bundled Tesseract). Mandatory for `ocr: on`. |
@@ -139,12 +138,9 @@ the local Tesseract binary.
 ## Full-page images and multimodal (`render_page_images`)
 
 With `render_page_images: "true"`, every page is rendered to a PNG (via PDFium,
-no external OCR needed), written to `image_store` (a local path is written
-immediately and readable right away; a remote `s3://` URI is recorded but
-**not uploaded** — there is no upload pass yet, so `page_image_ref` would
-point at bytes that don't exist anywhere), and its URI is set on the row's
-`page_image_ref`. Use a local `image_store` until remote upload lands. This
-is what the multimodal
+no external OCR needed), written to `image_store` — local directory or
+`s3://` prefix, both are real writes readable right away — and its URI is set
+on the row's `page_image_ref`. This is what the multimodal
 `llm_extract` escalation consumes (`llm_extract(markdown, page_image_ref, …)`),
 so **`render_page_images` must be enabled (with an `image_store`) for multimodal
 extraction to have an image to escalate to** — otherwise `page_image_ref` is
@@ -155,3 +151,47 @@ extraction to have an image to escalate to** — otherwise `page_image_ref` is
 - A single unparseable file is logged (`tracing::warn`) and skipped; the rest of
   the directory still produces rows.
 - An empty or fully-unmatched source returns zero rows, not an error.
+- **Wholesale failure is a hard error:** if the listing is non-empty but *every*
+  matched file fails to fetch/parse (e.g. credentials expired after listing),
+  the scan errors instead of silently returning zero rows that would masquerade
+  as an empty corpus.
+
+## S3 / object store
+
+`path` and `image_store` may each independently be local or `s3://bucket/prefix`.
+
+**Credentials and region come from the environment, never from config.**
+Putting `aws_access_key_id` / `aws_secret_access_key` / `aws_session_token` /
+`aws_region` in `options` fails registration. Set `AWS_REGION` (or
+`AWS_DEFAULT_REGION`) plus `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`
+(and `AWS_SESSION_TOKEN` for temporary credentials). Note the S3 client reads
+**environment variables only** — `~/.aws/` profiles are not consulted at
+request time, so if you normally use a profile, export it first:
+
+```bash
+eval "$(aws configure export-credentials --format env)"
+export AWS_REGION=us-east-1
+```
+
+Constraints and behavior:
+
+- **Same bucket when both sides are S3.** An `s3://` `path` with an `s3://`
+  `image_store` in a *different* bucket fails registration — one registered
+  store / region / credential set cannot serve two buckets. Cross-bucket
+  support is a tracked follow-up. Local + S3 combinations are unrestricted.
+- **Registration-time preflight.** Before the source registers, the server
+  checks read connectivity (a prefix-scoped list of `path`; an
+  empty-but-reachable prefix is fine) and, when `image_store` is `s3://`,
+  write access (put + delete of a `.skardi-write-probe` object under the
+  prefix). Missing permissions (`s3:ListBucket`/`s3:GetObject`/`s3:PutObject`),
+  a bad bucket, or missing env config all fail startup with an actionable
+  error instead of surfacing mid-scan.
+- **Prefix scoping.** `s3://bucket/corpus` lists exactly the `corpus/` prefix —
+  a sibling `corpus-2/` never matches.
+- **Self-ingestion guard.** Anything under the `image_store` location is
+  excluded from the scan, so crops written by a previous scan are never
+  re-ingested even when `image_store` nests inside `path` and matches
+  `include_globs`.
+- `doc_id` and `path` are computed from the prefix-relative key with `/`
+  separators, identical to the local backend — moving a corpus between a local
+  directory and S3 keeps ids stable.

--- a/docs/documents.md
+++ b/docs/documents.md
@@ -177,6 +177,52 @@ hint rather than being misread as a filesystem path.
   matched file fails to fetch/parse (e.g. credentials expired after listing),
   the scan errors instead of silently returning zero rows that would masquerade
   as an empty corpus.
+- **Image-write failures are counted, not hidden.** A crop / page-image write
+  that fails is logged and the affected row simply carries no
+  `page_image_ref` / crop ref — but the scan logs an aggregate
+  `N/M image_store write(s) failed` summary, and if *every* write fails the scan
+  errors rather than returning rows that look exactly as if `image_store` were
+  never configured. This is the only guard for a local `image_store` (the
+  registration preflight covers `s3://` targets only) and it catches S3
+  credentials that expire after the preflight.
+
+## Performance and cost
+
+**Every scan re-reads the whole corpus, and every query triggers a scan.**
+There is no caching layer: a `SELECT` against a `documents` table lists the
+source prefix, fetches each matching file, parses it, and — when `image_store`
+and `render_page_images` / `image_mode: embedded` are set — **re-writes the
+image outputs**, overwriting the previous scan's objects. Two identical queries
+do all of that twice.
+
+On a local path this costs CPU and disk I/O. On S3 it also costs money and
+latency, roughly per query:
+
+| Operation | Count per query |
+|---|---|
+| `ListObjectsV2` | 1 per prefix (paged, so more for >1000 keys) |
+| `GetObject` | one per matched file, plus egress if leaving the region |
+| `PutObject` | one per page render + one per extracted crop |
+
+A measured example: a 4-PDF, 9-page corpus took ~7s and ~21 S3 requests per
+query, rewriting 12 objects each time. Scaling that to a few thousand documents
+makes interactive querying impractical and the request bill non-trivial.
+
+Practical mitigations until caching exists:
+
+- Materialize once instead of querying repeatedly — run the scan through a
+  [job](jobs.md) that writes to a table (Parquet/Lance/Postgres), then query
+  that. This is the recommended shape for anything beyond a small corpus.
+- Narrow `include_globs` and point `path` at the tightest prefix that holds
+  the documents you need; both cut the per-query file count directly.
+- Leave `render_page_images` off unless multimodal escalation is actually
+  used — it is the largest contributor to per-query `PutObject` volume
+  (full-page PNGs are far bigger than crops).
+- Keep the bucket in the same region as the server to avoid egress charges on
+  every re-read.
+
+Files are also fetched and parsed **sequentially**, so wall-clock scales
+linearly with corpus size; there is no per-file concurrency yet.
 
 ## S3 / object store
 

--- a/docs/documents.md
+++ b/docs/documents.md
@@ -66,7 +66,7 @@ All keys are optional except `path`.
 | `recursive` | `true` | Descend into subdirectories. |
 | `include_globs` | all supported | Comma-separated `*.ext` globs; only matching files are parsed. |
 | `image_mode` | `off` | `embedded` extracts image bytes; `placeholder` keeps refs only; `off` strips images. |
-| `image_store` | — | Destination for extracted image crops — a local path or an `s3://bucket/prefix`. Both backends perform a real write (S3 objects get a `Content-Type` inferred from the extension), so refs are safe to use as-is (including as `llm_extract`'s `image_ref`). When both `path` and `image_store` are `s3://`, they must be in the **same bucket** (see [S3 / object store](#s3--object-store)). |
+| `image_store` | — | Destination for extracted image crops — a local path or an `s3://bucket/prefix`. Both backends perform a real write (S3 objects get a `Content-Type` inferred from the extension). Local refs are usable as `llm_extract`'s `image_ref` as-is; `s3://` refs are readable too but **only with `LLM_EXTRACT_IMAGE_FETCH=1`** — see [Image refs and `llm_extract`](#image-refs-and-llm_extract). When both `path` and `image_store` are `s3://`, they must be in the **same bucket** (see [S3 / object store](#s3--object-store)). |
 | `ocr` | `auto` | `auto` OCRs only complex pages (needs `ocr_server_url`); `on` always (requires `ocr_server_url`, else hard error); `off` never. See OCR. |
 | `render_page_images` | `false` | Render each page to a PNG into `image_store` and set `page_image_ref` (needed for multimodal `llm_extract`). |
 | `ocr_server_url` | — | HTTP OCR engine URL. The only way to do OCR in this build (no bundled Tesseract). Mandatory for `ocr: on`. |
@@ -145,6 +145,28 @@ on the row's `page_image_ref`. This is what the multimodal
 so **`render_page_images` must be enabled (with an `image_store`) for multimodal
 extraction to have an image to escalate to** — otherwise `page_image_ref` is
 `NULL` and only the text path is available.
+
+### Image refs and `llm_extract`
+
+`llm_extract` treats `image_ref` as **untrusted data** (it is a column value, so
+a crafted row could point it anywhere). Fetching is therefore default-deny:
+only inline `data:` URIs resolve unless you set `LLM_EXTRACT_IMAGE_FETCH=1`,
+which enables `http(s)://`, `s3://`, and local-file refs alike.
+
+That means a **local** `image_store` needs `LLM_EXTRACT_IMAGE_FETCH=1` for
+multimodal escalation, and so does an **`s3://`** one:
+
+```bash
+export LLM_EXTRACT_IMAGE_FETCH=1
+```
+
+`s3://` refs are read through the same object-store client and env-only
+credential contract as the connector itself, so the process needs
+`s3:GetObject` on the `image_store` prefix — which is *not* required for
+writing crops, so a least-privilege policy scoped to `PutObject` alone will
+fail here. `s3://` support also requires the `documents` Cargo feature (it owns
+the S3 client); an `s3://` ref in a build without it is refused with a build
+hint rather than being misread as a filesystem path.
 
 ## Error handling
 

--- a/docs/superpowers/specs/2026-07-23-documents-s3-object-store-support-design.md
+++ b/docs/superpowers/specs/2026-07-23-documents-s3-object-store-support-design.md
@@ -5,7 +5,10 @@
 - **Date:** 2026-07-23
 - **Scope:** S3 read path for the source `path`, and S3 write path for `image_store`.
   All four combinations of `{local, s3://}` source × `{local, s3://}` image store
-  are supported. Predicate/prefix pushdown (issue question 2) is **out of scope**.
+  are supported, with one constraint: when **both** `path` and `image_store` are
+  `s3://` they must reference the **same bucket** (see §4 — a single registered
+  store, region, and credential set can only serve one bucket). Predicate/prefix
+  pushdown (issue question 2) is **out of scope**.
 
 ## 1. Motivation
 
@@ -89,25 +92,40 @@ spec:
         # Credentials/region come from env / IAM role.
 ```
 
-The `path` and `image_store` values are **independent** — either may be local or
-`s3://`, and they may live in **different buckets**. All 2×2 combinations are
-valid.
+The `path` and `image_store` values are **independent in scheme** — either may be
+local or `s3://`, so all four scheme combinations are valid. **Constraint:** when
+both are `s3://`, they must resolve to the **same bucket**. A single S3 object
+store is built per bucket from one region (`AWS_REGION`/`AWS_DEFAULT_REGION`) and
+one credential set (`remote_storage.rs:135`); it cannot serve a second bucket in a
+different region or account (S3 answers with a 301 `PermanentRedirect` /
+`AccessDenied`). Mismatched buckets are **rejected at registration** with a clear
+message. Cross-bucket read/write (per-bucket region + credential resolution) is a
+tracked follow-up.
 
 ### Registration flow (`config.rs`, `DataSourceType::Documents` arm)
 
 Before registering the `DocumentsTable`:
 
 1. Collect the S3 buckets referenced by `path` and (if set) `options.image_store`.
-2. For each source whose `path` is `s3://`, call
-   `S3Storage::validate_configuration(source)` so the credential-rejection rule
-   applies to `documents` exactly as it does to CSV/Parquet.
-3. For each **distinct** bucket, build and register an object store via a new
+2. **Same-bucket check.** If both `path` and `image_store` are `s3://` and their
+   buckets differ, fail registration (see §4 constraint). This bounds the design
+   to a single registered store / region / credential set.
+3. **Credential rejection.** Run the `aws_*`-key rejection whenever *either*
+   `path` **or** `image_store` is `s3://`. `S3Storage::validate_configuration`
+   today only fires when `source.path` is `s3://` (`remote_storage.rs:58`), so a
+   local-`path` + `s3://`-image_store source would otherwise skip the check and
+   silently accept credentials in `options`. Either generalize
+   `validate_configuration` to take the S3 URI(s) to inspect, or add an explicit
+   options scan for the image-store-only case.
+4. Build and register the object store for the (single) bucket via a new
    `S3Storage::setup_object_store_for_bucket` (a refactor of the existing
    `setup_object_store` that separates "build + register a bucket store" from
    "connectivity-test a single object" — see below). Registration is idempotent
    per bucket for the session.
-4. Run a **prefix-aware connectivity check** (see §7) instead of the object
-   `head` test.
+5. Run a **prefix-aware connectivity check** (see §7) instead of the object
+   `head` test. When `image_store` is `s3://`, also run a **write preflight**
+   (put + delete a probe key) so a missing `s3:PutObject` fails loudly at
+   registration rather than silently dropping crops mid-scan (§7).
 
 `register_documents_tables` gains no new required parameter; the table pulls its
 store handles from `runtime_env` at scan time via `TaskContext`.
@@ -134,6 +152,13 @@ enum BlobStore {
 impl BlobStore {
     /// List every object/file under `prefix` (honoring `recursive`), returning
     /// (loc, rel_key) pairs where rel_key is relative to the prefix.
+    ///
+    /// The S3 prefix is **normalized to a trailing `/`** before listing, so
+    /// `s3://b/corpus` does not spuriously match `corpus-2/…` (object listing is
+    /// string-prefix, unlike the local walk's real directory boundaries).
+    /// `rel_key` is the object key with that normalized prefix stripped, using
+    /// `/` separators — identical to the local `strip_prefix(root)` result so
+    /// `doc_id = blake3(rel_path)` and the `path` column match across backends.
     async fn list(&self, prefix: &Loc, recursive: bool) -> Result<Vec<(Loc, String)>>;
 
     /// Fetch the full bytes of one object/file.
@@ -157,8 +182,20 @@ fn resolve(uri: &str, rt: &RuntimeEnv) -> Result<(BlobStore, Loc)>;
     (recursive) or a delimiter-scoped list (non-recursive).
   - `parse_file()` signature changes from `(abs_path, rel_path, opts)` to
     `(bytes, rel_path, file_type, opts, write_store, image_loc_base)`. It calls
-    `parser.parse_input(PdfInput::Bytes(bytes))` and, for page renders,
-    `parser.screenshot_input(PdfInput::Bytes(bytes), …)`.
+    `parser.parse_input(PdfInput::Bytes(bytes))`, `parser.screenshot_input(
+    PdfInput::Bytes(bytes), …)` for page renders, **and** the OCR-Auto probe
+    `parser.is_complex(PdfInput::Bytes(bytes))` — the probe at `parse.rs:312`
+    currently passes `PdfInput::Path` and must switch to `Bytes` (the API accepts
+    it). To avoid re-decoding the same bytes for each call, clone the `Vec<u8>`
+    into each `PdfInput` as needed.
+  - **Routing-semantics note.** Feeding `PdfInput::Bytes` routes *all* inputs
+    (including local) through liteparse's content sniff (`conversion.rs:115`),
+    whereas the current local path routes by file **extension**
+    (`conversion.rs:99`). For a correctly-named corpus these agree; a *mislabeled*
+    file (e.g. `report.pdf` that is really DOCX) will parse under S3/bytes but
+    fails today under local/extension. This is an intentional, documented
+    behavior change — the §9 "byte-for-byte" regression claim is corrected
+    accordingly. `file_type` remains derived from the `rel_path` extension.
   - `write_image_crop()` is replaced by `write_store.put(loc, bytes)`. The
     `s3://` no-op branch is **deleted**; both local and S3 now perform a real
     write. `file_type` is derived from the `rel_path` extension (unchanged
@@ -176,10 +213,24 @@ fn resolve(uri: &str, rt: &RuntimeEnv) -> Result<(BlobStore, Loc)>;
 `parse_source` already runs its blocking loop on a **dedicated OS thread that
 owns a current-thread tokio runtime** (because DataFusion calls the scan from a
 tokio worker and liteparse is async). The same runtime `block_on`s the
-`BlobStore` async calls (`list` / `get` / `put`). The `Arc<dyn ObjectStore>`
-handles are `Send + Sync`, so they are moved into that thread. `parse_source`
-gains the resolved `BlobStore`s as parameters; it stays a synchronous call from
+`BlobStore` async calls (`list` / `get` / `put`). `parse_source` gains the
+resolved `BlobStore`s as parameters; it stays a synchronous call from
 DataFusion's perspective.
+
+**Cross-runtime hazard — build the S3 client inside the parse thread.** The
+`object_store::aws` client wraps a `reqwest` client whose connection pool is
+bound to the tokio reactor it was **created on**. If we build the store at config
+time (server's multi-threaded runtime) and then `block_on` it from the parse
+thread's *separate* current-thread runtime, requests can hang or fail
+("dispatch task is gone"). So `resolve()` must **construct the `AmazonS3Builder`
+store lazily on the parse thread's runtime**, not reuse the config-time handle
+from `runtime_env`. Concretely: register the store on `runtime_env` for
+CSV/Parquet-style consumers as before, but for the documents scan resolve
+credentials/region/bucket into a small `S3StoreSpec` (plain `Send` data) that is
+moved into the parse thread and turned into an `ObjectStore` there. This also
+keeps the §9 tests honest — an `InMemory` store is synchronous and cannot catch
+this, so a test against an HTTP-backed mock (localstack / `httpmock`) is required
+(§9).
 
 ## 6. Data flow
 
@@ -200,9 +251,23 @@ DataFusion's perspective.
    (`{image_store}/{relpath_underscored}_{id}.png`). This URI is recorded in the
    `image_refs` / `page_image_ref` output columns.
 3. `write_store.put(loc, bytes)` writes the crop. For `Local` this is the current
-   `create_dir_all` + `std::fs::write`; for S3 it is `ObjectStore::put`.
+   `create_dir_all` + `std::fs::write`; for S3 it is `ObjectStore::put` with
+   `PutOptions`/attributes setting `Content-Type: image/png`, so consumers that
+   read crops by HTTP content-type (not just the `.png` extension) get the right
+   MIME type instead of `application/octet-stream`.
 4. On a per-image write failure the ref is dropped and a warning logged — the
-   existing local behavior, now applied uniformly to S3.
+   existing local behavior, now applied uniformly to S3. (A wholesale write
+   failure, e.g. missing `s3:PutObject`, is caught earlier by the §4 write
+   preflight rather than silently dropping every crop here.)
+
+**Self-ingestion guard.** The default globs include image extensions
+(`*.png, *.jpg …`), so if `image_store` sits **inside** the source prefix
+(e.g. `path=s3://b/corpus/`, `image_store=s3://b/corpus/crops/`) the crops
+written on one scan are re-listed and re-parsed on the next. Same-bucket
+read+write is the headline capability, so this is easy to hit. `list_docs`
+therefore **excludes any entry under the resolved `image_store` prefix** (a cheap
+prefix check on `rel_key`); local and S3 apply the same rule. This also makes an
+`image_store` nested under `path` safe by construction rather than a footgun.
 
 ## 7. Reliability & error handling
 
@@ -217,10 +282,20 @@ DataFusion's perspective.
   fails the scan loudly rather than looking like an empty corpus). For S3, a
   `list` that fails on auth/permission/network errors fails the scan with a clear
   message; a successful list returning zero objects yields zero rows.
-- **Per-file fault isolation (unchanged).** A `get` or parse failure for one
-  object is logged (`tracing::warn`) and skipped; remaining objects still produce
-  rows. This already exists for local parse errors and now also covers per-object
-  fetch failures.
+- **Write preflight (S3 `image_store`).** The connectivity check above only
+  exercises `list`/`get` (read). A missing `s3:PutObject` would otherwise surface
+  only mid-scan as a per-image `warn` + dropped ref (`parse.rs:394`), so the query
+  *succeeds* with silently missing crops. When `image_store` is `s3://`,
+  registration additionally writes and deletes a small probe object under the
+  image-store prefix, turning a permission gap into a loud registration error.
+- **Per-file fault isolation (unchanged, but bounded).** A `get` or parse failure
+  for one object is logged (`tracing::warn`) and skipped; remaining objects still
+  produce rows. This already exists for local parse errors and now also covers
+  per-object fetch failures. **Guard against silent wholesale failure:** if the
+  `list` succeeded with N ≥ 1 objects but *every* `get` fails (e.g. credentials
+  expired after listing), the scan fails loudly rather than returning zero rows
+  that look like an empty corpus. (Threshold: all-fail is a hard error; partial
+  failures stay warn-and-skip.)
 - **Pagination.** `ObjectStore::list` returns a paginated stream; the backend
   drains it fully, so large prefixes are enumerated completely.
 - **Memory.** v1 fetches each object fully into memory (`get` → `Vec<u8>`), then
@@ -256,20 +331,44 @@ DataFusion's perspective.
   bucket URL, seed a small PDF fixture, and assert `SELECT path, page FROM
   documents` yields the expected rows — proving the `list`→`get`→`parse_input`
   path without a live AWS dependency.
+- **Integration — S3 read over a real HTTP mock (required, not just `InMemory`):**
+  drive the actual `object_store::aws` client against an HTTP-backed mock
+  (localstack or `httpmock`) **from the parse thread's own runtime**, to catch the
+  cross-runtime reqwest-affinity hazard (§5) that a synchronous `InMemory` store
+  cannot surface.
 - **Integration — S3 write:** with `image_mode=embedded` over an in-memory store,
-  assert crops are `put` under the derived keys and the refs are recorded.
-- **Regression — local unchanged:** all existing `parse.rs` / `table.rs` tests
-  must pass unmodified (the `Local` backend preserves current behavior byte for
-  byte).
+  assert crops are `put` under the derived keys, the refs are recorded, and the
+  written object carries `Content-Type: image/png`.
+- **Regression — local behavior:** all existing `parse.rs` / `table.rs` tests must
+  pass unmodified. Note the routing change in §5: local input now goes through
+  content-sniff rather than extension, so add a test pinning the *new* documented
+  behavior for a mislabeled file (extension ≠ content) rather than asserting
+  byte-for-byte identity.
+- **Prefix normalization:** a bucket seeded with `corpus/a.pdf` and
+  `corpus-2/b.pdf` scanned with prefix `s3://b/corpus` yields only `a.pdf`
+  (trailing-`/` normalization), and `rel_path`/`doc_id` match the local walk.
+- **Self-ingestion guard:** with `image_store` nested under `path`, a second scan
+  does not re-ingest the crops written by the first.
+- **Same-bucket enforcement:** `path` and `image_store` in *different* S3 buckets
+  is rejected at registration with a clear message.
 - **Connectivity check:** unit-test that the prefix-aware check treats an empty
-  prefix as OK and an auth/network error as a hard failure.
+  prefix as OK and an auth/network error as a hard failure; and that the
+  `image_store` write preflight fails registration when `PutObject` is denied.
 - **Credential rejection:** assert an `aws_secret_access_key` under a documents
-  source's `options` is rejected at registration.
+  source's `options` is rejected at registration — covering **both** the `s3://`
+  `path` case and the local-`path` + `s3://`-`image_store` case (§4).
+- **Wholesale fetch failure:** a non-empty `list` followed by all-`get`-fail is a
+  hard scan error, not an empty result set.
 
 ## 10. Rollout / follow-ups
 
-- No schema change; the output columns are identical. Existing local sources are
-  unaffected (they resolve to the `Local` backend).
+- No schema change; the output columns are identical. Existing local sources
+  resolve to the `Local` backend and are unaffected **except** for the
+  extension→content-sniff routing change in §5, which only alters behavior for
+  mislabeled files (extension ≠ content) — documented and tested, not silent.
+- Follow-up: **cross-bucket (and thus cross-region / cross-account) S3** for
+  `path` vs `image_store`, lifting the §4 same-bucket constraint via per-bucket
+  region + credential resolution.
 - Follow-up (issue question 2): prefix/predicate + `limit` pushdown and per-file
   streaming, which also reduces the whole-prefix memory/latency cost.
 - Follow-up (optional): generalize the backend to `gs://` / `az://` via

--- a/docs/superpowers/specs/2026-07-23-documents-s3-object-store-support-design.md
+++ b/docs/superpowers/specs/2026-07-23-documents-s3-object-store-support-design.md
@@ -1,0 +1,277 @@
+# `documents` connector: S3 / object-store support for source and image paths
+
+- **Issue:** [SkardiLabs/skardi#167](https://github.com/SkardiLabs/skardi/issues/167) (question 1)
+- **Status:** Draft for review
+- **Date:** 2026-07-23
+- **Scope:** S3 read path for the source `path`, and S3 write path for `image_store`.
+  All four combinations of `{local, s3://}` source × `{local, s3://}` image store
+  are supported. Predicate/prefix pushdown (issue question 2) is **out of scope**.
+
+## 1. Motivation
+
+The `documents` connector today is local-filesystem only:
+
+- `parse.rs::collect_files()` walks the tree with `std::fs::read_dir`.
+- `parse.rs::parse_file()` hands a **local path string** to `LiteParse::parse(path)`.
+- `parse.rs::write_image_crop()` writes crops to a local `image_store` and is an
+  explicit **no-op** for `s3://` stores (the ref is still recorded).
+
+Cloud customers want to point a source at their **own** bucket
+(`path: "s3://bucket/prefix/"`) rather than landing files on a mounted volume
+(PVC/hostPath) inside our deployment, and to have extracted image crops written
+back to a bucket they own. This design adds both directions.
+
+### Non-goals
+
+- Predicate/prefix pushdown, `limit` pushdown, or per-file streaming (issue
+  question 2 — tracked separately). The scan stays eager: it parses the whole
+  prefix into one `RecordBatch`, exactly as the local path does today.
+- Non-S3 object stores (`gs://`, `az://`). The abstraction does not preclude
+  them, but this design wires and tests **S3 only**, matching the convention the
+  repo already enforces (`crates/server/src/remote_storage.rs`).
+- Caching parsed output across scans.
+
+## 2. Key finding that shapes the design
+
+`liteparse` **2.4.0 already accepts in-memory bytes**:
+
+```rust
+pub async fn parse_input(&self, input: PdfInput) -> Result<ParseResult, ...>;
+pub async fn screenshot_input(&self, input: PdfInput, pages) -> Result<...>;
+// PdfInput::Bytes(Vec<u8>) is a first-class variant; liteparse writes its own
+// temp files internally when it must convert non-PDF inputs via LibreOffice.
+```
+
+So skardi does **not** need to modify liteparse (despite the branch name). The
+documents provider fetches object bytes itself and feeds `PdfInput::Bytes`.
+liteparse stays a pure parser with no knowledge of cloud I/O or credentials.
+
+## 3. Reuse of the existing S3 convention
+
+The repo already standardizes S3 access in `crates/server/src/remote_storage.rs`
+(`S3Storage`) and documents it in `docs/basic/ctx_s3_examples.yaml`. This design
+**reuses that machinery** rather than introducing a second S3 stack:
+
+- Uses the **`object_store` crate** (`object_store::aws::AmazonS3Builder`).
+- **Credentials are environment-only, enforced.** `S3Storage::validate_configuration`
+  *rejects* `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`,
+  and `aws_region` if present in a source's `options`. Credentials come from
+  `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` (+ optional `AWS_SESSION_TOKEN`),
+  `AWS_PROFILE`, or an IAM role / IRSA; region from `AWS_REGION` /
+  `AWS_DEFAULT_REGION`.
+- Registers the built store on the DataFusion `SessionContext.runtime_env()` for
+  the `s3://<bucket>/` scheme, so it can be retrieved later by URL.
+
+Today `S3Storage::setup_object_store` is only invoked for `Csv | Parquet | Lance`
+(`config.rs:1056`), because those use DataFusion's own `ListingTable`, which
+reads *through* the registered store. `documents` does its **own** listing and
+parsing, so it must retrieve the store handle and call `list` / `get` / `put`
+directly.
+
+## 4. Configuration & credentials
+
+### ctx.yaml (no new option keys required)
+
+```yaml
+spec:
+  data_sources:
+    - name: "documents"
+      type: "documents"
+      access_mode: "read_only"
+      path: "s3://my-bucket/corpus/"      # local dir OR s3:// prefix
+      description: "Parsed corpus, one row per (file, page)"
+      options:
+        recursive: "true"
+        include_globs: "*.pdf, *.docx"
+        image_mode: "embedded"             # off | placeholder | embedded
+        image_store: "s3://my-bucket/crops/"  # local dir OR s3:// prefix
+        # NO aws_* keys — rejected by S3Storage::validate_configuration.
+        # Credentials/region come from env / IAM role.
+```
+
+The `path` and `image_store` values are **independent** — either may be local or
+`s3://`, and they may live in **different buckets**. All 2×2 combinations are
+valid.
+
+### Registration flow (`config.rs`, `DataSourceType::Documents` arm)
+
+Before registering the `DocumentsTable`:
+
+1. Collect the S3 buckets referenced by `path` and (if set) `options.image_store`.
+2. For each source whose `path` is `s3://`, call
+   `S3Storage::validate_configuration(source)` so the credential-rejection rule
+   applies to `documents` exactly as it does to CSV/Parquet.
+3. For each **distinct** bucket, build and register an object store via a new
+   `S3Storage::setup_object_store_for_bucket` (a refactor of the existing
+   `setup_object_store` that separates "build + register a bucket store" from
+   "connectivity-test a single object" — see below). Registration is idempotent
+   per bucket for the session.
+4. Run a **prefix-aware connectivity check** (see §7) instead of the object
+   `head` test.
+
+`register_documents_tables` gains no new required parameter; the table pulls its
+store handles from `runtime_env` at scan time via `TaskContext`.
+
+## 5. Component design (Approach A — blob-backend abstraction)
+
+New internal module `crates/skardi/src/sources/providers/documents/blob.rs`.
+`object_store` is already available to the `skardi` crate transitively through
+DataFusion; it will be made an explicit dependency for clarity.
+
+```rust
+/// A parsed source/target location.
+enum Loc {
+    Local(PathBuf),
+    S3 { bucket: String, key: String },   // key has no leading '/'
+}
+
+/// All local-vs-S3 I/O for the documents connector lives here.
+enum BlobStore {
+    Local,
+    Remote(Arc<dyn object_store::ObjectStore>),
+}
+
+impl BlobStore {
+    /// List every object/file under `prefix` (honoring `recursive`), returning
+    /// (loc, rel_key) pairs where rel_key is relative to the prefix.
+    async fn list(&self, prefix: &Loc, recursive: bool) -> Result<Vec<(Loc, String)>>;
+
+    /// Fetch the full bytes of one object/file.
+    async fn get(&self, loc: &Loc) -> Result<Vec<u8>>;
+
+    /// Write bytes to one object/file (used for image crops / page renders).
+    async fn put(&self, loc: &Loc, bytes: &[u8]) -> Result<()>;
+}
+
+/// Parse a URI and pick a backend: bare/`file:` path -> Local; `s3://` ->
+/// Remote, looking the bucket's store up from `runtime_env`.
+fn resolve(uri: &str, rt: &RuntimeEnv) -> Result<(BlobStore, Loc)>;
+```
+
+### Changed call sites (all inside the documents module + its dispatch)
+
+- `parse.rs`
+  - `collect_files()` → `list_docs(store, prefix, opts)`: returns `(Loc, rel_path)`
+    for entries whose **basename** matches `include_globs`. For `Local` this is the
+    current `read_dir` walk; for `Remote` it is `ObjectStore::list(Some(prefix))`
+    (recursive) or a delimiter-scoped list (non-recursive).
+  - `parse_file()` signature changes from `(abs_path, rel_path, opts)` to
+    `(bytes, rel_path, file_type, opts, write_store, image_loc_base)`. It calls
+    `parser.parse_input(PdfInput::Bytes(bytes))` and, for page renders,
+    `parser.screenshot_input(PdfInput::Bytes(bytes), …)`.
+  - `write_image_crop()` is replaced by `write_store.put(loc, bytes)`. The
+    `s3://` no-op branch is **deleted**; both local and S3 now perform a real
+    write. `file_type` is derived from the `rel_path` extension (unchanged
+    `file_type_for`) rather than a filesystem `Path`.
+- `table.rs`
+  - `DocumentsScanExec::execute()` obtains `context.runtime_env()`, calls
+    `resolve()` for the source `path` (read store) and for `options.image_store`
+    (write store, if any), and threads both into the parse loop.
+- `config.rs`
+  - The `Documents` arm performs the S3 validation + per-bucket registration
+    described in §4 when `path`/`image_store` are `s3://`.
+
+### Sync ↔ async bridge (unchanged strategy)
+
+`parse_source` already runs its blocking loop on a **dedicated OS thread that
+owns a current-thread tokio runtime** (because DataFusion calls the scan from a
+tokio worker and liteparse is async). The same runtime `block_on`s the
+`BlobStore` async calls (`list` / `get` / `put`). The `Arc<dyn ObjectStore>`
+handles are `Send + Sync`, so they are moved into that thread. `parse_source`
+gains the resolved `BlobStore`s as parameters; it stays a synchronous call from
+DataFusion's perspective.
+
+## 6. Data flow
+
+### Read (source `path`)
+
+1. `execute()` resolves the source `path` to `(read_store, prefix_loc)`.
+2. `list_docs` enumerates matching entries → `Vec<(Loc, rel_path)>`, sorted for
+   deterministic output.
+3. For each entry: `read_store.get(loc)` → bytes → `parse_file(bytes, rel_path,
+   …)` → `PdfInput::Bytes` → liteparse → `Vec<ParsedPage>`.
+4. `doc_id = blake3(rel_path)` and `path = rel_path` — identical semantics to the
+   local walk (rel path uses `/` separators; for S3 the key already does).
+
+### Write (`image_store`, only when `image_mode=embedded` or `render_page_images`)
+
+1. `execute()` resolves `options.image_store` to `(write_store, base_loc)`.
+2. `image_ref_uri` / `page_image_uri` build the per-image URI exactly as today
+   (`{image_store}/{relpath_underscored}_{id}.png`). This URI is recorded in the
+   `image_refs` / `page_image_ref` output columns.
+3. `write_store.put(loc, bytes)` writes the crop. For `Local` this is the current
+   `create_dir_all` + `std::fs::write`; for S3 it is `ObjectStore::put`.
+4. On a per-image write failure the ref is dropped and a warning logged — the
+   existing local behavior, now applied uniformly to S3.
+
+## 7. Reliability & error handling
+
+- **Prefix-aware connectivity check.** The existing `test_connectivity` does
+  `head(object_path)`, which is correct for a single object but returns
+  `NotFound` for a **prefix** (`s3://bucket/corpus/`). The documents registration
+  uses a `list(prefix)` with a small bound (e.g. take the first item) to verify
+  credentials + bucket reachability without requiring the prefix itself to be a
+  key. An empty-but-reachable prefix is **not** a startup error (it is a valid,
+  currently-empty corpus); auth/network/permission failures **are**.
+- **Missing/unreadable source.** Local semantics are unchanged (a missing root
+  fails the scan loudly rather than looking like an empty corpus). For S3, a
+  `list` that fails on auth/permission/network errors fails the scan with a clear
+  message; a successful list returning zero objects yields zero rows.
+- **Per-file fault isolation (unchanged).** A `get` or parse failure for one
+  object is logged (`tracing::warn`) and skipped; remaining objects still produce
+  rows. This already exists for local parse errors and now also covers per-object
+  fetch failures.
+- **Pagination.** `ObjectStore::list` returns a paginated stream; the backend
+  drains it fully, so large prefixes are enumerated completely.
+- **Memory.** v1 fetches each object fully into memory (`get` → `Vec<u8>`), then
+  hands bytes to liteparse. This mirrors the current eager, whole-batch model and
+  is bounded by the largest single file, not the whole corpus (files are parsed
+  one at a time). Streaming/`spawn_blocking` remains the `TODO(scale)` tracked by
+  issue question 2. This tradeoff is called out explicitly, not silent.
+- **Multiple buckets / cross-bucket writes.** Distinct buckets across `path` and
+  `image_store` each get their own registered store. Writing to an `image_store`
+  bucket additionally requires `s3:PutObject`.
+
+## 8. Security
+
+- Credentials never live in ctx.yaml — enforced by reusing
+  `S3Storage::validate_configuration` (rejects `aws_*` keys) for `documents`.
+- The source `path` and `image_store` are operator-authored config, not
+  data-derived values, so this is not the SSRF surface that data-derived image
+  refs are in `llm_extract`; no per-request URL policy is needed here. (If a
+  future feature lets agents author documents sources, revisit with the
+  default-deny pattern from `llm_extract::fetch_image_with_policy`.)
+- Required IAM: `s3:ListBucket` + `s3:GetObject` on the source bucket/prefix; add
+  `s3:PutObject` on the `image_store` bucket/prefix when writing crops.
+
+## 9. Testing
+
+- **Unit — `Loc`/`resolve`:** scheme detection (`s3://` vs bare vs `file:`),
+  bucket/key parsing, `image_ref_uri` for both local and `s3://` bases (extend
+  the existing `image_ref_uri_and_page_image_uri_without_store` test).
+- **Unit — `list_docs` glob filtering:** matches on basename for both backends
+  (the S3 case uses a mocked/in-memory `ObjectStore`).
+- **Integration — S3 read (mocked store):** register an
+  `object_store::memory::InMemory` (or the S3-compatible in-memory) store under a
+  bucket URL, seed a small PDF fixture, and assert `SELECT path, page FROM
+  documents` yields the expected rows — proving the `list`→`get`→`parse_input`
+  path without a live AWS dependency.
+- **Integration — S3 write:** with `image_mode=embedded` over an in-memory store,
+  assert crops are `put` under the derived keys and the refs are recorded.
+- **Regression — local unchanged:** all existing `parse.rs` / `table.rs` tests
+  must pass unmodified (the `Local` backend preserves current behavior byte for
+  byte).
+- **Connectivity check:** unit-test that the prefix-aware check treats an empty
+  prefix as OK and an auth/network error as a hard failure.
+- **Credential rejection:** assert an `aws_secret_access_key` under a documents
+  source's `options` is rejected at registration.
+
+## 10. Rollout / follow-ups
+
+- No schema change; the output columns are identical. Existing local sources are
+  unaffected (they resolve to the `Local` backend).
+- Follow-up (issue question 2): prefix/predicate + `limit` pushdown and per-file
+  streaming, which also reduces the whole-prefix memory/latency cost.
+- Follow-up (optional): generalize the backend to `gs://` / `az://` via
+  `object_store`'s other builders — the `resolve()` seam is the only place that
+  would change.


### PR DESCRIPTION
## What

Adds S3 / object-store support to the `documents` connector (issue [#167](https://github.com/SkardiLabs/skardi/issues/167) question 1) — **design + implementation + docs** in this PR.

The source `path` can be an `s3://` prefix and image crops / page renders can be written to an `s3://` `image_store`, in any local/s3 scheme combination. When *both* are `s3://` they must be the **same bucket** (a single store / region / credential set can't serve two; cross-bucket is a follow-up).

## Implementation

- **`documents/blob.rs`** (new): `Loc` (local vs `s3://` with bucket/key) and `BlobStore` (`Local` via `std::fs`, `Remote` via `object_store`) with `list`/`get`/`put`, prefix normalization, and crop `Content-Type` inference. `BlobStore::resolve` builds the S3 client lazily so it lives on the parse thread's own runtime (no reqwest cross-runtime pool hazard).
- **`parse.rs`**: all I/O routed through `BlobStore`; inputs fed to liteparse as `PdfInput::Bytes` (`parse_input`/`screenshot_input`/`is_complex`); `list_docs` filters by glob and **excludes the `image_store` prefix** (self-ingestion guard); a non-empty listing where every object fails is now a hard error, not a silent empty result.
- **`remote_storage.rs`**: `validate_documents_configuration` (same-bucket enforcement, `aws_*` credential rejection when *either* side is `s3://`, and **rejection of an `image_store` that equals or is an ancestor of the source `path`** — local or s3 — since that would exclude every source doc via the self-ingestion guard and yield an empty scan) and `preflight_documents_s3` (bounded read check that polls only the **first** list-stream item so a large prefix isn't fully inventoried at startup + put/delete write preflight). The `config.rs` Documents arm runs both before registration.
- `object_store` added to the `skardi` crate under the `documents` feature.

## Docs

`docs/documents.md` predated this change ("`path` is local-filesystem only in v1", "s3 `image_store` records refs but bytes are not uploaded") — both passages rewritten, plus a new **"S3 / object store"** section covering the env-only credential contract, same-bucket constraint, registration preflight, prefix scoping, and self-ingestion guard. README source table updated to match. A doc comment on `require_s3_region_and_creds` records that `AWS_PROFILE` satisfies the startup check only for parity with `setup_object_store` — `object_store` never reads `~/.aws/` profiles, so profile-only setups fail loudly at the preflight call; the docs point at `aws configure export-credentials` as the working path.

## Tests

`blob` (local + `InMemory` remote round-trips, prefix scoping, content-type), `parse` (`list_docs` glob + self-ingestion exclusion, `loc_is_under`, bytes routing via the existing fixtures), `remote_storage` (same-bucket, credential-gap, image_store equal/ancestor-of-path rejection for local + s3). All green: **42 documents + 13 remote_storage**.

Coverage-review follow-up closed three untested paths:
- `parse.rs` — regression test for the wholesale-failure guard (non-empty listing where every file fails to parse → hard error, not a silent empty corpus).
- `remote_storage.rs` — extracted `write_probe_key` and `require_s3_region_and_creds` as pure helpers (behavior-preserving) so they're unit-testable without live S3 or racy env mutation; added tests for the probe-key scoping, `s3_key_prefix`, `parse_bucket`, and all four region/credential branches.

Full-suite run with `--features documents`: `skardi` 750 unit + 31 doctests, `skardi-server` 151 unit + 48 integration — 0 failures. (`skardi-cli` excluded: its default `gguf` feature has a pre-existing `llama-cpp-sys` bindgen failure on the test machine, unrelated to this branch.)

## Live e2e (real S3, us-east-1)

Ran `skardi-server --features documents` against a dedicated bucket with a nested corpus (`corpus/two_pages.pdf`, `corpus/sub/nested.pdf`, a non-matching `.txt`, and a `corpus-sibling/decoy.pdf`), `path: s3://…/corpus`, `image_store: s3://…/corpus/crops`, `image_mode: embedded`, `render_page_images: true`:

- `POST /query` returned exactly 4 rows (2 files × 2 pages) with correct markdown; the sibling-prefix decoy and the `.txt` were excluded (prefix scoping + globs against real S3 listing).
- Page renders were genuinely uploaded: 4 valid PNGs under `corpus/crops/` with `ContentType: image/png`; the `.skardi-write-probe` object was cleaned up.
- **Self-ingestion guard live**: rescanning with the crops now inside the source prefix (and matching `*.png`) still returned 4 rows.
- Negative startup cases all fail with actionable errors: cross-bucket `image_store` (same-bucket message), nonexistent bucket (read-connectivity 404), `aws_secret_access_key` smuggled into `options` with a *local* path + s3 `image_store` (the gap-closer), missing `AWS_REGION`/credentials in env, and an `image_store` on a read-only public bucket (write preflight 403 on the probe key).

**Follow-ups:** a live HTTP-mock (localstack/`httpmock`) test for the reqwest cross-runtime path; cross-bucket (cross-region/account) support.

## Review context

Design spec at `docs/superpowers/specs/2026-07-23-documents-s3-object-store-support-design.md`; the review round's inline comments are resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

