### PR TITLE
fix(sources): paginate github issues on the gateway raw page length

### DIFF
--- a/crates/skardi/src/sources/providers/open_connector/error.rs
+++ b/crates/skardi/src/sources/providers/open_connector/error.rs
@@ -230,6 +230,19 @@ pub enum OpenConnectorError {
         found: String,
     },
 
+    /// The declared raw-page-size signal was present but not a non-negative
+    /// integer. Treating it as anything else would either truncate the scan
+    /// or loop it; carries the JSON *kind* only, never the value.
+    #[error(
+        "Open Connector pagination raw page size at '{path}' on page {page} is {found}, \
+         expected a non-negative integer"
+    )]
+    PaginationRawPageSizeInvalid {
+        path: String,
+        page: usize,
+        found: String,
+    },
+
     /// A continuation cursor was present at the declared path but was not a
     /// string. Treating it as end-of-collection would silently truncate the
     /// scan, so it fails instead. Carries the JSON *kind* only, never the

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/github/contracts/list_repository_issues.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/github/contracts/list_repository_issues.json
@@ -123,6 +123,21 @@
         },
         "additionalProperties": true
       }
+    },
+    "pageInfo": {
+      "type": "object",
+      "properties": {
+        "fetched": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of items GitHub returned on this page before filtering. Continue paginating while this equals perPage, which defaults to 30."
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "fetched"
+      ],
+      "description": "Pagination signals from the raw GitHub page, before pull requests are filtered out."
     }
   },
   "additionalProperties": false

--- a/crates/skardi/src/sources/providers/open_connector/packs/github.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/github.rs
@@ -7,8 +7,15 @@
 //! - **Page-number pagination everywhere** (`page`/`perPage`, 100 per page
 //!   — GitHub's maximum; the camelCase keys are Open Connector's strict
 //!   action-input contract, not GitHub's raw REST parameters). A short or
-//!   empty page terminates the scan, which is GitHub's documented
-//!   end-of-collection signal.
+//!   empty page terminates the scan — except for `issues`, whose OC action
+//!   filters pull requests out AFTER paginating, so a filtered page's
+//!   length is not a termination signal: the table declares
+//!   `raw_page_size_path: $.pageInfo.fetched` (upstream #228) and the scan
+//!   continues while the RAW page was full, even when the filtered rows
+//!   come back short or empty. Requires a gateway with
+//!   oomol-lab/open-connector#228 (older gateways fail the fingerprint
+//!   gate at registration, and their responses would fail the scan loudly
+//!   with a missing `$.pageInfo.fetched` — never a silent truncation).
 //! - **Filters are allowlisted only where faithful — and every string-enum
 //!   push is Inexact.** `issues.state` / `pull_requests.state` narrow the
 //!   fetch but DataFusion re-applies them: the translation is faithful only
@@ -113,6 +120,49 @@ mod tests {
             .map(|(_, schema)| *schema)
             .unwrap_or(r#"{"type": "object"}"#);
         MockResponse::ok(&discovery_ok("{}", output_schema, true, None))
+    }
+
+    #[tokio::test]
+    async fn filtered_issue_pages_do_not_truncate_the_scan() {
+        // The OC action filters pull requests out AFTER paginating, so a
+        // filtered page can be short — or entirely empty — while more pages
+        // exist. The raw signal (pageInfo.fetched, upstream #228) must
+        // drive continuation: page 1 returns 2 issues of a full raw page,
+        // page 2 is ALL pull requests (0 issues, raw full), page 3 is the
+        // genuine final page. Short-page termination would stop after page
+        // 1 and lose everything after it.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return github_discovery(&req.path);
+            }
+            if req.method == "POST" && req.path == "/v1/actions/github.list_repository_issues" {
+                let body: Value = serde_json::from_str(&req.body).unwrap_or_default();
+                let page = body["input"]["page"].as_u64().unwrap_or(1);
+                let response = match page {
+                    1 => json!({"issues": [issue(1, "open", "2026-01-01T00:00:00Z"),
+                                             issue(2, "open", "2026-01-01T00:00:00Z")],
+                                 "pageInfo": {"fetched": 100}}),
+                    2 => json!({"issues": [], "pageInfo": {"fetched": 100}}),
+                    3 => json!({"issues": [issue(3, "open", "2026-01-02T00:00:00Z")],
+                                 "pageInfo": {"fetched": 1}}),
+                    other => panic!("unexpected page {other}"),
+                };
+                return MockResponse::ok(&envelope_ok(&response.to_string()));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (_gw, ctx) = setup_with_gateway(gateway, "SKARDI_TEST_OC_GITHUB_RAW_PAGE").await;
+
+        let batches = collect(&ctx, "SELECT number FROM saas.gh.issues ORDER BY number").await;
+        assert_eq!(
+            rows_of(&batches),
+            3,
+            "all three pages were scanned: the short and the all-PR page did not terminate"
+        );
     }
 
     #[test]
@@ -623,16 +673,24 @@ bindings:
                 .and_then(Value::as_str)
                 .unwrap_or("open")
                 .to_string();
-            let slice: Vec<_> = rows
+            let matching: Vec<_> = rows
                 .iter()
                 .filter(|row| {
                     state == "all" || row.get("state").and_then(Value::as_str) == Some(&state)
                 })
+                .collect();
+            let slice: Vec<_> = matching
+                .iter()
                 .skip((page - 1) * per_page)
                 .take(per_page)
-                .cloned()
+                .map(|row| (*row).clone())
                 .collect();
-            return MockResponse::ok(&envelope_ok(&json!({"issues": slice}).to_string()));
+            // The raw page length before any post-pagination filtering; the
+            // stub does none, so it equals the slice length.
+            let fetched = slice.len();
+            return MockResponse::ok(&envelope_ok(
+                &json!({"issues": slice, "pageInfo": {"fetched": fetched}}).to_string(),
+            ));
         }
         MockResponse::new(404, "{}")
     }
