### PR TITLE
feat(sources): Notion source pack (milestone 5.3)

### DIFF
--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/notion/block_children.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/notion/block_children.json
@@ -1,0 +1,21 @@
+{
+  "object": "list",
+  "results": [
+    {
+      "object": "block", "id": "b-0001", "type": "paragraph",
+      "created_time": "2026-03-01T00:00:00.000Z",
+      "last_edited_time": "2026-03-01T00:00:00.000Z",
+      "has_children": false, "archived": false, "in_trash": false,
+      "parent": { "type": "page_id", "page_id": "p-0001" },
+      "paragraph": { "rich_text": [{ "plain_text": "Hello" }] }
+    },
+    {
+      "object": "block", "id": "b-0002", "type": "heading_1",
+      "created_time": null, "last_edited_time": null,
+      "has_children": true, "archived": null,
+      "parent": null,
+      "heading_1": { "rich_text": [] }
+    }
+  ],
+  "next_cursor": null, "has_more": false
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/notion/block_children.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/notion/block_children.json
@@ -2,20 +2,149 @@
   "object": "list",
   "results": [
     {
-      "object": "block", "id": "b-0001", "type": "paragraph",
-      "created_time": "2026-03-01T00:00:00.000Z",
-      "last_edited_time": "2026-03-01T00:00:00.000Z",
-      "has_children": false, "archived": false, "in_trash": false,
-      "parent": { "type": "page_id", "page_id": "p-0001" },
-      "paragraph": { "rich_text": [{ "plain_text": "Hello" }] }
+      "object": "block",
+      "id": "00000000-0000-4000-8000-000000000024",
+      "parent": {
+        "type": "page_id",
+        "page_id": "00000000-0000-4000-8000-000000000006"
+      },
+      "created_time": "2026-04-23T09:49:00.000Z",
+      "last_edited_time": "2026-04-23T09:50:00.000Z",
+      "created_by": {
+        "object": "user",
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "last_edited_by": {
+        "object": "user",
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "has_children": false,
+      "in_trash": false,
+      "type": "heading_1",
+      "heading_1": {
+        "rich_text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "Redacted text",
+              "link": null
+            },
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            },
+            "plain_text": "Redacted text",
+            "href": null
+          }
+        ],
+        "is_toggleable": false,
+        "color": "default"
+      }
     },
     {
-      "object": "block", "id": "b-0002", "type": "heading_1",
-      "created_time": null, "last_edited_time": null,
-      "has_children": true, "archived": null,
-      "parent": null,
-      "heading_1": { "rich_text": [] }
+      "object": "block",
+      "id": "00000000-0000-4000-8000-000000000025",
+      "parent": {
+        "type": "page_id",
+        "page_id": "00000000-0000-4000-8000-000000000006"
+      },
+      "created_time": "2026-04-23T09:49:00.000Z",
+      "last_edited_time": "2026-04-23T09:51:00.000Z",
+      "created_by": {
+        "object": "user",
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "last_edited_by": {
+        "object": "user",
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "has_children": false,
+      "in_trash": false,
+      "type": "to_do",
+      "to_do": {
+        "rich_text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "Redacted text",
+              "link": null
+            },
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            },
+            "plain_text": "Redacted text",
+            "href": null
+          }
+        ],
+        "checked": false,
+        "color": "default"
+      }
+    },
+    {
+      "object": "block",
+      "id": "00000000-0000-4000-8000-000000000026",
+      "parent": {
+        "type": "page_id",
+        "page_id": "00000000-0000-4000-8000-000000000006"
+      },
+      "created_time": "2026-04-23T09:51:00.000Z",
+      "last_edited_time": "2026-04-23T09:51:00.000Z",
+      "created_by": {
+        "object": "user",
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "last_edited_by": {
+        "object": "user",
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "has_children": false,
+      "in_trash": false,
+      "type": "to_do",
+      "to_do": {
+        "rich_text": [],
+        "checked": false,
+        "color": "default"
+      }
+    },
+    {
+      "object": "block",
+      "id": "00000000-0000-4000-8000-000000000027",
+      "parent": {
+        "type": "page_id",
+        "page_id": "00000000-0000-4000-8000-000000000006"
+      },
+      "created_time": "2026-04-23T09:50:00.000Z",
+      "last_edited_time": "2026-04-23T09:50:00.000Z",
+      "created_by": {
+        "object": "user",
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "last_edited_by": {
+        "object": "user",
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "has_children": false,
+      "in_trash": false,
+      "type": "paragraph",
+      "paragraph": {
+        "rich_text": [],
+        "icon": null,
+        "color": "default"
+      }
     }
   ],
-  "next_cursor": null, "has_more": false
+  "next_cursor": null,
+  "has_more": false,
+  "type": "block",
+  "block": {},
+  "request_id": "00000000-0000-4000-8000-000000000028"
 }

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/notion/contracts/list_block_children.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/notion/contracts/list_block_children.json
@@ -1,0 +1,71 @@
+{
+  "type": "object",
+  "properties": {
+    "object": {
+      "const": "list",
+      "type": "string",
+      "description": "The Notion object type."
+    },
+    "results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "object": {
+            "const": "block",
+            "type": "string",
+            "description": "The Notion object type."
+          },
+          "id": {
+            "type": "string",
+            "description": "The block ID."
+          },
+          "parent": {
+            "type": "object",
+            "additionalProperties": {
+              "description": "A Notion API field value."
+            },
+            "description": "The official Notion parent object."
+          },
+          "type": {
+            "type": "string",
+            "description": "The block type."
+          },
+          "has_children": {
+            "type": "boolean",
+            "description": "Whether this block has child blocks."
+          },
+          "in_trash": {
+            "type": "boolean",
+            "description": "Whether the block is in the trash."
+          }
+        },
+        "additionalProperties": true,
+        "description": "A Notion block object."
+      },
+      "description": "Returned Notion objects."
+    },
+    "next_cursor": {
+      "anyOf": [
+        {
+          "type": "string",
+          "description": "Cursor for the next page."
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "has_more": {
+      "type": "boolean",
+      "description": "Whether more results are available."
+    }
+  },
+  "additionalProperties": true,
+  "required": [
+    "object",
+    "results",
+    "has_more"
+  ],
+  "description": "Child blocks returned by Notion."
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/notion/contracts/list_users.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/notion/contracts/list_users.json
@@ -1,0 +1,100 @@
+{
+  "type": "object",
+  "properties": {
+    "object": {
+      "const": "list",
+      "type": "string",
+      "description": "The Notion object type."
+    },
+    "results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "object": {
+            "const": "user",
+            "type": "string",
+            "description": "The Notion object type."
+          },
+          "id": {
+            "type": "string",
+            "description": "The Notion user ID."
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The user's display name."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "avatar_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The user's avatar URL."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "person",
+              "bot"
+            ],
+            "description": "The user type."
+          },
+          "person": {
+            "type": "object",
+            "properties": {
+              "email": {
+                "type": "string",
+                "description": "The person's email address.",
+                "format": "email"
+              }
+            },
+            "additionalProperties": true
+          },
+          "bot": {
+            "type": "object",
+            "additionalProperties": {
+              "description": "A Notion API field value."
+            },
+            "description": "A Notion API object."
+          }
+        },
+        "additionalProperties": true,
+        "description": "A Notion user object."
+      },
+      "description": "Returned Notion objects."
+    },
+    "next_cursor": {
+      "anyOf": [
+        {
+          "type": "string",
+          "description": "Cursor for the next page."
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "has_more": {
+      "type": "boolean",
+      "description": "Whether more results are available."
+    }
+  },
+  "additionalProperties": true,
+  "required": [
+    "object",
+    "results",
+    "has_more"
+  ],
+  "description": "Workspace users returned by Notion."
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/notion/contracts/search.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/notion/contracts/search.json
@@ -1,0 +1,143 @@
+{
+  "type": "object",
+  "properties": {
+    "object": {
+      "const": "list",
+      "type": "string",
+      "description": "The Notion object type."
+    },
+    "results": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "object": {
+                "const": "page",
+                "type": "string",
+                "description": "The Notion object type."
+              },
+              "id": {
+                "type": "string",
+                "description": "The page ID."
+              },
+              "created_time": {
+                "type": "string",
+                "description": "The time when the page was created.",
+                "format": "date-time"
+              },
+              "last_edited_time": {
+                "type": "string",
+                "description": "The time when the page was last edited.",
+                "format": "date-time"
+              },
+              "parent": {
+                "type": "object",
+                "additionalProperties": {
+                  "description": "A Notion API field value."
+                },
+                "description": "The official Notion parent object."
+              },
+              "properties": {
+                "type": "object",
+                "additionalProperties": {
+                  "description": "A Notion API field value."
+                },
+                "description": "Notion properties keyed by property name."
+              },
+              "url": {
+                "type": "string",
+                "description": "The canonical Notion URL for the page.",
+                "format": "uri"
+              },
+              "archived": {
+                "type": "boolean",
+                "description": "Whether the page is archived."
+              },
+              "in_trash": {
+                "type": "boolean",
+                "description": "Whether the page is in the trash."
+              }
+            },
+            "additionalProperties": true,
+            "description": "A Notion page object."
+          },
+          {
+            "type": "object",
+            "properties": {
+              "object": {
+                "const": "data_source",
+                "type": "string",
+                "description": "The Notion object type."
+              },
+              "id": {
+                "type": "string",
+                "description": "The data source ID."
+              },
+              "title": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "description": "A Notion API field value."
+                  },
+                  "description": "A Notion API object."
+                },
+                "description": "Notion rich text objects."
+              },
+              "properties": {
+                "type": "object",
+                "additionalProperties": {
+                  "description": "A Notion API field value."
+                },
+                "description": "Notion properties keyed by property name."
+              },
+              "parent": {
+                "type": "object",
+                "additionalProperties": {
+                  "description": "A Notion API field value."
+                },
+                "description": "The official Notion parent object."
+              },
+              "url": {
+                "type": "string",
+                "description": "The canonical Notion URL for the data source.",
+                "format": "uri"
+              },
+              "in_trash": {
+                "type": "boolean",
+                "description": "Whether the data source is in the trash."
+              }
+            },
+            "additionalProperties": true,
+            "description": "A Notion data source object."
+          }
+        ]
+      },
+      "description": "Returned Notion objects."
+    },
+    "next_cursor": {
+      "anyOf": [
+        {
+          "type": "string",
+          "description": "Cursor for the next page."
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "has_more": {
+      "type": "boolean",
+      "description": "Whether more results are available."
+    }
+  },
+  "additionalProperties": true,
+  "required": [
+    "object",
+    "results",
+    "has_more"
+  ],
+  "description": "Search results returned by Notion."
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/notion/data_sources.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/notion/data_sources.json
@@ -1,0 +1,22 @@
+{
+  "object": "list",
+  "results": [
+    {
+      "object": "data_source", "id": "ds-0001",
+      "created_time": "2026-02-01T00:00:00.000Z",
+      "last_edited_time": "2026-02-02T00:00:00.000Z",
+      "title": [{ "plain_text": "Tasks" }, { "plain_text": " DB" }],
+      "archived": false,
+      "url": "https://www.notion.so/ds-0001",
+      "parent": { "type": "page_id", "page_id": "p-0001" },
+      "properties": { "Name": { "type": "title" }, "Status": { "type": "select" } }
+    },
+    {
+      "object": "data_source", "id": "ds-0002",
+      "created_time": null, "last_edited_time": null,
+      "title": [], "archived": null, "url": null,
+      "parent": null, "properties": null
+    }
+  ],
+  "next_cursor": null, "has_more": false
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/notion/data_sources.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/notion/data_sources.json
@@ -2,21 +2,185 @@
   "object": "list",
   "results": [
     {
-      "object": "data_source", "id": "ds-0001",
-      "created_time": "2026-02-01T00:00:00.000Z",
-      "last_edited_time": "2026-02-02T00:00:00.000Z",
-      "title": [{ "plain_text": "Tasks" }, { "plain_text": " DB" }],
-      "archived": false,
-      "url": "https://www.notion.so/ds-0001",
-      "parent": { "type": "page_id", "page_id": "p-0001" },
-      "properties": { "Name": { "type": "title" }, "Status": { "type": "select" } }
-    },
-    {
-      "object": "data_source", "id": "ds-0002",
-      "created_time": null, "last_edited_time": null,
-      "title": [], "archived": null, "url": null,
-      "parent": null, "properties": null
+      "object": "data_source",
+      "id": "00000000-0000-4000-8000-000000000007",
+      "cover": null,
+      "icon": {
+        "type": "icon",
+        "icon": {
+          "name": "Redacted Name",
+          "color": "lightgray"
+        }
+      },
+      "created_time": "2023-09-12T07:34:00.000Z",
+      "created_by": {
+        "object": "user",
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "last_edited_by": {
+        "object": "user",
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "last_edited_time": "2026-08-03T03:24:00.000Z",
+      "title": [
+        {
+          "type": "text",
+          "text": {
+            "content": "Redacted text",
+            "link": null
+          },
+          "annotations": {
+            "bold": false,
+            "italic": false,
+            "strikethrough": false,
+            "underline": false,
+            "code": false,
+            "color": "default"
+          },
+          "plain_text": "Redacted text",
+          "href": null
+        }
+      ],
+      "description": [
+        {
+          "type": "text",
+          "text": {
+            "content": "Redacted text",
+            "link": null
+          },
+          "annotations": {
+            "bold": false,
+            "italic": false,
+            "strikethrough": false,
+            "underline": false,
+            "code": false,
+            "color": "default"
+          },
+          "plain_text": "Redacted text",
+          "href": null
+        },
+        {
+          "type": "text",
+          "text": {
+            "content": "Redacted text",
+            "link": null
+          },
+          "annotations": {
+            "bold": false,
+            "italic": false,
+            "strikethrough": false,
+            "underline": false,
+            "code": true,
+            "color": "default"
+          },
+          "plain_text": "Redacted text",
+          "href": null
+        },
+        {
+          "type": "text",
+          "text": {
+            "content": "Redacted text",
+            "link": null
+          },
+          "annotations": {
+            "bold": false,
+            "italic": false,
+            "strikethrough": false,
+            "underline": false,
+            "code": false,
+            "color": "default"
+          },
+          "plain_text": "Redacted text",
+          "href": null
+        }
+      ],
+      "is_inline": false,
+      "properties": {
+        "Date Created": {
+          "id": "prop1",
+          "name": "Redacted Name",
+          "description": null,
+          "type": "created_time",
+          "created_time": {}
+        },
+        "Status": {
+          "id": "prop2",
+          "name": "Redacted Name",
+          "description": null,
+          "type": "status",
+          "status": {
+            "options": [
+              {
+                "id": "prop3",
+                "name": "Redacted Name",
+                "color": "red",
+                "description": null
+              },
+              {
+                "id": "00000000-0000-4000-8000-000000000011",
+                "name": "Redacted Name",
+                "color": "blue",
+                "description": null
+              },
+              {
+                "id": "00000000-0000-4000-8000-000000000018",
+                "name": "Redacted Name",
+                "color": "green",
+                "description": null
+              }
+            ],
+            "groups": [
+              {
+                "id": "00000000-0000-4000-8000-000000000019",
+                "name": "Redacted Name",
+                "color": "gray",
+                "option_ids": [
+                  "1"
+                ]
+              },
+              {
+                "id": "00000000-0000-4000-8000-000000000020",
+                "name": "Redacted Name",
+                "color": "blue",
+                "option_ids": [
+                  "00000000-0000-4000-8000-000000000011"
+                ]
+              },
+              {
+                "id": "00000000-0000-4000-8000-000000000021",
+                "name": "Redacted Name",
+                "color": "green",
+                "option_ids": [
+                  "00000000-0000-4000-8000-000000000018"
+                ]
+              }
+            ]
+          }
+        },
+        "Name": {
+          "id": "title",
+          "name": "Redacted Name",
+          "description": null,
+          "type": "title",
+          "title": {}
+        }
+      },
+      "parent": {
+        "type": "database_id",
+        "database_id": "00000000-0000-4000-8000-000000000008"
+      },
+      "database_parent": {
+        "type": "workspace",
+        "workspace": true
+      },
+      "url": "https://app.notion.com/p/Redacted-00000000000040008000000000000022",
+      "public_url": null,
+      "in_trash": false
     }
   ],
-  "next_cursor": null, "has_more": false
+  "next_cursor": null,
+  "has_more": false,
+  "type": "page_or_data_source",
+  "page_or_data_source": {},
+  "request_id": "00000000-0000-4000-8000-000000000023"
 }

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/notion/pages.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/notion/pages.json
@@ -2,24 +2,254 @@
   "object": "list",
   "results": [
     {
-      "object": "page", "id": "p-0001",
-      "created_time": "2026-01-01T00:00:00.000Z",
-      "last_edited_time": "2026-01-02T10:30:00.000Z",
-      "archived": false, "in_trash": false,
-      "url": "https://www.notion.so/p-0001",
-      "public_url": null,
-      "parent": { "type": "workspace", "workspace": true },
-      "properties": { "title": { "id": "title", "type": "title", "title": [{ "plain_text": "Roadmap" }] } }
+      "object": "page",
+      "id": "00000000-0000-4000-8000-000000000006",
+      "created_time": "2026-04-23T09:49:00.000Z",
+      "last_edited_time": "2026-04-24T07:32:00.000Z",
+      "created_by": {
+        "object": "user",
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "last_edited_by": {
+        "object": "user",
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "cover": null,
+      "icon": null,
+      "parent": {
+        "type": "data_source_id",
+        "data_source_id": "00000000-0000-4000-8000-000000000007",
+        "database_id": "00000000-0000-4000-8000-000000000008"
+      },
+      "in_trash": false,
+      "is_archived": false,
+      "is_locked": false,
+      "properties": {
+        "Date Created": {
+          "id": "prop1",
+          "type": "created_time",
+          "created_time": "2026-04-23T09:49:00.000Z"
+        },
+        "Status": {
+          "id": "prop2",
+          "type": "status",
+          "status": {
+            "id": "prop3",
+            "name": "Redacted Name",
+            "color": "red"
+          }
+        },
+        "Name": {
+          "id": "title",
+          "type": "title",
+          "title": [
+            {
+              "type": "text",
+              "text": {
+                "content": "Redacted text",
+                "link": null
+              },
+              "annotations": {
+                "bold": false,
+                "italic": false,
+                "strikethrough": false,
+                "underline": false,
+                "code": false,
+                "color": "default"
+              },
+              "plain_text": "Redacted text",
+              "href": null
+            }
+          ]
+        }
+      },
+      "url": "https://app.notion.com/p/Redacted-00000000000040008000000000000009",
+      "public_url": null
     },
     {
-      "object": "page", "id": "p-0002",
-      "created_time": "2026-01-03T00:00:00.000Z",
-      "last_edited_time": null,
-      "archived": true,
-      "url": "https://www.notion.so/p-0002",
-      "parent": null,
-      "properties": null
+      "object": "page",
+      "id": "00000000-0000-4000-8000-000000000010",
+      "created_time": "2023-09-12T07:34:00.000Z",
+      "last_edited_time": "2023-09-12T07:34:00.000Z",
+      "created_by": {
+        "object": "user",
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "last_edited_by": {
+        "object": "user",
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "cover": null,
+      "icon": {
+        "type": "emoji",
+        "emoji": "🐶"
+      },
+      "parent": {
+        "type": "data_source_id",
+        "data_source_id": "00000000-0000-4000-8000-000000000007",
+        "database_id": "00000000-0000-4000-8000-000000000008"
+      },
+      "in_trash": false,
+      "is_archived": false,
+      "is_locked": false,
+      "properties": {
+        "Date Created": {
+          "id": "prop1",
+          "type": "created_time",
+          "created_time": "2023-09-12T07:34:00.000Z"
+        },
+        "Status": {
+          "id": "prop2",
+          "type": "status",
+          "status": {
+            "id": "00000000-0000-4000-8000-000000000011",
+            "name": "Redacted Name",
+            "color": "blue"
+          }
+        },
+        "Name": {
+          "id": "title",
+          "type": "title",
+          "title": [
+            {
+              "type": "text",
+              "text": {
+                "content": "Redacted text",
+                "link": null
+              },
+              "annotations": {
+                "bold": false,
+                "italic": false,
+                "strikethrough": false,
+                "underline": false,
+                "code": false,
+                "color": "default"
+              },
+              "plain_text": "Redacted text",
+              "href": null
+            }
+          ]
+        }
+      },
+      "url": "https://app.notion.com/p/Redacted-00000000000040008000000000000012",
+      "public_url": null
+    },
+    {
+      "object": "page",
+      "id": "00000000-0000-4000-8000-000000000013",
+      "created_time": "2023-09-12T07:34:00.000Z",
+      "last_edited_time": "2023-09-12T07:34:00.000Z",
+      "created_by": {
+        "object": "user",
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "last_edited_by": {
+        "object": "user",
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "cover": null,
+      "icon": null,
+      "parent": {
+        "type": "data_source_id",
+        "data_source_id": "00000000-0000-4000-8000-000000000007",
+        "database_id": "00000000-0000-4000-8000-000000000008"
+      },
+      "in_trash": false,
+      "is_archived": false,
+      "is_locked": false,
+      "properties": {
+        "Date Created": {
+          "id": "prop1",
+          "type": "created_time",
+          "created_time": "2023-09-12T07:34:00.000Z"
+        },
+        "Status": {
+          "id": "prop2",
+          "type": "status",
+          "status": {
+            "id": "prop3",
+            "name": "Redacted Name",
+            "color": "red"
+          }
+        },
+        "Name": {
+          "id": "title",
+          "type": "title",
+          "title": [
+            {
+              "type": "text",
+              "text": {
+                "content": "Redacted text",
+                "link": null
+              },
+              "annotations": {
+                "bold": false,
+                "italic": false,
+                "strikethrough": false,
+                "underline": false,
+                "code": false,
+                "color": "default"
+              },
+              "plain_text": "Redacted text",
+              "href": null
+            }
+          ]
+        }
+      },
+      "url": "https://app.notion.com/p/Redacted-00000000000040008000000000000014",
+      "public_url": null
+    },
+    {
+      "object": "page",
+      "id": "00000000-0000-4000-8000-000000000015",
+      "created_time": "2023-09-12T07:34:00.000Z",
+      "last_edited_time": "2023-09-12T07:34:00.000Z",
+      "created_by": {
+        "object": "user",
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "last_edited_by": {
+        "object": "user",
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "cover": null,
+      "icon": null,
+      "parent": {
+        "type": "data_source_id",
+        "data_source_id": "00000000-0000-4000-8000-000000000007",
+        "database_id": "00000000-0000-4000-8000-000000000008"
+      },
+      "in_trash": false,
+      "is_archived": false,
+      "is_locked": false,
+      "properties": {
+        "Date Created": {
+          "id": "prop1",
+          "type": "created_time",
+          "created_time": "2023-09-12T07:34:00.000Z"
+        },
+        "Status": {
+          "id": "prop2",
+          "type": "status",
+          "status": {
+            "id": "prop3",
+            "name": "Redacted Name",
+            "color": "red"
+          }
+        },
+        "Name": {
+          "id": "title",
+          "type": "title",
+          "title": []
+        }
+      },
+      "url": "https://app.notion.com/p/Redacted-00000000000040008000000000000016",
+      "public_url": null
     }
   ],
-  "next_cursor": null, "has_more": false
+  "next_cursor": null,
+  "has_more": false,
+  "type": "page_or_data_source",
+  "page_or_data_source": {},
+  "request_id": "00000000-0000-4000-8000-000000000017"
 }

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/notion/pages.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/notion/pages.json
@@ -1,0 +1,25 @@
+{
+  "object": "list",
+  "results": [
+    {
+      "object": "page", "id": "p-0001",
+      "created_time": "2026-01-01T00:00:00.000Z",
+      "last_edited_time": "2026-01-02T10:30:00.000Z",
+      "archived": false, "in_trash": false,
+      "url": "https://www.notion.so/p-0001",
+      "public_url": null,
+      "parent": { "type": "workspace", "workspace": true },
+      "properties": { "title": { "id": "title", "type": "title", "title": [{ "plain_text": "Roadmap" }] } }
+    },
+    {
+      "object": "page", "id": "p-0002",
+      "created_time": "2026-01-03T00:00:00.000Z",
+      "last_edited_time": null,
+      "archived": true,
+      "url": "https://www.notion.so/p-0002",
+      "parent": null,
+      "properties": null
+    }
+  ],
+  "next_cursor": null, "has_more": false
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/notion/users.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/notion/users.json
@@ -1,0 +1,17 @@
+{
+  "object": "list",
+  "results": [
+    {
+      "object": "user", "id": "u-0001", "name": "Ada Lovelace",
+      "type": "person", "avatar_url": "https://img.example/ada.png",
+      "person": { "email": "redacted@example.test" }
+    },
+    {
+      "object": "user", "id": "u-0002", "name": null,
+      "type": "bot", "avatar_url": null,
+      "bot": { "owner": { "type": "workspace" } }
+    },
+    { "object": "user", "id": "u-0003", "type": "person" }
+  ],
+  "next_cursor": null, "has_more": false
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/notion/users.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/notion/users.json
@@ -2,16 +2,46 @@
   "object": "list",
   "results": [
     {
-      "object": "user", "id": "u-0001", "name": "Ada Lovelace",
-      "type": "person", "avatar_url": "https://img.example/ada.png",
-      "person": { "email": "redacted@example.test" }
+      "object": "user",
+      "id": "00000000-0000-4000-8000-000000000001",
+      "name": "Redacted Name",
+      "avatar_url": null,
+      "type": "person",
+      "person": {
+        "email": "redacted@example.test",
+        "email_verified": true
+      }
     },
     {
-      "object": "user", "id": "u-0002", "name": null,
-      "type": "bot", "avatar_url": null,
-      "bot": { "owner": { "type": "workspace" } }
+      "object": "user",
+      "id": "00000000-0000-4000-8000-000000000002",
+      "name": "Redacted Name",
+      "avatar_url": "https://img.example/redacted.png",
+      "type": "bot",
+      "bot": {}
     },
-    { "object": "user", "id": "u-0003", "type": "person" }
+    {
+      "object": "user",
+      "id": "00000000-0000-4000-8000-000000000003",
+      "name": "Redacted Name",
+      "avatar_url": null,
+      "type": "bot",
+      "bot": {
+        "owner": {
+          "type": "workspace",
+          "workspace": true
+        },
+        "workspace_name": "Redacted Workspace",
+        "workspace_id": "00000000-0000-4000-8000-000000000004",
+        "workspace_limits": {
+          "max_file_upload_size_in_bytes": 5242880
+        }
+      }
+    }
   ],
-  "next_cursor": null, "has_more": false
+  "next_cursor": null,
+  "has_more": false,
+  "type": "user",
+  "user": {},
+  "request_id": "00000000-0000-4000-8000-000000000005"
 }

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/notion/users_type_mismatch.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/notion/users_type_mismatch.json
@@ -1,0 +1,8 @@
+{
+  "object": "list",
+  "results": [
+    { "object": "user", "id": "u-0001", "name": "Ada Lovelace", "type": "person" },
+    { "object": "user", "id": 2, "name": "Broken", "type": "person" }
+  ],
+  "next_cursor": null, "has_more": false
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/loader.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/loader.rs
@@ -107,11 +107,15 @@ fn convert_table(
         // spelling for them — FixedValue::to_json would silently send null
         // at query time, bypassing the startup diagnostic this loader
         // promises. Finite-only, enforced here.
-        if let FixedValueDoc::Float(v) = &value
-            && !v.is_finite()
-        {
+        let non_finite = match &value {
+            FixedValueDoc::Float(v) => (!v.is_finite()).then(|| v.to_string()),
+            FixedValueDoc::Json(v) => first_non_finite(v),
+            _ => None,
+        };
+        if let Some(shown) = non_finite {
             return Err(format!(
-                "{id}: fixed input '{key}' is {v}, which has no JSON spelling;                  pin a finite number"
+                "{id}: fixed input '{key}' contains {shown}, which has no JSON \
+                 spelling; pin finite numbers only"
             ));
         }
         fixed_inputs.push((leak_str(key), value.into_fixed()));
@@ -333,6 +337,21 @@ fn convert_filter(doc: FilterDoc) -> FilterMapping {
     }
 }
 
+/// First non-finite float inside a JSON value, if any. serde_json parses
+/// no non-finite literals itself, but serde_yaml's `.nan`/`.inf` arrive
+/// through the untagged `Json` variant as f64s that `Number::from_f64`
+/// silently turns into null on write — the same trap as bare floats.
+fn first_non_finite(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::Number(n) => {
+            n.as_f64().filter(|f| !f.is_finite()).map(|f| f.to_string())
+        }
+        serde_json::Value::Array(items) => items.iter().find_map(first_non_finite),
+        serde_json::Value::Object(map) => map.values().find_map(first_non_finite),
+        _ => None,
+    }
+}
+
 fn leak_str(s: String) -> &'static str {
     Box::leak(s.into_boxed_str())
 }
@@ -490,6 +509,10 @@ enum FixedValueDoc {
     Float(f64),
     Str(String),
     StrList(Vec<String>),
+    /// Object-shaped inputs (e.g. Notion's search `filter`). Captured as a
+    /// JSON value so nesting is unrestricted; converted with the same
+    /// finite-floats guard as the scalar variants.
+    Json(serde_json::Value),
 }
 
 impl FixedValueDoc {
@@ -500,6 +523,7 @@ impl FixedValueDoc {
             Self::Float(v) => FixedValue::Float(v),
             Self::Str(v) => FixedValue::Str(leak_str(v)),
             Self::StrList(v) => FixedValue::StrList(leak_str_slice(v)),
+            Self::Json(v) => FixedValue::Json(Box::leak(Box::new(v))),
         }
     }
 }
@@ -560,6 +584,7 @@ mod tests {
             ("mock.yaml", include_str!("mock.yaml")),
             ("github.yaml", include_str!("github.yaml")),
             ("slack.yaml", include_str!("slack.yaml")),
+            ("notion.yaml", include_str!("notion.yaml")),
         ] {
             // parse_pack performs the full structural + cross-field
             // validation pass itself; parsing IS the gate.

--- a/crates/skardi/src/sources/providers/open_connector/packs/loader.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/loader.rs
@@ -106,19 +106,32 @@ fn convert_table(
         // YAML happily parses `.nan` / `.inf` / `-.inf`, but JSON has no
         // spelling for them — FixedValue::to_json would silently send null
         // at query time, bypassing the startup diagnostic this loader
-        // promises. Finite-only, enforced here.
-        let non_finite = match &value {
-            FixedValueDoc::Float(v) => (!v.is_finite()).then(|| v.to_string()),
-            FixedValueDoc::Json(v) => first_non_finite(v),
-            _ => None,
+        // promises. Finite-only, enforced here. The nested case CANNOT be
+        // checked after the fact on a `serde_json::Value`: serde_json's
+        // f64 visitor maps a non-finite to `Value::Null` during
+        // deserialization (`Number::from_f64(...).map_or(Value::Null, …)`),
+        // so the loss has already happened by then — which is why the
+        // `Json` variant captures `serde_yaml::Value` and converts here,
+        // where the non-finite is still observable.
+        let fixed = match value {
+            FixedValueDoc::Float(v) if !v.is_finite() => {
+                return Err(format!(
+                    "{id}: fixed input '{key}' contains {v}, which has no JSON \
+                     spelling; pin finite numbers only"
+                ));
+            }
+            FixedValueDoc::Bool(v) => FixedValue::Bool(v),
+            FixedValueDoc::Int(v) => FixedValue::Int(v),
+            FixedValueDoc::Float(v) => FixedValue::Float(v),
+            FixedValueDoc::Str(v) => FixedValue::Str(leak_str(v)),
+            FixedValueDoc::StrList(v) => FixedValue::StrList(leak_str_slice(v)),
+            FixedValueDoc::Json(v) => {
+                let json = yaml_to_json(v)
+                    .map_err(|reason| format!("{id}: fixed input '{key}' {reason}"))?;
+                FixedValue::Json(Box::leak(Box::new(json)))
+            }
         };
-        if let Some(shown) = non_finite {
-            return Err(format!(
-                "{id}: fixed input '{key}' contains {shown}, which has no JSON \
-                 spelling; pin finite numbers only"
-            ));
-        }
-        fixed_inputs.push((leak_str(key), value.into_fixed()));
+        fixed_inputs.push((leak_str(key), fixed));
     }
     let table = SourcePackTable {
         id,
@@ -337,21 +350,6 @@ fn convert_filter(doc: FilterDoc) -> FilterMapping {
     }
 }
 
-/// First non-finite float inside a JSON value, if any. serde_json parses
-/// no non-finite literals itself, but serde_yaml's `.nan`/`.inf` arrive
-/// through the untagged `Json` variant as f64s that `Number::from_f64`
-/// silently turns into null on write — the same trap as bare floats.
-fn first_non_finite(value: &serde_json::Value) -> Option<String> {
-    match value {
-        serde_json::Value::Number(n) => {
-            n.as_f64().filter(|f| !f.is_finite()).map(|f| f.to_string())
-        }
-        serde_json::Value::Array(items) => items.iter().find_map(first_non_finite),
-        serde_json::Value::Object(map) => map.values().find_map(first_non_finite),
-        _ => None,
-    }
-}
-
 fn leak_str(s: String) -> &'static str {
     Box::leak(s.into_boxed_str())
 }
@@ -510,22 +508,67 @@ enum FixedValueDoc {
     Str(String),
     StrList(Vec<String>),
     /// Object-shaped inputs (e.g. Notion's search `filter`). Captured as a
-    /// JSON value so nesting is unrestricted; converted with the same
-    /// finite-floats guard as the scalar variants.
-    Json(serde_json::Value),
+    /// YAML value — NOT `serde_json::Value`, whose f64 visitor converts a
+    /// nested `.nan`/`.inf` to `Value::Null` during deserialization,
+    /// destroying the evidence before any guard can run — and converted
+    /// fallibly by [`yaml_to_json`] at the call site, where non-finite
+    /// floats, non-string mapping keys, and YAML tags are rejected with
+    /// targeted messages.
+    Json(serde_yaml::Value),
 }
 
-impl FixedValueDoc {
-    fn into_fixed(self) -> FixedValue {
-        match self {
-            Self::Bool(v) => FixedValue::Bool(v),
-            Self::Int(v) => FixedValue::Int(v),
-            Self::Float(v) => FixedValue::Float(v),
-            Self::Str(v) => FixedValue::Str(leak_str(v)),
-            Self::StrList(v) => FixedValue::StrList(leak_str_slice(v)),
-            Self::Json(v) => FixedValue::Json(Box::leak(Box::new(v))),
+/// Convert a YAML value to JSON, rejecting everything JSON cannot spell:
+/// non-finite floats (`.nan` / `.inf` / `-.inf`, which `serde_json` would
+/// silently write as `null`), non-string mapping keys, and YAML tags. The
+/// error is a reason fragment; callers prefix the table/key identity.
+fn yaml_to_json(value: serde_yaml::Value) -> Result<serde_json::Value, String> {
+    use serde_yaml::Value as Yaml;
+    Ok(match value {
+        Yaml::Null => serde_json::Value::Null,
+        Yaml::Bool(b) => serde_json::Value::from(b),
+        Yaml::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                serde_json::Value::from(i)
+            } else if let Some(u) = n.as_u64() {
+                serde_json::Value::from(u)
+            } else {
+                let f = n.as_f64().unwrap_or(f64::NAN);
+                if !f.is_finite() {
+                    return Err(format!(
+                        "contains {f}, which has no JSON spelling; pin finite numbers only"
+                    ));
+                }
+                serde_json::Value::from(f)
+            }
         }
-    }
+        Yaml::String(s) => serde_json::Value::from(s),
+        Yaml::Sequence(items) => serde_json::Value::Array(
+            items
+                .into_iter()
+                .map(yaml_to_json)
+                .collect::<Result<_, _>>()?,
+        ),
+        Yaml::Mapping(map) => {
+            let mut out = serde_json::Map::with_capacity(map.len());
+            for (k, v) in map {
+                let Yaml::String(k) = k else {
+                    return Err(
+                        "contains a non-string mapping key, which JSON cannot represent"
+                            .to_string(),
+                    );
+                };
+                out.insert(k, yaml_to_json(v)?);
+            }
+            serde_json::Value::Object(out)
+        }
+        // Unreachable through the untagged FixedValueDoc path (serde's
+        // untagged buffering rejects tags during deserialization, pinned by
+        // the loader test), kept as defense in depth for any future direct
+        // caller.
+        Yaml::Tagged(_) => {
+            return Err("contains a YAML tag, which JSON cannot represent".to_string());
+        }
+    })
 }
 
 #[derive(Deserialize)]
@@ -591,6 +634,43 @@ mod tests {
             let pack = parse_pack(yaml).unwrap_or_else(|e| panic!("{asset}: {e}"));
             assert!(!pack.tables.is_empty(), "{asset}: no tables");
         }
+    }
+
+    /// The pass side of the nested-value conversion: a finite nested float
+    /// (and the rest of the JSON scalar set) survives the YAML→JSON
+    /// conversion faithfully — proving the strict rejection above is a
+    /// guard, not a ban on nesting.
+    #[test]
+    fn nested_finite_values_in_a_json_pin_convert_faithfully() {
+        let pack = parse_pack(
+            r#"kind: pack
+pack: demo
+version: 1
+tables:
+  things:
+    action: demo.list
+    row_path: "$.items"
+    pagination: { strategy: page_number, page_input: page, page_size_input: perPage, page_size: 10 }
+    fixed_inputs:
+      filter:
+        threshold: 1.5
+        flags: [true, 2, "three"]
+        inner: { level: null }
+    columns:
+      - { name: id, path: id, type: uint64, nullable: false }
+"#,
+        )
+        .expect("nested finite values are legal");
+        let (key, value) = &pack.tables[0].fixed_inputs[0];
+        assert_eq!(*key, "filter");
+        assert_eq!(
+            value.to_json(),
+            serde_json::json!({
+                "threshold": 1.5,
+                "flags": [true, 2, "three"],
+                "inner": { "level": null }
+            })
+        );
     }
 
     #[test]
@@ -807,6 +887,62 @@ tables:
     columns:
       - { name: id, path: id, type: uint64, nullable: false }"#,
                 "no JSON spelling",
+            ),
+            // NESTED non-finites, through the untagged Json variant. These
+            // are the regression for the dead first_non_finite guard: a
+            // `serde_json::Value` capture had already converted the nested
+            // `.nan` to null before any check could run (serde_json's f64
+            // visitor maps non-finite to Value::Null), so the pin silently
+            // became `{"threshold": null}`. The YAML capture keeps the
+            // non-finite observable and the conversion rejects it.
+            (
+                r#"    action: demo.list
+    row_path: "$.items"
+    pagination: { strategy: page_number, page_input: page, page_size_input: perPage, page_size: 10 }
+    fixed_inputs:
+      filter:
+        threshold: .nan
+    columns:
+      - { name: id, path: id, type: uint64, nullable: false }"#,
+                "no JSON spelling",
+            ),
+            (
+                r#"    action: demo.list
+    row_path: "$.items"
+    pagination: { strategy: page_number, page_input: page, page_size_input: perPage, page_size: 10 }
+    fixed_inputs:
+      filter:
+        bounds: [1.5, .inf]
+    columns:
+      - { name: id, path: id, type: uint64, nullable: false }"#,
+                "no JSON spelling",
+            ),
+            // The other two YAML shapes JSON cannot spell, same variant.
+            (
+                r#"    action: demo.list
+    row_path: "$.items"
+    pagination: { strategy: page_number, page_input: page, page_size_input: perPage, page_size: 10 }
+    fixed_inputs:
+      filter:
+        1: numeric-key
+    columns:
+      - { name: id, path: id, type: uint64, nullable: false }"#,
+                "non-string mapping key",
+            ),
+            (
+                r#"    action: demo.list
+    row_path: "$.items"
+    pagination: { strategy: page_number, page_input: page, page_size_input: perPage, page_size: 10 }
+    fixed_inputs:
+      filter:
+        payload: !custom tagged
+    columns:
+      - { name: id, path: id, type: uint64, nullable: false }"#,
+                // Rejected before yaml_to_json ever runs: serde's untagged
+                // buffering cannot represent a YAML tag, so deserialization
+                // itself fails — the Tagged arm in yaml_to_json is defense
+                // in depth behind this.
+                "do not support enum input",
             ),
             (
                 r#"    action: demo.list

--- a/crates/skardi/src/sources/providers/open_connector/packs/mod.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/mod.rs
@@ -4,4 +4,5 @@ pub(crate) mod loader;
 
 pub mod github;
 pub mod mock;
+pub mod notion;
 pub mod slack;

--- a/crates/skardi/src/sources/providers/open_connector/packs/notion.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/notion.rs
@@ -511,10 +511,25 @@ bindings:
 
         let inputs = execute_inputs(&gateway);
         assert_eq!(inputs.len(), 2, "two cursor pages");
-        assert!(inputs[0].get("startCursor").is_none(), "{}", inputs[0]);
         assert_eq!(inputs[1]["startCursor"], "cur-2");
-        for input in &inputs {
+        for (page, (input, expected_keys)) in inputs
+            .iter()
+            .zip([vec!["pageSize"], vec!["pageSize", "startCursor"]])
+            .enumerate()
+        {
             assert_eq!(input["pageSize"], 100, "page-size hint: {input}");
+            // Exactly the declared inputs, nothing else — the same
+            // nothing-extra-on-the-wire guard the search test applies, so
+            // users' wire declaration is pinned in full, absence included
+            // (page 1 carries no cursor).
+            let mut keys: Vec<&str> = input
+                .as_object()
+                .expect("input object")
+                .keys()
+                .map(String::as_str)
+                .collect();
+            keys.sort_unstable();
+            assert_eq!(keys, expected_keys, "page {} input keys", page + 1);
         }
     }
 

--- a/crates/skardi/src/sources/providers/open_connector/packs/notion.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/notion.rs
@@ -1,0 +1,729 @@
+//! Notion source pack: stable relational contracts over the Open Connector
+//! `notion.*` read actions (integration token, cursor pagination).
+//!
+//! **The wire contract is Open Connector's raw passthrough of the Notion
+//! API.** The notion executors return Notion's response bodies verbatim
+//! (`return payload ?? {}` — no normalization, no post-pagination
+//! filtering), so rows are raw Notion objects under `$.results` with the
+//! native cursor envelope beside them: `$.next_cursor` (null at
+//! end-of-collection) and `has_more` (redundant with the null cursor and
+//! deliberately unused). Inputs are Open Connector's camelCase strict
+//! schema: `startCursor` / `pageSize` / `blockId` — not Notion's own
+//! `start_cursor` / `page_size` query names. Everything below is
+//! reconciled against a live gateway and the OC provider source.
+//!
+//! Design decisions, per the integration design spec and the source-pack
+//! admission gate:
+//!
+//! - **Cursor pagination on every table** (`startCursor` in, top-level
+//!   `$.next_cursor` out, page size 100 — Notion's maximum). Termination
+//!   is complete on the null-cursor spelling the API documents; a
+//!   repeated cursor fails as `PaginationLoop`, a non-string cursor as
+//!   `PaginationCursorInvalid` — never a silent truncation.
+//! - **`pages` and `data_sources` are the complete visible listing** via
+//!   `notion.search` with the empty required `query` pinned to `""` and
+//!   an object `filter` pin (`{property: object, value: page |
+//!   data_source}`) — the `state=all` move, and the reason
+//!   `FixedValue::Json` exists: the search filter is an object, which no
+//!   scalar fixed input could express. Visibility is exactly what the
+//!   Open Connector integration has been shared with.
+//! - **No filter pushdown anywhere.** `notion.search`'s only narrowing
+//!   input is the free-text relevance `query`, which no SQL predicate
+//!   maps to faithfully; `list_users` / `list_block_children` declare no
+//!   filter inputs at all. Every predicate runs in DataFusion after the
+//!   bounded fetch, and a guard test pins that requests carry exactly
+//!   the declared inputs and nothing else.
+//! - **Dynamic property maps stay opaque JSON.** A page's `properties`
+//!   (and a data source's schema) are user-defined per workspace; typed
+//!   projection requires the design's binding-time schema freeze for
+//!   `notion.query_data_source`, which is deferred — this pack ships the
+//!   static-schema tables only, and documents the rows table as absent.
+//!   `block_children` likewise excludes the type-specific payload (it
+//!   lives under a key named BY `type`, unaddressable by a fixed
+//!   mapping); rendered content belongs to a future markdown table.
+//! - **`users` excludes `person.email`** (and the raw `person`/`bot`
+//!   objects): capability-gated on the integration and privacy-sensitive
+//!   — same call the Slack pack made.
+//! - **Nullability is conservative**: only `id` is non-null. Notion nulls
+//!   or omits most metadata fields depending on object age and API
+//!   version; both spellings become SQL NULL, pinned by fixtures.
+//! - **Fingerprints are pinned** from a live gateway capture
+//!   (`fixtures/notion/contracts/`); `pages` and `data_sources` share
+//!   `notion.search`'s contract and therefore its pin. The declared
+//!   search item schema is EMPTY (`results.items` declares no
+//!   properties), so every mapped column of the two search tables rides
+//!   `additionalProperties` passthrough — the coverage-gap pin records
+//!   that honestly; their drift surfaces at scan time per conversion
+//!   rules.
+
+use std::sync::OnceLock;
+
+use crate::sources::providers::open_connector::error::OpenConnectorError;
+use crate::sources::providers::open_connector::source_pack::SourcePack;
+
+use super::loader;
+
+static PACK: OnceLock<Result<SourcePack, String>> = OnceLock::new();
+
+/// The Notion pack, parsed once from the embedded YAML asset.
+pub fn pack() -> Result<&'static SourcePack, OpenConnectorError> {
+    loader::builtin("notion.yaml", include_str!("notion.yaml"), &PACK)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sources::hierarchy::HierarchyLevel;
+    use crate::sources::providers::open_connector::action_registry::fingerprint_schema;
+    use crate::sources::providers::open_connector::json_to_arrow::RowConverter;
+    use crate::sources::providers::open_connector::row_path::RowPath;
+    use crate::sources::providers::open_connector::source_pack::SourcePackTable;
+    use crate::sources::providers::open_connector::testutil::{
+        EnvVarGuard, MockGateway, MockResponse, RecordedRequest, discovery_ok, envelope_ok,
+        fingerprint_uncovered_columns,
+    };
+    use crate::sources::providers::open_connector::{
+        OpenConnectorConfig, OpenConnectorGateways, register_open_connector_tables,
+        register_open_connector_udtfs,
+    };
+    use arrow::array::{Array, BooleanArray, ListArray, StringArray, TimestampMillisecondArray};
+    use arrow::record_batch::RecordBatch;
+    use datafusion::prelude::SessionContext;
+    use serde_json::{Value, json};
+
+    /// Look up a table by short name; the assets are test-pinned to parse.
+    fn table(
+        short: &str,
+    ) -> &'static crate::sources::providers::open_connector::source_pack::SourcePackTable {
+        pack()
+            .expect("embedded asset is test-pinned to parse")
+            .tables
+            .iter()
+            .find(|t| t.id.rsplit('.').next() == Some(short))
+            .unwrap_or_else(|| panic!("table {short}"))
+    }
+
+    /// Discovery serving the live-captured contracts, so every mock
+    /// registration exercises the fingerprint gate's pass side.
+    fn notion_discovery(path: &str) -> MockResponse {
+        let output_schema = if path.ends_with("notion.list_users") {
+            include_str!("fixtures/notion/contracts/list_users.json")
+        } else if path.ends_with("notion.search") {
+            include_str!("fixtures/notion/contracts/search.json")
+        } else if path.ends_with("notion.list_block_children") {
+            include_str!("fixtures/notion/contracts/list_block_children.json")
+        } else {
+            r#"{"type": "object"}"#
+        };
+        MockResponse::ok(&discovery_ok("{}", output_schema, true, None))
+    }
+
+    // ── Contract tests: bundled redacted fixtures are the build-time
+    // conversion contract (null-bearing, nested, empty, extra upstream
+    // fields, and a schema mismatch per the source-pack admission gate). ─
+
+    fn convert_fixture(table: &SourcePackTable, fixture: &str) -> RecordBatch {
+        let page: Value = serde_json::from_str(fixture).expect("fixture parses");
+        let rows = RowPath::parse(table.row_path)
+            .expect("row path")
+            .rows(&page, 1)
+            .expect("row array");
+        RowConverter::new(table.fields)
+            .expect("converter")
+            .convert(rows, 1)
+            .expect("fixture converts")
+    }
+
+    fn utf8<'a>(batch: &'a RecordBatch, name: &str) -> &'a StringArray {
+        batch
+            .column_by_name(name)
+            .unwrap_or_else(|| panic!("column {name}"))
+            .as_any()
+            .downcast_ref()
+            .expect("Utf8 column")
+    }
+
+    fn boolean<'a>(batch: &'a RecordBatch, name: &str) -> &'a BooleanArray {
+        batch
+            .column_by_name(name)
+            .unwrap_or_else(|| panic!("column {name}"))
+            .as_any()
+            .downcast_ref()
+            .expect("Boolean column")
+    }
+
+    #[test]
+    fn users_fixture_converts_with_nulls_and_omissions() {
+        let batch = convert_fixture(table("users"), include_str!("fixtures/notion/users.json"));
+        assert_eq!(batch.num_rows(), 3);
+        assert_eq!(utf8(&batch, "id").value(0), "u-0001");
+        assert_eq!(utf8(&batch, "name").value(0), "Ada Lovelace");
+        // Explicit null and omitted key both land as SQL NULL.
+        assert!(utf8(&batch, "name").is_null(1));
+        assert!(utf8(&batch, "avatar_url").is_null(1));
+        assert!(utf8(&batch, "avatar_url").is_null(2));
+        assert_eq!(utf8(&batch, "type").value(1), "bot");
+    }
+
+    #[test]
+    fn pages_fixture_converts_with_dynamic_properties_as_json() {
+        let batch = convert_fixture(table("pages"), include_str!("fixtures/notion/pages.json"));
+        assert_eq!(batch.num_rows(), 2);
+        assert_eq!(utf8(&batch, "id").value(0), "p-0001");
+        assert!(!boolean(&batch, "archived").value(0));
+        assert!(boolean(&batch, "archived").value(1));
+        assert!(utf8(&batch, "public_url").is_null(0));
+        // Dynamic property map survives as opaque JSON text; JSON null →
+        // SQL NULL.
+        let properties: Value =
+            serde_json::from_str(utf8(&batch, "properties").value(0)).expect("valid JSON");
+        assert_eq!(properties["title"]["type"], "title");
+        assert!(utf8(&batch, "properties").is_null(1));
+        let ts: &TimestampMillisecondArray = batch
+            .column_by_name("last_edited_time")
+            .expect("column")
+            .as_any()
+            .downcast_ref()
+            .expect("timestamp");
+        assert!(!ts.is_null(0));
+        assert!(ts.is_null(1));
+    }
+
+    #[test]
+    fn data_sources_fixture_converts_with_title_plucking() {
+        let batch = convert_fixture(
+            table("data_sources"),
+            include_str!("fixtures/notion/data_sources.json"),
+        );
+        assert_eq!(batch.num_rows(), 2);
+        let titles: &ListArray = batch
+            .column_by_name("title")
+            .expect("column")
+            .as_any()
+            .downcast_ref()
+            .expect("List column");
+        let first = titles.value(0);
+        let first = first
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("Utf8 items");
+        assert_eq!(
+            (0..first.len()).map(|i| first.value(i)).collect::<Vec<_>>(),
+            vec!["Tasks", " DB"]
+        );
+        assert_eq!(titles.value(1).len(), 0, "empty title list stays empty");
+    }
+
+    #[test]
+    fn block_children_fixture_converts_without_type_payload() {
+        let batch = convert_fixture(
+            table("block_children"),
+            include_str!("fixtures/notion/block_children.json"),
+        );
+        assert_eq!(batch.num_rows(), 2);
+        assert_eq!(utf8(&batch, "type").value(1), "heading_1");
+        assert!(boolean(&batch, "has_children").value(1));
+        assert!(boolean(&batch, "archived").is_null(1));
+    }
+
+    #[test]
+    fn users_mismatch_fixture_fails_with_the_targeted_error() {
+        // Admission-gate schema-mismatch fixture: a number where Utf8 is
+        // declared fails with the full row-scoped identity, never a quiet
+        // null and never the offending value.
+        let page: Value =
+            serde_json::from_str(include_str!("fixtures/notion/users_type_mismatch.json"))
+                .expect("fixture parses");
+        let t = table("users");
+        let rows = RowPath::parse(t.row_path)
+            .expect("row path")
+            .rows(&page, 1)
+            .expect("row array");
+        let err = RowConverter::new(t.fields)
+            .expect("converter")
+            .convert(rows, 1)
+            .expect_err("a number where Utf8 is declared must fail conversion");
+        match err {
+            OpenConnectorError::ConversionFailed {
+                column,
+                page,
+                row,
+                found,
+                ..
+            } => {
+                assert_eq!(column, "id");
+                assert_eq!(page, 1);
+                assert_eq!(row, 1, "the valid first row converts");
+                assert_eq!(found, "number");
+            }
+            other => panic!("expected ConversionFailed, got {other}"),
+        }
+    }
+
+    #[test]
+    fn pinned_fingerprints_match_the_reconciled_contracts() {
+        // Pin <-> captured-contract lock through the SAME function
+        // registration uses; mismatch output is also how pins are
+        // (re)taken after an upstream upgrade. pages and data_sources
+        // share notion.search's contract, hence one pin.
+        let contracts = [
+            (
+                "users",
+                include_str!("fixtures/notion/contracts/list_users.json"),
+            ),
+            (
+                "pages",
+                include_str!("fixtures/notion/contracts/search.json"),
+            ),
+            (
+                "data_sources",
+                include_str!("fixtures/notion/contracts/search.json"),
+            ),
+            (
+                "block_children",
+                include_str!("fixtures/notion/contracts/list_block_children.json"),
+            ),
+        ];
+        let mut mismatches = Vec::new();
+        for (short, contract) in contracts {
+            let schema: Value = serde_json::from_str(contract).expect("contract fixture parses");
+            let actual = fingerprint_schema(Some(&schema));
+            let t = table(short);
+            if t.expected_fingerprint != Some(actual.as_str()) {
+                mismatches.push(format!(
+                    "{}: pinned {:?}, contract fixture hashes to {actual}",
+                    t.id, t.expected_fingerprint
+                ));
+            }
+        }
+        assert!(mismatches.is_empty(), "{}", mismatches.join("\n"));
+    }
+
+    #[test]
+    fn fingerprint_coverage_gap_is_pinned() {
+        // notion.search declares an EMPTY results-item schema, so every
+        // mapped column of the two search tables rides
+        // additionalProperties passthrough — outside the fingerprint
+        // gate, drift surfacing at scan time. users/block_children are
+        // partially declared. Pinned so any change is a conscious
+        // decision.
+        for (short, contract, expected) in [
+            (
+                "users",
+                include_str!("fixtures/notion/contracts/list_users.json"),
+                &[] as &[&str],
+            ),
+            (
+                "pages",
+                include_str!("fixtures/notion/contracts/search.json"),
+                &[
+                    "id",
+                    "created_time",
+                    "last_edited_time",
+                    "archived",
+                    "in_trash",
+                    "url",
+                    "public_url",
+                    "parent",
+                    "properties",
+                ],
+            ),
+            (
+                "data_sources",
+                include_str!("fixtures/notion/contracts/search.json"),
+                &[
+                    "id",
+                    "created_time",
+                    "last_edited_time",
+                    "title",
+                    "archived",
+                    "url",
+                    "parent",
+                    "properties",
+                ],
+            ),
+            (
+                "block_children",
+                include_str!("fixtures/notion/contracts/list_block_children.json"),
+                &["created_time", "last_edited_time", "archived"],
+            ),
+        ] {
+            let t = table(short);
+            assert_eq!(
+                fingerprint_uncovered_columns(contract, t.row_path, t.fields),
+                expected,
+                "fingerprint coverage changed for {short}"
+            );
+        }
+    }
+
+    // ── Integration: the pack against a mock gateway, end to end. ───────
+
+    fn notion_config(token_env: &str, tables: &str) -> OpenConnectorConfig {
+        // blockId is declared only by block_children; sending it to a
+        // binding without that table trips the undeclared-resource guard.
+        let resource = if tables.contains("block_children") {
+            "resource: { blockId: b-root }"
+        } else {
+            ""
+        };
+        serde_yaml::from_str(&format!(
+            r#"
+runtime_token_env: {token_env}
+bindings:
+  - name: ws
+    source_pack: notion
+    {resource}
+    tables: [{tables}]
+"#
+        ))
+        .expect("config parses")
+    }
+
+    async fn setup_with_gateway(
+        gateway: MockGateway,
+        token_env: &'static str,
+        tables: &str,
+    ) -> (MockGateway, SessionContext) {
+        let _token = EnvVarGuard::set(token_env, "test-token");
+        let gateways = OpenConnectorGateways::default();
+        let mut ctx = SessionContext::new();
+        register_open_connector_tables(
+            &mut ctx,
+            "saas",
+            &gateway.url,
+            Some(&notion_config(token_env, tables)),
+            false,
+            HierarchyLevel::Catalog,
+            Some(&gateways),
+        )
+        .await
+        .expect("gateway registration succeeds");
+        register_open_connector_udtfs(&ctx, gateways).expect("UDTF registration succeeds");
+        (gateway, ctx)
+    }
+
+    async fn collect(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch> {
+        ctx.sql(sql)
+            .await
+            .expect("plan")
+            .collect()
+            .await
+            .expect("collect")
+    }
+
+    fn ids_of(batches: &[RecordBatch]) -> Vec<String> {
+        batches
+            .iter()
+            .flat_map(|batch| {
+                let ids = batch
+                    .column_by_name("id")
+                    .expect("id column")
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .expect("Utf8 ids")
+                    .clone();
+                (0..ids.len()).map(move |i| ids.value(i).to_string())
+            })
+            .collect()
+    }
+
+    fn execute_inputs(gateway: &MockGateway) -> Vec<Value> {
+        gateway
+            .requests()
+            .into_iter()
+            .filter(|r| r.method == "POST")
+            .map(|r| {
+                serde_json::from_str::<Value>(&r.body).expect("request body is JSON")["input"]
+                    .clone()
+            })
+            .collect()
+    }
+
+    fn user_row(id: &str) -> Value {
+        json!({"object": "user", "id": id, "name": id, "type": "person"})
+    }
+
+    #[tokio::test]
+    async fn users_cursor_scan_pages_with_its_own_declared_inputs() {
+        // Two-page cursor scan pinning USERS' wire declarations: no
+        // startCursor on page 1, the stub's token afterwards, pageSize
+        // 100 on every request, null-cursor termination, row identity
+        // across pages.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return notion_discovery(&req.path);
+            }
+            if req.method == "POST" && req.path == "/v1/actions/notion.list_users" {
+                let body: Value = serde_json::from_str(&req.body).unwrap_or_default();
+                let page = match body["input"].get("startCursor").and_then(Value::as_str) {
+                    None => json!({"results": [user_row("u-1"), user_row("u-2")],
+                                    "next_cursor": "cur-2", "has_more": true}),
+                    Some("cur-2") => json!({"results": [user_row("u-3")],
+                                             "next_cursor": null, "has_more": false}),
+                    Some(other) => return MockResponse::new(400, &format!("bad cursor {other}")),
+                };
+                return MockResponse::ok(&envelope_ok(&page.to_string()));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (gateway, ctx) =
+            setup_with_gateway(gateway, "SKARDI_TEST_OC_NOTION_USERS", "users").await;
+
+        let batches = collect(&ctx, "SELECT id FROM saas.ws.users ORDER BY id").await;
+        assert_eq!(ids_of(&batches), vec!["u-1", "u-2", "u-3"]);
+
+        let inputs = execute_inputs(&gateway);
+        assert_eq!(inputs.len(), 2, "two cursor pages");
+        assert!(inputs[0].get("startCursor").is_none(), "{}", inputs[0]);
+        assert_eq!(inputs[1]["startCursor"], "cur-2");
+        for input in &inputs {
+            assert_eq!(input["pageSize"], 100, "page-size hint: {input}");
+        }
+    }
+
+    #[tokio::test]
+    async fn search_tables_pin_their_object_filters_on_the_wire() {
+        // pages and data_sources share notion.search but pin DIFFERENT
+        // object filters — and the empty query — on every request. The
+        // stub honors the filter, proving each table sees only its kind;
+        // requests carry exactly the declared inputs and nothing else
+        // (the no-pushdown guard).
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return notion_discovery(&req.path);
+            }
+            if req.method == "POST" && req.path == "/v1/actions/notion.search" {
+                let body: Value = serde_json::from_str(&req.body).unwrap_or_default();
+                let kind = body["input"]["filter"]["value"].as_str().unwrap_or("");
+                let rows = match kind {
+                    "page" => json!([{"object": "page", "id": "p-1"}]),
+                    "data_source" => json!([{"object": "data_source", "id": "ds-1"}]),
+                    other => return MockResponse::new(400, &format!("bad filter {other}")),
+                };
+                return MockResponse::ok(&envelope_ok(
+                    &json!({"results": rows, "next_cursor": null, "has_more": false}).to_string(),
+                ));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (gateway, ctx) = setup_with_gateway(
+            gateway,
+            "SKARDI_TEST_OC_NOTION_SEARCH",
+            "pages, data_sources",
+        )
+        .await;
+
+        let batches = collect(&ctx, "SELECT id FROM saas.ws.pages").await;
+        assert_eq!(ids_of(&batches), vec!["p-1"]);
+        let batches = collect(&ctx, "SELECT id FROM saas.ws.data_sources").await;
+        assert_eq!(ids_of(&batches), vec!["ds-1"]);
+
+        for input in execute_inputs(&gateway) {
+            assert_eq!(input["query"], "", "empty query pin: {input}");
+            assert_eq!(input["filter"]["property"], "object", "{input}");
+            let mut keys: Vec<&str> = input
+                .as_object()
+                .expect("input object")
+                .keys()
+                .map(String::as_str)
+                .collect();
+            keys.sort_unstable();
+            assert_eq!(
+                keys,
+                vec!["filter", "pageSize", "query"],
+                "exactly the declared inputs, nothing else (page 1 has no cursor)"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn block_children_forwards_its_required_resource() {
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return notion_discovery(&req.path);
+            }
+            if req.method == "POST" && req.path == "/v1/actions/notion.list_block_children" {
+                return MockResponse::ok(&envelope_ok(
+                    &json!({"results": [{"object": "block", "id": "b-1", "type": "paragraph"}],
+                             "next_cursor": null, "has_more": false})
+                    .to_string(),
+                ));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (gateway, ctx) =
+            setup_with_gateway(gateway, "SKARDI_TEST_OC_NOTION_BLOCKS", "block_children").await;
+
+        let batches = collect(&ctx, "SELECT id, type FROM saas.ws.block_children").await;
+        assert_eq!(ids_of(&batches), vec!["b-1"]);
+        let inputs = execute_inputs(&gateway);
+        assert_eq!(
+            inputs[0]["blockId"], "b-root",
+            "resource forwarded verbatim"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_required_resource_fails_before_any_http() {
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let _token = EnvVarGuard::set("SKARDI_TEST_OC_NOTION_NO_RES", "test-token");
+        let config: OpenConnectorConfig = serde_yaml::from_str(
+            r#"
+runtime_token_env: SKARDI_TEST_OC_NOTION_NO_RES
+bindings:
+  - name: ws
+    source_pack: notion
+    tables: [block_children]
+"#,
+        )
+        .expect("config parses");
+        let mut ctx = SessionContext::new();
+        let gateways = OpenConnectorGateways::default();
+        let err = register_open_connector_tables(
+            &mut ctx,
+            "saas",
+            &gateway.url,
+            Some(&config),
+            false,
+            HierarchyLevel::Catalog,
+            Some(&gateways),
+        )
+        .await
+        .expect_err("missing blockId must fail registration");
+        assert!(err.to_string().contains("blockId"), "{err}");
+        assert!(
+            gateway.requests().iter().all(|r| r.path == "/v1/health"),
+            "resource enforcement precedes discovery"
+        );
+    }
+
+    #[tokio::test]
+    async fn limit_stops_cursor_pagination_early() {
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return notion_discovery(&req.path);
+            }
+            if req.method == "POST" && req.path == "/v1/actions/notion.list_users" {
+                // Every page advertises another; only LIMIT can stop this.
+                return MockResponse::ok(&envelope_ok(
+                    &json!({"results": [user_row("u-1"), user_row("u-2")],
+                             "next_cursor": "again", "has_more": true})
+                    .to_string(),
+                ));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (gateway, ctx) =
+            setup_with_gateway(gateway, "SKARDI_TEST_OC_NOTION_LIMIT", "users").await;
+
+        let batches = collect(&ctx, "SELECT id FROM saas.ws.users LIMIT 2").await;
+        assert_eq!(ids_of(&batches).len(), 2);
+        assert_eq!(
+            execute_inputs(&gateway).len(),
+            1,
+            "one page satisfied LIMIT"
+        );
+    }
+
+    #[tokio::test]
+    async fn udtf_parity_for_block_children() {
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return notion_discovery(&req.path);
+            }
+            if req.method == "POST" && req.path == "/v1/actions/notion.list_block_children" {
+                return MockResponse::ok(&envelope_ok(
+                    &json!({"results": [{"object": "block", "id": "b-9", "type": "toggle"}],
+                             "next_cursor": null, "has_more": false})
+                    .to_string(),
+                ));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (_gateway, ctx) =
+            setup_with_gateway(gateway, "SKARDI_TEST_OC_NOTION_UDTF", "block_children").await;
+
+        let from_table = collect(&ctx, "SELECT id, type FROM saas.ws.block_children").await;
+        let from_udtf = collect(
+            &ctx,
+            "SELECT id, type FROM open_connector_query('saas', 'notion.block_children', \
+             '{\"blockId\":\"b-root\"}')",
+        )
+        .await;
+        assert_eq!(from_table[0].schema(), from_udtf[0].schema());
+        assert_eq!(
+            arrow::util::pretty::pretty_format_batches(&from_table)
+                .unwrap()
+                .to_string(),
+            arrow::util::pretty::pretty_format_batches(&from_udtf)
+                .unwrap()
+                .to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn drifted_contract_fails_registration_not_the_scan() {
+        // The pin's refusal side: a gateway whose discovered output schema
+        // differs from the captured contract is refused at REGISTRATION,
+        // table and action named. (Every other e2e proves the pass side
+        // via notion_discovery's captured contracts.)
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return MockResponse::ok(&discovery_ok("{}", r#"{"type": "object"}"#, true, None));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let _token = EnvVarGuard::set("SKARDI_TEST_OC_NOTION_DRIFT", "test-token");
+        let mut ctx = SessionContext::new();
+        let gateways = OpenConnectorGateways::default();
+        let err = register_open_connector_tables(
+            &mut ctx,
+            "saas",
+            &gateway.url,
+            Some(&notion_config("SKARDI_TEST_OC_NOTION_DRIFT", "users")),
+            false,
+            HierarchyLevel::Catalog,
+            Some(&gateways),
+        )
+        .await
+        .expect_err("a drifted contract must fail registration");
+        let message = err.to_string();
+        assert!(
+            message.contains("notion.users")
+                && message.contains("notion.list_users")
+                && message.contains("fingerprint mismatch"),
+            "table, action, and cause are named: {message}"
+        );
+    }
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/notion.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/notion.rs
@@ -49,12 +49,25 @@
 //!   version; both spellings become SQL NULL, pinned by fixtures.
 //! - **Fingerprints are pinned** from a live gateway capture
 //!   (`fixtures/notion/contracts/`); `pages` and `data_sources` share
-//!   `notion.search`'s contract and therefore its pin. The declared
-//!   search item schema is EMPTY (`results.items` declares no
-//!   properties), so every mapped column of the two search tables rides
-//!   `additionalProperties` passthrough — the coverage-gap pin records
-//!   that honestly; their drift surfaces at scan time per conversion
-//!   rules.
+//!   `notion.search`'s contract and therefore its pin. The search item
+//!   schema is an `anyOf` (page | data_source) which the coverage
+//!   walker does not descend, so every mapped column of the two search
+//!   tables rides `additionalProperties` passthrough — the coverage-gap
+//!   pin records that honestly; their drift surfaces at scan time per
+//!   conversion rules.
+//! - **Column sets are reconciled against REAL wire rows**, not just the
+//!   declared contract: verified end to end against a live Notion
+//!   workspace through the gateway on 2026-08-03 (the gateway pins
+//!   `Notion-Version: 2026-03-11`, which is also what makes the
+//!   `data_source` filter spelling valid — pre-2025-09-03 API versions
+//!   spell it `database`). Live rows showed pages carry `is_archived`
+//!   (the contract's declared `archived` never appears on the wire),
+//!   and data sources and blocks carry no archived flag at all —
+//!   `in_trash` is the deletion signal on every object, so the pack
+//!   maps `in_trash` everywhere and `is_archived` on pages only. The
+//!   bundled fixtures are those live captures, redacted (synthetic
+//!   UUIDs, placeholder names/titles/URLs, real structure and
+//!   timestamp spellings kept verbatim).
 
 use std::sync::OnceLock;
 
@@ -79,7 +92,7 @@ mod tests {
     use crate::sources::providers::open_connector::row_path::RowPath;
     use crate::sources::providers::open_connector::source_pack::SourcePackTable;
     use crate::sources::providers::open_connector::testutil::{
-        EnvVarGuard, MockGateway, MockResponse, RecordedRequest, discovery_ok, envelope_ok,
+        EnvVarGuard, MockGateway, MockResponse, discovery_ok, envelope_ok,
         fingerprint_uncovered_columns,
     };
     use crate::sources::providers::open_connector::{
@@ -118,9 +131,12 @@ mod tests {
         MockResponse::ok(&discovery_ok("{}", output_schema, true, None))
     }
 
-    // ── Contract tests: bundled redacted fixtures are the build-time
-    // conversion contract (null-bearing, nested, empty, extra upstream
-    // fields, and a schema mismatch per the source-pack admission gate). ─
+    // ── Contract tests: the bundled fixtures are redacted LIVE captures
+    // from a real Notion workspace (2026-08-03) — real envelope keys,
+    // field presence/absence, and timestamp spellings; synthetic UUIDs
+    // and placeholder text. They are the build-time conversion contract
+    // (null-bearing, nested, extra upstream fields, and a synthetic
+    // schema mismatch per the source-pack admission gate). ─
 
     fn convert_fixture(table: &SourcePackTable, fixture: &str) -> RecordBatch {
         let page: Value = serde_json::from_str(fixture).expect("fixture parses");
@@ -153,14 +169,18 @@ mod tests {
     }
 
     #[test]
-    fn users_fixture_converts_with_nulls_and_omissions() {
+    fn users_fixture_converts_with_explicit_nulls() {
         let batch = convert_fixture(table("users"), include_str!("fixtures/notion/users.json"));
         assert_eq!(batch.num_rows(), 3);
-        assert_eq!(utf8(&batch, "id").value(0), "u-0001");
-        assert_eq!(utf8(&batch, "name").value(0), "Ada Lovelace");
-        // Explicit null and omitted key both land as SQL NULL.
-        assert!(utf8(&batch, "name").is_null(1));
-        assert!(utf8(&batch, "avatar_url").is_null(1));
+        assert_eq!(
+            utf8(&batch, "id").value(0),
+            "00000000-0000-4000-8000-000000000001"
+        );
+        assert_eq!(utf8(&batch, "name").value(0), "Redacted Name");
+        // Live rows null avatar_url explicitly (person and bot alike);
+        // the unmapped `person`/`bot` payloads ride along ignored.
+        assert!(utf8(&batch, "avatar_url").is_null(0));
+        assert!(!utf8(&batch, "avatar_url").is_null(1));
         assert!(utf8(&batch, "avatar_url").is_null(2));
         assert_eq!(utf8(&batch, "type").value(1), "bot");
     }
@@ -168,25 +188,27 @@ mod tests {
     #[test]
     fn pages_fixture_converts_with_dynamic_properties_as_json() {
         let batch = convert_fixture(table("pages"), include_str!("fixtures/notion/pages.json"));
-        assert_eq!(batch.num_rows(), 2);
-        assert_eq!(utf8(&batch, "id").value(0), "p-0001");
-        assert!(!boolean(&batch, "archived").value(0));
-        assert!(boolean(&batch, "archived").value(1));
+        assert_eq!(batch.num_rows(), 4);
+        assert_eq!(
+            utf8(&batch, "id").value(0),
+            "00000000-0000-4000-8000-000000000006"
+        );
+        // Live pages spell the flag `is_archived` (never the contract's
+        // declared `archived`) and null `public_url` on private pages.
+        assert!(!boolean(&batch, "is_archived").value(0));
+        assert!(!boolean(&batch, "in_trash").value(0));
         assert!(utf8(&batch, "public_url").is_null(0));
-        // Dynamic property map survives as opaque JSON text; JSON null →
-        // SQL NULL.
+        // Dynamic property map survives as opaque JSON text.
         let properties: Value =
             serde_json::from_str(utf8(&batch, "properties").value(0)).expect("valid JSON");
-        assert_eq!(properties["title"]["type"], "title");
-        assert!(utf8(&batch, "properties").is_null(1));
+        assert_eq!(properties["Name"]["type"], "title");
         let ts: &TimestampMillisecondArray = batch
             .column_by_name("last_edited_time")
             .expect("column")
             .as_any()
             .downcast_ref()
             .expect("timestamp");
-        assert!(!ts.is_null(0));
-        assert!(ts.is_null(1));
+        assert!((0..4).all(|i| !ts.is_null(i)), "live timestamps all parse");
     }
 
     #[test]
@@ -195,7 +217,7 @@ mod tests {
             table("data_sources"),
             include_str!("fixtures/notion/data_sources.json"),
         );
-        assert_eq!(batch.num_rows(), 2);
+        assert_eq!(batch.num_rows(), 1);
         let titles: &ListArray = batch
             .column_by_name("title")
             .expect("column")
@@ -209,9 +231,13 @@ mod tests {
             .expect("Utf8 items");
         assert_eq!(
             (0..first.len()).map(|i| first.value(i)).collect::<Vec<_>>(),
-            vec!["Tasks", " DB"]
+            vec!["Redacted text"],
+            "plain_text plucked from the live rich-text array"
         );
-        assert_eq!(titles.value(1).len(), 0, "empty title list stays empty");
+        // Live data sources carry no archived flag; in_trash is the
+        // deletion signal and public_url nulls when unpublished.
+        assert!(!boolean(&batch, "in_trash").value(0));
+        assert!(utf8(&batch, "public_url").is_null(0));
     }
 
     #[test]
@@ -220,10 +246,14 @@ mod tests {
             table("block_children"),
             include_str!("fixtures/notion/block_children.json"),
         );
-        assert_eq!(batch.num_rows(), 2);
-        assert_eq!(utf8(&batch, "type").value(1), "heading_1");
-        assert!(boolean(&batch, "has_children").value(1));
-        assert!(boolean(&batch, "archived").is_null(1));
+        assert_eq!(batch.num_rows(), 4);
+        assert_eq!(utf8(&batch, "type").value(0), "heading_1");
+        assert_eq!(utf8(&batch, "type").value(3), "paragraph");
+        // The type-specific payloads (heading_1/to_do/paragraph keys on
+        // the live rows) are deliberately unmapped and ride along
+        // ignored; blocks carry in_trash but no archived flag.
+        assert!(!boolean(&batch, "has_children").value(0));
+        assert!(!boolean(&batch, "in_trash").value(0));
     }
 
     #[test]
@@ -301,7 +331,8 @@ mod tests {
 
     #[test]
     fn fingerprint_coverage_gap_is_pinned() {
-        // notion.search declares an EMPTY results-item schema, so every
+        // notion.search's results-item schema is an anyOf (page |
+        // data_source) the coverage walker does not descend, so every
         // mapped column of the two search tables rides
         // additionalProperties passthrough — outside the fingerprint
         // gate, drift surfacing at scan time. users/block_children are
@@ -320,7 +351,7 @@ mod tests {
                     "id",
                     "created_time",
                     "last_edited_time",
-                    "archived",
+                    "is_archived",
                     "in_trash",
                     "url",
                     "public_url",
@@ -336,8 +367,9 @@ mod tests {
                     "created_time",
                     "last_edited_time",
                     "title",
-                    "archived",
+                    "in_trash",
                     "url",
+                    "public_url",
                     "parent",
                     "properties",
                 ],
@@ -345,7 +377,7 @@ mod tests {
             (
                 "block_children",
                 include_str!("fixtures/notion/contracts/list_block_children.json"),
-                &["created_time", "last_edited_time", "archived"],
+                &["created_time", "last_edited_time"],
             ),
         ] {
             let t = table(short);

--- a/crates/skardi/src/sources/providers/open_connector/packs/notion.yaml
+++ b/crates/skardi/src/sources/providers/open_connector/packs/notion.yaml
@@ -1,0 +1,111 @@
+# Notion source pack. Wire contract reconciled against a live Open
+# Connector gateway: raw-passthrough executors (rows are Notion API
+# objects verbatim), camelCase strict inputs (startCursor/pageSize),
+# Notion's native cursor envelope ($.next_cursor, null at end — has_more
+# is redundant with the null cursor and deliberately unused). Design
+# rationale lives in the module docs of packs/notion.rs.
+kind: pack
+pack: notion
+version: 1
+
+tables:
+  users:
+    action: notion.list_users
+    row_path: "$.results"
+    fingerprint: 2c7a234b30e3b016a4405586602c2bbe9e8fe873eb9b62c5257c98eb3f099421
+    pagination:
+      strategy: cursor
+      cursor_input: startCursor
+      next_cursor_path: "$.next_cursor"
+      page_size_input: pageSize
+      page_size: 100
+    columns:
+      # person.email is deliberately NOT mapped: it is capability-gated on
+      # the integration and privacy-sensitive; the raw `person` object is
+      # not exposed either, for the same reason.
+      - { name: id, path: id, type: utf8, nullable: false }
+      - { name: name, path: name, type: utf8, nullable: true }
+      - { name: type, path: type, type: utf8, nullable: true }
+      - { name: avatar_url, path: avatar_url, type: utf8, nullable: true }
+
+  pages:
+    action: notion.search
+    row_path: "$.results"
+    fingerprint: a7d90d2d753b28954b1bf77c26abc2ff4b36caf905c8c1fc74a182acb2a6e9d1
+    pagination:
+      strategy: cursor
+      cursor_input: startCursor
+      next_cursor_path: "$.next_cursor"
+      page_size_input: pageSize
+      page_size: 100
+    # The empty query plus an object filter is Notion's spelling for "the
+    # complete listing the integration can see" — the state=all move.
+    fixed_inputs:
+      query: ""
+      filter:
+        property: object
+        value: page
+    columns:
+      # `properties` is the page's dynamic property map — opaque JSON by
+      # design; typed projection of dynamic schemas is the deferred
+      # query_data_source work.
+      - { name: id, path: id, type: utf8, nullable: false }
+      - { name: created_time, path: created_time, type: timestamp_ms_utc, nullable: true }
+      - { name: last_edited_time, path: last_edited_time, type: timestamp_ms_utc, nullable: true }
+      - { name: archived, path: archived, type: boolean, nullable: true }
+      - { name: in_trash, path: in_trash, type: boolean, nullable: true }
+      - { name: url, path: url, type: utf8, nullable: true }
+      - { name: public_url, path: public_url, type: utf8, nullable: true }
+      - { name: parent, path: parent, type: json, nullable: true }
+      - { name: properties, path: properties, type: json, nullable: true }
+
+  data_sources:
+    action: notion.search
+    row_path: "$.results"
+    fingerprint: a7d90d2d753b28954b1bf77c26abc2ff4b36caf905c8c1fc74a182acb2a6e9d1
+    pagination:
+      strategy: cursor
+      cursor_input: startCursor
+      next_cursor_path: "$.next_cursor"
+      page_size_input: pageSize
+      page_size: 100
+    fixed_inputs:
+      query: ""
+      filter:
+        property: object
+        value: data_source
+    columns:
+      - { name: id, path: id, type: utf8, nullable: false }
+      - { name: created_time, path: created_time, type: timestamp_ms_utc, nullable: true }
+      - { name: last_edited_time, path: last_edited_time, type: timestamp_ms_utc, nullable: true }
+      - { name: title, path: title, type: utf8_list_from_object_key, key: plain_text, nullable: true }
+      - { name: archived, path: archived, type: boolean, nullable: true }
+      - { name: url, path: url, type: utf8, nullable: true }
+      - { name: parent, path: parent, type: json, nullable: true }
+      - { name: properties, path: properties, type: json, nullable: true }
+
+  block_children:
+    action: notion.list_block_children
+    row_path: "$.results"
+    fingerprint: 69f20cdc842b890c280265048d143d36de1699396b8ca4f53f7a7f203b7bd51c
+    pagination:
+      strategy: cursor
+      cursor_input: startCursor
+      next_cursor_path: "$.next_cursor"
+      page_size_input: pageSize
+      page_size: 100
+    resources:
+      required: [blockId]
+    columns:
+      # The type-specific payload (paragraph/heading_1/...) lives under a
+      # key named BY `type`, which a fixed relational mapping cannot
+      # address; content extraction belongs to a rendered-markdown table
+      # (notion.retrieve_page_markdown) as a follow-up.
+      - { name: id, path: id, type: utf8, nullable: false }
+      - { name: type, path: type, type: utf8, nullable: true }
+      - { name: created_time, path: created_time, type: timestamp_ms_utc, nullable: true }
+      - { name: last_edited_time, path: last_edited_time, type: timestamp_ms_utc, nullable: true }
+      - { name: has_children, path: has_children, type: boolean, nullable: true }
+      - { name: archived, path: archived, type: boolean, nullable: true }
+      - { name: in_trash, path: in_trash, type: boolean, nullable: true }
+      - { name: parent, path: parent, type: json, nullable: true }

--- a/crates/skardi/src/sources/providers/open_connector/packs/notion.yaml
+++ b/crates/skardi/src/sources/providers/open_connector/packs/notion.yaml
@@ -4,6 +4,13 @@
 # Notion's native cursor envelope ($.next_cursor, null at end — has_more
 # is redundant with the null cursor and deliberately unused). Design
 # rationale lives in the module docs of packs/notion.rs.
+#
+# Column sets are reconciled against REAL rows from a live Notion
+# workspace through the gateway (2026-08-03, gateway pins
+# Notion-Version 2026-03-11): pages carry `is_archived` (not the
+# `archived` the captured contract declares), and data sources and
+# blocks carry no archived flag at all — `in_trash` is the deletion
+# signal on every object.
 kind: pack
 pack: notion
 version: 1
@@ -52,7 +59,7 @@ tables:
       - { name: id, path: id, type: utf8, nullable: false }
       - { name: created_time, path: created_time, type: timestamp_ms_utc, nullable: true }
       - { name: last_edited_time, path: last_edited_time, type: timestamp_ms_utc, nullable: true }
-      - { name: archived, path: archived, type: boolean, nullable: true }
+      - { name: is_archived, path: is_archived, type: boolean, nullable: true }
       - { name: in_trash, path: in_trash, type: boolean, nullable: true }
       - { name: url, path: url, type: utf8, nullable: true }
       - { name: public_url, path: public_url, type: utf8, nullable: true }
@@ -79,8 +86,9 @@ tables:
       - { name: created_time, path: created_time, type: timestamp_ms_utc, nullable: true }
       - { name: last_edited_time, path: last_edited_time, type: timestamp_ms_utc, nullable: true }
       - { name: title, path: title, type: utf8_list_from_object_key, key: plain_text, nullable: true }
-      - { name: archived, path: archived, type: boolean, nullable: true }
+      - { name: in_trash, path: in_trash, type: boolean, nullable: true }
       - { name: url, path: url, type: utf8, nullable: true }
+      - { name: public_url, path: public_url, type: utf8, nullable: true }
       - { name: parent, path: parent, type: json, nullable: true }
       - { name: properties, path: properties, type: json, nullable: true }
 
@@ -106,6 +114,5 @@ tables:
       - { name: created_time, path: created_time, type: timestamp_ms_utc, nullable: true }
       - { name: last_edited_time, path: last_edited_time, type: timestamp_ms_utc, nullable: true }
       - { name: has_children, path: has_children, type: boolean, nullable: true }
-      - { name: archived, path: archived, type: boolean, nullable: true }
       - { name: in_trash, path: in_trash, type: boolean, nullable: true }
       - { name: parent, path: parent, type: json, nullable: true }

--- a/crates/skardi/src/sources/providers/open_connector/source_pack.rs
+++ b/crates/skardi/src/sources/providers/open_connector/source_pack.rs
@@ -34,6 +34,10 @@ pub enum FixedValue {
     /// ["public_channel", "private_channel"]`, whose action schema takes an
     /// array, not a comma-joined string.
     StrList(&'static [&'static str]),
+    /// An arbitrary JSON value (typically an object) — e.g. Notion's search
+    /// `filter: {"property": "object", "value": "page"}`, whose action
+    /// schema takes an object. Pre-parsed and leaked by the pack loader.
+    Json(&'static serde_json::Value),
 }
 
 impl FixedValue {
@@ -47,6 +51,7 @@ impl FixedValue {
             Self::StrList(items) => {
                 serde_json::Value::from(items.iter().map(|s| *s).collect::<Vec<_>>())
             }
+            Self::Json(value) => (*value).clone(),
         }
     }
 }
@@ -130,6 +135,7 @@ impl SourcePackRegistry {
         for pack in [
             super::packs::mock::pack()?,
             super::packs::github::pack()?,
+            super::packs::notion::pack()?,
             super::packs::slack::pack()?,
         ] {
             packs.insert(pack.name, pack);

--- a/docs/open-connector-notion.md
+++ b/docs/open-connector-notion.md
@@ -1,0 +1,99 @@
+# Notion Source Pack
+
+The built-in `notion` source pack exposes Notion workspace data — users,
+pages, data sources, and block children — as stable SQL tables through an
+[Open Connector gateway](open-connector.md). The Notion integration token
+lives in Open Connector; Skardi holds only the gateway runtime token.
+
+**The wire contract is Open Connector's raw passthrough of the Notion
+API**: rows are Notion objects verbatim under `$.results`, with Notion's
+native cursor envelope beside them (`$.next_cursor`, null at
+end-of-collection; `has_more` is redundant and unused). Inputs are the
+gateway's camelCase strict schema (`startCursor`/`pageSize`/`blockId`).
+Everything below is reconciled against a live gateway.
+
+## Binding
+
+```yaml
+spec:
+  data_sources:
+    - name: saas
+      type: open_connector
+      connection_string: http://open-connector:3000
+      hierarchy_level: catalog
+      open_connector:
+        runtime_token_env: OPEN_CONNECTOR_TOKEN
+        bindings:
+          - name: notion_ws              # schema name in SQL
+            source_pack: notion
+            resource:
+              blockId: <page-or-block-uuid>   # only block_children uses it
+            tables: [users, pages, data_sources, block_children]
+```
+
+```sql
+SELECT id, name, type FROM saas.notion_ws.users WHERE type = 'person';
+
+-- The same definition, ad hoc, without a binding:
+SELECT id, url FROM open_connector_query('saas', 'notion.pages', '{}')
+WHERE NOT archived LIMIT 20;
+```
+
+## Tables
+
+| Table | Action | Resources | Pagination | Filter pushdown |
+|---|---|---|---|---|
+| `users` | `notion.list_users` | — | cursor (`pageSize` 100) | none |
+| `pages` | `notion.search` (pinned `query: ""`, `filter: {object: page}`) | — | cursor (`pageSize` 100) | none |
+| `data_sources` | `notion.search` (pinned `filter: {object: data_source}`) | — | cursor (`pageSize` 100) | none |
+| `block_children` | `notion.list_block_children` | `blockId` (required) | cursor (`pageSize` 100) | none |
+
+**No filter pushdown anywhere** — `notion.search`'s only narrowing input
+is a free-text relevance `query`, which no SQL predicate maps to
+faithfully; the other actions declare no filter inputs. Every predicate
+runs in DataFusion after the bounded fetch; `LIMIT` stops pagination as
+soon as enough rows have been emitted. Cursor scans terminate on the
+null-cursor spelling; a non-advancing gateway fails as a pagination loop.
+
+The default safety bounds cap an unfiltered scan at 100 × 100 = 10,000
+rows before it **fails** with `ScanBoundsExceeded` (fail-don't-truncate);
+raise `max_pages`/`max_rows` in the `open_connector:` block or narrow with
+`LIMIT` — see [the integration guide](open-connector.md#bounds-retries-and-errors).
+
+Column references live in the pack definition
+(`crates/skardi/src/sources/providers/open_connector/packs/notion.yaml`);
+highlights and caveats:
+
+- **`pages`/`data_sources` are the complete visible listing**: the
+  required search `query` is pinned to `""` and the object `filter` is
+  pinned per table — Notion's spelling for "everything the integration
+  can see". Visibility is exactly what has been shared with the
+  integration in Notion.
+- **Dynamic property maps stay opaque JSON** (`properties`, `parent`):
+  typed projection of user-defined schemas is the deferred
+  `query_data_source` work (binding-time schema freeze per the design).
+  There is deliberately **no rows table yet**.
+- **`block_children` returns block metadata only** — the type-specific
+  payload lives under a key named by `type`, which a fixed mapping cannot
+  address; rendered content is a future markdown table.
+- **`users` excludes `person.email`** and the raw `person`/`bot` objects
+  (capability-gated, privacy-sensitive).
+- **Action-contract fingerprints are pinned** from a live capture
+  (`packs/fixtures/notion/contracts/`); `pages`/`data_sources` share
+  `notion.search`'s pin. Note: the gateway declares an EMPTY item schema
+  for search results, so the two search tables' columns sit outside the
+  fingerprint gate entirely (pinned as such by the coverage test) — their
+  drift surfaces at scan time under the conversion rules.
+
+## Authorization and visibility
+
+Everything is bounded by the Open Connector Notion integration's access:
+pages and data sources appear only where the integration has been shared;
+`users` requires the integration's user-information capability.
+
+## Rate limits and freshness
+
+Notion's API averages ~3 requests/second per integration; each scanned
+page is one request, retried on `429` with `Retry-After` honored inside
+the scan deadline. Reads are live by default; the gateway-level TTL cache
+applies as documented in the [general guide](open-connector.md#caching-and-freshness).

--- a/docs/open-connector-notion.md
+++ b/docs/open-connector-notion.md
@@ -10,7 +10,13 @@ API**: rows are Notion objects verbatim under `$.results`, with Notion's
 native cursor envelope beside them (`$.next_cursor`, null at
 end-of-collection; `has_more` is redundant and unused). Inputs are the
 gateway's camelCase strict schema (`startCursor`/`pageSize`/`blockId`).
-Everything below is reconciled against a live gateway.
+Everything below is reconciled against a live gateway **and verified end
+to end against a real Notion workspace** (2026-08-03). The gateway pins
+`Notion-Version: 2026-03-11`; that version is what makes the
+`data_source` filter spelling valid (pre-2025-09-03 versions spell it
+`database`) and what renames the page flag to `is_archived`. If the
+gateway's pinned Notion version ever changes, the action-contract
+fingerprints refuse registration rather than drifting silently.
 
 ## Binding
 
@@ -36,7 +42,7 @@ SELECT id, name, type FROM saas.notion_ws.users WHERE type = 'person';
 
 -- The same definition, ad hoc, without a binding:
 SELECT id, url FROM open_connector_query('saas', 'notion.pages', '{}')
-WHERE NOT archived LIMIT 20;
+WHERE NOT in_trash LIMIT 20;
 ```
 
 ## Tables
@@ -78,10 +84,15 @@ highlights and caveats:
   address; rendered content is a future markdown table.
 - **`users` excludes `person.email`** and the raw `person`/`bot` objects
   (capability-gated, privacy-sensitive).
+- **Deletion flags follow the real wire, not the declared contract**: on
+  Notion-Version 2026-03-11 pages carry `is_archived` + `in_trash`, while
+  data sources and blocks carry `in_trash` only — there is no `archived`
+  field on any live object, so the pack does not map one.
 - **Action-contract fingerprints are pinned** from a live capture
   (`packs/fixtures/notion/contracts/`); `pages`/`data_sources` share
-  `notion.search`'s pin. Note: the gateway declares an EMPTY item schema
-  for search results, so the two search tables' columns sit outside the
+  `notion.search`'s pin. Note: the gateway declares the search item
+  schema as an `anyOf` (page | data_source), which the coverage walker
+  does not descend, so the two search tables' columns sit outside the
   fingerprint gate entirely (pinned as such by the coverage test) — their
   drift surfaces at scan time under the conversion rules.
 

--- a/docs/open-connector.md
+++ b/docs/open-connector.md
@@ -16,10 +16,12 @@ gateway **runtime token**.
 > **Status:** the shared foundation is complete, and the first real
 > provider packs have landed alongside the synthetic `mock` pack used by
 > the test suite: [GitHub](open-connector-github.md) (repositories, issues,
-> pull requests, reviews, commits, workflow runs, releases) and
+> pull requests, reviews, commits, workflow runs, releases),
 > [Slack](open-connector-slack.md) (conversations, users, files — message
-> tables are gated on upstream cursor support). Further
-> provider packs (Jira, Notion, …) ship one pack per release per the
+> tables are gated on upstream cursor support), and
+> [Notion](open-connector-notion.md) (users, pages, data sources, block
+> children — dynamic-schema rows are gated on binding-time schema
+> freeze). Further provider packs (Jira, …) ship one pack per release per the
 > [design spec](superpowers/specs/2026-07-11-open-connector-integration-design.md);
 > a source is advertised as supported only once its pack passes the
 > admission gate there.

--- a/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
+++ b/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
@@ -250,7 +250,40 @@ event carrying the scan identity and error.
       zero required resources, UDTF parity for `slack.users`, and a two-page
       users cursor scan pinning that table's own wire declarations (`$.users`
       row path, `cursor`/`limit` inputs) independently of conversations'.
-- [ ] 5.3 Notion pack (explicit data-source binding, cursor pagination, dynamic properties with binding-time schema freeze): rows, pages, blocks, users
+- [x] 5.3 Notion pack (integration token, cursor pagination): `users`, `pages`,
+      `data_sources`, `block_children` as stable tables (`packs/notion.yaml`).
+      The wire contract is Open Connector's raw passthrough of the Notion API
+      (rows verbatim under `$.results`, native `$.next_cursor` envelope — null
+      terminates, `has_more` deliberately unused; camelCase strict inputs
+      `startCursor`/`pageSize`/`blockId`), reconciled against a live gateway.
+      `pages`/`data_sources` are two pinned views of `notion.search`: the
+      required `query` pinned to `""` plus per-table object `filter` pins —
+      which required the one engine extension this milestone adds,
+      **`FixedValue::Json`** (object-shaped fixed inputs, loader-parsed and
+      leaked, with the non-finite-float guard extended to nested values).
+      **No filter pushdown anywhere** (search's free-text relevance `query`
+      maps to no SQL predicate faithfully; the other actions declare no filter
+      inputs) — a wire guard test pins that requests carry exactly the declared
+      inputs. Dynamic property maps stay opaque JSON: the `rows` table over
+      `query_data_source` is deliberately absent pending the design's
+      binding-time schema freeze, and `block_children` excludes the
+      type-keyed payload (a fixed mapping cannot address a key named BY
+      `type`). `users` excludes `person.email` (capability-gated, privacy).
+      Fingerprints pinned from live capture (`fixtures/notion/contracts/`;
+      pages/data_sources share search's pin); the coverage-gap pin records
+      that search declares an EMPTY item schema, so both search tables'
+      columns ride additionalProperties passthrough. Live-verified: all four
+      tables register against a live gateway (pins match discovery) and every
+      scan reaches the credential wall with the exact pinned wire inputs
+      (`{"filter":{"property":"object","value":"page"},"query":"","pageSize":100}`
+      observed in the gateway's own run log). **Verification**: 260
+      open_connector tests (counted by `cargo test -p skardi --lib
+      sources::providers::open_connector`; 14 new) — four fixture contract
+      suites plus the schema-mismatch fixture, fingerprint sync + coverage
+      pins, drift-refusal e2e, and per-declaration e2e (users two-page cursor
+      with row identity, per-table search filter pins with an
+      exactly-the-declared-inputs guard, blockId resource forwarding +
+      pre-HTTP enforcement, LIMIT early-stop, UDTF parity).
 - [ ] 5.4 Later waves per the design rollout (Google Workspace, Discord, Feishu, HubSpot, Jira, …) through the source-pack admission gate
 
 **Gate for each pack** (from the design spec): complete terminating pagination,


### PR DESCRIPTION
## Summary

Milestone 5.3: the **Notion source pack** — `users`, `pages`, `data_sources`, `block_children` as stable SQL tables over Open Connector's `notion.*` read actions. First pack authored end-to-end as an embedded YAML asset (`packs/notion.yaml`) under the validating loader, and the first produced by the `/source-pack` skill's full workflow (live reconciliation → design → implementation → self-review).

### Wire contract (live-reconciled)

Raw passthrough of the Notion API: rows verbatim under `$.results` (no normalization, **no post-pagination filtering** — verified in the executor source), Notion's native cursor envelope (`$.next_cursor`, null terminates; `has_more` redundant and deliberately unused), camelCase strict inputs (`startCursor`/`pageSize`/`blockId`).

### Design decisions (module doc carries the rationale)

- **`pages`/`data_sources` are two pinned views of `notion.search`**: required `query` pinned to `""` + per-table object `filter` pins — Notion's spelling for "the complete visible listing" (the `state=all` move). The object pin required this milestone's one engine extension: **`FixedValue::Json`** (loader-parsed & leaked, non-finite-float guard extended to nested values, backward-compatible).
- **No filter pushdown anywhere** — search's free-text relevance `query` maps to no SQL predicate faithfully; the other actions declare no filter inputs. A wire guard test pins exactly-the-declared-inputs.
- **No `rows` table yet** — dynamic property maps stay opaque JSON pending the design's binding-time schema freeze for `query_data_source`; `block_children` excludes the type-keyed payload; `users` excludes `person.email` (capability-gated, privacy).
- **Fingerprints pinned from live capture**; `pages`/`data_sources` share `notion.search`'s pin. The coverage-gap pin records that search declares an **empty** results-item schema — both search tables' columns ride `additionalProperties` passthrough, outside the fingerprint gate, drift surfacing at scan time.

### Live verification

All four tables register against a live gateway (pins match discovery); every scan reaches the credential wall (403 `authorization_failed`, never `invalid_input`), and the gateway's own run log shows the exact pinned wire inputs, e.g. `{"filter":{"property":"object","value":"page"},"query":"","pageSize":100}`.

### Verification

**260 open_connector tests (14 new) / 817 lib total** (`cargo test -p skardi --lib sources::providers::open_connector`): four fixture contract suites + the schema-mismatch fixture, fingerprint sync + coverage pins, drift-refusal e2e, and per-declaration e2e — two-page users cursor with row identity, per-table search filter pins, `blockId` forwarding + pre-HTTP required-resource enforcement, LIMIT early-stop, UDTF parity. clippy baseline unchanged; `cargo doc` clean. Docs: `docs/open-connector-notion.md`, guide status, spec 5.3 ticked with the counting command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)