@@ -658,6 +716,14 @@ bindings:
             let served = std::sync::Arc::clone(&served);
             MockGateway::start(move |req| issues_handler(req, &served)).await
         };
+        setup_with_gateway(gateway, token_env).await
+    }
+
+    /// Register the issues binding against an arbitrary gateway stub.
+    async fn setup_with_gateway(
+        gateway: MockGateway,
+        token_env: &str,
+    ) -> (MockGateway, SessionContext) {
         unsafe {
             std::env::set_var(token_env, "test-token");
         }
@@ -1356,7 +1422,9 @@ bindings:
                 return MockResponse::ok(&envelope_ok(r#"{"repositories": []}"#));
             }
             if req.method == "POST" && req.path == "/v1/actions/github.list_repository_issues" {
-                return MockResponse::ok(&envelope_ok(r#"{"issues": []}"#));
+                return MockResponse::ok(&envelope_ok(
+                    r#"{"issues": [], "pageInfo": {"fetched": 0}}"#,
+                ));
             }
             MockResponse::new(404, "{}")
         })

--- a/crates/skardi/src/sources/providers/open_connector/packs/github.yaml
+++ b/crates/skardi/src/sources/providers/open_connector/packs/github.yaml
@@ -35,13 +35,17 @@ tables:
 
   issues:
     action: github.list_repository_issues
-    fingerprint: 45fbef8622d90702e536b9b2e0ade6bcc7da61f7cb654d62a90b2e36df13c64b
+    fingerprint: 0530ff93d700f3aba2754160a76cf69919a7753fe14b26835463fdb88cfad8e3
     row_path: "$.issues"
     pagination:
       strategy: page_number
       page_input: page
       page_size_input: perPage
       page_size: 100
+      # The OC action filters pull requests out AFTER paginating; the raw
+      # page length (oomol-lab/open-connector#228) is the only sound
+      # termination signal — a short or empty issues array is not.
+      raw_page_size_path: "$.pageInfo.fetched"
     resources:
       required: [owner, repo]
     fixed_inputs:

--- a/crates/skardi/src/sources/providers/open_connector/packs/loader.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/loader.rs
@@ -400,6 +400,8 @@ enum PaginationDoc {
         page_size: u32,
         #[serde(default)]
         total_pages_path: Option<String>,
+        #[serde(default)]
+        raw_page_size_path: Option<String>,
     },
     Cursor {
         cursor_input: String,
@@ -418,11 +420,13 @@ impl PaginationDoc {
                 page_size_input,
                 page_size,
                 total_pages_path,
+                raw_page_size_path,
             } => PaginationStrategy::PageNumber {
                 page_param: leak_str(page_input),
                 per_page_param: leak_str(page_size_input),
                 per_page: page_size,
                 total_pages_path: total_pages_path.map(leak_str),
+                raw_page_size_path: raw_page_size_path.map(leak_str),
             },
             Self::Cursor {
                 cursor_input,

--- a/crates/skardi/src/sources/providers/open_connector/pagination.rs
+++ b/crates/skardi/src/sources/providers/open_connector/pagination.rs
@@ -23,8 +23,16 @@ pub enum PaginationStrategy {
     /// `page >= total pages` — a short or even empty non-final page keeps
     /// going, because providers that filter rows *after* paginating
     /// (permission checks, deletions) can legally return short middle pages.
-    /// Without a declared path, the short/empty-page heuristic ends the scan
-    /// — the only signal providers like GitHub give.
+    /// When `raw_page_size_path` is declared, the scan trusts the provider's
+    /// reported RAW page length (the count before any post-pagination
+    /// filtering) and continues while it equals the requested page size —
+    /// the signal Open Connector's `github.list_repository_issues`
+    /// publishes as `$.pageInfo.fetched` (oomol-lab/open-connector#228),
+    /// whose filtered row array says nothing about whether more pages
+    /// exist.
+    ///
+    /// Without either path, the short/empty-page heuristic ends the scan —
+    /// sound only when the returned rows ARE the raw page.
     PageNumber {
         /// Action input field for the page number.
         page_param: &'static str,
@@ -33,9 +41,13 @@ pub enum PaginationStrategy {
         /// Page size to request (also the limit-pushdown ceiling).
         per_page: u32,
         /// Row-path-style location of the provider's total page count in the
-        /// response envelope (e.g. Slack's `$.paging.pages`). `None` falls
-        /// back to short/empty-page termination.
+        /// response envelope (e.g. Slack's `$.paging.pages`). Mutually
+        /// exclusive with `raw_page_size_path`; with neither, the heuristic
+        /// applies.
         total_pages_path: Option<&'static str>,
+        /// Row-path-style location of the raw (pre-filter) page length in
+        /// the response envelope (e.g. `$.pageInfo.fetched`).
+        raw_page_size_path: Option<&'static str>,
     },
     /// Cursor pagination: the request carries the previous page's cursor
     /// (absent on the first page); the response carries the next cursor at a
@@ -73,6 +85,8 @@ pub struct Pagination {
     cursor_path: Option<RowPath>,
     /// Pre-parsed total-pages path (PageNumber only), same discipline.
     total_pages_path: Option<RowPath>,
+    /// Pre-parsed raw-page-size path (PageNumber only).
+    raw_page_size_path: Option<RowPath>,
 }
 
 impl PaginationStrategy {
@@ -86,10 +100,27 @@ impl PaginationStrategy {
                 RowPath::parse(next_cursor_path)?;
             }
             PaginationStrategy::PageNumber {
-                total_pages_path: Some(path),
+                total_pages_path,
+                raw_page_size_path,
                 ..
             } => {
-                RowPath::parse(path)?;
+                if let Some(path) = total_pages_path {
+                    RowPath::parse(path)?;
+                }
+                if let Some(path) = raw_page_size_path {
+                    RowPath::parse(path)?;
+                }
+                // Two authoritative signals cannot coexist: a page where
+                // they disagree would have no defensible winner.
+                if total_pages_path.is_some() && raw_page_size_path.is_some() {
+                    return Err(OpenConnectorError::InvalidRowPath {
+                        path: "<pagination>".to_string(),
+                        reason: "total_pages_path and raw_page_size_path are mutually \
+                                 exclusive; declare the one signal the provider makes \
+                                 authoritative"
+                            .to_string(),
+                    });
+                }
             }
             _ => {}
         }
@@ -121,6 +152,13 @@ impl Pagination {
             } => Some(RowPath::parse(path)?),
             _ => None,
         };
+        let raw_page_size_path = match &strategy {
+            PaginationStrategy::PageNumber {
+                raw_page_size_path: Some(path),
+                ..
+            } => Some(RowPath::parse(path)?),
+            _ => None,
+        };
         Ok(Self {
             strategy,
             page: 1,
@@ -128,6 +166,7 @@ impl Pagination {
             seen_tokens: HashSet::new(),
             cursor_path,
             total_pages_path,
+            raw_page_size_path,
         })
     }
 
@@ -200,9 +239,26 @@ impl Pagination {
                         })?;
                         (self.page as u64) < total
                     }
-                    // Heuristic: short or empty page → last page (all the
-                    // signal providers like GitHub give).
-                    None => rows_in_page >= *per_page as usize,
+                    // Raw page length: the provider filters rows AFTER
+                    // paginating but reports how many it fetched — continue
+                    // while the raw page was full, no matter how short (or
+                    // empty) the filtered row array is.
+                    None => match &self.raw_page_size_path {
+                        Some(path) => {
+                            let fetched = path.extract(envelope, self.page)?;
+                            let fetched = fetched.as_u64().ok_or_else(|| {
+                                OpenConnectorError::PaginationRawPageSizeInvalid {
+                                    path: path.as_str().to_string(),
+                                    page: self.page,
+                                    found: json_kind(fetched),
+                                }
+                            })?;
+                            fetched >= u64::from(*per_page)
+                        }
+                        // Heuristic: short or empty page → last page (all
+                        // the signal the provider gives).
+                        None => rows_in_page >= *per_page as usize,
+                    },
                 };
                 if more {
                     self.page += 1;
@@ -266,6 +322,7 @@ mod tests {
             per_page_param: "per_page",
             per_page,
             total_pages_path: None,
+            raw_page_size_path: None,
         })
         .unwrap()
     }
@@ -329,6 +386,79 @@ mod tests {
     fn page_number_stops_on_empty_page() {
         let mut pagination = page_number(10);
         assert!(!pagination.advance(&json!({}), 0).unwrap());
+    }
+
+    fn page_number_with_raw(per_page: u32) -> Pagination {
+        Pagination::new(PaginationStrategy::PageNumber {
+            page_param: "page",
+            per_page_param: "perPage",
+            per_page,
+            total_pages_path: None,
+            raw_page_size_path: Some("$.pageInfo.fetched"),
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn raw_page_size_drives_termination_regardless_of_filtered_rows() {
+        // Full raw page + short (even empty) filtered rows → continue: the
+        // provider filtered rows AFTER paginating, so the filtered count
+        // says nothing. Short raw page → done, even if rows LOOK full.
+        let mut pagination = page_number_with_raw(100);
+        assert!(
+            pagination
+                .advance(&json!({"pageInfo": {"fetched": 100}}), 37)
+                .unwrap(),
+            "full raw page with a short filtered page continues"
+        );
+        assert!(
+            pagination
+                .advance(&json!({"pageInfo": {"fetched": 100}}), 0)
+                .unwrap(),
+            "an all-filtered (empty) page continues while the raw page was full"
+        );
+        assert!(
+            !pagination
+                .advance(&json!({"pageInfo": {"fetched": 99}}), 99)
+                .unwrap(),
+            "a short raw page terminates"
+        );
+    }
+
+    #[test]
+    fn missing_or_invalid_raw_page_size_fails_the_scan() {
+        // The declared signal going missing or changing type is drift, not
+        // end-of-collection — reading it as termination would truncate.
+        let mut pagination = page_number_with_raw(100);
+        assert!(matches!(
+            pagination.advance(&json!({"issues": []}), 0),
+            Err(OpenConnectorError::RowPathNotFound { .. })
+        ));
+
+        let mut pagination = page_number_with_raw(100);
+        assert!(matches!(
+            pagination.advance(&json!({"pageInfo": {"fetched": "100"}}), 0),
+            Err(OpenConnectorError::PaginationRawPageSizeInvalid { page: 1, ref found, .. })
+                if found == "a string"
+        ));
+    }
+
+    #[test]
+    fn total_and_raw_page_size_are_mutually_exclusive() {
+        let err = PaginationStrategy::PageNumber {
+            page_param: "page",
+            per_page_param: "perPage",
+            per_page: 100,
+            total_pages_path: Some("$.paging.pages"),
+            raw_page_size_path: Some("$.pageInfo.fetched"),
+        }
+        .validate()
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            OpenConnectorError::InvalidRowPath { ref reason, .. }
+                if reason.contains("mutually")
+        ));
     }
 
     #[test]
@@ -442,6 +572,7 @@ mod tests {
             per_page_param: "count",
             per_page,
             total_pages_path: Some("$.paging.pages"),
+            raw_page_size_path: None,
         })
         .unwrap()
     }
@@ -507,6 +638,7 @@ mod tests {
             per_page_param: "count",
             per_page: 2,
             total_pages_path: Some("not-a-path"),
+            raw_page_size_path: None,
         };
         assert!(matches!(
             strategy.validate(),

--- a/docs/open-connector-github.md
+++ b/docs/open-connector-github.md
@@ -61,9 +61,17 @@ repo-scoped tables without tripping the gateway's strict input schemas.
 
 All tables use page-number pagination at GitHub's 100-row maximum, sent as
 the gateway's camelCase `page`/`perPage` inputs (Open Connector's action
-schemas are strict — snake_case keys are rejected); a short or empty page
-terminates the scan (GitHub's documented end-of-collection signal), so
-every scan is complete and bounded by `max_pages` / `max_rows`.
+schemas are strict — snake_case keys are rejected). A short or empty page
+terminates the scan (GitHub's documented end-of-collection signal) — with
+one deliberate exception: the `issues` action filters pull requests out
+*after* paginating, so a short or even empty issues page can sit in the
+middle of the collection. The table therefore paginates on the gateway's
+raw page length (`$.pageInfo.fetched`, added in
+[open-connector#228](https://github.com/oomol-lab/open-connector/pull/228))
+and continues while the raw page was full. This requires a gateway that
+includes that fix; older gateways fail `issues` registration at the
+fingerprint gate rather than silently truncating. Every scan is complete
+and bounded by `max_pages` / `max_rows`.
 
 | Table | Action | Resources | Filter pushdown |
 |---|---|---|---|

--- a/docs/open-connector/stub_gateway.py
+++ b/docs/open-connector/stub_gateway.py
@@ -146,7 +146,11 @@ def execute(action_id, params):
     page = int(params.get("page", 1))
     # Open Connector action inputs are camelCase (and strict about it).
     per_page = int(params.get("perPage", 30))
-    return {row_key: rows[(page - 1) * per_page : page * per_page]}
+    sliced = rows[(page - 1) * per_page : page * per_page]
+    # The raw page length before any post-pagination filtering (the stub
+    # does none), matching open-connector#228's pageInfo signal that the
+    # issues table paginates on.
+    return {row_key: sliced, "pageInfo": {"fetched": len(sliced)}}
 
 
 class Handler(BaseHTTPRequestHandler):

--- a/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
+++ b/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
@@ -149,7 +149,16 @@ event carrying the scan identity and error.
       input keys, row paths, and HTTP protocol are reconciled against a live gateway,
       and fingerprint pins are now taken from live-captured contracts
       (`fixtures/github/contracts/`, landed alongside 5.2's pinning recipe: sync
-      test, contract-serving mocks, drift-refusal e2e).
+      test, contract-serving mocks, drift-refusal e2e). The `issues` table
+      paginates on the gateway's raw page length (`raw_page_size_path:
+      $.pageInfo.fetched`, a `PageNumber` extension mirroring `total_pages_path`;
+      upstream fix oomol-lab/open-connector#228): the OC action filters pull
+      requests out after paginating, so filtered page length is not a termination
+      signal — short-page termination would silently truncate on any PR-bearing
+      page, and even empty-page termination fails on 100 consecutive PRs. Engine
+      unit tests pin continue-on-full-raw/terminate-on-short-raw/missing-and-
+      invalid-signal failures plus total/raw mutual exclusion; a pack e2e drives
+      a 3-page scan whose middle page is all pull requests.
       Docs: `docs/open-connector-github.md` (per-table filter/limit behavior, authz/
       visibility incl. the pure-issues note, rate limits, freshness), README row updated.
       Verification: 27 pack tests (counted by
@@ -225,7 +234,7 @@ event carrying the scan identity and error.
       targeted `SourcePackAssetInvalid` registration/UDTF-setup diagnostic —
       never a panic — with a parse-all test keeping shipped assets valid.
 
-      **Verification**: 240 open_connector tests (counted by `cargo test -p skardi --lib
+      **Verification**: 246 open_connector tests (counted by `cargo test -p skardi --lib
       sources::providers::open_connector`): per-table fixture contract tests against the
       normalized shapes (explicit nulls vs omitted `memberCount`, flattened profiles,
       deleted users, Slack's empty-string convention, epoch-seconds `files.created`, empty


### PR DESCRIPTION
## Summary

Closes the deferred P1 on `github.issues`: the OC action filters pull requests out **after** paginating, so the filtered page length is not a termination signal — short-page termination silently truncated on the first PR-bearing page, and even empty-page termination fails on 100 consecutive PRs. Upstream now reports the raw page length ([open-connector#228](https://github.com/oomol-lab/open-connector/pull/228), merged); this PR consumes it.

- **Engine**: `PageNumber` gains `raw_page_size_path` (mirroring `total_pages_path`) — the scan continues while the RAW page was full, regardless of how short or empty the filtered rows are. Missing signal → `RowPathNotFound`; non-integer → new `PaginationRawPageSizeInvalid` (kind-only). The two authoritative signals are mutually exclusive at validate time.
- **Pack**: `github.yaml` issues declares `raw_page_size_path: "$.pageInfo.fetched"`; contract re-captured from a live gateway carrying the fix and the fingerprint re-pinned — older gateways fail issues registration at the fingerprint gate instead of truncating (documented, incl. the minimum-gateway note).
- **Tests**: engine units (continue on full-raw/short-filtered and full-raw/empty pages, terminate on short raw page, missing/invalid signal, mutual exclusion) + a pack e2e driving a 3-page scan whose middle page is **all pull requests** — the case that defeats every filtered-count heuristic. Mock stubs and the demo stub gateway now emit `pageInfo`.
- **Live-verified**: all 11 tables register with the new pin against a local gateway at upstream HEAD; the issues scan reaches the credential wall.

246 open_connector / 803 lib tests green; clippy baseline unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)