### PR TITLE
feat(sources): RSS provider 2/4 — sanitation ladder, HTML→Markdown, parsing, schemas, TTL cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3936,6 +3936,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "feed-rs"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "369995dae0733f1fe5ab0e3f345f6503a5f384179df5d8da333702031a131cf9"
+dependencies = [
+ "chrono",
+ "mediatype",
+ "quick-xml 0.41.0",
+ "regex",
+ "serde",
+ "serde_json",
+ "siphasher",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "file-format"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4824,6 +4841,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "htmd"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5a1c7113c831fec68cbd79cd8bf281a84e5b6943f51473dc266b0b88a6a017e"
+dependencies = [
+ "html5ever",
+ "markup5ever_rcdom",
+ "phf 0.13.1",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
+dependencies = [
+ "log",
+ "markup5ever",
 ]
 
 [[package]]
@@ -6512,6 +6550,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "markup5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.38.0+unofficial"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333171ccdf66e915257740d44e38ea5b1b19ce7b45d33cc35cb6f118fbd981ff"
+dependencies = [
+ "html5ever",
+ "markup5ever",
+ "tendril",
+ "xml5ever",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6572,6 +6633,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51c55d61e72fc3ab704396c5fa16f4c184db37978ae4e94ca8959693a235fc0e"
 dependencies = [
  "log",
+]
+
+[[package]]
+name = "mediatype"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120fa187be19d9962f0926633453784691731018a2bf936ddb4e29101b79c4a7"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -6942,6 +7012,12 @@ name = "never-say-never"
 version = "6.6.666"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf5a574dadd7941adeaa71823ecba5e28331b8313fb2e1c6a5c7e5981ea53ad6"
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nom"
@@ -7594,8 +7670,42 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
+ "phf_macros",
  "phf_shared 0.13.1",
  "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7781,6 +7891,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prefix-trie"
@@ -8048,6 +8164,7 @@ version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
+ "encoding_rs",
  "memchr",
 ]
 
@@ -9371,10 +9488,13 @@ dependencies = [
  "datafusion-federation",
  "datafusion-table-providers",
  "derivative",
+ "encoding_rs",
+ "feed-rs",
  "futures",
  "gguf-rs-lib",
  "glob",
  "hex",
+ "htmd",
  "httpdate",
  "iceberg",
  "iceberg-datafusion",
@@ -9769,6 +9889,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51f1e89f093f99e7432c491c382b88a6860a5adbe6bf02574bf0a08efff1978"
 
 [[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.13.1",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10132,6 +10277,15 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tendril"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
+dependencies = [
+ "new_debug_unreachable",
 ]
 
 [[package]]
@@ -11078,6 +11232,7 @@ dependencies = [
  "idna 1.1.0",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -11321,6 +11476,18 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
+dependencies = [
+ "phf 0.13.1",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]
@@ -11705,6 +11872,16 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix 1.1.4",
+]
+
+[[package]]
+name = "xml5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dc9559429edf0cd3f327cc0afd9d6b36fa8cec6d93107b7fbe64f806b5f2d9"
+dependencies = [
+ "log",
+ "markup5ever",
 ]
 
 [[package]]

--- a/crates/skardi/Cargo.toml
+++ b/crates/skardi/Cargo.toml
@@ -63,6 +63,9 @@ documents = ["dep:liteparse", "dep:glob", "dep:object_store"]
 rss = [
     "dep:quick-xml",
     "reqwest/gzip",
+    "dep:encoding_rs",
+    "dep:htmd",
+    "dep:feed-rs",
 ]
 
 [dependencies]
@@ -143,6 +146,12 @@ liteparse = { version = "2.4.0", default-features = false, optional = true }
 blake3 = "1"
 # include_globs matching for the documents connector.
 glob = { version = "0.3", optional = true }
+# Label lookup + transcoding for the rss sanitation ladder's re-encode rung.
+encoding_rs = { version = "0.8", optional = true }
+# Deterministic HTML→Markdown for rss item content.
+htmd = { version = "0.5.5", optional = true }
+# RSS 0.9x/1.0/2.0, Atom, and JSON Feed parsing into one model.
+feed-rs = { version = "2.4", optional = true }
 # object-store (S3/GCS/Azure) backend for the documents connector's source `path`
 # and `image_store`. Only the `aws` scheme is wired in v1 (see blob.rs).
 object_store = { workspace = true, optional = true }

--- a/crates/skardi/src/sources/providers/rss/cache.rs
+++ b/crates/skardi/src/sources/providers/rss/cache.rs
@@ -1,0 +1,1038 @@
+//! Per-feed TTL cache: the health record and parsed window a scan reads
+//! between fetches.
+//!
+//! Each feed key holds two things that age independently:
+//!
+//! - an [`FeedObservation`] — the feed's health (status, last error, dialect,
+//!   item count, ...) — which persists across every call that doesn't remove
+//!   its whole entry: [`FeedCache::record_success`] replaces it wholesale,
+//!   [`FeedCache::record_failure`] and [`FeedCache::record_not_modified`]
+//!   mutate select fields of it in place, and only [`MemoryFeedCache`]'s
+//!   last-resort `max_observations` backstop (see below) ever discards one
+//!   outright; and
+//! - an optional [`CachedWindow`] — the parsed `items` batch plus the
+//!   conditional-GET validators that produced it — which the byte/entry
+//!   budget can evict independently of the observation.
+//!
+//! ## TTL re-arms on every attempt
+//!
+//! [`FeedCache::record_success`], [`FeedCache::record_not_modified`], and
+//! [`FeedCache::record_failure`] all take an `armed_until: Instant` the
+//! caller computes and push the feed's next-attempt time to exactly that
+//! instant, regardless of which of the three ran. This is what makes a dead
+//! feed a bounded cost rather than a per-scan one: a failure is retried at
+//! most once per [`failure_fuse`] window instead of on every scan, and a
+//! server's `Retry-After` (folded into the caller's `armed_until`) survives
+//! across scans instead of resetting the moment the attempt that read it
+//! finishes.
+//!
+//! ## Only a complete window is ever stored
+//!
+//! The only method that takes a window is [`FeedCache::record_success`] —
+//! there is no partial-window setter, so a half-parsed feed has no path into
+//! the cache.
+//!
+//! ## Eviction keeps the observation
+//!
+//! When the byte or entry budget forces a window out, [`MemoryFeedCache`]
+//! drops the [`CachedWindow`] (batch and validators together — they live in
+//! the same `Option`) but leaves the feed's [`FeedObservation`] in place, so
+//! a `feeds` scan — specified to be a pure state read that never fetches —
+//! never loses a feed's health just because its window happened to be
+//! evicted.
+//!
+//! A separate, much larger `max_observations` bound exists purely as a
+//! last-resort backstop: `feed` is a fully generic `&str`, nothing in this
+//! module restricts it to a known subscription list, so the map of
+//! observations alone (unlike the windowed subset above) has no bound
+//! without one. See [`MemoryFeedCache`]'s doc for why removing a whole entry
+//! there does not conflict with the guarantee just described.
+//!
+//! ## A `304` can outlive the window it would have confirmed
+//!
+//! Eviction is driven by *other* feeds' `record_success` calls, so it can land
+//! between the moment a caller reads a feed's validators out of
+//! [`FeedCache::snapshot`] and the moment the resulting `304` comes back. The
+//! conditional request was well-formed and the answer is truthful — the
+//! caller's copy *is* still current upstream — but the copy itself is gone, so
+//! there is nothing left to serve. This is a reachable state under memory
+//! pressure, not a caller bug: [`FeedCache::record_not_modified`] handles it
+//! by re-arming the timer like any other attempt and recording
+//! [`FeedStatus::Error`] with [`WINDOW_EVICTED_ON_REVALIDATION`] as the
+//! reason, so the zero rows that follow have an explanation an operator can
+//! read. See that method's doc for why `Error` rather than `Revalidated`.
+//!
+//! ## A single window larger than the whole byte budget
+//!
+//! [`MemoryFeedCache::record_success`] measures the incoming window with
+//! `RecordBatch::get_array_memory_size()` before inserting anything. If that
+//! alone exceeds `max_bytes`, the window can never fit no matter what else is
+//! evicted, so it is never stored — not even transiently — while the
+//! observation is still recorded. Any window the feed previously held is
+//! dropped too: `record_success` always replaces wholesale, so an
+//! oversized new window does not leave a stale one behind under the new
+//! observation's identity.
+//!
+//! ## No in-flight coalescing
+//!
+//! Two scans that both find the same feed's TTL expired can both fetch it —
+//! there is no request coalescing here, matching `open_connector`'s cache.
+//! That is a documented future extension, not this module's job.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use arrow::record_batch::RecordBatch;
+
+use super::error::{MAX_ERROR_CHARS, truncate};
+
+/// A feed's freshness state, and the single source of the exact strings the
+/// `feeds.last_status` column serves.
+///
+/// Callers must go through [`FeedStatus::as_str`] rather than writing the
+/// literal — `"never"`, `"fresh"`, `"revalidated"`, `"stale-error"`,
+/// `"error"` — themselves. Within this module, `as_str` is the only place
+/// that spells those strings for `feeds.last_status`, so a typo like
+/// `stale_error` fails to compile here instead of silently breaking that
+/// column's contract.
+///
+/// The same holds for `items.window_status`: `schema.rs`'s two sites both go
+/// through [`FeedStatus::window_status_str`] — `build_items_batch` stamps a
+/// freshly built window from [`FeedStatus::Fresh`], and `with_window_status`
+/// takes a [`FeedStatus`] rather than a `&str` — so neither column's domain
+/// can be broken by a typo at a call site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FeedStatus {
+    /// No fetch attempt has ever completed for this feed.
+    #[default]
+    Never,
+    /// The last attempt fetched a fresh body and parsed it successfully.
+    Fresh,
+    /// The last attempt got a conditional `304`; the cached window is still
+    /// current.
+    Revalidated,
+    /// The last attempt failed, but a window from an earlier success is
+    /// still cached and can be served stale.
+    StaleError,
+    /// The last attempt failed and no window is cached to fall back on.
+    Error,
+}
+
+impl FeedStatus {
+    /// The exact string this status serializes to as `feeds.last_status`.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            FeedStatus::Never => "never",
+            FeedStatus::Fresh => "fresh",
+            FeedStatus::Revalidated => "revalidated",
+            FeedStatus::StaleError => "stale-error",
+            FeedStatus::Error => "error",
+        }
+    }
+
+    /// The `items.window_status` label a snapshot with this status should
+    /// serve, or `None` for the two statuses that serve zero rows (nothing
+    /// has ever been fetched, or the last attempt failed with nothing
+    /// cached to fall back on).
+    pub fn window_status_str(&self) -> Option<&'static str> {
+        match self {
+            FeedStatus::Fresh => Some("fresh"),
+            FeedStatus::Revalidated => Some("revalidated"),
+            FeedStatus::StaleError => Some("stale-error"),
+            FeedStatus::Never | FeedStatus::Error => None,
+        }
+    }
+}
+
+/// One feed's health, independent of whether its window is currently cached.
+///
+/// `Default` is the state of a feed that has never been attempted: every
+/// field `None` and [`FeedStatus::Never`].
+#[derive(Debug, Clone, Default)]
+pub struct FeedObservation {
+    pub last_fetch_ms: Option<i64>,
+    pub last_status: FeedStatus,
+    pub http_status: Option<u16>,
+    pub last_error: Option<String>,
+    pub dialect: Option<String>,
+    pub dialect_declared: Option<String>,
+    pub conformance_notes: Option<String>,
+    pub title: Option<String>,
+    pub site_url: Option<String>,
+    pub description: Option<String>,
+    pub item_count: Option<u64>,
+}
+
+/// A feed's cached window: the parsed `items` batch plus the conditional-GET
+/// validators that produced it. The two travel together — a batch is never
+/// kept without the validators that would let a future fetch revalidate it,
+/// and eviction drops both at once by dropping this whole struct.
+#[derive(Debug, Clone)]
+pub struct CachedWindow {
+    pub batch: RecordBatch,
+    pub etag: Option<String>,
+    pub last_modified: Option<String>,
+}
+
+/// A point-in-time read of one feed's cached state.
+#[derive(Debug, Clone)]
+pub struct FeedSnapshot {
+    pub observation: FeedObservation,
+    pub window: Option<CachedWindow>,
+    pub within_ttl: bool,
+}
+
+/// Per-feed TTL cache. A sync trait with a `Mutex` behind each implementation
+/// (see [`MemoryFeedCache`]) rather than an async one, so a later persistent
+/// implementation can swap in without touching callers — every observation of
+/// this cache's state flows through these four methods.
+pub trait FeedCache: Send + Sync {
+    /// Read `feed`'s current state as of `now`. Unknown feeds report
+    /// [`FeedStatus::Never`], no window, and `within_ttl: false`.
+    fn snapshot(&self, feed: &str, now: Instant) -> FeedSnapshot;
+
+    /// Record a successful fetch-and-parse: replace both the window and the
+    /// observation wholesale, and arm the feed's next-attempt time to
+    /// `armed_until`.
+    fn record_success(
+        &self,
+        feed: &str,
+        window: CachedWindow,
+        observation: FeedObservation,
+        armed_until: Instant,
+    );
+
+    /// Record a conditional `304`: the existing window is still current, so
+    /// it is left untouched, but the observation's fetch metadata and status
+    /// move to [`FeedStatus::Revalidated`], and the next-attempt time re-arms
+    /// to `armed_until`.
+    ///
+    /// If the window was evicted while this attempt was in flight — see the
+    /// module doc — the fetch metadata and the re-arm still apply (an attempt
+    /// happened, and skipping the re-arm would leave the feed expired and
+    /// refetching on every scan), but the status becomes
+    /// [`FeedStatus::Error`] with [`WINDOW_EVICTED_ON_REVALIDATION`] as
+    /// `last_error` rather than [`FeedStatus::Revalidated`].
+    ///
+    /// `Error` is the honest answer there even though the feed itself is
+    /// healthy. It is the one status whose contract is "no window is cached to
+    /// fall back on", which is exactly the situation; it is also the status
+    /// whose [`FeedStatus::window_status_str`] is `None`, so *from the next scan
+    /// on* it agrees with the zero rows that scan will serve. `Revalidated`
+    /// would instead claim a current window exists indefinitely — leaving
+    /// `feeds` reporting a healthy feed with a non-zero `item_count` while
+    /// `items` returns nothing, and no column anywhere explaining why.
+    ///
+    /// The serve that *records* this state is the one exception: the engine
+    /// already read a window out of its pre-permit snapshot and stamps those
+    /// rows `revalidated` from a literal, so for that one racing scan
+    /// `items.window_status = 'revalidated'` sits beside
+    /// `feeds.last_status = 'error'`. That is the same no-coalescing
+    /// consequence the engine's `304` branch documents — the rows it serves are
+    /// a real window the `304` really did vouch for — and it lasts exactly one
+    /// scan.
+    ///
+    /// Recovery does not depend on this choice: with no window there are no
+    /// validators to send, so the next attempt after the timer expires is an
+    /// unconditional `GET` that rebuilds the window whatever status was
+    /// recorded here.
+    fn record_not_modified(
+        &self,
+        feed: &str,
+        http_status: u16,
+        last_fetch_ms: i64,
+        armed_until: Instant,
+    );
+
+    /// Record a failed attempt: the observation's status becomes
+    /// [`FeedStatus::StaleError`] if a window is currently cached (serve
+    /// stale) or [`FeedStatus::Error`] if not, `last_error` is recorded, and
+    /// the next-attempt time re-arms to `armed_until` regardless — this is
+    /// the negative-caching half of the TTL contract.
+    ///
+    /// `dialect_declared` carries a sniff that succeeded even though the
+    /// attempt as a whole did not: the declared dialect is read off the raw
+    /// bytes before parsing, so a document that fails to parse still has one
+    /// to report. `Some` overwrites the recorded value, `None` leaves
+    /// whatever was already known in place — a transport failure has no
+    /// document to sniff and must not erase an earlier success's answer.
+    fn record_failure(
+        &self,
+        feed: &str,
+        http_status: Option<u16>,
+        error: String,
+        dialect_declared: Option<String>,
+        last_fetch_ms: i64,
+        armed_until: Instant,
+    );
+}
+
+/// `feeds.last_error` for a `304` whose window was evicted while the request
+/// was in flight — see [`FeedCache::record_not_modified`]. Names no particular
+/// bound, since any of the three can produce the state: `max_bytes` and
+/// `max_entries` through `Inner::evict`, and the `max_observations` backstop
+/// through `Inner::evict_observations`. Carries no response content of any
+/// kind: the condition is entirely local to this cache, and the string is a
+/// fixed literal.
+pub const WINDOW_EVICTED_ON_REVALIDATION: &str = "revalidated (304) but the cached window had already been evicted from the feed \
+     cache; the next attempt refetches it unconditionally";
+
+/// The negative-cache TTL for a feed that just failed: `clamp(ttl / 4, 30s,
+/// 300s)`. Shorter than the success TTL so a dead feed is retried sooner
+/// than a healthy one's normal refresh, but still bounded away from zero
+/// when `ttl_seconds` is 0 (always-live) so a failing always-live feed is not
+/// retried on literally every scan.
+pub fn failure_fuse(ttl: Duration) -> Duration {
+    (ttl / 4).clamp(Duration::from_secs(30), Duration::from_secs(300))
+}
+
+/// How many times `max_entries` the last-resort whole-entry bound
+/// (`max_observations`) is set to, before the [`MIN_OBSERVATIONS`] floor is
+/// applied. `max_entries` bounds feeds holding a window, sized by the
+/// operator for a realistic number of concurrently fetched feeds; feeds that
+/// are failing or being revalidated hold no window at all and so don't count
+/// against it, yet still occupy a map slot. 8x gives that traffic
+/// comfortable headroom over the windowed bound before the backstop below
+/// ever engages, while still capping unbounded growth in the number of
+/// distinct feed keys ever seen (`feed` is a plain `&str` — nothing here
+/// restricts it to a known subscription list).
+const MAX_OBSERVATIONS_MULTIPLIER: usize = 8;
+
+/// Floor under `max_observations`, so a caller-supplied `max_entries` of `0`
+/// (window caching fully disabled — a coherent configuration: `feeds`
+/// health is still worth tracking with no window cache at all) cannot turn
+/// the backstop into "discard the observation the instant it's inserted."
+/// 8 mirrors `1 * MAX_OBSERVATIONS_MULTIPLIER` — the headroom the smallest
+/// *window-caching* configuration (`max_entries == 1`) already gets — so
+/// disabling window caching entirely doesn't collapse observation tracking
+/// below what the smallest windowed configuration would have.
+const MIN_OBSERVATIONS: usize = 8;
+
+/// A cached window plus the byte count it was charged against the budget
+/// with, so eviction can subtract exactly what was added.
+struct WindowEntry {
+    window: CachedWindow,
+    bytes: usize,
+}
+
+/// One feed's full cache entry: an always-present observation, and an
+/// optional window that the byte/entry budget can evict independently.
+struct Entry {
+    observation: FeedObservation,
+    window: Option<WindowEntry>,
+    armed_until: Instant,
+}
+
+struct Inner {
+    map: HashMap<String, Entry>,
+    /// Feeds that currently hold a window, most-recently-used first. Feeds
+    /// with no window (never fetched, or evicted) are not tracked here —
+    /// see [`MemoryFeedCache`]'s doc for why `max_entries` bounds this list
+    /// rather than the whole map.
+    window_order: VecDeque<String>,
+    window_bytes: usize,
+    /// Every feed key currently in `map`, most-recently-used first, where
+    /// "used" means touched by any of the four [`FeedCache`] methods —
+    /// unlike `window_order` above, this includes feeds with no window.
+    /// Backs the `max_observations` last-resort bound; see
+    /// [`MemoryFeedCache`]'s doc.
+    entry_order: VecDeque<String>,
+}
+
+impl Inner {
+    /// Drop `feed`'s window (if any) and remove it from the LRU list,
+    /// crediting its bytes back to the budget. A no-op if `feed` has no
+    /// entry or no window.
+    fn drop_window(&mut self, feed: &str) {
+        if let Some(entry) = self.map.get_mut(feed)
+            && let Some(w) = entry.window.take()
+        {
+            self.window_bytes = self.window_bytes.saturating_sub(w.bytes);
+        }
+        self.window_order.retain(|k| k != feed);
+    }
+
+    /// Move `feed` to the front of the window LRU list.
+    fn touch_window(&mut self, feed: &str) {
+        self.window_order.retain(|k| k != feed);
+        self.window_order.push_front(feed.to_string());
+    }
+
+    /// Move `feed` to the front of the whole-entry LRU list. Called on every
+    /// access or update, whether or not `feed` currently holds a window, so
+    /// an observation-only entry that keeps getting queried or refreshed is
+    /// exactly as protected from the `max_observations` backstop as a
+    /// windowed one.
+    fn touch_entry(&mut self, feed: &str) {
+        self.entry_order.retain(|k| k != feed);
+        self.entry_order.push_front(feed.to_string());
+    }
+
+    /// Evict least-recently-used windows (dropping only the window, never
+    /// the observation) until both the byte and entry budgets hold.
+    fn evict(&mut self, max_bytes: usize, max_entries: usize) {
+        while self.window_order.len() > max_entries || self.window_bytes > max_bytes {
+            let Some(oldest) = self.window_order.pop_back() else {
+                break;
+            };
+            if let Some(entry) = self.map.get_mut(&oldest)
+                && let Some(w) = entry.window.take()
+            {
+                self.window_bytes = self.window_bytes.saturating_sub(w.bytes);
+            }
+        }
+    }
+
+    /// Last-resort backstop: evict least-recently-used *whole* entries,
+    /// observation included, until the map holds at most `max_observations`
+    /// distinct feed keys. See [`MemoryFeedCache`]'s doc for why this
+    /// coexists with (rather than contradicts) `evict`'s observation-
+    /// preserving eviction above.
+    fn evict_observations(&mut self, max_observations: usize) {
+        while self.map.len() > max_observations {
+            let Some(oldest) = self.entry_order.pop_back() else {
+                break;
+            };
+            if let Some(entry) = self.map.remove(&oldest)
+                && let Some(w) = entry.window
+            {
+                self.window_bytes = self.window_bytes.saturating_sub(w.bytes);
+            }
+            self.window_order.retain(|k| k != &oldest);
+        }
+    }
+}
+
+/// In-memory [`FeedCache`], bounded by window bytes, window count, and
+/// (as a last resort) total observation count, behind a `Mutex`
+/// (hand-rolled LRU, following `open_connector/cache.rs`'s precedent rather
+/// than adding the `lru` crate).
+///
+/// `max_entries` bounds how many feeds may hold a cached window at once —
+/// it does not bound the map itself, since a feed that is only failing or
+/// being revalidated holds no window and so never counts against it. That
+/// gap is what `max_observations` (`max(max_entries *
+/// MAX_OBSERVATIONS_MULTIPLIER, MIN_OBSERVATIONS)`) closes: it
+/// caps the map's total size — windowed and observation-only entries
+/// together — and, once exceeded, evicts the least-recently-used *whole*
+/// entry, observation included, via `Inner::evict_observations`. The floor
+/// matters at `max_entries == 0` (window caching disabled entirely, a
+/// coherent configuration on its own): without it, `max_observations` would
+/// also be `0`, and the backstop would discard every observation the moment
+/// it was inserted instead of leaving observation tracking intact.
+///
+/// This does not contradict the "eviction keeps the observation" guarantee
+/// the module doc describes for `max_bytes`/`max_entries`: that guarantee
+/// exists so a `feeds` scan can still report health for a feed whose
+/// *window* was evicted under memory pressure while the feed is still being
+/// actively scanned. A whole entry only reaches `max_observations` once the
+/// map holds far more distinct keys than the configured subscription list
+/// could produce for `max_entries`-many concurrently windowed feeds — i.e.
+/// keys that are no longer being scanned at all — and for a key this cache
+/// has never seen, [`FeedCache::snapshot`] already answers
+/// [`FeedStatus::Never`], which is the honest answer for a subscription this
+/// cache has no record of. The two bounds protect different things: one
+/// keeps a live feed's health visible after its window is reclaimed, the
+/// other keeps the map itself from growing without limit.
+pub struct MemoryFeedCache {
+    inner: Mutex<Inner>,
+    max_bytes: usize,
+    max_entries: usize,
+    max_observations: usize,
+}
+
+impl MemoryFeedCache {
+    pub fn new(max_bytes: usize, max_entries: usize) -> Self {
+        Self {
+            inner: Mutex::new(Inner {
+                map: HashMap::new(),
+                window_order: VecDeque::new(),
+                window_bytes: 0,
+                entry_order: VecDeque::new(),
+            }),
+            max_bytes,
+            max_entries,
+            max_observations: max_entries
+                .saturating_mul(MAX_OBSERVATIONS_MULTIPLIER)
+                .max(MIN_OBSERVATIONS),
+        }
+    }
+
+    /// Lock the inner state. Poisoning degrades to the inner state rather
+    /// than panicking, matching `open_connector/cache.rs`'s `ScanCache`.
+    fn lock(&self) -> std::sync::MutexGuard<'_, Inner> {
+        self.inner.lock().unwrap_or_else(|p| p.into_inner())
+    }
+}
+
+impl FeedCache for MemoryFeedCache {
+    fn snapshot(&self, feed: &str, now: Instant) -> FeedSnapshot {
+        let mut inner = self.lock();
+        let Some(entry) = inner.map.get(feed) else {
+            return FeedSnapshot {
+                observation: FeedObservation::default(),
+                window: None,
+                within_ttl: false,
+            };
+        };
+        let within_ttl = now < entry.armed_until;
+        let observation = entry.observation.clone();
+        let window = entry.window.as_ref().map(|w| w.window.clone());
+        let has_window = window.is_some();
+
+        if has_window {
+            inner.touch_window(feed);
+        }
+        // A read is still an access for the whole-entry LRU, whether or not
+        // this feed currently holds a window — see `Inner::touch_entry`.
+        inner.touch_entry(feed);
+        FeedSnapshot {
+            observation,
+            window,
+            within_ttl,
+        }
+    }
+
+    fn record_success(
+        &self,
+        feed: &str,
+        window: CachedWindow,
+        observation: FeedObservation,
+        armed_until: Instant,
+    ) {
+        // Measured before taking the lock: a batch's memory size is a pure
+        // function of its own buffers, so there's no need to hold the lock
+        // while computing it.
+        let bytes = window.batch.get_array_memory_size();
+        let mut inner = self.lock();
+
+        // `record_success` always replaces wholesale: whatever window this
+        // feed held before is gone now, whether or not the new one below
+        // ends up fitting.
+        inner.drop_window(feed);
+
+        let entry = inner.map.entry(feed.to_string()).or_insert_with(|| Entry {
+            observation: FeedObservation::default(),
+            window: None,
+            armed_until,
+        });
+        entry.observation = observation;
+        entry.armed_until = armed_until;
+
+        // A window that alone exceeds the whole byte budget can never fit no
+        // matter what else is evicted — see the module doc. Store the
+        // observation (already done above) but skip the window entirely
+        // rather than insert-then-immediately-evict it.
+        if bytes <= self.max_bytes {
+            entry.window = Some(WindowEntry { window, bytes });
+            inner.window_bytes += bytes;
+            inner.window_order.push_front(feed.to_string());
+            inner.evict(self.max_bytes, self.max_entries);
+        }
+
+        inner.touch_entry(feed);
+        inner.evict_observations(self.max_observations);
+    }
+
+    fn record_not_modified(
+        &self,
+        feed: &str,
+        http_status: u16,
+        last_fetch_ms: i64,
+        armed_until: Instant,
+    ) {
+        let mut inner = self.lock();
+        let entry = inner.map.entry(feed.to_string()).or_insert_with(|| Entry {
+            observation: FeedObservation::default(),
+            window: None,
+            armed_until,
+        });
+
+        // An attempt happened and it is the caller's `armed_until` that
+        // decides when the next one may, so the fetch metadata and the re-arm
+        // are unconditional. In particular they must not be skipped when the
+        // window turns out to be gone: the module doc's TTL contract is that
+        // all three recording methods push the next-attempt time to exactly
+        // `armed_until`, and a `304` that quietly declined to would leave the
+        // feed expired and refetching on every scan.
+        entry.observation.http_status = Some(http_status);
+        entry.observation.last_fetch_ms = Some(last_fetch_ms);
+        entry.armed_until = armed_until;
+
+        if entry.window.is_some() {
+            entry.observation.last_status = FeedStatus::Revalidated;
+            entry.observation.last_error = None;
+        } else {
+            // Reachable without any caller mistake — another feed's
+            // `record_success` can evict this one's window between the
+            // snapshot that produced the validators and the `304` answering
+            // them — so this is reported, not asserted. See the trait
+            // method's doc for why `Error` is the honest status.
+            entry.observation.last_status = FeedStatus::Error;
+            // Routed through the cap like every other write to this column
+            // rather than relying on the literal above staying short. It is 131
+            // characters today, so this is a no-op; the point is that the
+            // column has one bound and no writer sits outside it.
+            entry.observation.last_error =
+                Some(truncate(WINDOW_EVICTED_ON_REVALIDATION, MAX_ERROR_CHARS));
+            tracing::warn!(
+                feed,
+                http_status,
+                "rss feed revalidated but its cached window had already been evicted"
+            );
+        }
+
+        inner.touch_entry(feed);
+        // Normally a no-op — the entry existed already, since a conditional
+        // request needs validators this cache handed out — but `entry()` above
+        // can insert, so the bound is re-checked rather than assumed.
+        inner.evict_observations(self.max_observations);
+    }
+
+    fn record_failure(
+        &self,
+        feed: &str,
+        http_status: Option<u16>,
+        error: String,
+        dialect_declared: Option<String>,
+        last_fetch_ms: i64,
+        armed_until: Instant,
+    ) {
+        let mut inner = self.lock();
+        let entry = inner.map.entry(feed.to_string()).or_insert_with(|| Entry {
+            observation: FeedObservation::default(),
+            window: None,
+            armed_until,
+        });
+        // A failed refresh does not invalidate a previously cached window —
+        // it is left exactly as it was, available to serve stale, and
+        // determines which of the two failure statuses applies.
+        entry.observation.last_status = if entry.window.is_some() {
+            FeedStatus::StaleError
+        } else {
+            FeedStatus::Error
+        };
+        entry.observation.http_status = http_status;
+        entry.observation.last_error = Some(error);
+        entry.observation.last_fetch_ms = Some(last_fetch_ms);
+        // Only overwrite when the caller actually has a sniff to report — see
+        // the trait method's doc.
+        if dialect_declared.is_some() {
+            entry.observation.dialect_declared = dialect_declared;
+        }
+        entry.armed_until = armed_until;
+
+        inner.touch_entry(feed);
+        inner.evict_observations(self.max_observations);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::UInt64Array;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use std::sync::Arc;
+
+    /// A minimal window with `rows` rows of a single `UInt64` column — real
+    /// enough to size and count, without pulling in `schema::build_items_batch`
+    /// (this module doesn't depend on the `items` schema shape at all).
+    fn window_with_rows(rows: usize) -> CachedWindow {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::UInt64, false)]));
+        let ids: UInt64Array = (0..rows as u64).collect();
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(ids)]).unwrap();
+        CachedWindow {
+            batch,
+            etag: Some("\"etag\"".into()),
+            last_modified: Some("Mon, 20 Jul 2026 10:00:00 GMT".into()),
+        }
+    }
+
+    fn obs_fresh(item_count: u64) -> FeedObservation {
+        FeedObservation {
+            last_fetch_ms: Some(1_700_000_000_000),
+            last_status: FeedStatus::Fresh,
+            http_status: Some(200),
+            last_error: None,
+            dialect: Some("rss2".into()),
+            dialect_declared: Some("rss2".into()),
+            conformance_notes: None,
+            title: Some("Feed".into()),
+            site_url: Some("https://example.com".into()),
+            description: Some("desc".into()),
+            item_count: Some(item_count),
+        }
+    }
+
+    #[test]
+    fn success_arms_ttl_and_snapshot_reports_within_ttl() {
+        let cache = MemoryFeedCache::new(1 << 20, 64);
+        let t0 = Instant::now();
+        cache.record_success(
+            "a",
+            window_with_rows(2),
+            obs_fresh(2),
+            t0 + Duration::from_secs(900),
+        );
+        let snap = cache.snapshot("a", t0 + Duration::from_secs(1));
+        assert!(snap.within_ttl);
+        assert!(matches!(snap.observation.last_status, FeedStatus::Fresh));
+        assert_eq!(snap.window.as_ref().unwrap().batch.num_rows(), 2);
+        assert!(
+            !cache
+                .snapshot("a", t0 + Duration::from_secs(901))
+                .within_ttl
+        );
+    }
+
+    #[test]
+    fn failure_is_negative_cached_with_window_kept() {
+        let cache = MemoryFeedCache::new(1 << 20, 64);
+        let t0 = Instant::now();
+        cache.record_success("a", window_with_rows(2), obs_fresh(2), t0); // expired immediately
+        cache.record_failure(
+            "a",
+            Some(503),
+            "http status 503".into(),
+            None,
+            1,
+            t0 + Duration::from_secs(30),
+        );
+        let snap = cache.snapshot("a", t0 + Duration::from_secs(1));
+        assert!(
+            snap.within_ttl,
+            "failure re-armed the timer (negative cache)"
+        );
+        assert!(matches!(
+            snap.observation.last_status,
+            FeedStatus::StaleError
+        ));
+        assert!(
+            snap.window.is_some(),
+            "stale window retained for serve-stale"
+        );
+        assert_eq!(
+            snap.observation.last_error.as_deref(),
+            Some("http status 503")
+        );
+    }
+
+    #[test]
+    fn failure_without_window_is_error_status() {
+        let cache = MemoryFeedCache::new(1 << 20, 64);
+        let t0 = Instant::now();
+        cache.record_failure(
+            "a",
+            Some(500),
+            "http status 500".into(),
+            None,
+            1,
+            t0 + Duration::from_secs(30),
+        );
+        let snap = cache.snapshot("a", t0 + Duration::from_secs(1));
+        assert!(matches!(snap.observation.last_status, FeedStatus::Error));
+        assert!(snap.window.is_none());
+        assert_eq!(
+            snap.observation.last_error.as_deref(),
+            Some("http status 500")
+        );
+        assert!(
+            snap.within_ttl,
+            "failure still arms the negative-cache timer"
+        );
+    }
+
+    #[test]
+    fn eviction_drops_window_and_validators_but_keeps_observation() {
+        let one = window_with_rows(2);
+        let bytes = one.batch.get_array_memory_size();
+        // Room for exactly one window: inserting a second must evict the first.
+        let cache = MemoryFeedCache::new(bytes + 8, 64);
+        let t0 = Instant::now();
+        let armed = t0 + Duration::from_secs(900);
+        cache.record_success("a", window_with_rows(2), obs_fresh(2), armed);
+        cache.record_success("b", window_with_rows(2), obs_fresh(3), armed);
+
+        let snap_a = cache.snapshot("a", t0 + Duration::from_secs(1));
+        assert!(
+            snap_a.window.is_none(),
+            "a's window (and its validators) must be evicted to make room for b"
+        );
+        assert!(
+            matches!(snap_a.observation.last_status, FeedStatus::Fresh),
+            "the observation survives eviction of its window"
+        );
+        assert_eq!(snap_a.observation.item_count, Some(2));
+
+        let snap_b = cache.snapshot("b", t0 + Duration::from_secs(1));
+        assert_eq!(snap_b.window.as_ref().unwrap().batch.num_rows(), 2);
+    }
+
+    #[test]
+    fn unknown_feed_snapshot_is_never() {
+        let cache = MemoryFeedCache::new(1 << 20, 64);
+        let snap = cache.snapshot("ghost", Instant::now());
+        assert!(matches!(snap.observation.last_status, FeedStatus::Never));
+        assert!(snap.window.is_none());
+        assert!(!snap.within_ttl);
+    }
+
+    #[test]
+    fn failure_fuse_is_clamped() {
+        assert_eq!(
+            failure_fuse(Duration::from_secs(0)),
+            Duration::from_secs(30)
+        );
+        assert_eq!(
+            failure_fuse(Duration::from_secs(900)),
+            Duration::from_secs(225)
+        );
+        assert_eq!(
+            failure_fuse(Duration::from_secs(10_000)),
+            Duration::from_secs(300)
+        );
+    }
+
+    #[test]
+    fn not_modified_rearms_and_flips_to_revalidated() {
+        let cache = MemoryFeedCache::new(1 << 20, 64);
+        let t0 = Instant::now();
+        cache.record_success("a", window_with_rows(2), obs_fresh(2), t0); // expired immediately
+        cache.record_not_modified("a", 304, 1, t0 + Duration::from_secs(900));
+        let snap = cache.snapshot("a", t0 + Duration::from_secs(1));
+        assert!(
+            snap.within_ttl,
+            "a 304 re-arms the timer exactly like success/failure do"
+        );
+        assert!(matches!(
+            snap.observation.last_status,
+            FeedStatus::Revalidated
+        ));
+        assert_eq!(snap.observation.http_status, Some(304));
+        assert_eq!(snap.observation.last_fetch_ms, Some(1));
+        assert!(
+            snap.window.is_some(),
+            "the existing window is kept across revalidation"
+        );
+        assert_eq!(snap.window.as_ref().unwrap().batch.num_rows(), 2);
+    }
+
+    /// A `304` whose window was evicted while the request was in flight. This
+    /// state is reachable without any caller mistake — the eviction below is
+    /// driven entirely by another feed's `record_success` against the byte
+    /// budget, exactly as it would be in production — so the contract is that
+    /// it re-arms and reports, in *both* build profiles. It previously fired a
+    /// `debug_assert!` (a panic inside a partition's poll for every debug
+    /// build, integration suites included) and returned early without arming,
+    /// which left the feed expired and refetching on every scan.
+    #[test]
+    fn record_not_modified_after_window_eviction_rearms_and_records_it() {
+        let one = window_with_rows(1);
+        let bytes = one.batch.get_array_memory_size();
+        // Room for exactly one window, so "b" arriving evicts "a"'s.
+        let cache = MemoryFeedCache::new(bytes + 8, 64);
+        let t0 = Instant::now();
+        // "a" is armed to `t0`, i.e. already expired — which is the only state
+        // that makes a caller send validators in the first place, and what
+        // makes the re-arm below the *only* thing that can put the feed back
+        // within its TTL.
+        cache.record_success("a", window_with_rows(1), obs_fresh(1), t0);
+        // "a" holds a window and its validators; a scan would send them now.
+        assert!(cache.snapshot("a", t0).window.is_some());
+        assert!(!cache.snapshot("a", t0 + Duration::from_secs(1)).within_ttl);
+
+        // Natural byte pressure from another feed drops "a"'s window while
+        // that conditional request is in flight.
+        cache.record_success(
+            "b",
+            window_with_rows(1),
+            obs_fresh(1),
+            t0 + Duration::from_secs(900),
+        );
+        assert!(
+            cache.snapshot("a", t0).window.is_none(),
+            "b's window evicted a's under the byte budget"
+        );
+
+        // No panic in either profile: run it directly rather than through
+        // `catch_unwind`, so a reintroduced assertion fails this test.
+        cache.record_not_modified("a", 304, 42, t0 + Duration::from_secs(600));
+
+        let snap = cache.snapshot("a", t0 + Duration::from_secs(1));
+        assert!(
+            snap.within_ttl,
+            "the 304 re-armed the timer even though the window was gone — \
+             otherwise the feed refetches on every scan"
+        );
+        assert!(
+            matches!(snap.observation.last_status, FeedStatus::Error),
+            "no window means zero rows, and Error is the status that says so: {:?}",
+            snap.observation.last_status
+        );
+        assert_eq!(
+            snap.observation.last_error.as_deref(),
+            Some(WINDOW_EVICTED_ON_REVALIDATION),
+            "the zero rows an operator will see have a stated reason"
+        );
+        assert_eq!(snap.observation.http_status, Some(304));
+        assert_eq!(snap.observation.last_fetch_ms, Some(42));
+        assert!(snap.window.is_none());
+        // The earlier success's identity survives, as eviction always leaves
+        // the observation in place.
+        assert_eq!(snap.observation.item_count, Some(1));
+    }
+
+    #[test]
+    fn lru_touch_order_respected() {
+        let one = window_with_rows(1);
+        let bytes = one.batch.get_array_memory_size();
+        // Room for exactly two windows.
+        let cache = MemoryFeedCache::new(bytes * 2 + 8, 64);
+        let t0 = Instant::now();
+        let armed = t0 + Duration::from_secs(900);
+        cache.record_success("a", window_with_rows(1), obs_fresh(1), armed);
+        cache.record_success("b", window_with_rows(1), obs_fresh(1), armed);
+        // Touch "a" so "b" becomes the least-recently-used entry.
+        assert!(
+            cache
+                .snapshot("a", t0 + Duration::from_secs(1))
+                .window
+                .is_some()
+        );
+        cache.record_success("c", window_with_rows(1), obs_fresh(1), armed);
+
+        assert!(
+            cache
+                .snapshot("a", t0 + Duration::from_secs(1))
+                .window
+                .is_some(),
+            "recently touched entry stays"
+        );
+        assert!(
+            cache
+                .snapshot("b", t0 + Duration::from_secs(1))
+                .window
+                .is_none(),
+            "least-recently-used entry is evicted, not the touched one"
+        );
+        assert!(
+            cache
+                .snapshot("c", t0 + Duration::from_secs(1))
+                .window
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn max_entries_bound_evicts_lru_window() {
+        // Bytes budget is generous; only the entry-count bound is at play.
+        let cache = MemoryFeedCache::new(1 << 20, 2);
+        let t0 = Instant::now();
+        let armed = t0 + Duration::from_secs(900);
+        cache.record_success("a", window_with_rows(1), obs_fresh(1), armed);
+        cache.record_success("b", window_with_rows(1), obs_fresh(1), armed);
+        cache.record_success("c", window_with_rows(1), obs_fresh(1), armed);
+
+        let snap_a = cache.snapshot("a", t0 + Duration::from_secs(1));
+        assert!(
+            snap_a.window.is_none(),
+            "the entry-count bound must evict the LRU window, not just the byte budget"
+        );
+        assert!(matches!(snap_a.observation.last_status, FeedStatus::Fresh));
+        assert!(
+            cache
+                .snapshot("b", t0 + Duration::from_secs(1))
+                .window
+                .is_some()
+        );
+        assert!(
+            cache
+                .snapshot("c", t0 + Duration::from_secs(1))
+                .window
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn max_observations_backstop_evicts_lru_whole_entry() {
+        // `max_entries` of 1 sets `max_observations` to `1 * 8 = 8` (see
+        // `MAX_OBSERVATIONS_MULTIPLIER`). Every feed here is recorded via
+        // `record_failure` with no window at all, so this drives the
+        // whole-entry backstop in isolation from the windowed bound above.
+        let cache = MemoryFeedCache::new(1 << 20, 1);
+        let t0 = Instant::now();
+        let armed = t0 + Duration::from_secs(30);
+        for i in 0..8 {
+            cache.record_failure(
+                &format!("feed-{i}"),
+                Some(500),
+                "http status 500".into(),
+                None,
+                1,
+                armed,
+            );
+        }
+        // 8 distinct keys now fill the map exactly to `max_observations`;
+        // touch "feed-0" so it is not the least-recently-used entry once a
+        // 9th key arrives.
+        let touched = cache.snapshot("feed-0", t0 + Duration::from_secs(1));
+        assert!(matches!(touched.observation.last_status, FeedStatus::Error));
+
+        // A 9th distinct feed key pushes the map to 9 entries, over the
+        // 8-entry `max_observations` bound; "feed-1" — never touched again
+        // after its own insertion, and now the least-recently-used key —
+        // must be the one dropped, whole entry and all.
+        cache.record_failure(
+            "feed-8",
+            Some(500),
+            "http status 500".into(),
+            None,
+            1,
+            armed,
+        );
+
+        let evicted = cache.snapshot("feed-1", t0 + Duration::from_secs(1));
+        assert!(
+            matches!(evicted.observation.last_status, FeedStatus::Never),
+            "the least-recently-used whole entry, observation included, must be gone"
+        );
+        let survivor = cache.snapshot("feed-0", t0 + Duration::from_secs(1));
+        assert!(
+            matches!(survivor.observation.last_status, FeedStatus::Error),
+            "the recently touched entry survives with its observation intact"
+        );
+    }
+
+    #[test]
+    fn max_entries_zero_disables_window_cache_but_keeps_observations() {
+        // `max_entries = 0` is a coherent way to disable window caching
+        // entirely while still wanting `feeds` health tracked. Without the
+        // `MIN_OBSERVATIONS` floor, `max_observations` would also be 0 and
+        // the backstop would discard each observation the instant it was
+        // inserted; this pins the floor keeping it alive instead.
+        let cache = MemoryFeedCache::new(1 << 20, 0);
+        let t0 = Instant::now();
+        let armed = t0 + Duration::from_secs(900);
+
+        cache.record_success("a", window_with_rows(2), obs_fresh(2), armed);
+        let snap_a = cache.snapshot("a", t0 + Duration::from_secs(1));
+        assert!(
+            snap_a.window.is_none(),
+            "max_entries = 0 must disable window caching, not just shrink it"
+        );
+        assert!(matches!(snap_a.observation.last_status, FeedStatus::Fresh));
+
+        // Insert a second, different feed — with no floor, `max_observations`
+        // would be 0 and this insert's `evict_observations` call would have
+        // already discarded "a"'s observation before this snapshot ever runs.
+        cache.record_success("b", window_with_rows(1), obs_fresh(1), armed);
+        let snap_a_after = cache.snapshot("a", t0 + Duration::from_secs(1));
+        assert!(
+            matches!(snap_a_after.observation.last_status, FeedStatus::Fresh),
+            "the floor must keep a's observation alive across a later, unrelated insert"
+        );
+        let snap_b = cache.snapshot("b", t0 + Duration::from_secs(1));
+        assert!(matches!(snap_b.observation.last_status, FeedStatus::Fresh));
+    }
+}

--- a/crates/skardi/src/sources/providers/rss/cache.rs
+++ b/crates/skardi/src/sources/providers/rss/cache.rs
@@ -79,13 +79,13 @@
 //! there is no request coalescing here, matching `open_connector`'s cache.
 //! That is a documented future extension, not this module's job.
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use arrow::record_batch::RecordBatch;
 
-use super::error::{MAX_ERROR_CHARS, truncate};
+use super::error::{MAX_ERROR_CHARS, MAX_FEED_TEXT_CHARS, truncate};
 
 /// A feed's freshness state, and the single source of the exact strings the
 /// `feeds.last_status` column serves.
@@ -149,6 +149,23 @@ impl FeedStatus {
 ///
 /// `Default` is the state of a feed that has never been attempted: every
 /// field `None` and [`FeedStatus::Never`].
+///
+/// Every feed- or server-controlled string retained here is length-capped.
+/// Six of the fields below are written from the wire: `title` and
+/// `description` carry the document's own text, `site_url` its alternate
+/// link, `dialect_declared` and `conformance_notes` sniffs that quote it, and
+/// `last_error` a diagnostic that may. Nothing downstream bounds any of them —
+/// [`MemoryFeedCache`]'s budget meters `RecordBatch` bytes only (see
+/// [`MemoryFeedCache::record_success`]), so an observation is never charged
+/// against `max_bytes` at all — and an observation deliberately outlives the
+/// window it describes (the module doc's "eviction keeps the observation"), so
+/// an uncapped string here is retained past the point where the bytes it came
+/// from are gone. A single `<title>` may be as large as `max_response_bytes`.
+///
+/// [`FeedObservation::capped`] is where that holds: it is applied where an
+/// observation is stored, so the bound is a property of this boundary rather
+/// than something each construction site has to remember. Adding a
+/// feed-controlled string field means adding it there too.
 #[derive(Debug, Clone, Default)]
 pub struct FeedObservation {
     pub last_fetch_ms: Option<i64>,
@@ -162,6 +179,37 @@ pub struct FeedObservation {
     pub site_url: Option<String>,
     pub description: Option<String>,
     pub item_count: Option<u64>,
+}
+
+impl FeedObservation {
+    /// This observation with every feed- or server-controlled string bounded
+    /// to its column's cap — see the struct doc for why one is needed at all.
+    ///
+    /// Two caps, because the fields divide into two kinds of text.
+    /// `title` and `description` are the feed's own prose and get the looser
+    /// [`MAX_FEED_TEXT_CHARS`]; `site_url`, `dialect_declared`,
+    /// `conformance_notes`, and `last_error` are identifiers and diagnostics
+    /// and get [`MAX_ERROR_CHARS`], the bound every other feed-influenced
+    /// diagnostic in this provider is held to.
+    ///
+    /// `dialect` is absent because it is never feed-controlled: its only
+    /// writer is [`super::conformance::parsed_dialect`], which returns a
+    /// `&'static str` from a closed set. `last_error` is included even though
+    /// its writers cap it already, so the guarantee at this boundary is total
+    /// rather than inherited from every upstream remembering to. Non-string
+    /// fields are untouched — this is a length bound and nothing else.
+    pub fn capped(mut self) -> Self {
+        fn cap(text: Option<String>, max_chars: usize) -> Option<String> {
+            text.map(|t| truncate(&t, max_chars))
+        }
+        self.last_error = cap(self.last_error, MAX_ERROR_CHARS);
+        self.dialect_declared = cap(self.dialect_declared, MAX_ERROR_CHARS);
+        self.conformance_notes = cap(self.conformance_notes, MAX_ERROR_CHARS);
+        self.site_url = cap(self.site_url, MAX_ERROR_CHARS);
+        self.title = cap(self.title, MAX_FEED_TEXT_CHARS);
+        self.description = cap(self.description, MAX_FEED_TEXT_CHARS);
+        self
+    }
 }
 
 /// A feed's cached window: the parsed `items` batch plus the conditional-GET
@@ -318,69 +366,143 @@ struct WindowEntry {
 
 /// One feed's full cache entry: an always-present observation, and an
 /// optional window that the byte/entry budget can evict independently.
+///
+/// Recency lives here, as a tick per entry, rather than in a list of keys
+/// held beside the map. A key list has to be *searched* to move a feed to the
+/// front, so every access costs a scan of every other feed — and `snapshot`
+/// runs once per feed per scan, against a list `max_observations` (8x
+/// `max_entries`) long, with `max_entries` itself sized to the subscription
+/// count. That is quadratic in the number of subscriptions for bookkeeping a
+/// cache hit does not need. The order is only ever *read* when a bound is
+/// exceeded, so it is recorded here in O(1) and derived by the scans in
+/// `evict`/`evict_observations`, which are the rare path.
 struct Entry {
     observation: FeedObservation,
     window: Option<WindowEntry>,
     armed_until: Instant,
+    /// Tick of the last access of any kind — the order `max_observations`
+    /// evicts by. Set by every one of the four [`FeedCache`] methods, so an
+    /// observation-only entry that keeps getting queried or refreshed is
+    /// exactly as protected from the backstop as a windowed one.
+    last_used: u64,
+    /// Tick of the last access that served or stored `window` — the order
+    /// `max_bytes`/`max_entries` evict by. Meaningless while `window` is
+    /// `None`, which is why the scan that reads it filters on that first.
+    window_last_used: u64,
+}
+
+impl Entry {
+    fn new(armed_until: Instant) -> Self {
+        Self {
+            observation: FeedObservation::default(),
+            window: None,
+            armed_until,
+            last_used: 0,
+            window_last_used: 0,
+        }
+    }
 }
 
 struct Inner {
     map: HashMap<String, Entry>,
-    /// Feeds that currently hold a window, most-recently-used first. Feeds
-    /// with no window (never fetched, or evicted) are not tracked here —
-    /// see [`MemoryFeedCache`]'s doc for why `max_entries` bounds this list
-    /// rather than the whole map.
-    window_order: VecDeque<String>,
     window_bytes: usize,
-    /// Every feed key currently in `map`, most-recently-used first, where
-    /// "used" means touched by any of the four [`FeedCache`] methods —
-    /// unlike `window_order` above, this includes feeds with no window.
-    /// Backs the `max_observations` last-resort bound; see
-    /// [`MemoryFeedCache`]'s doc.
-    entry_order: VecDeque<String>,
+    /// How many entries in `map` hold a window — what `max_entries` bounds,
+    /// kept as a count so the check stays O(1) instead of a scan on every
+    /// write. See [`MemoryFeedCache`]'s doc for why `max_entries` bounds this
+    /// rather than the whole map. It changes in exactly two places,
+    /// [`Inner::store_window`] and [`Inner::drop_window`], so it cannot drift
+    /// from the map it describes.
+    windowed: usize,
+    /// Hands out the strictly increasing ticks the entries above record. At
+    /// one tick per nanosecond a `u64` lasts ~584 years, so wrap-around is not
+    /// a case this reasons about.
+    clock: u64,
 }
 
 impl Inner {
-    /// Drop `feed`'s window (if any) and remove it from the LRU list,
-    /// crediting its bytes back to the budget. A no-op if `feed` has no
-    /// entry or no window.
-    fn drop_window(&mut self, feed: &str) {
-        if let Some(entry) = self.map.get_mut(feed)
-            && let Some(w) = entry.window.take()
-        {
-            self.window_bytes = self.window_bytes.saturating_sub(w.bytes);
+    /// The next tick. Strictly increasing, so no two accesses ever compare
+    /// equal and the eviction scans always have a single minimum — the
+    /// eviction order is therefore total, not merely a partial one broken by
+    /// `HashMap` iteration order.
+    fn tick(&mut self) -> u64 {
+        self.clock += 1;
+        self.clock
+    }
+
+    /// Store `feed`'s window, charging its bytes and marking it used now.
+    fn store_window(&mut self, feed: &str, window: CachedWindow, bytes: usize) {
+        let tick = self.tick();
+        let Some(entry) = self.map.get_mut(feed) else {
+            return;
+        };
+        entry.window_last_used = tick;
+        let previous = entry.window.replace(WindowEntry { window, bytes });
+
+        match previous {
+            // Replacing in place would otherwise leak the old window's bytes.
+            // `record_success` drops first, so this arm is defensive.
+            Some(old) => self.window_bytes = self.window_bytes.saturating_sub(old.bytes),
+            None => self.windowed += 1,
         }
-        self.window_order.retain(|k| k != feed);
+        self.window_bytes += bytes;
     }
 
-    /// Move `feed` to the front of the window LRU list.
+    /// Drop `feed`'s window (if any), crediting its bytes and the windowed
+    /// count back. A no-op if `feed` has no entry or no window.
+    fn drop_window(&mut self, feed: &str) {
+        let Some(entry) = self.map.get_mut(feed) else {
+            return;
+        };
+        let Some(w) = entry.window.take() else {
+            return;
+        };
+        self.window_bytes = self.window_bytes.saturating_sub(w.bytes);
+        self.windowed -= 1;
+    }
+
+    /// Mark `feed`'s window used now.
     fn touch_window(&mut self, feed: &str) {
-        self.window_order.retain(|k| k != feed);
-        self.window_order.push_front(feed.to_string());
+        let tick = self.tick();
+        if let Some(entry) = self.map.get_mut(feed) {
+            entry.window_last_used = tick;
+        }
     }
 
-    /// Move `feed` to the front of the whole-entry LRU list. Called on every
-    /// access or update, whether or not `feed` currently holds a window, so
-    /// an observation-only entry that keeps getting queried or refreshed is
-    /// exactly as protected from the `max_observations` backstop as a
-    /// windowed one.
+    /// Mark `feed` used now, whether or not it currently holds a window.
     fn touch_entry(&mut self, feed: &str) {
-        self.entry_order.retain(|k| k != feed);
-        self.entry_order.push_front(feed.to_string());
+        let tick = self.tick();
+        if let Some(entry) = self.map.get_mut(feed) {
+            entry.last_used = tick;
+        }
+    }
+
+    /// The windowed feed whose window was least recently used. `None` when no
+    /// feed holds one. O(map), and reached only from [`Inner::evict`].
+    fn oldest_windowed(&self) -> Option<String> {
+        self.map
+            .iter()
+            .filter(|(_, entry)| entry.window.is_some())
+            .min_by_key(|(_, entry)| entry.window_last_used)
+            .map(|(feed, _)| feed.clone())
+    }
+
+    /// The least recently used entry of any kind. O(map), and reached only
+    /// from [`Inner::evict_observations`].
+    fn oldest_entry(&self) -> Option<String> {
+        self.map
+            .iter()
+            .min_by_key(|(_, entry)| entry.last_used)
+            .map(|(feed, _)| feed.clone())
     }
 
     /// Evict least-recently-used windows (dropping only the window, never
     /// the observation) until both the byte and entry budgets hold.
     fn evict(&mut self, max_bytes: usize, max_entries: usize) {
-        while self.window_order.len() > max_entries || self.window_bytes > max_bytes {
-            let Some(oldest) = self.window_order.pop_back() else {
+        while self.windowed > max_entries || self.window_bytes > max_bytes {
+            let Some(oldest) = self.oldest_windowed() else {
                 break;
             };
-            if let Some(entry) = self.map.get_mut(&oldest)
-                && let Some(w) = entry.window.take()
-            {
-                self.window_bytes = self.window_bytes.saturating_sub(w.bytes);
-            }
+            self.drop_window(&oldest);
         }
     }
 
@@ -391,15 +513,14 @@ impl Inner {
     /// preserving eviction above.
     fn evict_observations(&mut self, max_observations: usize) {
         while self.map.len() > max_observations {
-            let Some(oldest) = self.entry_order.pop_back() else {
+            let Some(oldest) = self.oldest_entry() else {
                 break;
             };
-            if let Some(entry) = self.map.remove(&oldest)
-                && let Some(w) = entry.window
-            {
-                self.window_bytes = self.window_bytes.saturating_sub(w.bytes);
-            }
-            self.window_order.retain(|k| k != &oldest);
+            // Through `drop_window` so the byte and windowed counts are
+            // credited by the one place that maintains them, rather than by a
+            // second copy of that arithmetic here.
+            self.drop_window(&oldest);
+            self.map.remove(&oldest);
         }
     }
 }
@@ -407,7 +528,9 @@ impl Inner {
 /// In-memory [`FeedCache`], bounded by window bytes, window count, and
 /// (as a last resort) total observation count, behind a `Mutex`
 /// (hand-rolled LRU, following `open_connector/cache.rs`'s precedent rather
-/// than adding the `lru` crate).
+/// than adding the `lru` crate). Recency is a tick recorded on each entry
+/// rather than a list of keys kept beside the map — see [`Entry`] for why
+/// that shape and not the other.
 ///
 /// `max_entries` bounds how many feeds may hold a cached window at once —
 /// it does not bound the map itself, since a feed that is only failing or
@@ -447,9 +570,9 @@ impl MemoryFeedCache {
         Self {
             inner: Mutex::new(Inner {
                 map: HashMap::new(),
-                window_order: VecDeque::new(),
                 window_bytes: 0,
-                entry_order: VecDeque::new(),
+                windowed: 0,
+                clock: 0,
             }),
             max_bytes,
             max_entries,
@@ -512,12 +635,14 @@ impl FeedCache for MemoryFeedCache {
         // ends up fitting.
         inner.drop_window(feed);
 
-        let entry = inner.map.entry(feed.to_string()).or_insert_with(|| Entry {
-            observation: FeedObservation::default(),
-            window: None,
-            armed_until,
-        });
-        entry.observation = observation;
+        let entry = inner
+            .map
+            .entry(feed.to_string())
+            .or_insert_with(|| Entry::new(armed_until));
+        // The one place a whole observation enters the store, and so where its
+        // strings are bounded — see [`FeedObservation::capped`]. Applied here
+        // rather than at the caller so no future construction site can omit it.
+        entry.observation = observation.capped();
         entry.armed_until = armed_until;
 
         // A window that alone exceeds the whole byte budget can never fit no
@@ -525,9 +650,7 @@ impl FeedCache for MemoryFeedCache {
         // observation (already done above) but skip the window entirely
         // rather than insert-then-immediately-evict it.
         if bytes <= self.max_bytes {
-            entry.window = Some(WindowEntry { window, bytes });
-            inner.window_bytes += bytes;
-            inner.window_order.push_front(feed.to_string());
+            inner.store_window(feed, window, bytes);
             inner.evict(self.max_bytes, self.max_entries);
         }
 
@@ -543,11 +666,10 @@ impl FeedCache for MemoryFeedCache {
         armed_until: Instant,
     ) {
         let mut inner = self.lock();
-        let entry = inner.map.entry(feed.to_string()).or_insert_with(|| Entry {
-            observation: FeedObservation::default(),
-            window: None,
-            armed_until,
-        });
+        let entry = inner
+            .map
+            .entry(feed.to_string())
+            .or_insert_with(|| Entry::new(armed_until));
 
         // An attempt happened and it is the caller's `armed_until` that
         // decides when the next one may, so the fetch metadata and the re-arm
@@ -600,11 +722,10 @@ impl FeedCache for MemoryFeedCache {
         armed_until: Instant,
     ) {
         let mut inner = self.lock();
-        let entry = inner.map.entry(feed.to_string()).or_insert_with(|| Entry {
-            observation: FeedObservation::default(),
-            window: None,
-            armed_until,
-        });
+        let entry = inner
+            .map
+            .entry(feed.to_string())
+            .or_insert_with(|| Entry::new(armed_until));
         // A failed refresh does not invalidate a previously cached window —
         // it is left exactly as it was, available to serve stale, and
         // determines which of the two failure statuses applies.
@@ -622,6 +743,13 @@ impl FeedCache for MemoryFeedCache {
             entry.observation.dialect_declared = dialect_declared;
         }
         entry.armed_until = armed_until;
+        // The other path that writes feed- and server-controlled strings into a
+        // retained observation, so it is held to the same bound `record_success`
+        // is, through the same entry point. Both fields it just wrote are capped
+        // by their own writers too; going through `capped()` here is what keeps
+        // that a redundancy rather than the only thing holding the invariant up.
+        let observation = std::mem::take(&mut entry.observation);
+        entry.observation = observation.capped();
 
         inner.touch_entry(feed);
         inner.evict_observations(self.max_observations);
@@ -663,6 +791,199 @@ mod tests {
             description: Some("desc".into()),
             item_count: Some(item_count),
         }
+    }
+
+    /// Every field an over-long value, so a cap that is missing or applied to
+    /// the wrong field shows up as a wrong length rather than passing by luck.
+    fn obs_all_strings_long(chars: usize) -> FeedObservation {
+        let long = "x".repeat(chars);
+        FeedObservation {
+            last_fetch_ms: Some(1_700_000_000_000),
+            last_status: FeedStatus::Fresh,
+            http_status: Some(200),
+            last_error: Some(long.clone()),
+            dialect: Some("rss-2.0".into()),
+            dialect_declared: Some(long.clone()),
+            conformance_notes: Some(long.clone()),
+            title: Some(long.clone()),
+            site_url: Some(long.clone()),
+            description: Some(long),
+            item_count: Some(7),
+        }
+    }
+
+    /// Every feed- or server-controlled string is bounded, each at its own
+    /// column's cap: prose (`title`, `description`) at `MAX_FEED_TEXT_CHARS`,
+    /// identifiers and diagnostics at `MAX_ERROR_CHARS`. Nothing downstream
+    /// bounds these — the cache's budget meters `RecordBatch` bytes only — so
+    /// this is the only place the length is decided.
+    #[test]
+    fn capped_bounds_every_feed_controlled_string_at_its_own_cap() {
+        let capped = obs_all_strings_long(10_000).capped();
+
+        assert_eq!(
+            capped.title.as_ref().unwrap().chars().count(),
+            MAX_FEED_TEXT_CHARS
+        );
+        assert_eq!(
+            capped.description.as_ref().unwrap().chars().count(),
+            MAX_FEED_TEXT_CHARS
+        );
+        assert_eq!(
+            capped.site_url.as_ref().unwrap().chars().count(),
+            MAX_ERROR_CHARS
+        );
+        assert_eq!(
+            capped.dialect_declared.as_ref().unwrap().chars().count(),
+            MAX_ERROR_CHARS
+        );
+        assert_eq!(
+            capped.conformance_notes.as_ref().unwrap().chars().count(),
+            MAX_ERROR_CHARS
+        );
+        assert_eq!(
+            capped.last_error.as_ref().unwrap().chars().count(),
+            MAX_ERROR_CHARS,
+            "capped again here even though its writers cap it, so the bound at \
+             this boundary does not depend on them"
+        );
+    }
+
+    /// The conservativeness direction: a realistic observation passes through
+    /// unchanged. A cap applied to the wrong field, or one off by a character,
+    /// is visible here as a value that no longer matches what went in.
+    #[test]
+    fn capped_leaves_values_within_bounds_byte_identical() {
+        let before = FeedObservation {
+            last_fetch_ms: Some(1_700_000_000_000),
+            last_status: FeedStatus::Fresh,
+            http_status: Some(200),
+            last_error: None,
+            dialect: Some("rss-2.0".into()),
+            dialect_declared: Some("rss-2.0".into()),
+            conformance_notes: Some("duplicate-identity: 1".into()),
+            title: Some("Daily Notes on Distributed Systems".into()),
+            site_url: Some("https://example.com/blog/index.html".into()),
+            description: Some("Occasional writing about storage engines.".into()),
+            item_count: Some(42),
+        };
+        let after = before.clone().capped();
+
+        assert_eq!(after.title, before.title);
+        assert_eq!(after.description, before.description);
+        assert_eq!(after.site_url, before.site_url);
+        assert_eq!(after.dialect_declared, before.dialect_declared);
+        assert_eq!(after.conformance_notes, before.conformance_notes);
+        assert_eq!(after.last_error, before.last_error);
+        assert_eq!(
+            after.dialect, before.dialect,
+            "never feed-controlled, never cut"
+        );
+    }
+
+    /// The cap counts characters, not bytes, so a feed writing in a script
+    /// whose scalars are 3 or 4 bytes wide is not cut to a third of the
+    /// allowance — and never mid-scalar. `truncate` decides this; the point
+    /// here is that the field-level use inherits it.
+    #[test]
+    fn capped_counts_characters_on_multi_byte_text() {
+        let title = "标题".repeat(10_000);
+        // Spelled as an escape: a single 4-byte scalar, with no chance of a
+        // variation selector riding along and making the byte count ambiguous.
+        let description = "\u{1F680}".repeat(10_000);
+        let capped = FeedObservation {
+            title: Some(title),
+            description: Some(description),
+            ..FeedObservation::default()
+        }
+        .capped();
+
+        let title = capped.title.expect("title survives");
+        assert_eq!(title.chars().count(), MAX_FEED_TEXT_CHARS);
+        // 3-byte scalars: a byte-counting cap would have kept a third of these.
+        assert_eq!(title.len(), MAX_FEED_TEXT_CHARS * 3);
+        let description = capped.description.expect("description survives");
+        assert_eq!(description.chars().count(), MAX_FEED_TEXT_CHARS);
+        assert_eq!(description.len(), MAX_FEED_TEXT_CHARS * 4);
+    }
+
+    /// A pure length bound: the fields that carry no feed text are the feed's
+    /// health, and `capped()` must not be a place where health can change.
+    #[test]
+    fn capped_leaves_non_string_fields_alone() {
+        let before = obs_all_strings_long(10_000);
+        let after = before.clone().capped();
+
+        assert_eq!(after.item_count, before.item_count);
+        assert_eq!(after.http_status, before.http_status);
+        assert_eq!(after.last_fetch_ms, before.last_fetch_ms);
+        assert!(matches!(after.last_status, FeedStatus::Fresh));
+    }
+
+    /// The bound is reached through the cache's own API, not only by calling
+    /// `capped()` directly: `record_success` is where an observation enters the
+    /// store, so a caller that never heard of the cap still cannot get an
+    /// unbounded string retained. The window it stored alongside is untouched —
+    /// `items` content is bounded by the byte budget instead, and must stay
+    /// verbatim.
+    #[test]
+    fn record_success_caps_the_observation_it_stores_and_leaves_the_window_whole() {
+        let cache = MemoryFeedCache::new(1 << 20, 64);
+        let t0 = Instant::now();
+        cache.record_success(
+            "a",
+            window_with_rows(3),
+            obs_all_strings_long(10_000),
+            t0 + Duration::from_secs(900),
+        );
+
+        let snap = cache.snapshot("a", t0 + Duration::from_secs(1));
+        assert_eq!(
+            snap.observation.title.as_ref().unwrap().chars().count(),
+            MAX_FEED_TEXT_CHARS
+        );
+        assert_eq!(
+            snap.observation.site_url.as_ref().unwrap().chars().count(),
+            MAX_ERROR_CHARS
+        );
+        assert_eq!(snap.window.as_ref().unwrap().batch.num_rows(), 3);
+    }
+
+    /// `record_failure` writes feed- and server-controlled strings straight
+    /// into a retained observation, so it is held to the same bound rather
+    /// than trusting its caller to have applied one.
+    #[test]
+    fn record_failure_caps_the_strings_it_writes() {
+        let cache = MemoryFeedCache::new(1 << 20, 64);
+        let t0 = Instant::now();
+        cache.record_failure(
+            "a",
+            Some(500),
+            "x".repeat(10_000),
+            Some(format!("unknown:{}", "y".repeat(10_000))),
+            1,
+            t0 + Duration::from_secs(30),
+        );
+
+        let snap = cache.snapshot("a", t0 + Duration::from_secs(1));
+        assert_eq!(
+            snap.observation
+                .last_error
+                .as_ref()
+                .unwrap()
+                .chars()
+                .count(),
+            MAX_ERROR_CHARS
+        );
+        assert_eq!(
+            snap.observation
+                .dialect_declared
+                .as_ref()
+                .unwrap()
+                .chars()
+                .count(),
+            MAX_ERROR_CHARS
+        );
     }
 
     #[test]
@@ -1001,6 +1322,52 @@ mod tests {
         assert!(
             matches!(survivor.observation.last_status, FeedStatus::Error),
             "the recently touched entry survives with its observation intact"
+        );
+    }
+
+    /// `windowed` and `window_bytes` are counters kept beside the map rather
+    /// than derived from it, so what the eviction bounds test is only as true
+    /// as the two places that maintain them. This drives every path that
+    /// stores or drops a window — a first success, a replacing success, a
+    /// failure that must leave the window alone, a byte-budget eviction, and
+    /// the whole-entry backstop — and then compares both counters against the
+    /// map itself.
+    #[test]
+    fn window_accounting_agrees_with_the_map_after_every_path() {
+        let bytes = window_with_rows(1).batch.get_array_memory_size();
+        // Room for two windows, so the third success evicts.
+        let cache = MemoryFeedCache::new(bytes * 2 + 8, 8);
+        let t0 = Instant::now();
+        let armed = t0 + Duration::from_secs(900);
+
+        cache.record_success("a", window_with_rows(1), obs_fresh(1), armed);
+        cache.record_success("b", window_with_rows(1), obs_fresh(1), armed);
+        // Replacing an existing window must credit the old bytes back.
+        cache.record_success("a", window_with_rows(1), obs_fresh(1), armed);
+        // A failure leaves "a"'s window in place to serve stale.
+        cache.record_failure("a", Some(500), "boom".into(), None, 1, armed);
+        // Over the byte budget: one window is evicted, its observation kept.
+        cache.record_success("c", window_with_rows(1), obs_fresh(1), armed);
+        // Windowless keys, driving the whole-entry backstop at 8 * 8 = 64.
+        for i in 0..70 {
+            cache.record_failure(&format!("f{i}"), Some(500), "boom".into(), None, 1, armed);
+        }
+
+        let inner = cache.lock();
+        assert_eq!(
+            inner.windowed,
+            inner.map.values().filter(|e| e.window.is_some()).count(),
+            "the windowed count must equal the windows the map actually holds"
+        );
+        assert_eq!(
+            inner.window_bytes,
+            inner
+                .map
+                .values()
+                .filter_map(|e| e.window.as_ref())
+                .map(|w| w.bytes)
+                .sum::<usize>(),
+            "the byte total must equal the bytes the map actually holds"
         );
     }
 

--- a/crates/skardi/src/sources/providers/rss/cache.rs
+++ b/crates/skardi/src/sources/providers/rss/cache.rs
@@ -529,8 +529,8 @@ impl Inner {
 /// (as a last resort) total observation count, behind a `Mutex`
 /// (hand-rolled LRU, following `open_connector/cache.rs`'s precedent rather
 /// than adding the `lru` crate). Recency is a tick recorded on each entry
-/// rather than a list of keys kept beside the map — see [`Entry`] for why
-/// that shape and not the other.
+/// rather than a list of keys kept beside the map — see `Entry` (private,
+/// so named in code font, not linked) for why that shape and not the other.
 ///
 /// `max_entries` bounds how many feeds may hold a cached window at once —
 /// it does not bound the map itself, since a feed that is only failing or

--- a/crates/skardi/src/sources/providers/rss/conformance.rs
+++ b/crates/skardi/src/sources/providers/rss/conformance.rs
@@ -23,12 +23,17 @@ pub fn sniff_declared_dialect(bytes: &[u8], family: DocFamily) -> Option<String>
             let local = name.rsplit(':').next().unwrap_or(&name);
             let version = attr_value(&attrs, "version");
             // `name` is a raw root element name off the wire, so this is
-            // feed-controlled text of whatever length the document supplies —
-            // and it is retained in a `FeedObservation`, which
-            // `MemoryFeedCache` never byte-bounds (its budget meters
-            // `RecordBatch` bytes only, `cache.rs:505`). Capped at the same
-            // bound its sibling `feeds.last_error` gets: a 4 KB root element
-            // name was measured producing a 4,104-character column value, and
+            // feed-controlled text of whatever length the document supplies.
+            // Every such string that reaches a `FeedObservation` is bounded —
+            // `MemoryFeedCache` never byte-bounds observations (its budget
+            // meters `RecordBatch` bytes only), and
+            // `FeedObservation::capped()` is where that invariant is enforced
+            // for the store as a whole. This is the local, at-the-source
+            // instance of it: capping each note and identifier where it is
+            // built keeps one hostile value from consuming the whole column's
+            // allowance and crowding out the rest. Capped at the same bound
+            // its sibling `feeds.last_error` gets — a 4 KB root element name
+            // was measured producing a 4,104-character column value, and
             // nothing stopped a 5 MiB one from producing 5 MiB.
             let unknown = || truncate(&format!("unknown:{name}"), MAX_ERROR_CHARS);
 
@@ -197,8 +202,18 @@ pub fn content_type_family_note(content_type: Option<&str>, parsed: FeedType) ->
     if served == family {
         return None;
     }
-    Some(format!(
-        "content-type-mismatch: served {essence}, parsed {family}"
+    // `essence` is a served response header, i.e. server-controlled text of
+    // whatever length, and this note lands in `feeds.conformance_notes` — so
+    // it is bounded here, at the source, like `unknown:<root>` above. The
+    // `served` match is what makes this a no-op today: only the eight literals
+    // it names get past it, and the longest is 20 characters. It stands so
+    // that widening that match — a prefix arm, a wildcard, a vendor `+xml`
+    // suffix rule — cannot quietly put an unbounded header value into the
+    // column, and so that no single note can consume the whole allowance
+    // `FeedObservation::capped()` gives the joined string.
+    Some(truncate(
+        &format!("content-type-mismatch: served {essence}, parsed {family}"),
+        MAX_ERROR_CHARS,
     ))
 }
 
@@ -276,8 +291,10 @@ mod tests {
         );
     }
 
-    /// `unknown:<root>` is feed-controlled text and is capped, because it is
-    /// retained in a `FeedObservation` that nothing else byte-bounds.
+    /// `unknown:<root>` is feed-controlled text and is capped at the source,
+    /// because it is retained in a `FeedObservation` that nothing else
+    /// byte-bounds — the same invariant `FeedObservation::capped()` holds for
+    /// the store as a whole.
     #[test]
     fn an_absurd_root_element_name_is_capped_like_last_error() {
         let doc = format!("<{}/>", "x".repeat(4_096));
@@ -363,6 +380,49 @@ mod tests {
             content_type_family_note(Some("application/rss+xml"), FeedType::RSS1),
             None
         );
+    }
+
+    /// A served `Content-Type` is server-controlled text of whatever length,
+    /// and the note quoting it lands in `feeds.conformance_notes`, so the note
+    /// is bounded however long the header is.
+    ///
+    /// Two ways that holds, and the distinction is the point. An absurd type
+    /// carries no family opinion, so it produces no note at all — it never
+    /// reaches the format string, which is why the cap there is a no-op today
+    /// rather than the thing keeping this column bounded. The cap is the
+    /// backstop for a `served` match that later recognises more than eight
+    /// exact literals; what this pins is that the column is bounded either
+    /// way, and that a note that *is* produced is still the exact string an
+    /// operator reads.
+    #[test]
+    fn a_pathological_content_type_cannot_produce_an_unbounded_note() {
+        let absurd = format!("application/{}+xml", "x".repeat(10_000));
+        assert_eq!(
+            content_type_family_note(Some(&absurd), FeedType::Atom),
+            None,
+            "an unrecognised type names no family and so can disagree with none"
+        );
+        // Same, with the length pushed into a parameter the essence split
+        // discards rather than into the essence itself.
+        let padded = format!("application/rss+xml; charset={}", "x".repeat(10_000));
+        assert_eq!(
+            content_type_family_note(Some(&padded), FeedType::Atom)
+                .expect("the essence still names rss, which disagrees with atom"),
+            "content-type-mismatch: served application/rss+xml, parsed atom",
+            "a recognised essence yields the note verbatim, parameters and all dropped"
+        );
+        for note in [
+            content_type_family_note(Some(&padded), FeedType::Atom),
+            content_type_family_note(Some("application/atom+xml"), FeedType::RSS2),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            assert!(
+                note.chars().count() <= MAX_ERROR_CHARS,
+                "no note may exceed the per-note cap: {note}"
+            );
+        }
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/rss/conformance.rs
+++ b/crates/skardi/src/sources/providers/rss/conformance.rs
@@ -1,0 +1,414 @@
+//! Dialect sniffing and conformance observations.
+//!
+//! Two notions of dialect are kept apart on purpose: what the document *claims*
+//! (a lexical sniff of the root element, which still works on bytes too broken
+//! to parse) and what `feed-rs` actually *parsed*. Disagreement between them is
+//! an observation about the feed, not an error.
+
+use feed_rs::model::{Feed, FeedType};
+
+use super::error::{MAX_ERROR_CHARS, truncate};
+use super::sanitize::{DocFamily, find_sub};
+
+const ATOM_1_0_NS: &str = "http://www.w3.org/2005/Atom";
+const ATOM_0_3_NS: &str = "http://purl.org/atom/ns#";
+const JSON_FEED_VERSION_MARKER: &[u8] = b"jsonfeed.org/version/";
+
+/// The dialect the document declares, sniffed lexically.
+pub fn sniff_declared_dialect(bytes: &[u8], family: DocFamily) -> Option<String> {
+    match family {
+        DocFamily::Json => sniff_json_feed_version(bytes),
+        DocFamily::Xml => {
+            let (name, attrs) = first_start_element(bytes)?;
+            let local = name.rsplit(':').next().unwrap_or(&name);
+            let version = attr_value(&attrs, "version");
+            // `name` is a raw root element name off the wire, so this is
+            // feed-controlled text of whatever length the document supplies —
+            // and it is retained in a `FeedObservation`, which
+            // `MemoryFeedCache` never byte-bounds (its budget meters
+            // `RecordBatch` bytes only, `cache.rs:505`). Capped at the same
+            // bound its sibling `feeds.last_error` gets: a 4 KB root element
+            // name was measured producing a 4,104-character column value, and
+            // nothing stopped a 5 MiB one from producing 5 MiB.
+            let unknown = || truncate(&format!("unknown:{name}"), MAX_ERROR_CHARS);
+
+            let dialect = if local.eq_ignore_ascii_case("RDF") {
+                "rss-1.0".to_string()
+            } else if local.eq_ignore_ascii_case("rss") {
+                match version.as_deref() {
+                    Some("2.0") => "rss-2.0".to_string(),
+                    Some("0.91") => "rss-0.91".to_string(),
+                    Some("0.92") => "rss-0.92".to_string(),
+                    Some("0.9") => "rss-0.9".to_string(),
+                    _ => unknown(),
+                }
+            } else if local.eq_ignore_ascii_case("feed") {
+                let ns = attr_value(&attrs, "xmlns").unwrap_or_default();
+                if ns == ATOM_1_0_NS {
+                    "atom-1.0".to_string()
+                } else if ns == ATOM_0_3_NS || version.as_deref() == Some("0.3") {
+                    "atom-0.3".to_string()
+                } else {
+                    unknown()
+                }
+            } else {
+                unknown()
+            };
+            Some(dialect)
+        }
+    }
+}
+
+/// `"1.1"` / `"1"` out of a JSON Feed `version` URL, found lexically so that a
+/// document too broken to deserialize still reports what it claims to be.
+fn sniff_json_feed_version(bytes: &[u8]) -> Option<String> {
+    let at = find_sub(bytes, JSON_FEED_VERSION_MARKER)? + JSON_FEED_VERSION_MARKER.len();
+    let tail = &bytes[at..];
+    let end = tail
+        .iter()
+        .position(|c| !(c.is_ascii_digit() || *c == b'.'))
+        .unwrap_or(tail.len());
+    match &tail[..end] {
+        b"1.1" => Some("json-feed-1.1".to_string()),
+        b"1" => Some("json-feed-1".to_string()),
+        _ => None,
+    }
+}
+
+/// The first start element's name and raw attribute text, skipping the prolog's
+/// comments, processing instructions, and declarations.
+fn first_start_element(bytes: &[u8]) -> Option<(String, String)> {
+    let mut i = 0;
+    while i < bytes.len() {
+        let rest = &bytes[i..];
+        if rest[0] != b'<' {
+            i += 1;
+            continue;
+        }
+        if rest.starts_with(b"<!--") {
+            i += 4 + find_sub(&rest[4..], b"-->")? + 3;
+            continue;
+        }
+        if rest.starts_with(b"<?") {
+            i += 2 + find_sub(&rest[2..], b"?>")? + 2;
+            continue;
+        }
+        if rest.starts_with(b"<!") {
+            // A declaration (doctype, cdata); not the root element.
+            i += rest.iter().position(|&c| c == b'>')? + 1;
+            continue;
+        }
+
+        let tag_end = rest.iter().position(|&c| c == b'>')?;
+        let inner = &rest[1..tag_end];
+        let name_end = inner
+            .iter()
+            .position(|c| c.is_ascii_whitespace() || *c == b'/')
+            .unwrap_or(inner.len());
+        return Some((
+            String::from_utf8_lossy(&inner[..name_end]).into_owned(),
+            String::from_utf8_lossy(&inner[name_end..]).into_owned(),
+        ));
+    }
+    None
+}
+
+/// The value of attribute `want` in raw attribute text.
+fn attr_value(attrs: &str, want: &str) -> Option<String> {
+    let b = attrs.as_bytes();
+    let mut i = 0;
+    while i < b.len() {
+        if b[i] != b'=' {
+            i += 1;
+            continue;
+        }
+        // The name ends just before the `=`, modulo whitespace.
+        let mut name_end = i;
+        while name_end > 0 && b[name_end - 1].is_ascii_whitespace() {
+            name_end -= 1;
+        }
+        let mut name_start = name_end;
+        while name_start > 0 && is_xml_name_byte(b[name_start - 1]) {
+            name_start -= 1;
+        }
+
+        let mut j = i + 1;
+        while j < b.len() && b[j].is_ascii_whitespace() {
+            j += 1;
+        }
+        let &quote = b.get(j)?;
+        if quote != b'"' && quote != b'\'' {
+            i += 1;
+            continue;
+        }
+        j += 1;
+        let value_start = j;
+        while j < b.len() && b[j] != quote {
+            j += 1;
+        }
+        if &attrs[name_start..name_end] == want {
+            return Some(attrs[value_start..j].to_string());
+        }
+        i = j + 1;
+    }
+    None
+}
+
+fn is_xml_name_byte(c: u8) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, b'_' | b'-' | b'.' | b':')
+}
+
+/// The dialect `feed-rs` parsed, as a `feeds.dialect` enum-domain value.
+pub fn parsed_dialect(t: FeedType) -> &'static str {
+    match t {
+        FeedType::RSS0 => "rss-0.9x",
+        FeedType::RSS1 => "rss-1.0",
+        FeedType::RSS2 => "rss-2.0",
+        FeedType::Atom => "atom",
+        FeedType::JSON => "json-feed-1.x",
+    }
+}
+
+/// The feed family a parsed `FeedType` belongs to.
+fn parsed_family(t: &FeedType) -> &'static str {
+    match t {
+        FeedType::RSS0 | FeedType::RSS1 | FeedType::RSS2 => "rss",
+        FeedType::Atom => "atom",
+        FeedType::JSON => "json",
+    }
+}
+
+/// A note when the served `Content-Type` disagrees with the parsed family.
+/// Generic and absent types carry no opinion and produce no note.
+pub fn content_type_family_note(content_type: Option<&str>, parsed: FeedType) -> Option<String> {
+    // Drop any `; charset=…` parameters before comparing.
+    let essence = content_type?.split(';').next()?.trim().to_ascii_lowercase();
+
+    let served = match essence.as_str() {
+        "application/rss+xml" | "text/rss+xml" => "rss",
+        "application/atom+xml" | "text/atom+xml" => "atom",
+        "application/feed+json" | "application/json" | "text/json" => "json",
+        // `text/xml`, `application/xml`, `application/octet-stream` and anything
+        // unrecognized name no particular family, so they cannot disagree with one.
+        _ => return None,
+    };
+
+    let family = parsed_family(&parsed);
+    if served == family {
+        return None;
+    }
+    Some(format!(
+        "content-type-mismatch: served {essence}, parsed {family}"
+    ))
+}
+
+/// Notes for dialect-required fields the feed omitted.
+pub fn required_field_notes(parsed: FeedType, feed: &Feed) -> Vec<String> {
+    let mut absent: Vec<&str> = Vec::new();
+    match parsed {
+        FeedType::RSS2 => {
+            if feed.title.is_none() {
+                absent.push("channel/title");
+            }
+            if feed.links.is_empty() {
+                absent.push("channel/link");
+            }
+            if feed.description.is_none() {
+                absent.push("channel/description");
+            }
+        }
+        FeedType::Atom => {
+            if feed.title.is_none() {
+                absent.push("feed/title");
+            }
+            if feed.updated.is_none() {
+                absent.push("feed/updated");
+            }
+        }
+        // RSS 0.9x/1.0 and JSON Feed required-field sets extend via the corpus
+        // evidence loop (Task 17) rather than being guessed here.
+        FeedType::RSS0 | FeedType::RSS1 | FeedType::JSON => {}
+    }
+    absent
+        .into_iter()
+        .map(|path| format!("missing-required-field: {path}"))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(doc: &str) -> Feed {
+        feed_rs::parser::parse(doc.as_bytes()).expect("fixture must parse")
+    }
+
+    #[test]
+    fn declared_dialects_sniff_from_root_and_version() {
+        let cases: &[(&str, &str)] = &[
+            (r#"<rss version="2.0"><channel/></rss>"#, "rss-2.0"),
+            (r#"<rss version="0.91"><channel/></rss>"#, "rss-0.91"),
+            (
+                r#"<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>"#,
+                "rss-1.0",
+            ),
+            (r#"<feed xmlns="http://www.w3.org/2005/Atom"/>"#, "atom-1.0"),
+            (
+                r#"<feed version="0.3" xmlns="http://purl.org/atom/ns#"/>"#,
+                "atom-0.3",
+            ),
+            (r#"<html/>"#, "unknown:html"),
+        ];
+        for (doc, want) in cases {
+            assert_eq!(
+                sniff_declared_dialect(doc.as_bytes(), DocFamily::Xml).as_deref(),
+                Some(*want),
+                "{doc}"
+            );
+        }
+        assert_eq!(
+            sniff_declared_dialect(
+                br#"{"version":"https://jsonfeed.org/version/1.1","items":[]}"#,
+                DocFamily::Json
+            )
+            .as_deref(),
+            Some("json-feed-1.1")
+        );
+    }
+
+    /// `unknown:<root>` is feed-controlled text and is capped, because it is
+    /// retained in a `FeedObservation` that nothing else byte-bounds.
+    #[test]
+    fn an_absurd_root_element_name_is_capped_like_last_error() {
+        let doc = format!("<{}/>", "x".repeat(4_096));
+        let declared = sniff_declared_dialect(doc.as_bytes(), DocFamily::Xml)
+            .expect("an unrecognised root still sniffs to `unknown:…`");
+        assert_eq!(
+            declared.chars().count(),
+            MAX_ERROR_CHARS,
+            "a 4 KB root element name must be cut to the cap, not stored whole"
+        );
+        assert!(
+            declared.starts_with("unknown:xxx"),
+            "the prefix and enough of the name to diagnose it survive: {declared}"
+        );
+    }
+
+    #[test]
+    fn declared_sniff_skips_prolog_comments_and_pis() {
+        let doc = concat!(
+            r#"<?xml version="1.0"?>"#,
+            "<!-- <feed> decoy in a comment -->",
+            r#"<rss version="0.92"><channel/></rss>"#,
+        );
+        assert_eq!(
+            sniff_declared_dialect(doc.as_bytes(), DocFamily::Xml).as_deref(),
+            Some("rss-0.92"),
+            "the decoy in the comment must not win"
+        );
+    }
+
+    #[test]
+    fn json_feed_version_1_sniffs_without_minor() {
+        assert_eq!(
+            sniff_declared_dialect(
+                br#"{"version": "https://jsonfeed.org/version/1", "title": "t"}"#,
+                DocFamily::Json
+            )
+            .as_deref(),
+            Some("json-feed-1")
+        );
+    }
+
+    #[test]
+    fn parsed_dialect_maps_all_five_feedtypes() {
+        assert_eq!(parsed_dialect(FeedType::RSS0), "rss-0.9x");
+        assert_eq!(parsed_dialect(FeedType::RSS1), "rss-1.0");
+        assert_eq!(parsed_dialect(FeedType::RSS2), "rss-2.0");
+        assert_eq!(parsed_dialect(FeedType::Atom), "atom");
+        assert_eq!(parsed_dialect(FeedType::JSON), "json-feed-1.x");
+    }
+
+    #[test]
+    fn content_type_mismatch_notes() {
+        assert_eq!(
+            content_type_family_note(Some("application/rss+xml"), FeedType::Atom).as_deref(),
+            Some("content-type-mismatch: served application/rss+xml, parsed atom")
+        );
+        // Generic and matching types carry no opinion.
+        assert_eq!(
+            content_type_family_note(Some("text/xml"), FeedType::Atom),
+            None
+        );
+        assert_eq!(
+            content_type_family_note(Some("application/xml"), FeedType::RSS2),
+            None
+        );
+        assert_eq!(
+            content_type_family_note(Some("application/octet-stream"), FeedType::JSON),
+            None
+        );
+        assert_eq!(content_type_family_note(None, FeedType::Atom), None);
+        assert_eq!(
+            content_type_family_note(Some("application/atom+xml"), FeedType::Atom),
+            None
+        );
+        // Charset parameters must not defeat the comparison.
+        assert_eq!(
+            content_type_family_note(Some("application/atom+xml; charset=utf-8"), FeedType::Atom),
+            None
+        );
+        // Every RSS FeedType belongs to the same served family.
+        assert_eq!(
+            content_type_family_note(Some("application/rss+xml"), FeedType::RSS1),
+            None
+        );
+    }
+
+    #[test]
+    fn rss2_missing_description_noted() {
+        let feed = parse(
+            r#"<rss version="2.0"><channel><title>t</title><link>https://e.com</link></channel></rss>"#,
+        );
+        let notes = required_field_notes(FeedType::RSS2, &feed);
+        assert!(
+            notes
+                .iter()
+                .any(|n| n == "missing-required-field: channel/description"),
+            "{notes:?}"
+        );
+        assert!(
+            !notes.iter().any(|n| n.contains("channel/title")),
+            "a present field must not be noted: {notes:?}"
+        );
+    }
+
+    #[test]
+    fn atom_missing_updated_noted() {
+        let feed = parse(
+            r#"<feed xmlns="http://www.w3.org/2005/Atom"><title>t</title><id>urn:x</id></feed>"#,
+        );
+        let notes = required_field_notes(FeedType::Atom, &feed);
+        assert!(
+            notes
+                .iter()
+                .any(|n| n == "missing-required-field: feed/updated"),
+            "{notes:?}"
+        );
+        assert!(
+            !notes.iter().any(|n| n.contains("feed/title")),
+            "a present field must not be noted: {notes:?}"
+        );
+    }
+
+    #[test]
+    fn complete_feed_yields_no_required_field_notes() {
+        let feed = parse(
+            r#"<rss version="2.0"><channel><title>t</title><link>https://e.com</link><description>d</description></channel></rss>"#,
+        );
+        assert_eq!(
+            required_field_notes(FeedType::RSS2, &feed),
+            Vec::<String>::new()
+        );
+    }
+}

--- a/crates/skardi/src/sources/providers/rss/convert.rs
+++ b/crates/skardi/src/sources/providers/rss/convert.rs
@@ -1,0 +1,929 @@
+//! HTML → Markdown conversion for item `content`/`summary`.
+//!
+//! Deterministic by contract: identical input yields byte-identical output, and
+//! conversion never fails — pathological input degrades to its text content, or
+//! to the empty string at worst. No HTML *tag* survives into the output:
+//! `script` and `style` are dropped wholesale, and markup without a Markdown
+//! equivalent is reduced to the text it contains. That is narrower than "no
+//! raw HTML survives": a literal `<` can still appear as inert text when there
+//! is no Markdown place to escape it into (an attribute value, e.g.
+//! `title="<script>"` → a literal `<script>` in the output — pinned in this
+//! module's tests), and legitimate fenced code contains `<` too
+//! (`<pre><code>&lt;div&gt;</code></pre>` → a fence containing `<div>`).
+//! Neither is a defect.
+
+use htmd::HtmlToMarkdownBuilder;
+use htmd::options::{BrStyle, Options};
+
+use super::sanitize::find_sub;
+
+/// Ceiling on HTML open-tag nesting depth before conversion is handed to `htmd`.
+///
+/// `htmd`'s DOM walk (`dom_walker::walk_node`/`walk_children` in
+/// `htmd-0.5.5/src/dom_walker.rs`) is mutually recursive with no depth limit,
+/// and overflows the stack on deeply nested input. Probing the real path
+/// (`feed-rs` parse → `render_text` → `html_to_markdown`): a ~6.8 KB feed body
+/// with `content:encoded` nested 600 `<div>`s deep aborted the process on a
+/// 2 MiB thread stack (Tokio's default for both worker and `spawn_blocking`
+/// threads); 500 nested did not. `items.content` is attacker-authored by
+/// definition, so any subscribed feed can trigger this — there is no `Err` to
+/// return and no unwind a `catch_unwind` could intercept, only a process
+/// abort. Above this ceiling, conversion degrades to tag-stripped text
+/// (`strip_tags_to_text`) instead of walking the tree at all; nothing in this
+/// crate's fixtures comes close, so it only engages on pathological input.
+///
+/// The margin is narrower than the two numbers suggest, because the real tree
+/// can be deeper than the open-tag count (implied start tags — see
+/// [`max_open_tag_depth`]). Sweeping 2,057 repeated-unit shapes over a 42-tag
+/// pool, the deepest real tree reachable while the scan still reported ≤ 100
+/// was 203, always from `<table><td>`. Against the 500-600 overflow zone that
+/// is roughly 2.5x, not a wide margin. 203 is an empirical bound over those
+/// shapes, not a proof — and the whole argument presupposes the scan really is
+/// an upper bound on open-tag depth, which it only became once the stale
+/// `foreign` undercount was fixed (see the `foreign` counter in
+/// [`max_open_tag_depth`]).
+const MAX_HTML_DEPTH: usize = 100;
+
+/// Convert an HTML fragment to Markdown.
+pub fn html_to_markdown(html: &str) -> String {
+    if max_open_tag_depth(html) > MAX_HTML_DEPTH {
+        return tidy(&strip_tags_to_text(html));
+    }
+
+    let converter = HtmlToMarkdownBuilder::new()
+        .options(Options {
+            // A two-space hard break cannot survive the per-line trailing-whitespace
+            // trim below; a backslash can.
+            br_style: BrStyle::Backslash,
+            // htmd defaults to `*   item` / `1.  item`; the conventional single
+            // space is what downstream Markdown consumers expect.
+            ul_bullet_spacing: 1,
+            ol_number_spacing: 1,
+            ..Options::default()
+        })
+        // No Markdown equivalent, and their text content is not document
+        // content. A tag with no registered handler still has its children
+        // walked in htmd's default (`Pure`) mode, so unknown markup reduces to
+        // the text it wraps rather than vanishing — the "no handler" branch of
+        // `dom_walker::walk_node` (htmd-0.5.5/src/dom_walker.rs) calls
+        // `walk_children` rather than dropping the node. `noscript` and
+        // `template` are exceptions to that (see this module's tests), for
+        // reasons unrelated to this list. `head` is deliberately *not* here —
+        // skipping it discarded a leading `<title>` or a `<noscript>`
+        // fallback's text as a side effect (both can land inside an implied
+        // `<head>` under html5ever's document-parsing rules), not by design.
+        .skip_tags(vec!["script", "style"])
+        .build();
+
+    // `convert` is fallible only through `io::Write` against htmd's in-memory
+    // buffer, which cannot fail — but the contract is never to error, so degrade.
+    let md = converter.convert(html).unwrap_or_default();
+    tidy(&md)
+}
+
+/// Trim trailing whitespace from every line, then the document's outer whitespace.
+fn tidy(md: &str) -> String {
+    let mut out = String::with_capacity(md.len());
+    for line in md.lines() {
+        out.push_str(line.trim_end());
+        out.push('\n');
+    }
+    out.truncate(out.trim_end().len());
+    let start = out.len() - out.trim_start().len();
+    out.drain(..start);
+    out
+}
+
+/// Elements `html5ever` inserts and immediately pops in body content, so they
+/// never hold children and never increase nesting depth for
+/// [`max_open_tag_depth`].
+///
+/// Taken from the arms of `tree_builder/rules.rs` (html5ever-0.38.0) that call
+/// `insert_and_pop_element_for` in the "in body" insertion mode — `<area> |
+/// <br> | <embed> | <img> | <keygen> | <wbr>`, `<input>`, `<param> | <source> |
+/// <track>`, `<hr>` — plus `<base> | <basefont> | <bgsound> | <link> | <meta>`,
+/// which "in body" routes to the "in head" mode that pops them the same way.
+/// Anything not listed here is counted as nesting, which can only over-count —
+/// `<col>` is left off on purpose, since it is popped only in the table modes
+/// and merely *ignored* in body content (the `<caption> | <col> | … | <tr>` arm
+/// there reports it and returns), and paying an unnecessary degrade for a table
+/// with more than `MAX_HTML_DEPTH` columns is the cheap side of the trade.
+///
+/// The list only holds inside HTML content. In foreign content — anywhere under
+/// `<svg>` or `<math>` — a tag not on the tree builder's breakout list is an
+/// ordinary foreign element that nests, so [`max_open_tag_depth`] suspends the
+/// list there; `"<svg>".to_owned() + &"<wbr>".repeat(400)` measures at DOM depth
+/// 404 while a scan honoring the list scored 2.
+const VOID_ELEMENTS: &[&str] = &[
+    "area", "base", "basefont", "bgsound", "br", "embed", "hr", "img", "input", "keygen", "link",
+    "meta", "param", "source", "track", "wbr",
+];
+
+fn is_void_element(tag: &str) -> bool {
+    VOID_ELEMENTS.iter().any(|v| tag.eq_ignore_ascii_case(v))
+}
+
+/// The two elements that switch the tree builder into foreign content, where
+/// [`VOID_ELEMENTS`] stops applying and a self-closing tag really does close.
+fn is_foreign_root(tag: &str) -> bool {
+    tag.eq_ignore_ascii_case("svg") || tag.eq_ignore_ascii_case("math")
+}
+
+/// Upper bound on the element nesting depth `html5ever` will build from `html`,
+/// found in one non-recursive pass and capped at `MAX_HTML_DEPTH + 1` (all the
+/// caller needs in order to compare against the ceiling).
+///
+/// This is a lexical scan, not a parse — it never builds a tree, so it is safe
+/// to run ahead of `htmd`'s recursive DOM walker no matter how deeply nested
+/// the input is (see [`MAX_HTML_DEPTH`]). Its one obligation is never to
+/// *under*-count: under-counting is what lets a payload through to the walker
+/// and aborts the process, while over-counting only costs an unnecessary (but
+/// still safe) fallback to tag-stripped text. So every construct it does not
+/// specifically recognize is counted as an opening tag, and nothing an attacker
+/// writes may talk the count downward:
+///
+/// * A close tag pops only when it matches the name on top of the open-element
+///   stack. html5ever's `process_end_tag_in_body`
+///   (html5ever-0.38.0/src/tree_builder/mod.rs) walks its open elements looking
+///   for the name and gives up without popping once it meets a "special" tag
+///   (`div` among them, `tag_sets.rs`), so `<div></b>` leaves the `div` open.
+///   Decrementing on *every* close tag, as this scan used to, scored
+///   `"<div></b>".repeat(1000)` as depth 1 against a real DOM depth of 1003.
+/// * Comments and bogus comments end where the tokenizer ends them, not where
+///   symmetry suggests — see [`skip_comment_or_declaration`].
+/// * A quote only opens an attribute value directly after an `=`; see
+///   [`find_tag_end`].
+///
+/// A matching close tag can still close *more* than this pops (implied end
+/// tags, the adoption agency), and tags inside a `script`/`style`/`title` body
+/// are counted even though the tokenizer treats them as raw text: both make the
+/// real tree shallower than this estimate. The one direction html5ever goes
+/// *deeper* than the open-tag count is implied *start* tags — `<table><td>`
+/// builds `table > tbody > tr > td`, four levels from two tags, roughly
+/// doubling it — on top of the fixed `document > html > body` wrapper worth 3.
+/// A sweep of 2,057 repeated-unit shapes put the deepest reachable real tree at
+/// 203 while this scan still reported ≤ 100, `<table><td>` being the worst; see
+/// [`MAX_HTML_DEPTH`] for what that leaves against the overflow zone.
+fn max_open_tag_depth(html: &str) -> usize {
+    let bytes = html.as_bytes();
+    let mut i = 0;
+    // Names of the currently open elements, innermost last. Bounded by
+    // `MAX_HTML_DEPTH + 1` entries: the scan returns the moment it passes the
+    // ceiling, so hostile nesting never allocates proportional to its depth.
+    let mut open: Vec<&str> = Vec::with_capacity(16);
+    let mut max_depth: usize = 0;
+    // How many `svg`/`math` start tags are open and unclosed. This is *not* a
+    // reliable answer to "is the tree builder in foreign content here", and is
+    // only ever read where believing it too readily costs an over-count:
+    //
+    // * Trusted to suspend the [`VOID_ELEMENTS`] skip below. Wrong in the
+    //   direction of counting a void element as nesting, which over-counts.
+    // * *Not* trusted to decide that a self-closing tag closes itself. That
+    //   would under-count, and under-counting is the vulnerability.
+    //
+    // The reason it cannot be trusted is that html5ever leaves foreign content
+    // with no close tag for this scan to see, two ways: the breakout arm at
+    // `tree_builder/rules.rs:1618-1624` (`<b>`, `<br>`, `<div>`, `<table>`, …)
+    // calls `unexpected_start_tag_in_foreign_content` (`mod.rs:1829-1837`),
+    // which pops back to HTML content and re-steps the token there; and the
+    // HTML integration points (`svg foreignObject|desc|title`, mathml
+    // `mi|mo|mn|ms|mtext` — `tag_sets.rs:89-107`) parse their contents as HTML.
+    // A mismatched close tag under `<svg>` leaves it stale too. Tracking those
+    // exactly would mean replicating both sets, a far larger correctness
+    // surface for no safety gain, so this scan does not try.
+    let mut foreign: usize = 0;
+
+    while i < bytes.len() {
+        if bytes[i] != b'<' {
+            i += 1;
+            continue;
+        }
+        if let Some(end) = skip_comment_or_declaration(bytes, i) {
+            i = end;
+            continue;
+        }
+
+        let closing = bytes.get(i + 1) == Some(&b'/');
+        let name_start = if closing { i + 2 } else { i + 1 };
+        if !bytes.get(name_start).is_some_and(u8::is_ascii_alphabetic) {
+            // `<` not followed by an ASCII letter. For `<x`, `states::TagOpen`
+            // emits the `<` as text and reconsumes in `Data`, which is exactly
+            // this. For `</x`, `states::EndTagOpen` starts a bogus comment
+            // running to the next `>`; scanning that comment's body as markup
+            // instead can only over-count, so it is left alone.
+            i += 1;
+            continue;
+        }
+
+        let name_end = tag_name_end(bytes, name_start);
+        let tag = &html[name_start..name_end];
+        let Some((gt, self_closing)) = find_tag_end(bytes, name_end) else {
+            break; // EOF inside a tag: html5ever emits no token for it either
+        };
+        i = gt + 1;
+
+        if foreign == 0 && is_void_element(tag) {
+            continue;
+        }
+        if closing {
+            if open.last().is_some_and(|top| top.eq_ignore_ascii_case(tag)) {
+                let top = open.pop();
+                if top.is_some_and(is_foreign_root) {
+                    foreign -= 1;
+                }
+            }
+        } else {
+            // A self-closing tag closes itself in foreign content only. In HTML
+            // content the flag is acknowledged and then ignored, so `<div/>`
+            // opens a `div` there.
+            //
+            // Honored only for `<svg>`/`<math>` themselves, never for anything
+            // merely *under* one: `foreign` goes stale without a close tag (see
+            // its declaration above), and skipping the push on a stale count
+            // under-counts without bound — `"<svg>" + "<div/>".repeat(1000)`
+            // scanned as depth 1 against a real DOM depth of 1003, and reached
+            // htmd's walker, which aborted the process. The price is a
+            // deliberate over-count on a genuine `<svg>` holding more than
+            // `MAX_HTML_DEPTH` self-closing children (`<svg>` + `<path/>`x1000
+            // scans 101 against a real depth of 5, so it degrades to text) —
+            // the same safe side of the trade [`VOID_ELEMENTS`] takes for
+            // `<col>`.
+            if self_closing && is_foreign_root(tag) {
+                continue;
+            }
+            if is_foreign_root(tag) {
+                foreign += 1;
+            }
+            open.push(tag);
+            max_depth = max_depth.max(open.len());
+            if max_depth > MAX_HTML_DEPTH {
+                return max_depth;
+            }
+        }
+    }
+
+    max_depth
+}
+
+/// `html` with every tag removed and the text nodes kept verbatim (no entity
+/// decoding, no whitespace normalization beyond [`tidy`]'s). Used only when
+/// `html` is too deeply nested for `htmd`'s recursive walker to process safely
+/// ([`MAX_HTML_DEPTH`]); like [`max_open_tag_depth`], this is a lexical strip,
+/// not a parse, so it does not build a tree and cannot itself recurse.
+/// `script`/`style` bodies are dropped, matching the normal conversion path.
+fn strip_tags_to_text(html: &str) -> String {
+    let bytes = html.as_bytes();
+    let mut out = String::with_capacity(html.len());
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if bytes[i] != b'<' {
+            // `<` never appears as a continuation byte of a multi-byte UTF-8
+            // sequence (those are all >= 0x80), so slicing at its position
+            // cannot land inside a code point.
+            let next_lt = bytes[i..]
+                .iter()
+                .position(|&b| b == b'<')
+                .map_or(bytes.len(), |p| i + p);
+            out.push_str(&html[i..next_lt]);
+            i = next_lt;
+            continue;
+        }
+        if let Some(end) = skip_comment_or_declaration(bytes, i) {
+            i = end;
+            continue;
+        }
+
+        let closing = bytes.get(i + 1) == Some(&b'/');
+        let name_start = if closing { i + 2 } else { i + 1 };
+        if !bytes.get(name_start).is_some_and(u8::is_ascii_alphabetic) {
+            // Stray `<`: drop it, same as any other tag delimiter here.
+            i += 1;
+            continue;
+        }
+
+        let name_end = tag_name_end(bytes, name_start);
+        let tag = &html[name_start..name_end];
+        let Some((gt, _)) = find_tag_end(bytes, name_end) else {
+            break;
+        };
+
+        if !closing && (tag.eq_ignore_ascii_case("script") || tag.eq_ignore_ascii_case("style")) {
+            i = skip_element_body(bytes, gt + 1, tag);
+        } else {
+            i = gt + 1;
+        }
+    }
+
+    out
+}
+
+/// Whitespace that ends a tag name or an attribute name in the tokenizer.
+///
+/// The tag states spell the set as `'\t' | '\n' | '\x0C' | ' '`
+/// (html5ever-0.38.0/src/tokenizer/mod.rs: `states::TagName` at `:923`,
+/// `BeforeAttributeName` `:1143`, `AttributeName` `:1166`, `AfterAttributeName`
+/// `:1189`). `\r` is included here anyway because no tag state ever sees one:
+/// all four read through `get_char!` (`:698`) → `get_char` (`:294-303`) →
+/// `get_preprocessed_char` (`:259-290`), whose `//§ preprocessing-the-input-stream`
+/// body rewrites every `\r` to `\n` at `:267-270` and sets `ignore_lf` to swallow
+/// a following `\n`. So a `\r` arrives as `\n` and ends a name exactly like one.
+/// `states::AttributeValue(Unquoted)` (`:1258`) reaches the same result by
+/// listing `'\r'` in its `small_char_set`, which routes it through
+/// `get_preprocessed_char` (`:318`) onto the `FromSet('\n')` arm.
+///
+/// The one state that does see a raw `\r` is `states::BeforeAttributeValue`
+/// (`:1215-1217`), which is why that set spells `'\r'` out: it reads through
+/// `peek!`, and `peek` does not normalize — see the note on `discard_char`
+/// (`:606-611`), "peek() deals in un-processed characters (no newline
+/// normalization), while get_char() does". [`find_tag_end`] handles that state
+/// separately.
+///
+/// Omitting `\r` was safe in direction (longer names pop less often, which
+/// over-counts) but cost real content: `"<p\r\nclass=\"lede\">x</p>".repeat(101)`
+/// scanned as depth 101 against a real DOM depth of 4 and degraded to
+/// tag-stripped text, while the same document with LF endings scanned as 1 and
+/// converted. CRLF inside start tags is ordinary in HTTP-delivered feeds.
+fn is_tag_space(c: u8) -> bool {
+    matches!(c, b'\t' | b'\n' | b'\r' | b'\x0C' | b' ')
+}
+
+/// End of a tag name starting at `start` (one-past-the-last name byte).
+///
+/// `states::TagName` consumes everything except whitespace, `/` and `>` into
+/// the name, so `_`, `:` and `.` are name characters — stopping at them, as
+/// this used to, made `<div_>` and `</div>` compare equal and let
+/// `"<div_></div>".repeat(n)` pop a stack html5ever never pops.
+fn tag_name_end(bytes: &[u8], start: usize) -> usize {
+    let mut end = start;
+    while end < bytes.len() && !is_tag_space(bytes[end]) && !matches!(bytes[end], b'/' | b'>') {
+        end += 1;
+    }
+    end
+}
+
+/// Index of the `>` that ends the tag whose name ended at `from`, plus whether
+/// the tag carries the self-closing flag — or `None` at EOF inside the tag,
+/// where html5ever emits no token at all.
+///
+/// The flag is set only by a `/` consumed in `states::SelfClosingStartTag`'s
+/// predecessors, never by one inside an unquoted attribute value, where `/` is
+/// an ordinary value character: `<svg a=x/>` is *not* self-closing, and taking
+/// it for one would make `"<svg>" + "<path a=x/>".repeat(n)` undercount.
+///
+/// Quoting starts only in `states::BeforeAttributeValue`, i.e. directly after an
+/// attribute name's `=` (html5ever-0.38.0/src/tokenizer/mod.rs). Everywhere else
+/// a `"` or `'` is an ordinary attribute-name character:
+/// `states::BeforeAttributeName` and `states::AttributeName` push it onto the
+/// name and only flag a parse error, and `>` still ends the tag there. Treating
+/// every quote as opening a value, as this used to, let a single `<b '>` swallow
+/// the rest of the document — `"<b '>"` followed by 1000 `<div>`s scanned as
+/// depth 0 against a real DOM depth of 1004.
+fn find_tag_end(bytes: &[u8], from: usize) -> Option<(usize, bool)> {
+    /// Which of the tokenizer's tag states the scan stands in.
+    /// `states::SelfClosingStartTag` and `states::AfterAttributeValueQuoted`
+    /// both reconsume in `BeforeAttributeName` for everything except `>`, so
+    /// they need no state of their own.
+    #[derive(Clone, Copy)]
+    enum S {
+        BeforeName,
+        Name,
+        AfterName,
+        UnquotedValue,
+    }
+
+    let mut j = from;
+    let mut state = S::BeforeName;
+    let mut self_closing = false;
+    while j < bytes.len() {
+        let c = bytes[j];
+        if c == b'>' {
+            // Every one of these states emits the tag on `>`.
+            return Some((j, self_closing));
+        }
+        self_closing = c == b'/' && !matches!(state, S::UnquotedValue);
+        j += 1;
+        state = match (state, c) {
+            // `=` separates a name from its value only once a name has begun.
+            // In `states::BeforeAttributeName` it *is* the name's first
+            // character, so it does not open a value there.
+            (S::Name | S::AfterName, b'=') => {
+                // `states::BeforeAttributeValue` (`:1215-1217`): skip
+                // whitespace, then a `"`/`'` opens a value running to the
+                // matching quote — a character reference inside cannot contain
+                // one, so a plain search for it is exact. Anything else is an
+                // unquoted value. This is the one tag state whose set spells
+                // `'\r'` out, because it peeks rather than normalizing; the
+                // byte is in [`is_tag_space`] either way.
+                while bytes.get(j).is_some_and(|&c| is_tag_space(c)) {
+                    j += 1;
+                }
+                match bytes.get(j) {
+                    Some(&q @ (b'"' | b'\'')) => {
+                        // Unterminated: EOF inside a tag emits no token.
+                        j = find_byte(bytes, j + 1, q)? + 1;
+                        S::BeforeName
+                    }
+                    _ => S::UnquotedValue,
+                }
+            }
+            // An unquoted value ends at whitespace or `>`; `/` is part of it.
+            (S::UnquotedValue, c) if is_tag_space(c) => S::BeforeName,
+            (S::UnquotedValue, b'&') => {
+                // `states::AttributeValue(Unquoted)` hands `&` to
+                // `consume_char_ref`, so a `>` that belongs to a reference does
+                // not end the tag. Only a `;`-terminated run is skipped, and
+                // the run's character set excludes `>`, so this can never skip
+                // *past* a tag end — which is what would let the scan resume
+                // inside a tag and pop an element html5ever left open.
+                let run = bytes[j..]
+                    .iter()
+                    .take_while(|b| b.is_ascii_alphanumeric() || **b == b'#')
+                    .count();
+                if bytes.get(j + run) == Some(&b';') {
+                    j += run + 1;
+                }
+                S::UnquotedValue
+            }
+            (S::UnquotedValue, _) => S::UnquotedValue,
+            // Whitespace and `/` keep these two waiting for a name.
+            (S::BeforeName | S::AfterName, c) if is_tag_space(c) || c == b'/' => state,
+            (S::Name, c) if is_tag_space(c) => S::AfterName,
+            (S::Name, b'/') => S::BeforeName,
+            _ => S::Name,
+        };
+    }
+    None
+}
+
+/// If a comment, markup declaration or bogus comment starts at `at`, the index
+/// just past where html5ever's tokenizer ends it.
+///
+/// The termination rules are the tokenizer's, not the symmetric ones intuition
+/// suggests; each of these divergences was a way to make the depth scan skip
+/// the rest of the document (html5ever-0.38.0/src/tokenizer/mod.rs):
+///
+/// * `<!-->` and `<!--->` are complete comments containing no `-->` at all:
+///   `states::CommentStart` and `states::CommentStartDash` both emit the comment
+///   on `>`.
+/// * `--!>` ends a comment as well as `-->` does: `states::CommentEnd` routes
+///   `!` to `states::CommentEndBang`, which emits on `>`.
+/// * `<?…>` is a bogus comment ending at the first `>`, never at `?>` — HTML has
+///   no processing instructions, so `states::TagOpen`'s `'?'` arm reconsumes in
+///   `states::BogusComment`, which emits on `>`.
+/// * `<!` anything else is a doctype or (including `<![CDATA[` in HTML content)
+///   a bogus comment, and both also end at the first `>` — even one inside a
+///   doctype's quoted identifier, which `states::DoctypeIdentifierDoubleQuoted`
+///   treats as an abrupt end rather than as quoted content.
+fn skip_comment_or_declaration(bytes: &[u8], at: usize) -> Option<usize> {
+    if bytes[at..].starts_with(b"<!--") {
+        return Some(comment_end(bytes, at + 4));
+    }
+    if bytes[at..].starts_with(b"<!") || bytes[at..].starts_with(b"<?") {
+        return Some(find_byte(bytes, at, b'>').map_or(bytes.len(), |p| p + 1));
+    }
+    None
+}
+
+/// Index just past the end of the comment whose `<!--` ends at `body`.
+fn comment_end(bytes: &[u8], body: usize) -> usize {
+    // comment-start / comment-start-dash: a `>` closes the comment immediately.
+    if bytes.get(body) == Some(&b'>') {
+        return body + 1;
+    }
+    if bytes.get(body) == Some(&b'-') && bytes.get(body + 1) == Some(&b'>') {
+        return body + 2;
+    }
+    // Otherwise the first `-->` or `--!>` ends it, whichever comes first. A
+    // longer dash run ends the same way, since its last two dashes supply the
+    // `--`. Unterminated: EOF in any comment state emits the comment, so the
+    // rest of the input is comment body.
+    let close = find_sub(&bytes[body..], b"-->").map(|p| body + p + 3);
+    let close_bang = find_sub(&bytes[body..], b"--!>").map(|p| body + p + 4);
+    match (close, close_bang) {
+        (Some(a), Some(b)) => a.min(b),
+        (Some(e), None) | (None, Some(e)) => e,
+        (None, None) => bytes.len(),
+    }
+}
+
+/// First occurrence of byte `b` at or after `from` (used only where there are
+/// no attribute-style quotes to worry about).
+fn find_byte(bytes: &[u8], from: usize, b: u8) -> Option<usize> {
+    bytes[from..].iter().position(|&c| c == b).map(|p| from + p)
+}
+
+/// Index just past a case-insensitive `</tag>` at or after `from`, or the end
+/// of input if none appears (the remainder is then unreachable raw text with
+/// no closing tag to resume scanning after).
+fn skip_element_body(bytes: &[u8], from: usize, tag: &str) -> usize {
+    let mut i = from;
+    while i < bytes.len() {
+        if bytes[i] == b'<' && bytes.get(i + 1) == Some(&b'/') {
+            let name_end = tag_name_end(bytes, i + 2);
+            if bytes[i + 2..name_end].eq_ignore_ascii_case(tag.as_bytes()) {
+                return find_tag_end(bytes, name_end).map_or(bytes.len(), |(gt, _)| gt + 1);
+            }
+        }
+        i += 1;
+    }
+    bytes.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn structural_elements_convert_to_markdown() {
+        let html = r#"<h2>Title</h2><p>Some <em>emphasis</em> and <strong>bold</strong>.</p>
+<ul><li>one</li><li>two</li></ul>
+<p><a href="https://example.com/a">link</a> and <img src="https://example.com/i.png" alt="alt text"></p>
+<pre><code>let x = 1;</code></pre>"#;
+        let md = html_to_markdown(html);
+        assert!(md.contains("## Title"), "{md}");
+        assert!(
+            md.contains("*emphasis*") || md.contains("_emphasis_"),
+            "{md}"
+        );
+        assert!(md.contains("**bold**"), "{md}");
+        assert!(md.contains("- one") || md.contains("* one"), "{md}");
+        assert!(md.contains("[link](https://example.com/a)"), "{md}");
+        assert!(
+            md.contains("![alt text](https://example.com/i.png)"),
+            "{md}"
+        );
+        assert!(md.contains("let x = 1;"), "{md}");
+    }
+
+    #[test]
+    fn script_and_style_are_dropped_wholesale() {
+        let html =
+            r#"<p>keep</p><script>alert("x")</script><style>p{color:red}</style><!-- comment -->"#;
+        let md = html_to_markdown(html);
+        assert!(md.contains("keep"));
+        assert!(!md.contains("alert"), "{md}");
+        assert!(!md.contains("color"), "{md}");
+        assert!(!md.contains("comment"), "{md}");
+    }
+
+    #[test]
+    fn unknown_markup_reduces_to_text_content_no_raw_html_survives() {
+        let html = r#"<article data-x="1"><custom-widget>inner text</custom-widget><video controls>fallback</video></article>"#;
+        let md = html_to_markdown(html);
+        assert!(md.contains("inner text"));
+        assert!(md.contains("fallback"));
+        assert!(!md.contains('<'), "raw HTML survived: {md}");
+    }
+
+    #[test]
+    fn conversion_is_deterministic() {
+        let html = include_str!("fixtures/golden_probe.html");
+        let a = html_to_markdown(html);
+        let b = html_to_markdown(html);
+        assert_eq!(a, b);
+        assert!(!a.is_empty(), "the probe fixture must produce output");
+        // The fixture plants `leak` inside its script, style, and comment; none of
+        // the three may reach the output. Its custom element must keep its text.
+        assert!(!a.contains("leak"), "script/style/comment leaked: {a}");
+        assert!(a.contains("widget text"), "unknown element text lost: {a}");
+    }
+
+    #[test]
+    fn javascript_href_is_preserved_as_data_not_executed_markup() {
+        // The provider stores it; consumers filter schemes (spec: Security/Rendering).
+        let md = html_to_markdown(r#"<a href="javascript:alert(1)">x</a>"#);
+        assert!(!md.contains('<'));
+    }
+
+    #[test]
+    fn tables_convert_or_reduce_to_text() {
+        let html = r#"<table><thead><tr><th>h1</th><th>h2</th></tr></thead>
+<tbody><tr><td>a1</td><td>a2</td></tr><tr><td>b1</td><td>b2</td></tr></tbody></table>"#;
+        let md = html_to_markdown(html);
+        for cell in ["h1", "h2", "a1", "a2", "b1", "b2"] {
+            assert!(md.contains(cell), "cell {cell} lost: {md}");
+        }
+        assert!(!md.contains('<'), "raw HTML survived: {md}");
+        // htmd emits GFM pipe tables — pin the actual form.
+        assert!(md.contains('|'), "expected a pipe table: {md}");
+    }
+
+    #[test]
+    fn empty_and_whitespace_input_yield_empty() {
+        assert_eq!(html_to_markdown(""), "");
+        assert_eq!(html_to_markdown("   \n\t  "), "");
+        assert_eq!(html_to_markdown("<p></p>"), "");
+    }
+
+    #[test]
+    fn entities_decode_to_text_not_markup() {
+        // `&lt;b&gt;` decodes to the characters `<b>`, which must land in the
+        // output as *text*, never as a tag a renderer would interpret.
+        let md = html_to_markdown("<p>&lt;b&gt;not bold&lt;/b&gt; &amp; &#169;</p>");
+        assert!(md.contains("not bold"), "{md}");
+        assert!(md.contains('&') || md.contains("amp"), "{md}");
+        assert!(
+            md.contains('©'),
+            "numeric character reference decoded: {md}"
+        );
+        // Every `<` must be backslash-escaped — inert text, not a tag a renderer
+        // would interpret. A plain `contains("<b>")` cannot tell `\<b>` apart.
+        let unescaped = md
+            .char_indices()
+            .filter(|(i, c)| *c == '<' && !md[..*i].ends_with('\\'))
+            .count();
+        assert_eq!(unescaped, 0, "unescaped `<` survived: {md}");
+    }
+
+    #[test]
+    fn output_has_no_trailing_whitespace_and_hard_breaks_survive() {
+        // The trim contract ("trailing whitespace per line") is incompatible with
+        // a two-space hard break, so `<br>` must use a form that survives it.
+        let md = html_to_markdown("<p>first line<br>second line</p>");
+        assert!(md.contains("first line"), "{md}");
+        assert!(md.contains("second line"), "{md}");
+        assert!(
+            md.lines().all(|l| l == l.trim_end()),
+            "line kept trailing whitespace: {md:?}"
+        );
+        assert!(
+            md.lines().count() > 1,
+            "the hard break must survive trimming: {md:?}"
+        );
+        assert_eq!(md, md.trim(), "outer whitespace trimmed: {md:?}");
+    }
+
+    // --- C1: recursion ceiling -------------------------------------------
+
+    #[test]
+    fn beyond_max_depth_degrades_to_tag_stripped_text_not_markdown() {
+        // ~10x MAX_HTML_DEPTH. htmd's recursive DOM walker aborts the whole
+        // process well below this depth (see MAX_HTML_DEPTH's doc) — this
+        // input must never reach it, so the assertions below can only pass if
+        // the tag-stripped fallback ran instead.
+        let depth = 1000;
+        let html = format!(
+            "{}<em>innermost</em>{}",
+            "<div>".repeat(depth),
+            "</div>".repeat(depth)
+        );
+        let md = html_to_markdown(&html);
+        assert!(md.contains("innermost"), "{md}");
+        // A real Markdown conversion of <em> wraps this in `*`/`_`; the
+        // tag-stripped fallback does not, so this pins which path ran.
+        assert!(
+            !md.contains("*innermost*") && !md.contains("_innermost_"),
+            "output looks markdown-converted, not tag-stripped: {md}"
+        );
+    }
+
+    /// The ceiling's exact boundary, from both sides.
+    ///
+    /// Every other test on this path is an order of magnitude away from it: the
+    /// degradation cases nest ~1000 and every positive conversion is depth 1, so
+    /// `MAX_HTML_DEPTH` could be moved anywhere in roughly `[20, 400]` without
+    /// failing anything (measured: 20 and 400 both left the suite green). Both
+    /// directions are real. Tightened to 20, ordinary nested feed content —
+    /// nested lists, blockquotes, tables — would silently lose its Markdown
+    /// structure; loosened to 400, the ceiling walks toward the 500-600 zone
+    /// where htmd's recursive walker overflows a 2 MiB stack and aborts the
+    /// process, which is the whole reason it exists (see [`MAX_HTML_DEPTH`]).
+    ///
+    /// 100 and 101 are written as literals rather than derived from the constant,
+    /// so this cannot agree with a changed one. The real DOM at the passing end is
+    /// the open-tag count plus html5ever's fixed `document > html > body` wrapper
+    /// — ~103, nowhere near the overflow zone — so the converting side is safe to
+    /// actually run through htmd.
+    #[test]
+    fn the_depth_ceiling_converts_at_100_and_degrades_at_101() {
+        // `depth` is the whole document's open-tag depth: the `<em>` marker is
+        // itself an open tag, so it accounts for one of the levels and the divs
+        // supply the rest.
+        let nested = |depth: usize| {
+            format!(
+                "{}<em>innermost</em>{}",
+                "<div>".repeat(depth - 1),
+                "</div>".repeat(depth - 1)
+            )
+        };
+        // Fixture guard, so a drifting fixture cannot quietly stop straddling the
+        // boundary. `max_open_tag_depth` short-circuits at `MAX_HTML_DEPTH + 1`,
+        // so a ceiling moved below 100 makes these read low and fails here first
+        // rather than in the assertions below.
+        assert_eq!(max_open_tag_depth(&nested(100)), 100);
+        assert_eq!(max_open_tag_depth(&nested(101)), 101);
+
+        let at = html_to_markdown(&nested(100));
+        assert!(
+            at.contains("*innermost*") || at.contains("_innermost_"),
+            "depth 100 is the last depth htmd still converts, and this one degraded \
+             to tag-stripped text: {at}"
+        );
+
+        let past = html_to_markdown(&nested(101));
+        assert!(past.contains("innermost"), "text lost at depth 101: {past}");
+        assert!(
+            !past.contains("*innermost*") && !past.contains("_innermost_"),
+            "depth 101 is past the ceiling and must degrade to tag-stripped text: {past}"
+        );
+    }
+
+    /// `unit` nested `depth` times, ending in a marker the assertions can find.
+    fn deep(prefix: &str, unit: &str) -> String {
+        format!("{prefix}{}<em>innermost</em>", unit.repeat(1000))
+    }
+
+    /// Pin that `html` took the tag-stripped fallback, not `htmd`.
+    ///
+    /// Every caller's fixture nests ~1000 deep, past the 500-600 where htmd's
+    /// walker overflows a 2 MiB stack, so a scan that stopped seeing the
+    /// nesting would abort this test process rather than fail an assertion.
+    fn assert_degraded_to_text(html: &str, case: &str) {
+        let md = html_to_markdown(html);
+        assert!(md.contains("innermost"), "{case}: text lost: {md}");
+        assert!(
+            !md.contains("*innermost*") && !md.contains("_innermost_"),
+            "{case}: output is markdown-converted, not tag-stripped: {md}"
+        );
+    }
+
+    #[test]
+    fn mismatched_close_tags_do_not_reduce_the_scanned_depth() {
+        // html5ever discards an end tag matching nothing on its open-element
+        // stack, so these divs really do nest 1000 deep.
+        assert_degraded_to_text(&deep("", "<div></b>"), "</b>");
+        assert_degraded_to_text(&deep("", "<div></p>"), "</p>");
+    }
+
+    #[test]
+    fn abrupt_closing_empty_comment_does_not_hide_the_nesting() {
+        // `<!-->` / `<!--->` are complete comments; a scan demanding a literal
+        // `-->` treats everything after them as comment body.
+        assert_degraded_to_text(&deep("<!-->", "<div>"), "<!-->");
+        assert_degraded_to_text(&deep("<!--->", "<div>"), "<!--->");
+    }
+
+    #[test]
+    fn bang_comment_end_terminates_the_comment() {
+        assert_degraded_to_text(&deep("<!--x--!>", "<div>"), "--!>");
+    }
+
+    #[test]
+    fn question_mark_opens_a_bogus_comment_ending_at_the_first_gt() {
+        // HTML has no processing instructions, so `?>` is not a terminator.
+        assert_degraded_to_text(&deep("<?>", "<div>"), "<?>");
+        assert_degraded_to_text(&deep("<?php ", "<div>"), "<?php");
+    }
+
+    #[test]
+    fn a_quote_outside_an_attribute_value_does_not_swallow_the_document() {
+        // In `<b '>` the quote is an attribute-*name* character and the `>`
+        // ends the tag; treating it as opening a value hid every div after it.
+        assert_degraded_to_text(&deep("<b '>", "<div>"), "<b '>");
+        assert_degraded_to_text(&deep("<b ='>", "<div>"), "<b ='>");
+    }
+
+    #[test]
+    fn void_elements_nest_inside_foreign_content() {
+        // `<wbr>` is void in HTML content but an ordinary nesting SVG element
+        // under `<svg>`, which is not on the tree builder's breakout list.
+        assert_degraded_to_text(&deep("<svg>", "<wbr>"), "svg/wbr");
+        assert_degraded_to_text(&deep("<math>", "<input>"), "math/input");
+    }
+
+    #[test]
+    fn a_self_closing_tag_under_foreign_content_still_counts_as_nesting() {
+        // html5ever leaves foreign content without any close tag for the scan
+        // to see, so "am I in foreign content" cannot be tracked lexically. A
+        // self-closing tag is therefore only self-closing when it is `<svg>`
+        // or `<math>` itself.
+        //
+        // `<i/>` breaks out of foreign content (`rules.rs:1618-1624`) and then
+        // opens an `i` in HTML content, where the self-closing flag is
+        // discarded; `<div/>` inside a `foreignObject` integration point is
+        // parsed as HTML for the same reason. Both nest ~1000 deep, so a scan
+        // that honored the flag here would hand these to htmd's walker and
+        // abort this test process instead of failing an assertion.
+        assert_degraded_to_text(&deep("<svg>", "<i/>"), "svg/self-closing i");
+        assert_degraded_to_text(
+            &deep("<svg><foreignObject>", "<div/>"),
+            "svg/foreignObject/self-closing div",
+        );
+    }
+
+    #[test]
+    fn tag_names_are_compared_whole_not_truncated() {
+        // `div_` is a distinct name (`_` is a tag-name character), so `</div>`
+        // closes nothing here.
+        assert_degraded_to_text(&deep("", "<div_></div>"), "div_");
+    }
+
+    #[test]
+    fn balanced_content_far_past_the_ceiling_still_converts() {
+        // The other side of the contract: matching close tags must still pop,
+        // or ordinary long feed content would degrade to text.
+        let md = html_to_markdown(&format!("{}<em>innermost</em>", "<p>x</p>".repeat(1000)));
+        assert!(
+            md.contains("*innermost*") || md.contains("_innermost_"),
+            "1000 balanced paragraphs are depth 1, not 1000: {md}"
+        );
+    }
+
+    #[test]
+    fn crlf_inside_a_start_tag_does_not_inflate_the_scanned_depth() {
+        // `\r` never reaches a tag state: `get_preprocessed_char` normalizes it
+        // to `\n` first (see `is_tag_space`), so it ends a tag or attribute name
+        // like any other space and these paragraphs are depth 1, not 101.
+        // Treating it as a name character instead scored this document at 101
+        // and silently dropped the Markdown structure of ordinary
+        // HTTP-delivered feed content.
+        let html = format!(
+            "{}<em>innermost</em>",
+            "<p\r\nclass=\"lede\">x</p>".repeat(101)
+        );
+        let md = html_to_markdown(&html);
+        assert!(
+            md.contains("*innermost*") || md.contains("_innermost_"),
+            "CRLF in a start tag degraded a depth-1 document: {md}"
+        );
+        // The LF spelling is the control: both must take the same path.
+        let lf = html_to_markdown(&format!(
+            "{}<em>innermost</em>",
+            "<p\nclass=\"lede\">x</p>".repeat(101)
+        ));
+        assert_eq!(md, lf, "CRLF and LF spellings converted differently");
+    }
+
+    #[test]
+    fn many_void_elements_in_a_row_do_not_trip_the_depth_ceiling() {
+        // A long run of `<br>` (common for hard line breaks in real feed
+        // content) is not nesting — void elements never hold children — so
+        // this must still go through htmd's real conversion, not degrade.
+        let html = format!("line{}", "<br>".repeat(200));
+        let md = html_to_markdown(&html);
+        assert!(md.contains("line"), "{md}");
+        assert!(
+            md.contains('\\'),
+            "expected htmd's real <br> (BrStyle::Backslash) conversion: {md:?}"
+        );
+    }
+
+    // --- I4: "no raw HTML" narrowed to "no HTML tag" ----------------------
+
+    #[test]
+    fn no_tag_survives_but_a_bare_lt_can() {
+        // htmd only backslash-escapes a `<` that looks like it opens a real
+        // construct (`<letter`, `</letter`, `<!…`, `<?…` — see
+        // `htmd-0.5.5/src/html_escape.rs`'s `should_escape_html_like_sequence`);
+        // followed by `<` or `>` as here, neither qualifies, so both pass
+        // through completely unescaped.
+        let md = html_to_markdown(r#""><<>>"#);
+        assert_eq!(md, r#""><<>>"#);
+    }
+
+    #[test]
+    fn attribute_value_lt_survives_unescaped_in_the_output() {
+        // htmd consumes anything tag-shaped, but an attribute value has
+        // nowhere else to put a `<`: it lands in the output unescaped.
+        let md = html_to_markdown(r##"<a href="#" title="<script>">t</a>"##);
+        assert_eq!(md, r##"[t](# "<script>")"##);
+    }
+
+    // --- I5: noscript / template / leading title --------------------------
+
+    #[test]
+    fn noscript_fallback_text_is_preserved_now_that_head_is_not_skipped() {
+        // `<noscript>` is parsed as raw text and, per html5ever's "in head"
+        // insertion-mode rules (html5ever-0.38.0/src/tree_builder/rules.rs,
+        // the `<noframes> | <style> | <noscript>` arm), lands inside an
+        // implied `<head>` when it is the first content parsed and scripting
+        // is enabled (htmd's default). `head` used to be in `skip_tags`,
+        // which discards a node's children wholesale with no handler firing
+        // at all, so this text vanished as a side effect of that, not by
+        // design; not skip-tagging `head` restores it.
+        let md = html_to_markdown("<noscript><p>ns fallback text</p></noscript>");
+        assert!(md.contains("ns fallback text"), "{md}");
+    }
+
+    #[test]
+    fn leading_title_text_is_preserved_not_silently_dropped() {
+        let md = html_to_markdown("<title>TITLETEXT</title><p>body</p>");
+        assert!(md.contains("TITLETEXT"), "{md}");
+        assert!(md.contains("body"), "{md}");
+    }
+
+    #[test]
+    fn template_content_is_lost_not_reduced_to_text() {
+        // Unlike other unhandled markup, `<template>`'s content genuinely
+        // vanishes regardless of `skip_tags`: markup5ever_rcdom stores it in
+        // a separate `template_contents` `Node` field
+        // (markup5ever_rcdom-0.38.0/lib.rs), not in `.children`, and htmd's
+        // walker only ever iterates `.children` (referenced but never walked
+        // in htmd-0.5.5/src/dom_walker.rs's `can_combine`). Pinned here
+        // because the module doc used to claim no unhandled markup's text is
+        // lost.
+        let md = html_to_markdown("<template><p>tpl</p></template>");
+        assert_eq!(md, "", "{md}");
+    }
+}

--- a/crates/skardi/src/sources/providers/rss/convert.rs
+++ b/crates/skardi/src/sources/providers/rss/convert.rs
@@ -41,7 +41,10 @@ use super::sanitize::find_sub;
 /// shapes, not a proof — and the whole argument presupposes the scan really is
 /// an upper bound on open-tag depth, which it only became once the stale
 /// `foreign` undercount was fixed (see the `foreign` counter in
-/// [`max_open_tag_depth`]).
+/// [`max_open_tag_depth`]). The figure also predates the sibling-closing pops
+/// ([`implied_end_pops`]): those lower the scan only on shapes html5ever
+/// flattens the same way, so they should not widen the gap the sweep measured
+/// — an argument, not a re-measurement.
 const MAX_HTML_DEPTH: usize = 100;
 
 /// Convert an HTML fragment to Markdown.
@@ -123,6 +126,61 @@ fn is_void_element(tag: &str) -> bool {
     VOID_ELEMENTS.iter().any(|v| tag.eq_ignore_ascii_case(v))
 }
 
+/// Whether a start tag `incoming` implicitly closes a still-open `top`, per
+/// html5ever's sibling-closing rules — the reason `<p>one<p>two<p>three`
+/// builds three siblings at depth ~4, not a nest 3 deep.
+///
+/// Omitting `</p>`, `</li>`, `</td>`, `</tr>` is both legal HTML5 and the
+/// single most common shape of legacy feed HTML, so a scan that never pops on
+/// it scored `"<p>para".repeat(150)` as depth 150 against a real DOM depth of
+/// ~4 and degraded the whole document to tag-stripped text — an over-count in
+/// the technically-safe direction that turned a rare guard into routine
+/// content damage.
+///
+/// The obligation is [`max_open_tag_depth`]'s: never let a pop *under*-count.
+/// Each rule below fires only where the same token closes the same element in
+/// html5ever — `p` is closed by every sibling-closer here on its way in
+/// (`li`/`dd`/`dt` explicitly, the table tags via the cell they close), `li`
+/// by `li`, the definition and cell pairs by either sibling, `tr` by the next
+/// row, `option` by the next option. The scan consults only the top of its
+/// stack, so an element html5ever would *not* close — an `li` under a nested
+/// `<ul>`, a `p` sitting below any other element — is shielded by whatever
+/// sits above it, and genuinely nested input keeps its full count. And when
+/// the scan's stack disagrees with html5ever's, the disagreement is a stale
+/// entry for a token html5ever ignored outright (`<td>` outside any table,
+/// say) — this scan pushed that entry itself, so popping it retires the
+/// scan's own surplus while the push that follows restores it: the estimate
+/// stays an upper bound.
+fn implied_end_pops(incoming: &str, top: &str) -> bool {
+    let is = |t: &str, n: &str| t.eq_ignore_ascii_case(n);
+    let cell = |t: &str| is(t, "td") || is(t, "th");
+    let definition = |t: &str| is(t, "dd") || is(t, "dt");
+
+    if is(top, "p") {
+        return is(incoming, "p")
+            || is(incoming, "li")
+            || definition(incoming)
+            || cell(incoming)
+            || is(incoming, "tr");
+    }
+    if is(top, "li") {
+        return is(incoming, "li");
+    }
+    if definition(top) {
+        return definition(incoming);
+    }
+    if cell(top) {
+        return cell(incoming) || is(incoming, "tr");
+    }
+    if is(top, "tr") {
+        return is(incoming, "tr");
+    }
+    if is(top, "option") {
+        return is(incoming, "option");
+    }
+    false
+}
+
 /// The two elements that switch the tree builder into foreign content, where
 /// [`VOID_ELEMENTS`] stops applying and a self-closing tag really does close.
 fn is_foreign_root(tag: &str) -> bool {
@@ -157,7 +215,11 @@ fn is_foreign_root(tag: &str) -> bool {
 /// A matching close tag can still close *more* than this pops (implied end
 /// tags, the adoption agency), and tags inside a `script`/`style`/`title` body
 /// are counted even though the tokenizer treats them as raw text: both make the
-/// real tree shallower than this estimate. The one direction html5ever goes
+/// real tree shallower than this estimate. One family of implied end tags *is*
+/// popped — the sibling-closers (`<p>one<p>two`, unclosed `<li>`/`<td>`/`<tr>`
+/// runs), because there the over-count landed on the most common shape of
+/// legacy feed HTML rather than on an attacker; see [`implied_end_pops`] for
+/// the rules and why they cannot under-count. The one direction html5ever goes
 /// *deeper* than the open-tag count is implied *start* tags — `<table><td>`
 /// builds `table > tbody > tr > td`, four levels from two tags, roughly
 /// doubling it — on top of the fixed `document > html > body` wrapper worth 3.
@@ -253,6 +315,17 @@ fn max_open_tag_depth(html: &str) -> usize {
             }
             if is_foreign_root(tag) {
                 foreign += 1;
+            }
+            // Implied end tags: `<p>one<p>two` and unclosed `<li>`/`<td>`/`<tr>`
+            // runs — the most common legacy feed HTML — build siblings, not
+            // nests, so the sibling-closers pop what html5ever would close (see
+            // [`implied_end_pops`]). Suspended in foreign content like the
+            // [`VOID_ELEMENTS`] skip, and for the same reason: `foreign` can
+            // only be trusted where believing it too readily over-counts.
+            if foreign == 0 {
+                while open.last().is_some_and(|top| implied_end_pops(tag, top)) {
+                    open.pop();
+                }
             }
             open.push(tag);
             max_depth = max_depth.max(open.len());
@@ -827,6 +900,64 @@ mod tests {
         assert!(
             md.contains("*innermost*") || md.contains("_innermost_"),
             "1000 balanced paragraphs are depth 1, not 1000: {md}"
+        );
+    }
+
+    /// `</p>` is optional HTML5 and legacy feeds omit it as a matter of course:
+    /// a new `<p>` closes the previous one, so 150 unclosed paragraphs are 150
+    /// siblings at real depth ~4. A scan that never popped on the implied end
+    /// scored this 150, tripped the ceiling, and degraded ordinary content to
+    /// tag-stripped text — the exact shape from review.
+    #[test]
+    fn unclosed_paragraph_runs_are_siblings_not_nesting() {
+        let html = "<p>para".repeat(150);
+        assert_eq!(max_open_tag_depth(&html), 1);
+
+        let md = html_to_markdown(&html);
+        assert!(
+            md.contains("para\n\npara"),
+            "unclosed paragraphs must convert as paragraphs, not degrade to a \
+             single run of text: {md:?}"
+        );
+    }
+
+    /// The rest of the sibling-closing set, in the shapes legacy HTML actually
+    /// uses them: list items without `</li>`, definition pairs, table rows and
+    /// cells without `</td>`/`</tr>`, options without `</option>`.
+    #[test]
+    fn unclosed_sibling_runs_do_not_trip_the_ceiling() {
+        for (name, html) in [
+            ("li", format!("<ul>{}</ul>", "<li>item".repeat(150))),
+            ("dd/dt", format!("<dl>{}</dl>", "<dt>t<dd>d".repeat(150))),
+            (
+                "tr/td",
+                format!("<table>{}</table>", "<tr><td>a<td>b".repeat(150)),
+            ),
+            (
+                "option",
+                format!("<select>{}</select>", "<option>o".repeat(150)),
+            ),
+            // li closing the p left open inside the previous li.
+            ("li over p", format!("<ul>{}</ul>", "<li><p>x".repeat(150))),
+        ] {
+            let depth = max_open_tag_depth(&html);
+            assert!(
+                depth <= 10,
+                "{name}: unclosed sibling runs are flat, scanned {depth}"
+            );
+        }
+    }
+
+    /// The pops must not fire through a real container: `<ul><li><ul><li>…`
+    /// genuinely nests (html5ever's li rule stops at the `ul`, and so does the
+    /// scan, which only consults the top of its stack), and deep genuine
+    /// nesting is exactly what the ceiling exists to catch.
+    #[test]
+    fn genuinely_nested_lists_still_count_and_still_degrade() {
+        let html = "<ul><li>".repeat(60);
+        assert!(
+            max_open_tag_depth(&html) > MAX_HTML_DEPTH,
+            "60 nested ul/li pairs are real nesting, not siblings"
         );
     }
 

--- a/crates/skardi/src/sources/providers/rss/error.rs
+++ b/crates/skardi/src/sources/providers/rss/error.rs
@@ -25,9 +25,12 @@ use thiserror::Error;
 ///   `max_response_bytes`.
 ///
 /// The columns among those are held to it structurally by
-/// [`super::cache::FeedObservation::capped`], the one boundary every
-/// observation the cache retains passes through. The two sites that land in
-/// later phases of this stack (`engine.rs`, `parse.rs`) are not present yet.
+/// `FeedObservation::capped` (`cache.rs`), the one boundary every observation
+/// the cache retains passes through. Named in code font, not linked: this
+/// module compiles without the `rss` feature while `cache` exists only behind
+/// it, so an intra-doc link here is broken in exactly the builds this module
+/// stays parseable for. The two sites that land in later phases of this stack
+/// (`engine.rs`, `parse.rs`) are not present yet.
 ///
 /// A bound on *length* only. What content may reach `feeds.last_error` at all is
 /// a separate question, to be argued in `engine.rs`'s module doc when it lands.
@@ -39,8 +42,9 @@ use thiserror::Error;
 pub const MAX_ERROR_CHARS: usize = 512;
 
 /// Length cap, in characters, on the feed-authored *prose* fields —
-/// `feeds.title` and `feeds.description` — that enter a
-/// [`super::cache::FeedObservation`].
+/// `feeds.title` and `feeds.description` — that enter a `FeedObservation`
+/// (`cache.rs`; code font rather than a link for the reason given on
+/// [`MAX_ERROR_CHARS`]).
 ///
 /// Deliberately looser than [`MAX_ERROR_CHARS`]. Those two columns are not
 /// diagnostics: they carry the feed's own editorial text, where a channel

--- a/crates/skardi/src/sources/providers/rss/error.rs
+++ b/crates/skardi/src/sources/providers/rss/error.rs
@@ -6,20 +6,28 @@ use thiserror::Error;
 /// Length cap, in characters, on any feed-influenced diagnostic string this
 /// provider stores or logs.
 ///
-/// Three call sites will share it — all landing in later phases of this stack,
-/// none present in this PR, so the constant is exercised only by its own test
-/// for now. They will share it because they are bounded by the same thing —
-/// how many characters of feed-chosen text a document can push into a
-/// diagnostic — rather than by coincidence:
+/// Its call sites share it because they are bounded by the same thing — how
+/// many characters of feed-chosen text a document can push into a diagnostic —
+/// rather than by coincidence:
 ///
 /// - `feeds.last_error` (`engine.rs`, the column's only writer), including the
 ///   fixed literal `cache.rs` writes for an evicted-window `304`;
 /// - `feeds.dialect_declared`'s `unknown:<root element>` form
 ///   (`conformance.rs`), built from a raw root element name of whatever length
 ///   the document supplies;
+/// - `feeds.conformance_notes`, both per-note at the source
+///   (`conformance.rs`) and over the joined string;
+/// - `feeds.site_url`, a feed-authored link — not a diagnostic, but an
+///   identifier rather than prose, so this is the bound that fits it and not
+///   [`MAX_FEED_TEXT_CHARS`];
 /// - the `debug`-level parse-failure line (`parse.rs`), which logs the
 ///   dependency's own reason and would otherwise be bounded only by
 ///   `max_response_bytes`.
+///
+/// The columns among those are held to it structurally by
+/// [`super::cache::FeedObservation::capped`], the one boundary every
+/// observation the cache retains passes through. The two sites that land in
+/// later phases of this stack (`engine.rs`, `parse.rs`) are not present yet.
 ///
 /// A bound on *length* only. What content may reach `feeds.last_error` at all is
 /// a separate question, to be argued in `engine.rs`'s module doc when it lands.
@@ -29,6 +37,21 @@ use thiserror::Error;
 /// neither can reference this constant, so both name it as `MAX_ERROR_CHARS`'s
 /// value and this is where it is defined.
 pub const MAX_ERROR_CHARS: usize = 512;
+
+/// Length cap, in characters, on the feed-authored *prose* fields —
+/// `feeds.title` and `feeds.description` — that enter a
+/// [`super::cache::FeedObservation`].
+///
+/// Deliberately looser than [`MAX_ERROR_CHARS`]. Those two columns are not
+/// diagnostics: they carry the feed's own editorial text, where a channel
+/// description running past 512 characters is ordinary rather than hostile,
+/// and cutting there would truncate legitimate values. They still need *a*
+/// bound, and it is the same invariant [`MAX_ERROR_CHARS`] serves — the
+/// observation store is never byte-bounded by the cache, whose budget meters
+/// `RecordBatch` bytes only (`MemoryFeedCache::record_success`), so a
+/// `max_response_bytes`-sized `<title>` would otherwise be retained whole and
+/// outlive the window it described.
+pub const MAX_FEED_TEXT_CHARS: usize = 4096;
 
 /// Bound `text` to `max_chars` *characters*, cutting on a char boundary so a
 /// multi-byte sequence is never split.

--- a/crates/skardi/src/sources/providers/rss/fixtures/golden_probe.html
+++ b/crates/skardi/src/sources/providers/rss/fixtures/golden_probe.html
@@ -1,0 +1,21 @@
+<h1>Probe</h1>
+<p>Plain text with <em>emphasis</em>, <strong>bold</strong>, and <code>inline_code()</code>.</p>
+<h2>Lists</h2>
+<ul><li>alpha</li><li>beta</li></ul>
+<ol><li>first</li><li>second</li></ol>
+<h2>Link and image</h2>
+<p><a href="https://example.com/page?a=1&amp;b=2">anchor</a> then <img src="https://example.com/pic.png" alt="a picture"></p>
+<blockquote><p>quoted line</p></blockquote>
+<pre><code class="language-rust">fn main() { let x = 1; }</code></pre>
+<h2>Table</h2>
+<table>
+  <thead><tr><th>col a</th><th>col b</th></tr></thead>
+  <tbody><tr><td>r1a</td><td>r1b</td></tr><tr><td>r2a</td><td>r2b</td></tr></tbody>
+</table>
+<p>Entities: &lt;tag&gt; &amp; &quot;quotes&quot; &#169; &nbsp; done</p>
+<p>Hard break here<br>after the break</p>
+<hr>
+<script>var leak = 1;</script>
+<style>.leak { color: red }</style>
+<!-- leaked comment -->
+<custom-widget>widget text</custom-widget>

--- a/crates/skardi/src/sources/providers/rss/mod.rs
+++ b/crates/skardi/src/sources/providers/rss/mod.rs
@@ -1,7 +1,13 @@
 //! RSS/Atom subscriptions as a read-only data source (`type: rss`).
 //!
 //! See `docs/superpowers/specs/2026-07-22-rss-feed-support-design.md`.
+#[cfg(feature = "rss")]
+pub mod cache;
 pub mod config;
+#[cfg(feature = "rss")]
+pub mod conformance;
+#[cfg(feature = "rss")]
+pub mod convert;
 pub mod error;
 // Reads OPML files and pulls in `quick-xml`; gated so the config/error types
 // above stay parseable — and `ResolvedSubscription` below stays nameable —
@@ -30,11 +36,26 @@ mod fetch;
 // its only consumer, `fetch`'s test module, is.
 #[cfg(all(test, feature = "rss"))]
 pub(crate) mod testutil;
+// The parsing chain: byte-level sanitation rungs, the feed-rs parse driver
+// that applies them, and the fixed Arrow schemas the providers serve. These
+// were built on a parallel branch (Tasks 5-9) alongside the fetch chain
+// above, which is why they land as one merge rather than task by task.
+#[cfg(feature = "rss")]
+pub mod parse;
+#[cfg(feature = "rss")]
+pub mod sanitize;
+#[cfg(feature = "rss")]
+pub mod schema;
 
 pub use config::{FeedSubscription, RssConfig};
 pub use error::RssError;
 #[cfg(feature = "rss")]
 pub use opml::resolve_subscriptions;
+
+/// Integer version of the `feeds`/`items` public surface. Bumped only by
+/// breaking changes (column removal/rename/retype, nullability tightening,
+/// enum-domain repurposing, identity/window semantics changes).
+pub const RSS_SURFACE_VERSION: u32 = 1;
 
 /// One subscription, fully resolved from either of [`RssConfig`]'s two
 /// mutually exclusive input forms — an inline `feeds:` entry or an

--- a/crates/skardi/src/sources/providers/rss/parse.rs
+++ b/crates/skardi/src/sources/providers/rss/parse.rs
@@ -8,7 +8,7 @@
 //! actually changed bytes are recorded as repairs, so a document fixed by
 //! ampersand escaping alone does not claim to have been re-encoded.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 use feed_rs::model::{Category, Entry, Feed, Link};
 use serde_json::{Value, json};
@@ -206,9 +206,14 @@ pub struct ItemRow {
 #[derive(Debug, Clone)]
 pub struct ExtractedFeed {
     pub meta: FeedMeta,
+    /// Each `guid` appears at most once; the first entry in document order
+    /// claims it.
     pub items: Vec<ItemRow>,
     /// Entries dropped because they had neither an id nor a link.
     pub skipped_without_identity: usize,
+    /// Entries dropped because an earlier entry in the same document already
+    /// claimed their guid.
+    pub duplicate_identity: usize,
 }
 
 /// Everything the engine needs from one fetched document.
@@ -222,6 +227,10 @@ pub struct ParsedDocument {
 }
 
 /// Project a parsed feed onto `FeedMeta` + `ItemRow`s per the Field Mapping table.
+///
+/// `(feed, guid)` is the item identity, so a guid may appear only once: the
+/// first entry in document order keeps it, and later claimants are dropped
+/// and counted in `duplicate_identity`.
 pub fn extract(feed: Feed) -> ExtractedFeed {
     let meta = FeedMeta {
         title: feed.title.as_ref().map(|t| t.content.clone()),
@@ -231,9 +240,12 @@ pub fn extract(feed: Feed) -> ExtractedFeed {
 
     let mut items = Vec::with_capacity(feed.entries.len());
     let mut skipped_without_identity = 0;
+    let mut duplicate_identity = 0;
+    let mut seen_guids: HashSet<String> = HashSet::with_capacity(feed.entries.len());
     for entry in &feed.entries {
         match extract_entry(entry) {
-            Some(row) => items.push(row),
+            Some(row) if seen_guids.insert(row.guid.clone()) => items.push(row),
+            Some(_) => duplicate_identity += 1,
             None => skipped_without_identity += 1,
         }
     }
@@ -242,6 +254,7 @@ pub fn extract(feed: Feed) -> ExtractedFeed {
         meta,
         items,
         skipped_without_identity,
+        duplicate_identity,
     }
 }
 
@@ -500,6 +513,12 @@ pub fn parse_feed_document(
         conformance_notes.push(format!(
             "entries-without-identity: {}",
             extracted.skipped_without_identity
+        ));
+    }
+    if extracted.duplicate_identity > 0 {
+        conformance_notes.push(format!(
+            "duplicate-identity: {}",
+            extracted.duplicate_identity
         ));
     }
 
@@ -1068,6 +1087,70 @@ mod tests {
             a.conformance_notes
                 .iter()
                 .any(|n| n == "entries-without-identity: 1")
+        );
+    }
+
+    /// `(feed, guid)` is the item identity, so two entries claiming the same
+    /// guid cannot both become rows: the first in document order wins and the
+    /// rest are dropped and counted.
+    #[test]
+    fn duplicate_guid_keeps_the_first_entry_in_document_order() {
+        let doc = br#"<rss version="2.0"><channel><title>C</title><link>https://e.com</link><description>D</description>
+<item><guid>dup</guid><title>First</title></item>
+<item><guid>dup</guid><title>Second</title></item>
+</channel></rss>"#;
+        let extracted = extract(parse_with_ladder(doc).unwrap().feed);
+        assert_eq!(extracted.items.len(), 1);
+        assert_eq!(
+            extracted.items[0].title.as_deref(),
+            Some("First"),
+            "the first occurrence wins"
+        );
+        assert_eq!(extracted.duplicate_identity, 1);
+
+        let parsed = parse_feed_document(doc, None).unwrap();
+        assert!(
+            parsed
+                .conformance_notes
+                .iter()
+                .any(|n| n == "duplicate-identity: 1")
+        );
+    }
+
+    /// A link-fallback guid dedupes the same way an explicit one does.
+    #[test]
+    fn duplicate_link_fallback_collapses_to_one_row() {
+        let doc = br#"<rss version="2.0"><channel><title>C</title><link>https://e.com</link><description>D</description>
+<item><title>First</title><link>https://site.example/p</link></item>
+<item><title>Second</title><link>https://site.example/p</link></item>
+</channel></rss>"#;
+        let extracted = extract(parse_with_ladder(doc).unwrap().feed);
+        assert_eq!(extracted.items.len(), 1);
+        assert_eq!(extracted.items[0].guid, "https://site.example/p");
+        assert_eq!(
+            extracted.items[0].title.as_deref(),
+            Some("First"),
+            "the first occurrence wins"
+        );
+        assert_eq!(extracted.duplicate_identity, 1);
+    }
+
+    #[test]
+    fn distinct_identities_are_not_counted_as_duplicates() {
+        let doc = br#"<rss version="2.0"><channel><title>C</title><link>https://e.com</link><description>D</description>
+<item><guid>1</guid><title>A</title></item>
+<item><guid>2</guid><title>B</title></item>
+</channel></rss>"#;
+        let extracted = extract(parse_with_ladder(doc).unwrap().feed);
+        assert_eq!(extracted.items.len(), 2);
+        assert_eq!(extracted.duplicate_identity, 0);
+
+        let parsed = parse_feed_document(doc, None).unwrap();
+        assert!(
+            !parsed
+                .conformance_notes
+                .iter()
+                .any(|n| n.starts_with("duplicate-identity"))
         );
     }
 

--- a/crates/skardi/src/sources/providers/rss/parse.rs
+++ b/crates/skardi/src/sources/providers/rss/parse.rs
@@ -1,0 +1,1105 @@
+//! Sanitation-ladder parse driver.
+//!
+//! The rungs in `sanitize.rs` are pure byte transforms; this module applies them
+//! and turns the result into a feed. Rungs apply cumulatively *before* the parse
+//! rather than as a fallback after one fails — `feed-rs` answers malformed lexis
+//! by silently dropping the offending element instead of erroring, so there is no
+//! failure for a fallback to react to (see `parse_with_ladder`). Only rungs that
+//! actually changed bytes are recorded as repairs, so a document fixed by
+//! ampersand escaping alone does not claim to have been re-encoded.
+
+use std::collections::BTreeMap;
+
+use feed_rs::model::{Category, Entry, Feed, Link};
+use serde_json::{Value, json};
+
+use super::conformance::{
+    content_type_family_note, parsed_dialect, required_field_notes, sniff_declared_dialect,
+};
+use super::convert::html_to_markdown;
+use super::error::{MAX_ERROR_CHARS, truncate};
+use super::sanitize::{
+    DocFamily, Repair, detect_family, refuse_internal_dtd, rung_escape_naked_ampersands,
+    rung_reencode_utf8, rung_strip_control_chars,
+};
+
+/// Why a document could not be turned into a feed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseFailure {
+    /// `"refused-internal-dtd"` or `"strict-parse"` (the ladder was exhausted).
+    pub stage: &'static str,
+    pub reason: String,
+    pub dialect_declared: Option<String>,
+}
+
+/// A parsed feed plus what it took to get there.
+#[derive(Debug, Clone)]
+pub struct ParseSuccess {
+    pub feed: Feed,
+    pub dialect: &'static str,
+    pub dialect_declared: Option<String>,
+    pub repairs: Vec<Repair>,
+}
+
+/// One rung of the ladder: the transform and the repair it records.
+type Rung = (fn(&[u8]) -> (Vec<u8>, bool), Repair);
+
+/// Sanitize `bytes` with the applicable rungs, then parse them into a feed.
+pub fn parse_with_ladder(bytes: &[u8]) -> Result<ParseSuccess, ParseFailure> {
+    let family = detect_family(bytes);
+    let dialect_declared = sniff_declared_dialect(bytes, family);
+
+    if family == DocFamily::Xml
+        && let Err(reason) = refuse_internal_dtd(bytes)
+    {
+        tracing::debug!(stage = "refused-internal-dtd", %reason, "rss parse refused");
+        return Err(ParseFailure {
+            stage: "refused-internal-dtd",
+            reason,
+            dialect_declared,
+        });
+    }
+
+    // Rungs 2 and 3 repair XML lexis and would corrupt a JSON document (a naked
+    // `&` is legal inside a JSON string), so JSON climbs only the re-encode rung.
+    let rungs: &[Rung] = match family {
+        DocFamily::Xml => &[
+            (rung_reencode_utf8, Repair::ReencodedToUtf8),
+            (rung_strip_control_chars, Repair::StrippedControlChars),
+            (rung_escape_naked_ampersands, Repair::EscapedNakedAmpersands),
+        ],
+        DocFamily::Json => &[(rung_reencode_utf8, Repair::ReencodedToUtf8)],
+    };
+
+    // Sanitation runs *before* the parse rather than as a failure-triggered
+    // fallback. feed-rs does not reject malformed lexis — it succeeds while
+    // silently discarding the offending element, so a single naked `&` costs the
+    // whole `<title>`. A ladder driven by parse errors would therefore never fire
+    // on exactly the documents it exists to rescue. Applying the rungs up front
+    // is safe because each one is a byte-level no-op on well-formed input (spec
+    // AC16, pinned by the conservativeness test in `sanitize.rs`): a well-formed
+    // document comes through byte-identical and parses exactly as it would have.
+    let mut current = bytes.to_vec();
+    let mut repairs = Vec::new();
+    for (rung, repair) in rungs {
+        let (next, changed) = rung(&current);
+        current = next;
+        if changed {
+            tracing::debug!(?repair, "rss sanitation rung changed bytes");
+            repairs.push(*repair);
+        }
+    }
+
+    // The guard above inspects the *raw* bytes, before the rungs run — cheap,
+    // and enough on its own for any document whose input bytes already carry a
+    // literal `<!DOCTYPE … [`, in either case: `refuse_internal_dtd` matches the
+    // keyword with `starts_with_ignore_ascii_case` (`sanitize.rs:118`, helper at
+    // `:147`), so a lowercase `<!doctype` is caught there and needs nothing
+    // further. What the raw-bytes pass cannot see is a subset a rung *reveals*:
+    // a control character splitting `<!DOCTY\x01PE` (which rung 2 then removes)
+    // or a UTF-16 document whose ASCII is interleaved with NUL bytes (which rung
+    // 1 then transcodes). Re-running the guard on the sanitized bytes closes
+    // both: whatever the rungs uncover, this still sees it before the parse.
+    //
+    // The earlier pass is therefore defence in depth rather than the only catch
+    // for any document that reaches feed-rs carrying a live subset — by
+    // construction, sanitized bytes that still hold one are caught here. It
+    // earns its place by refusing before three byte-level passes over a body up
+    // to `max_response_bytes`, and it is the only guard that can refuse a
+    // document whose prolog the rungs mangle past recognition (pinned by
+    // `a_mislabelled_utf16_documents_subset_is_refused_before_the_rungs_run`).
+    if family == DocFamily::Xml
+        && let Err(reason) = refuse_internal_dtd(&current)
+    {
+        tracing::debug!(stage = "refused-internal-dtd", %reason, "rss parse refused (post-sanitation)");
+        return Err(ParseFailure {
+            stage: "refused-internal-dtd",
+            reason,
+            dialect_declared,
+        });
+    }
+
+    match try_parse(&current) {
+        Ok(feed) => {
+            tracing::debug!(?repairs, dialect = ?feed.feed_type, "rss document parsed");
+            Ok(success(feed, dialect_declared, repairs))
+        }
+        Err(reason) => {
+            // Logged capped, at the same bound the column gets. The reason is
+            // the dependency's own string, and the shapes `engine.rs`'s module
+            // doc measures include ones that quote a feed-supplied token
+            // verbatim and unabbreviated — so untruncated this line was bounded
+            // only by `max_response_bytes`. `engine.rs` caps its own copy
+            // separately (`parse_error_message` bounds the composed string,
+            // prefix included), so the two do not depend on each other.
+            tracing::debug!(
+                stage = "strict-parse",
+                reason = %truncate(&reason, MAX_ERROR_CHARS),
+                "rss parse exhausted the ladder"
+            );
+            Err(ParseFailure {
+                stage: "strict-parse",
+                reason,
+                dialect_declared,
+            })
+        }
+    }
+}
+
+/// A parser that never invents an entry id.
+///
+/// `feed-rs` fills a missing id itself: from a content hash when there is a link
+/// to hash, and from a **random UUID** otherwise. The random case is unusable as
+/// identity — the same item would get a new `(feed, guid)` on every scan, breaking
+/// window identity and idempotent archiving — and both cases mask the
+/// "no identity at all" entry that spec decision 5 says to skip and count. Handing
+/// `feed-rs` a generator that yields nothing leaves `entry.id` empty unless the
+/// feed really supplied one, so the Field Mapping fallback chain (id → link →
+/// skip) is what decides identity, deterministically.
+fn parser() -> feed_rs::parser::Parser {
+    feed_rs::parser::Builder::new()
+        .id_generator(|_links, _title, _uri| String::new())
+        .build()
+}
+
+fn try_parse(bytes: &[u8]) -> Result<Feed, String> {
+    parser().parse(bytes).map_err(|e| e.to_string())
+}
+
+fn success(feed: Feed, dialect_declared: Option<String>, repairs: Vec<Repair>) -> ParseSuccess {
+    let dialect = parsed_dialect(feed.feed_type.clone());
+    ParseSuccess {
+        feed,
+        dialect,
+        dialect_declared,
+        repairs,
+    }
+}
+
+/// Feed-level fields projected onto the `feeds` table.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct FeedMeta {
+    pub title: Option<String>,
+    pub site_url: Option<String>,
+    pub description: Option<String>,
+}
+
+/// One `items` row, before Arrow encoding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ItemRow {
+    pub guid: String,
+    pub title: Option<String>,
+    pub link: Option<String>,
+    pub author: Option<String>,
+    pub published_ms: Option<i64>,
+    pub updated_ms: Option<i64>,
+    pub content: Option<String>,
+    pub summary: Option<String>,
+    pub categories: Vec<String>,
+    pub enclosure_url: Option<String>,
+    pub enclosure_type: Option<String>,
+    pub enclosure_length: Option<u64>,
+    pub extensions_json: Option<String>,
+}
+
+/// The result of projecting a `feed-rs` model onto our row shapes.
+#[derive(Debug, Clone)]
+pub struct ExtractedFeed {
+    pub meta: FeedMeta,
+    pub items: Vec<ItemRow>,
+    /// Entries dropped because they had neither an id nor a link.
+    pub skipped_without_identity: usize,
+}
+
+/// Everything the engine needs from one fetched document.
+#[derive(Debug, Clone)]
+pub struct ParsedDocument {
+    pub meta: FeedMeta,
+    pub items: Vec<ItemRow>,
+    pub dialect: &'static str,
+    pub dialect_declared: Option<String>,
+    pub conformance_notes: Vec<String>,
+}
+
+/// Project a parsed feed onto `FeedMeta` + `ItemRow`s per the Field Mapping table.
+pub fn extract(feed: Feed) -> ExtractedFeed {
+    let meta = FeedMeta {
+        title: feed.title.as_ref().map(|t| t.content.clone()),
+        site_url: preferred_link(&feed.links).map(|l| l.href.clone()),
+        description: feed.description.as_ref().map(|t| t.content.clone()),
+    };
+
+    let mut items = Vec::with_capacity(feed.entries.len());
+    let mut skipped_without_identity = 0;
+    for entry in &feed.entries {
+        match extract_entry(entry) {
+            Some(row) => items.push(row),
+            None => skipped_without_identity += 1,
+        }
+    }
+
+    ExtractedFeed {
+        meta,
+        items,
+        skipped_without_identity,
+    }
+}
+
+/// Whether a link is an attachment to download rather than a page to visit.
+///
+/// Atom marks these `rel="enclosure"`. `feed-rs` turns JSON Feed attachments into
+/// `rel`-less links instead, which is also how a JSON item's own URL arrives — the
+/// `media_type` is what separates them, since `util::handle_link` (the RSS 0.9x/1.0/
+/// 2.0 and JSON url path) sets only `href`. Without this distinction an audio
+/// attachment can be promoted to the item's link, and from there to its `guid`.
+fn is_attachment(link: &Link) -> bool {
+    link.rel.as_deref() == Some("enclosure") || (link.rel.is_none() && link.media_type.is_some())
+}
+
+/// The link a reader should follow: the first non-attachment `rel`-less or
+/// `alternate` link.
+fn preferred_link(links: &[Link]) -> Option<&Link> {
+    links
+        .iter()
+        .filter(|l| !is_attachment(l))
+        .find(|l| matches!(l.rel.as_deref(), None | Some("alternate")))
+}
+
+/// `None` when the entry has neither an id nor a link — a `(feed, guid)` key
+/// cannot be null, so such an entry is skipped and counted.
+fn extract_entry(entry: &Entry) -> Option<ItemRow> {
+    let link = preferred_link(&entry.links)
+        .or_else(|| entry.links.iter().find(|l| !is_attachment(l)))
+        .map(|l| l.href.clone());
+
+    let guid = match entry.id.trim() {
+        "" => link.clone()?,
+        id => id.to_string(),
+    };
+
+    let enclosure = enclosure(entry);
+
+    Some(ItemRow {
+        guid,
+        title: entry.title.as_ref().map(|t| t.content.clone()),
+        link,
+        author: entry
+            .authors
+            .iter()
+            .map(|p| p.name.trim())
+            .find(|name| !name.is_empty())
+            .map(str::to_string),
+        published_ms: entry.published.map(|d| d.timestamp_millis()),
+        updated_ms: entry.updated.map(|d| d.timestamp_millis()),
+        content: entry.content.as_ref().and_then(|c| {
+            let body = c.body.as_ref()?;
+            Some(render_text(body, c.content_type.subty().as_str()))
+        }),
+        summary: entry
+            .summary
+            .as_ref()
+            .map(|t| render_text(&t.content, t.content_type.subty().as_str())),
+        categories: categories(&entry.categories),
+        enclosure_url: enclosure.url,
+        enclosure_type: enclosure.content_type,
+        enclosure_length: enclosure.length,
+        extensions_json: extensions_json(entry, enclosure.from_media),
+    })
+}
+
+/// HTML-typed bodies become Markdown; anything else is stored byte-exact.
+///
+/// MIME subtypes are case-insensitive (RFC 2045 §5.1). `mediatype::Name` (what
+/// `.subty()` returns before a call site's `.as_str()` throws it away) already
+/// implements a case-insensitive `PartialEq<&str>` — verified in
+/// `mediatype-0.21.0/src/name.rs`, whose impl compares via
+/// `eq_ignore_ascii_case` — so `eq_ignore_ascii_case` here restores the same
+/// comparison instead of `==`, which let e.g. `type="TEXT/HTML"` store raw
+/// HTML in `items.content`/`items.summary` rather than converting it.
+fn render_text(body: &str, subtype: &str) -> String {
+    if subtype.eq_ignore_ascii_case("html") || subtype.eq_ignore_ascii_case("xhtml") {
+        html_to_markdown(body)
+    } else {
+        body.to_string()
+    }
+}
+
+/// `term`, falling back to `label`, deduped preserving first-seen order.
+fn categories(cats: &[Category]) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for c in cats {
+        let term = match c.term.trim() {
+            "" => c.label.as_deref().unwrap_or_default().trim(),
+            term => term,
+        };
+        if term.is_empty() || out.iter().any(|seen| seen == term) {
+            continue;
+        }
+        out.push(term.to_string());
+    }
+    out
+}
+
+struct Enclosure {
+    url: Option<String>,
+    content_type: Option<String>,
+    length: Option<u64>,
+    /// Whether `media` supplied it, so `extensions_json` knows to skip that one.
+    from_media: bool,
+}
+
+/// The item's primary attachment.
+///
+/// `feed-rs` folds RSS 2.0 `<enclosure>` and MediaRSS into `media`, but *not*
+/// Atom `rel="enclosure"` links or JSON Feed attachments — both of those stay in
+/// `links` (a JSON attachment arrives `rel`-less but carries a `media_type`,
+/// which is what distinguishes it from the item's own URL).
+fn enclosure(entry: &Entry) -> Enclosure {
+    if let Some(mc) = entry
+        .media
+        .iter()
+        .flat_map(|object| object.content.iter())
+        .find(|c| c.url.is_some())
+    {
+        return Enclosure {
+            url: mc.url.as_ref().map(|u| u.to_string()),
+            content_type: mc.content_type.as_ref().map(|m| m.to_string()),
+            length: mc.size,
+            from_media: true,
+        };
+    }
+
+    if let Some(link) = entry.links.iter().find(|l| is_attachment(l)) {
+        return Enclosure {
+            url: Some(link.href.clone()),
+            content_type: link.media_type.clone(),
+            length: link.length,
+            from_media: false,
+        };
+    }
+
+    Enclosure {
+        url: None,
+        content_type: None,
+        length: None,
+        from_media: false,
+    }
+}
+
+/// Whatever the `feed-rs` model exposes beyond the pinned columns, as a compact
+/// JSON object with deterministic key order. `None` when nothing is present.
+fn extensions_json(entry: &Entry, enclosure_from_media: bool) -> Option<String> {
+    let mut fields: BTreeMap<&str, Value> = BTreeMap::new();
+
+    let media = remaining_media(entry, enclosure_from_media);
+    if !media.is_empty() {
+        fields.insert("media", Value::Array(media));
+    }
+    if let Some(source) = non_blank(entry.source.as_deref()) {
+        fields.insert("source", Value::String(source.to_string()));
+    }
+    if let Some(rights) = non_blank(entry.rights.as_ref().map(|t| t.content.as_str())) {
+        fields.insert("rights", Value::String(rights.to_string()));
+    }
+    if let Some(language) = non_blank(entry.language.as_deref()) {
+        fields.insert("language", Value::String(language.to_string()));
+    }
+
+    if fields.is_empty() {
+        return None;
+    }
+    serde_json::to_string(&fields).ok()
+}
+
+fn non_blank(s: Option<&str>) -> Option<&str> {
+    s.map(str::trim).filter(|s| !s.is_empty())
+}
+
+/// Media objects minus the single content already surfaced as the enclosure.
+fn remaining_media(entry: &Entry, enclosure_from_media: bool) -> Vec<Value> {
+    let mut enclosure_still_to_skip = enclosure_from_media;
+    let mut objects = Vec::new();
+
+    for object in &entry.media {
+        let mut contents = Vec::new();
+        for c in &object.content {
+            if enclosure_still_to_skip && c.url.is_some() {
+                enclosure_still_to_skip = false;
+                continue;
+            }
+            let mut one: BTreeMap<&str, Value> = BTreeMap::new();
+            if let Some(url) = &c.url {
+                one.insert("url", Value::String(url.to_string()));
+            }
+            if let Some(ct) = &c.content_type {
+                one.insert("content_type", Value::String(ct.to_string()));
+            }
+            if let Some(size) = c.size {
+                one.insert("size", Value::from(size));
+            }
+            if !one.is_empty() {
+                contents.push(json!(one));
+            }
+        }
+
+        let mut fields: BTreeMap<&str, Value> = BTreeMap::new();
+        if !contents.is_empty() {
+            fields.insert("content", Value::Array(contents));
+        }
+        if let Some(title) = non_blank(object.title.as_ref().map(|t| t.content.as_str())) {
+            fields.insert("title", Value::String(title.to_string()));
+        }
+        if let Some(description) =
+            non_blank(object.description.as_ref().map(|t| t.content.as_str()))
+        {
+            fields.insert("description", Value::String(description.to_string()));
+        }
+        if !object.thumbnails.is_empty() {
+            fields.insert(
+                "thumbnails",
+                Value::Array(
+                    object
+                        .thumbnails
+                        .iter()
+                        .map(|t| Value::String(t.image.uri.clone()))
+                        .collect(),
+                ),
+            );
+        }
+        if let Some(duration) = object.duration {
+            fields.insert("duration_secs", Value::from(duration.as_secs()));
+        }
+
+        if !fields.is_empty() {
+            objects.push(json!(fields));
+        }
+    }
+    objects
+}
+
+/// Parse and extract in one call — the entry point the engine uses.
+pub fn parse_feed_document(
+    bytes: &[u8],
+    content_type: Option<&str>,
+) -> Result<ParsedDocument, ParseFailure> {
+    let parsed = parse_with_ladder(bytes)?;
+    let feed_type = parsed.feed.feed_type.clone();
+
+    let mut conformance_notes: Vec<String> = parsed
+        .repairs
+        .iter()
+        .map(|r| r.note().to_string())
+        .collect();
+    if let Some(note) = content_type_family_note(content_type, feed_type.clone()) {
+        conformance_notes.push(note);
+    }
+    conformance_notes.extend(required_field_notes(feed_type, &parsed.feed));
+
+    let extracted = extract(parsed.feed);
+    if extracted.skipped_without_identity > 0 {
+        conformance_notes.push(format!(
+            "entries-without-identity: {}",
+            extracted.skipped_without_identity
+        ));
+    }
+
+    Ok(ParsedDocument {
+        meta: extracted.meta,
+        items: extracted.items,
+        dialect: parsed.dialect,
+        dialect_declared: parsed.dialect_declared,
+        conformance_notes,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strict_parse_records_no_repairs() {
+        let doc = br#"<rss version="2.0"><channel><title>t</title><link>https://e.com</link><description>d</description></channel></rss>"#;
+        let ok = parse_with_ladder(doc).unwrap();
+        assert!(ok.repairs.is_empty());
+        assert_eq!(ok.dialect, "rss-2.0");
+        assert_eq!(ok.dialect_declared.as_deref(), Some("rss-2.0"));
+    }
+
+    /// Why sanitation runs before the parse instead of after a failure. If a
+    /// future feed-rs either rejects this document or preserves the title on its
+    /// own, this test fails and the ordering decision deserves revisiting.
+    #[test]
+    fn feed_rs_alone_silently_drops_the_element_a_naked_ampersand_touches() {
+        let doc = br#"<rss version="2.0"><channel><title>Fish & Chips</title><link>https://e.com</link><description>d</description></channel></rss>"#;
+        let bare = feed_rs::parser::parse(&doc[..])
+            .expect("feed-rs tolerates a naked ampersand rather than erroring");
+        assert!(
+            bare.title.is_none(),
+            "feed-rs no longer drops the title; revisit the sanitize-first ordering"
+        );
+        // Through the ladder the same document keeps its title.
+        let ok = parse_with_ladder(doc).unwrap();
+        assert_eq!(ok.feed.title.as_ref().unwrap().content, "Fish & Chips");
+    }
+
+    #[test]
+    fn naked_ampersand_document_is_rescued_with_minimal_repair_set() {
+        let doc = br#"<rss version="2.0"><channel><title>Fish & Chips</title><link>https://e.com</link><description>d</description></channel></rss>"#;
+        let ok = parse_with_ladder(doc).unwrap();
+        // Rungs 1-2 changed nothing, so they are not recorded.
+        assert_eq!(ok.repairs, vec![Repair::EscapedNakedAmpersands]);
+        assert_eq!(ok.feed.title.as_ref().unwrap().content, "Fish & Chips");
+    }
+
+    #[test]
+    fn billion_laughs_is_refused_not_expanded() {
+        let doc = br#"<?xml version="1.0"?><!DOCTYPE lolz [<!ENTITY lol "lol"><!ENTITY lol2 "&lol;&lol;">]><rss version="2.0"><channel><title>&lol2;</title></channel></rss>"#;
+        let err = parse_with_ladder(doc).unwrap_err();
+        assert_eq!(err.stage, "refused-internal-dtd");
+        assert!(
+            err.reason.contains("internal DTD subset refused"),
+            "reason names the guard: {}",
+            err.reason
+        );
+    }
+
+    /// A lowercase `<!doctype`, which the guard's match used to miss because it
+    /// was case-sensitive.
+    ///
+    /// Unlike the two numbered evasions below, this input needs no sanitation to
+    /// become visible: the subset is literal in the raw bytes, and
+    /// `starts_with_ignore_ascii_case` (`sanitize.rs:118`, helper at `:147`)
+    /// recognizes the keyword in any case, so the refusal comes from the
+    /// *pre*-sanitation guard and the rungs never run. Grouped with them because
+    /// this spelling once slipped past that guard, not because it needs the
+    /// post-sanitation re-run.
+    #[test]
+    fn lowercase_doctype_with_internal_subset_is_refused() {
+        let doc = br#"<!doctype r [<!ENTITY a "b">]><r>x</r>"#;
+        let err = parse_with_ladder(doc).unwrap_err();
+        assert_eq!(err.stage, "refused-internal-dtd");
+        assert!(
+            err.reason.contains("internal DTD subset refused"),
+            "{}",
+            err.reason
+        );
+    }
+
+    /// The pre-sanitation guard is the only one that can refuse this document, so
+    /// deleting it fails a test rather than nothing.
+    ///
+    /// The two cases below are caught by the post-sanitation re-run, and every
+    /// other refusal in this module is caught by *both* passes — sanitized bytes
+    /// that still carry a live subset reach the second guard by construction,
+    /// which is why the first one could be deleted with the suite staying green
+    /// (measured).
+    ///
+    /// This document escapes that symmetry from the other side: it declares
+    /// `utf-16` while carrying a byte that is not valid UTF-8, so rung 1 takes
+    /// its transcoding path and decodes the whole body as UTF-16LE, pairing up
+    /// ASCII bytes into CJK. `<!DOCTYPE r [` is unrecognizable afterwards — the
+    /// second assertion below measures exactly that — so only the raw-bytes pass
+    /// can see it.
+    ///
+    /// Honest about what this is: the mangled bytes hold no DTD for feed-rs to
+    /// expand either, so this shape is not a live entity-expansion threat that
+    /// the early guard alone averts. What it pins is that the refusal happens
+    /// before the rungs, which is the guard's reason to exist (refusing early is
+    /// cheaper than three byte-level passes over a body up to
+    /// `max_response_bytes`) and was otherwise unobservable.
+    #[test]
+    fn a_mislabelled_utf16_documents_subset_is_refused_before_the_rungs_run() {
+        let mut doc =
+            br#"<?xml version="1.0" encoding="utf-16"?><!DOCTYPE r [<!ENTITY a "b">]><r>x"#
+                .to_vec();
+        doc.push(0xFF); // not valid UTF-8, so rung 1 transcodes rather than passing through
+        doc.extend_from_slice(b"</r>");
+
+        let err = parse_with_ladder(&doc).unwrap_err();
+        assert_eq!(err.stage, "refused-internal-dtd");
+        assert!(
+            err.reason.contains("internal DTD subset refused"),
+            "{}",
+            err.reason
+        );
+
+        // And the post-sanitation guard could not have produced that refusal:
+        // after rung 1 there is no `<!DOCTYPE` left to find.
+        let (sanitized, changed) = rung_reencode_utf8(&doc);
+        assert!(changed, "rung 1 must have rewritten the body");
+        assert!(
+            refuse_internal_dtd(&sanitized).is_ok(),
+            "the transcoded body still carries a recognizable subset, so this document \
+             no longer isolates the pre-sanitation guard"
+        );
+    }
+
+    /// Evasion 1: the guard used to run only on raw bytes, before rung 2
+    /// strips illegal control characters. `<!DOCTY\x01PE … [` does not match
+    /// `<!DOCTYPE` and passes that first check; rung 2 then removes the
+    /// control byte, producing a real `<!DOCTYPE … [` — which the
+    /// post-sanitation guard now catches.
+    #[test]
+    fn control_char_split_doctype_with_internal_subset_is_refused_after_sanitation() {
+        let mut doc = b"<!DOCTY".to_vec();
+        doc.push(0x01);
+        doc.extend_from_slice(br#"PE r [<!ENTITY lol "x">]><r>y</r>"#);
+        let err = parse_with_ladder(&doc).unwrap_err();
+        assert_eq!(err.stage, "refused-internal-dtd");
+        assert!(
+            err.reason.contains("internal DTD subset refused"),
+            "{}",
+            err.reason
+        );
+    }
+
+    /// Evasion 2: a UTF-16LE document's `<!DOCTYPE` is invisible to the
+    /// raw-bytes scanner (every ASCII byte is interleaved with a `0x00`);
+    /// rung 1 transcodes it to UTF-8, and the post-sanitation guard catches
+    /// the doctype rung 1 reveals.
+    #[test]
+    fn utf16_doctype_with_internal_subset_is_refused_after_reencoding() {
+        let text = r#"<!DOCTYPE r [<!ENTITY lol "x">]><r>y</r>"#;
+        let mut doc = vec![0xFF, 0xFE]; // UTF-16LE BOM
+        for unit in text.encode_utf16() {
+            doc.extend_from_slice(&unit.to_le_bytes());
+        }
+        let err = parse_with_ladder(&doc).unwrap_err();
+        assert_eq!(err.stage, "refused-internal-dtd");
+        assert!(
+            err.reason.contains("internal DTD subset refused"),
+            "{}",
+            err.reason
+        );
+    }
+
+    #[test]
+    fn hopeless_document_exhausts_ladder_with_strict_parse_stage() {
+        let err = parse_with_ladder(b"<rss version=\"2.0\"><channel><title>truncat").unwrap_err();
+        assert_eq!(err.stage, "strict-parse");
+        // The declared sniff still works on garbage.
+        assert_eq!(err.dialect_declared.as_deref(), Some("rss-2.0"));
+        assert!(!err.reason.is_empty(), "the last feed-rs error is carried");
+    }
+
+    /// `last_error` must carry no response-body content (global constraint). The
+    /// 512-char cap in the engine bounds length but does not redact, so the
+    /// guarantee has to come from `feed-rs` not echoing character data. If a future
+    /// version starts quoting it, this fails and a redaction filter is needed.
+    #[test]
+    fn parse_failure_reason_never_echoes_character_data() {
+        // Truncated mid-element, with a sentinel sitting in character data.
+        let doc = b"<rss version=\"2.0\"><channel><title>SHOULD-NOT-LEAK secret prose";
+        let err = parse_with_ladder(doc).unwrap_err();
+        assert_eq!(err.stage, "strict-parse");
+        assert!(
+            !err.reason.contains("SHOULD-NOT-LEAK"),
+            "parse error echoed character data into last_error: {}",
+            err.reason
+        );
+    }
+
+    #[test]
+    fn control_char_document_is_rescued_and_records_only_that_rung() {
+        let mut doc = br#"<rss version="2.0"><channel><title>ti"#.to_vec();
+        doc.push(0x08); // illegal in XML 1.0, legal UTF-8
+        doc.extend_from_slice(
+            br#"tle</title><link>https://e.com</link><description>d</description></channel></rss>"#,
+        );
+        let ok = parse_with_ladder(&doc).unwrap();
+        assert_eq!(ok.repairs, vec![Repair::StrippedControlChars]);
+        assert_eq!(ok.feed.title.as_ref().unwrap().content, "title");
+    }
+
+    #[test]
+    fn latin1_document_is_rescued_and_records_the_reencode_rung() {
+        let mut doc =
+            br#"<?xml version="1.0" encoding="iso-8859-1"?><rss version="2.0"><channel><title>caf"#
+                .to_vec();
+        doc.push(0xE9);
+        doc.extend_from_slice(
+            br#"</title><link>https://e.com</link><description>d</description></channel></rss>"#,
+        );
+        let ok = parse_with_ladder(&doc).unwrap();
+        assert_eq!(ok.repairs, vec![Repair::ReencodedToUtf8]);
+        assert_eq!(ok.feed.title.as_ref().unwrap().content, "café");
+    }
+
+    #[test]
+    fn lying_non_utf8_decl_over_utf8_bytes_is_repaired_and_noted() {
+        // decl claims iso-8859-1 but the title bytes are already UTF-8 (café,
+        // not Latin-1) — I3: this used to be a silent byte-level no-op that
+        // mojibaked for any consumer trusting the decl.
+        let doc = "<?xml version=\"1.0\" encoding=\"iso-8859-1\"?><rss version=\"2.0\"><channel><title>café</title><link>https://e.com</link><description>d</description></channel></rss>".as_bytes();
+        let ok = parse_with_ladder(doc).unwrap();
+        assert_eq!(ok.repairs, vec![Repair::ReencodedToUtf8]);
+        assert_eq!(ok.feed.title.as_ref().unwrap().content, "café");
+    }
+
+    #[test]
+    fn json_feed_parses_and_reports_its_dialect() {
+        let doc = br#"{"version":"https://jsonfeed.org/version/1.1","title":"t","items":[]}"#;
+        let ok = parse_with_ladder(doc).unwrap();
+        assert_eq!(ok.dialect, "json-feed-1.x");
+        assert_eq!(ok.dialect_declared.as_deref(), Some("json-feed-1.1"));
+        assert!(ok.repairs.is_empty());
+    }
+
+    #[test]
+    fn json_family_never_runs_the_xml_repair_rungs() {
+        // Naked `&` is legal inside a JSON string; the XML ampersand rung would
+        // corrupt it, so the JSON path must not apply it.
+        let doc =
+            br#"{"version":"https://jsonfeed.org/version/1.1","title":"Fish & Chips","items":[]}"#;
+        let ok = parse_with_ladder(doc).unwrap();
+        assert_eq!(ok.feed.title.as_ref().unwrap().content, "Fish & Chips");
+        assert!(ok.repairs.is_empty(), "{:?}", ok.repairs);
+    }
+
+    #[test]
+    fn rss2_maps_per_field_mapping_table() {
+        let doc = br#"<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:dc="http://purl.org/dc/elements/1.1/"><channel>
+<title>Chan</title><link>https://site.example/</link><description>D</description>
+<item>
+  <guid>tag:1</guid><title>Post</title><link>https://site.example/p1</link>
+  <dc:creator>Ada</dc:creator><pubDate>Mon, 20 Jul 2026 10:00:00 GMT</pubDate>
+  <description>&lt;p&gt;Sum &lt;b&gt;bold&lt;/b&gt;&lt;/p&gt;</description>
+  <content:encoded><![CDATA[<h1>Body</h1><p>text</p>]]></content:encoded>
+  <category>rust</category><category>news</category>
+  <enclosure url="https://site.example/e.mp3" type="audio/mpeg" length="123"/>
+</item>
+<item><title>NoGuid</title><link>https://site.example/p2</link></item>
+<item><title>NoIdentity</title></item>
+</channel></rss>"#;
+        let parsed = parse_feed_document(doc, Some("application/rss+xml")).unwrap();
+        assert_eq!(parsed.dialect, "rss-2.0");
+        assert_eq!(parsed.items.len(), 2);
+        let it = &parsed.items[0];
+        assert_eq!(it.guid, "tag:1");
+        assert_eq!(it.author.as_deref(), Some("Ada"));
+        assert_eq!(it.published_ms, Some(1_784_541_600_000)); // 2026-07-20T10:00:00Z
+        assert_eq!(it.content.as_deref(), Some("# Body\n\ntext")); // Markdown, not HTML
+        assert_eq!(it.summary.as_deref(), Some("Sum **bold**"));
+        assert_eq!(it.categories, vec!["rust", "news"]);
+        assert_eq!(
+            it.enclosure_url.as_deref(),
+            Some("https://site.example/e.mp3")
+        );
+        assert_eq!(it.enclosure_type.as_deref(), Some("audio/mpeg"));
+        assert_eq!(it.enclosure_length, Some(123));
+        assert_eq!(parsed.items[1].guid, "https://site.example/p2"); // link fallback
+        assert!(
+            parsed
+                .conformance_notes
+                .iter()
+                .any(|n| n == "entries-without-identity: 1")
+        );
+        assert_eq!(parsed.meta.title.as_deref(), Some("Chan"));
+        assert_eq!(
+            parsed.meta.site_url.as_deref(),
+            Some("https://site.example/")
+        );
+        assert_eq!(parsed.meta.description.as_deref(), Some("D"));
+    }
+
+    #[test]
+    fn atom10_maps_fields() {
+        // feed-rs does not fold Atom `rel="enclosure"` links into `media`, so this
+        // pins the `entry.links` fallback.
+        let doc = br#"<feed xmlns="http://www.w3.org/2005/Atom">
+<title>Chan</title><updated>2026-07-20T10:00:00Z</updated>
+<link rel="alternate" href="https://site.example/"/>
+<entry>
+  <id>urn:uuid:1</id><title>Post</title>
+  <link rel="alternate" href="https://site.example/p1"/>
+  <link rel="enclosure" type="audio/mpeg" length="99" href="https://site.example/e.mp3"/>
+  <author><name>Ada</name></author>
+  <published>2026-07-20T10:00:00Z</published><updated>2026-07-21T11:00:00Z</updated>
+  <content type="html">&lt;h1&gt;Body&lt;/h1&gt;</content>
+  <summary type="text">plain &lt; text</summary>
+  <category term="rust"/>
+</entry></feed>"#;
+        let parsed = parse_feed_document(doc, Some("application/atom+xml")).unwrap();
+        assert_eq!(parsed.dialect, "atom");
+        assert_eq!(parsed.dialect_declared.as_deref(), Some("atom-1.0"));
+        assert_eq!(parsed.items.len(), 1);
+        let it = &parsed.items[0];
+        assert_eq!(it.guid, "urn:uuid:1");
+        assert_eq!(it.link.as_deref(), Some("https://site.example/p1"));
+        assert_eq!(it.author.as_deref(), Some("Ada"));
+        assert!(it.published_ms.is_some() && it.updated_ms.is_some());
+        assert_ne!(
+            it.published_ms, it.updated_ms,
+            "published and updated are distinct"
+        );
+        assert_eq!(it.content.as_deref(), Some("# Body"));
+        // `type="text"` must pass through untouched, angle bracket and all.
+        assert_eq!(it.summary.as_deref(), Some("plain < text"));
+        assert_eq!(it.categories, vec!["rust"]);
+        assert_eq!(
+            it.enclosure_url.as_deref(),
+            Some("https://site.example/e.mp3")
+        );
+        assert_eq!(it.enclosure_type.as_deref(), Some("audio/mpeg"));
+    }
+
+    /// I1: MIME subtypes are case-insensitive (RFC 2045 §5.1); a `type=
+    /// "TEXT/HTML"` on `<content>` must still convert to Markdown, not store
+    /// raw HTML. Scoped to `<content>` deliberately — feed-rs's Atom
+    /// `<summary>`/`<title>`/`<rights>` handler (`atom::handle_text`, in
+    /// `feed-rs-2.4.0/src/parser/atom/mod.rs`) matches its `type` attribute
+    /// against literal lowercase strings and *errors the whole entry* on
+    /// anything else, so a mis-cased `<summary>` never even reaches our
+    /// case-sensitive comparison to trigger this bug in the first place; only
+    /// `<content>`'s handler has an "unrecognized type" fallback that lets a
+    /// mis-cased MIME type through as-is.
+    #[test]
+    fn atom_content_type_uppercase_html_still_converts_to_markdown() {
+        let doc = br#"<feed xmlns="http://www.w3.org/2005/Atom">
+<title>Chan</title><updated>2026-07-20T10:00:00Z</updated>
+<entry>
+  <id>urn:uuid:1</id><title>Post</title>
+  <content type="TEXT/HTML">&lt;h1&gt;Body&lt;/h1&gt;</content>
+</entry></feed>"#;
+        let parsed = parse_feed_document(doc, Some("application/atom+xml")).unwrap();
+        assert_eq!(
+            parsed.items[0].content.as_deref(),
+            Some("# Body"),
+            "uppercase MIME subtype must still be treated as HTML"
+        );
+    }
+
+    #[test]
+    fn jsonfeed_maps_fields() {
+        // feed-rs turns JSON Feed attachments into `entry.links`, not `media`.
+        let doc = br#"{"version":"https://jsonfeed.org/version/1.1","title":"Chan",
+"home_page_url":"https://site.example/",
+"items":[{"id":"1","url":"https://site.example/p1","title":"Post",
+"content_html":"<h1>Body</h1>","date_published":"2026-07-20T10:00:00Z",
+"date_modified":"2026-07-21T11:00:00Z","tags":["rust","news"],
+"authors":[{"name":"Ada"}],
+"attachments":[{"url":"https://site.example/e.mp3","mime_type":"audio/mpeg","size_in_bytes":123}]}]}"#;
+        let parsed = parse_feed_document(doc, Some("application/feed+json")).unwrap();
+        assert_eq!(parsed.dialect, "json-feed-1.x");
+        assert_eq!(parsed.items.len(), 1);
+        let it = &parsed.items[0];
+        assert_eq!(it.guid, "1");
+        assert_eq!(it.link.as_deref(), Some("https://site.example/p1"));
+        assert_eq!(it.author.as_deref(), Some("Ada"));
+        assert_eq!(it.content.as_deref(), Some("# Body"));
+        assert_eq!(it.categories, vec!["rust", "news"]);
+        assert_eq!(
+            it.enclosure_url.as_deref(),
+            Some("https://site.example/e.mp3")
+        );
+        assert_eq!(it.enclosure_type.as_deref(), Some("audio/mpeg"));
+        assert_eq!(it.enclosure_length, Some(123));
+        assert_ne!(it.published_ms, it.updated_ms);
+    }
+
+    #[test]
+    fn rss1_rdf_maps_fields() {
+        let doc = br#"<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+<channel rdf:about="https://site.example/"><title>Chan</title><link>https://site.example/</link><description>D</description></channel>
+<item rdf:about="https://site.example/p1"><title>Post</title><link>https://site.example/p1</link>
+<dc:creator>Ada</dc:creator><dc:date>2026-07-20T10:00:00Z</dc:date><description>Sum</description></item>
+</rdf:RDF>"#;
+        let parsed = parse_feed_document(doc, Some("application/rss+xml")).unwrap();
+        assert_eq!(parsed.dialect, "rss-1.0");
+        assert_eq!(parsed.items.len(), 1);
+        let it = &parsed.items[0];
+        assert!(!it.guid.is_empty(), "rdf:about or link supplies identity");
+        assert_eq!(it.title.as_deref(), Some("Post"));
+        assert_eq!(it.author.as_deref(), Some("Ada"));
+        assert_eq!(it.published_ms, Some(1_784_541_600_000));
+        assert_eq!(parsed.meta.title.as_deref(), Some("Chan"));
+    }
+
+    #[test]
+    fn plain_text_content_is_never_converted() {
+        let doc = br#"{"version":"https://jsonfeed.org/version/1.1","title":"C",
+"items":[{"id":"1","content_text":"a < b & c"}]}"#;
+        let parsed = parse_feed_document(doc, None).unwrap();
+        assert_eq!(parsed.items.len(), 1);
+        assert_eq!(
+            parsed.items[0].content.as_deref(),
+            Some("a < b & c"),
+            "plain text must be stored byte-exact, not Markdown-escaped"
+        );
+    }
+
+    #[test]
+    fn extensions_json_is_none_for_a_bare_item() {
+        let bare = br#"<rss version="2.0"><channel><title>C</title><link>https://e.com</link><description>D</description>
+<item><guid>1</guid><title>T</title></item></channel></rss>"#;
+        let parsed = parse_feed_document(bare, None).unwrap();
+        assert_eq!(
+            parsed.items[0].extensions_json, None,
+            "a bare item carries no extensions"
+        );
+    }
+
+    /// M1: the previous version of this test only asserted `.expect(...)`
+    /// on the whole object, so a `<source>` alone (which never touches
+    /// `remaining_media`) satisfied it just as well as real leftover media
+    /// would — the brief's most intricate rule went untested. This asserts
+    /// on the parsed JSON's actual keys instead, so `media` and `source`
+    /// can't stand in for each other.
+    #[test]
+    fn extensions_json_media_key_is_only_leftover_media_beyond_the_enclosure() {
+        let doc = br#"<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/"><channel>
+<title>C</title><link>https://e.com</link><description>D</description>
+<item><guid>1</guid><title>T</title>
+<enclosure url="https://e.com/a.mp3" type="audio/mpeg" length="1"/>
+<media:content url="https://e.com/b.jpg" type="image/jpeg" fileSize="2"/>
+</item></channel></rss>"#;
+        let parsed = parse_feed_document(doc, None).unwrap();
+        let ext = parsed.items[0]
+            .extensions_json
+            .as_deref()
+            .expect("a second media:content beyond the enclosure populates extensions");
+        let value: serde_json::Value = serde_json::from_str(ext).expect("valid JSON");
+        let obj = value.as_object().expect("extensions_json is a JSON object");
+        assert_eq!(
+            obj.keys().collect::<Vec<_>>(),
+            vec!["media"],
+            "only the leftover media, not source/rights/language: {ext}"
+        );
+        let media = obj["media"].as_array().expect("media is an array");
+        assert_eq!(media.len(), 1, "the enclosure's own content is excluded");
+        assert_eq!(
+            media[0]["content"][0]["url"], "https://e.com/b.jpg",
+            "the *other* media:content survives, not the enclosure's: {ext}"
+        );
+        assert_eq!(ext, serde_json::to_string(&value).unwrap(), "keys sorted");
+    }
+
+    /// M1: `<source>` alone — with no media beyond the single enclosure —
+    /// was meant to populate `extensions_json` with a `source` key and *no*
+    /// `media` key, distinguishing this from the media-key test above. But
+    /// `entry.source` (the field this crate's `extensions_json` reads) is
+    /// never actually assigned by feed-rs 2.4.0, for *any* dialect: there is
+    /// no `.source =` anywhere under `feed-rs-2.4.0/src/parser/**` (checked
+    /// `rss2`, `atom`, `rss1`, and `json`), and the RSS2 item handler
+    /// (`feed-rs-2.4.0/src/parser/rss2/mod.rs`'s `handle_item` match) has no
+    /// arm for `(NS::RSS, "source")` at all — the element this fixture used
+    /// is silently ignored, not mapped to the model's `source: Option<String>`
+    /// (whose doc describes *Atom's* copied-source-feed-metadata concept, a
+    /// different thing from RSS2's `<source url>` attribution element, and
+    /// which no parser path sets either). So no XML/JSON fixture can drive
+    /// this key through `parse_feed_document` today. This instead calls
+    /// `extensions_json` directly against a hand-built `Entry`, pinning the
+    /// mapping this crate's own code performs so the property is still
+    /// covered if a future feed-rs starts populating the field.
+    #[test]
+    fn extensions_json_source_key_present_without_a_media_key() {
+        let entry = Entry {
+            source: Some("Origin".to_string()),
+            ..Entry::default()
+        };
+        let ext = extensions_json(&entry, false)
+            .expect("source populates extensions even with no leftover media");
+        let value: serde_json::Value = serde_json::from_str(&ext).expect("valid JSON");
+        let obj = value.as_object().expect("extensions_json is a JSON object");
+        assert_eq!(
+            obj.keys().collect::<Vec<_>>(),
+            vec!["source"],
+            "source only, no media key when nothing is left over: {ext}"
+        );
+        assert_eq!(obj["source"], "Origin");
+    }
+
+    /// M1: `language`, named in the original test, was never actually
+    /// exercised by it. `entry.language` is populated only from the
+    /// `xml:lang` attribute on an Atom entry's `<content>` *child* element
+    /// (verified: `feed-rs-2.4.0/src/parser/atom/mod.rs`'s
+    /// `(NS::Atom, "content")` match arm is the only place that assigns
+    /// `entry.language`, via `util::handle_language_attr(&child)` where
+    /// `child` is that `<content>` element) — not from `xml:lang` on the
+    /// `<entry>` element itself, which the original fixture put it on and
+    /// which no code path reads for this field.
+    #[test]
+    fn extensions_json_language_key_from_atom_entry_xml_lang() {
+        let doc = br#"<feed xmlns="http://www.w3.org/2005/Atom">
+<title>Chan</title><updated>2026-07-20T10:00:00Z</updated>
+<entry>
+  <id>urn:uuid:1</id><title>Post</title>
+  <content type="text" xml:lang="fr">body</content>
+</entry></feed>"#;
+        let parsed = parse_feed_document(doc, Some("application/atom+xml")).unwrap();
+        let ext = parsed.items[0]
+            .extensions_json
+            .as_deref()
+            .expect("xml:lang on <content> populates extensions_json's language key");
+        let value: serde_json::Value = serde_json::from_str(ext).expect("valid JSON");
+        let obj = value.as_object().expect("extensions_json is a JSON object");
+        assert_eq!(obj.keys().collect::<Vec<_>>(), vec!["language"]);
+        assert_eq!(obj["language"], "fr");
+    }
+
+    /// Identity must be reproducible across scans, so a random id is never
+    /// acceptable. Left to itself feed-rs hands an entry with no id and no link a
+    /// fresh UUID on every parse; the entry is skipped and counted instead.
+    #[test]
+    fn item_identity_is_deterministic_and_never_a_random_uuid() {
+        let doc = br#"<rss version="2.0"><channel><title>C</title><link>https://e.com</link><description>D</description>
+<item><title>NoGuid</title><link>https://site.example/p2</link></item>
+<item><title>NoIdentity</title></item>
+</channel></rss>"#;
+
+        // Raw feed-rs invents a different id for the identity-less entry each time.
+        let bare_a = feed_rs::parser::parse(&doc[..]).unwrap();
+        let bare_b = feed_rs::parser::parse(&doc[..]).unwrap();
+        assert_ne!(
+            bare_a.entries[1].id, bare_b.entries[1].id,
+            "feed-rs no longer randomizes the id; revisit the injected generator"
+        );
+
+        let a = parse_feed_document(doc, None).unwrap();
+        let b = parse_feed_document(doc, None).unwrap();
+        assert_eq!(a.items, b.items, "identity is stable across parses");
+        assert_eq!(
+            a.items.len(),
+            1,
+            "the identity-less entry is skipped, not handed a UUID"
+        );
+        assert_eq!(a.items[0].guid, "https://site.example/p2", "link fallback");
+        assert!(
+            a.conformance_notes
+                .iter()
+                .any(|n| n == "entries-without-identity: 1")
+        );
+    }
+
+    /// An attachment is something to download, not the page to visit. feed-rs puts
+    /// JSON Feed attachments in `entry.links` `rel`-less, which is also how the
+    /// item's own URL arrives — so without care an audio file becomes the item's
+    /// link, and (via the identity fallback) its `guid`.
+    #[test]
+    fn a_json_attachment_is_never_mistaken_for_the_item_link() {
+        let doc = br#"{"version":"https://jsonfeed.org/version/1.1","title":"C",
+"items":[{"id":"only-id","title":"T",
+"attachments":[{"url":"https://e.com/a.mp3","mime_type":"audio/mpeg","size_in_bytes":7}]}]}"#;
+        let parsed = parse_feed_document(doc, None).unwrap();
+        let it = &parsed.items[0];
+        assert_eq!(it.guid, "only-id");
+        assert_eq!(it.link, None, "an attachment is not a link to the item");
+        assert_eq!(it.enclosure_url.as_deref(), Some("https://e.com/a.mp3"));
+        assert_eq!(it.enclosure_length, Some(7));
+    }
+
+    #[test]
+    fn extraction_is_deterministic_and_dedupes_categories() {
+        let doc = br#"<rss version="2.0"><channel><title>C</title><link>https://e.com</link><description>D</description>
+<item><guid>1</guid><title>T</title><category>rust</category><category>news</category><category>rust</category></item>
+</channel></rss>"#;
+        let a = parse_feed_document(doc, None).unwrap();
+        let b = parse_feed_document(doc, None).unwrap();
+        assert_eq!(a.items, b.items, "identical input, identical rows");
+        assert_eq!(
+            a.items[0].categories,
+            vec!["rust", "news"],
+            "deduped, original order preserved"
+        );
+    }
+}

--- a/crates/skardi/src/sources/providers/rss/parse.rs
+++ b/crates/skardi/src/sources/providers/rss/parse.rs
@@ -11,6 +11,7 @@
 use std::collections::{BTreeMap, HashSet};
 
 use feed_rs::model::{Category, Entry, Feed, Link};
+use feed_rs::parser::{Builder, Parser};
 use serde_json::{Value, json};
 
 use super::conformance::{
@@ -46,15 +47,22 @@ type Rung = (fn(&[u8]) -> (Vec<u8>, bool), Repair);
 
 /// Sanitize `bytes` with the applicable rungs, then parse them into a feed.
 pub fn parse_with_ladder(bytes: &[u8]) -> Result<ParseSuccess, ParseFailure> {
-    // The family of the bytes as they arrived. It decides the pre-sanitation
-    // guard and the declared-dialect sniff, both of which read those same raw
-    // bytes; the rungs below are chosen from a second, post-transcode reading.
+    // The family of the bytes as they arrived. It decides only the
+    // pre-sanitation guard, which reads those same raw bytes; the rungs and
+    // the declared-dialect sniff work from a second, post-transcode reading.
     let raw_family = detect_family(bytes);
-    let dialect_declared = sniff_declared_dialect(bytes, raw_family);
 
     if raw_family == DocFamily::Xml
         && let Err(reason) = refuse_internal_dtd(bytes)
     {
+        // The one sniff over raw bytes, because this path refuses before the
+        // rungs run and there is nothing else to sniff. It cannot produce the
+        // NUL-laden `unknown:` a UTF-16 document yields (the reason every
+        // other path sniffs after rung 1): this guard fired on a literal
+        // ASCII `<!DOCTYPE`, which UTF-16's interleaved NULs hide — a UTF-16
+        // subset is caught by the post-sanitation guard below instead, after
+        // the transcode has already happened.
+        let dialect_declared = sniff_declared_dialect(bytes, raw_family);
         tracing::debug!(stage = "refused-internal-dtd", %reason, "rss parse refused");
         return Err(ParseFailure {
             stage: "refused-internal-dtd",
@@ -91,9 +99,21 @@ pub fn parse_with_ladder(bytes: &[u8]) -> Result<ParseSuccess, ParseFailure> {
         repairs.push(repair);
     }
 
+    // The sniff reads the transcoded bytes for the same reason the rungs are
+    // chosen from them. Lexical scanning assumes ASCII-visible structure, and
+    // a valid BOM'd UTF-16 document has none until rung 1 runs: its `<?xml`
+    // arrives as `3C 00 3F 00 …`, so the `<?` check misses the interleaved
+    // NUL, the declaration is mistaken for the root element, and
+    // `dialect_declared` becomes `unknown:\0?\0x\0m\0l` — control characters
+    // in a user-facing column, for a feed that parses fine. Sniffing after
+    // the transcode reads the same bytes the parser will. What the sniff is
+    // *for* is unchanged: rung 1 converts encodings, it does not parse, so a
+    // document too broken to parse is exactly as sniffable as before.
+    let family = detect_family(&current);
+    let dialect_declared = sniff_declared_dialect(&current, family);
+
     // Rungs 2 and 3 repair XML lexis and would corrupt a JSON document (a naked
     // `&` is legal inside a JSON string), so JSON climbs only the re-encode rung.
-    let family = detect_family(&current);
     let rungs: &[Rung] = match family {
         DocFamily::Xml => &[
             (rung_strip_control_chars, Repair::StrippedControlChars),
@@ -179,8 +199,8 @@ pub fn parse_with_ladder(bytes: &[u8]) -> Result<ParseSuccess, ParseFailure> {
 /// `feed-rs` a generator that yields nothing leaves `entry.id` empty unless the
 /// feed really supplied one, so the Field Mapping fallback chain (id → link →
 /// skip) is what decides identity, deterministically.
-fn parser() -> feed_rs::parser::Parser {
-    feed_rs::parser::Builder::new()
+fn parser() -> Parser {
+    Builder::new()
         .id_generator(|_links, _title, _uri| String::new())
         .build()
 }
@@ -889,11 +909,44 @@ mod tests {
              `EscapedNakedAmpersands` here is both the corruption and a repair \
              note attributed to a document that needed none"
         );
-        // The declared-dialect sniff still reads the *raw* bytes, where an
-        // ASCII marker interleaved with NULs is not found. Known gap, separate
-        // from the family decision fixed here; this pins today's answer so that
-        // closing it has to update this line.
-        assert_eq!(ok.dialect_declared, None);
+        // The sniff reads the transcoded bytes too, so the version marker —
+        // invisible in UTF-16, where its ASCII is interleaved with NULs — is
+        // found. This asserted `None` while the sniff still read raw bytes.
+        assert_eq!(ok.dialect_declared.as_deref(), Some("json-feed-1.1"));
+    }
+
+    /// A valid BOM'd UTF-16 RSS 2.0 feed parses fine after rung 1, and its
+    /// declared dialect must come from those same transcoded bytes. Sniffed
+    /// raw, the `<?` check misses the NUL inside `3C 00 3F 00`, the XML
+    /// declaration is mistaken for the root element, and `dialect_declared`
+    /// becomes `unknown:\0?\0x\0m\0l` — control characters in a user-facing
+    /// column, for a healthy feed.
+    #[test]
+    fn utf16_rss_feed_declares_its_dialect_without_nul_garbage() {
+        let text = r#"<?xml version="1.0"?><rss version="2.0"><channel><title>T</title><link>https://e.com</link><description>D</description></channel></rss>"#;
+        for big_endian in [false, true] {
+            let mut doc = if big_endian {
+                vec![0xFE, 0xFF]
+            } else {
+                vec![0xFF, 0xFE]
+            };
+            for unit in text.encode_utf16() {
+                let bytes = if big_endian {
+                    unit.to_be_bytes()
+                } else {
+                    unit.to_le_bytes()
+                };
+                doc.extend_from_slice(&bytes);
+            }
+
+            let ok = parse_with_ladder(&doc).unwrap();
+            assert_eq!(
+                ok.dialect_declared.as_deref(),
+                Some("rss-2.0"),
+                "big_endian: {big_endian}"
+            );
+            assert_eq!(ok.repairs, vec![Repair::ReencodedToUtf8]);
+        }
     }
 
     /// The same document in the other byte order, which classifies correctly

--- a/crates/skardi/src/sources/providers/rss/parse.rs
+++ b/crates/skardi/src/sources/providers/rss/parse.rs
@@ -46,10 +46,13 @@ type Rung = (fn(&[u8]) -> (Vec<u8>, bool), Repair);
 
 /// Sanitize `bytes` with the applicable rungs, then parse them into a feed.
 pub fn parse_with_ladder(bytes: &[u8]) -> Result<ParseSuccess, ParseFailure> {
-    let family = detect_family(bytes);
-    let dialect_declared = sniff_declared_dialect(bytes, family);
+    // The family of the bytes as they arrived. It decides the pre-sanitation
+    // guard and the declared-dialect sniff, both of which read those same raw
+    // bytes; the rungs below are chosen from a second, post-transcode reading.
+    let raw_family = detect_family(bytes);
+    let dialect_declared = sniff_declared_dialect(bytes, raw_family);
 
-    if family == DocFamily::Xml
+    if raw_family == DocFamily::Xml
         && let Err(reason) = refuse_internal_dtd(bytes)
     {
         tracing::debug!(stage = "refused-internal-dtd", %reason, "rss parse refused");
@@ -60,17 +63,6 @@ pub fn parse_with_ladder(bytes: &[u8]) -> Result<ParseSuccess, ParseFailure> {
         });
     }
 
-    // Rungs 2 and 3 repair XML lexis and would corrupt a JSON document (a naked
-    // `&` is legal inside a JSON string), so JSON climbs only the re-encode rung.
-    let rungs: &[Rung] = match family {
-        DocFamily::Xml => &[
-            (rung_reencode_utf8, Repair::ReencodedToUtf8),
-            (rung_strip_control_chars, Repair::StrippedControlChars),
-            (rung_escape_naked_ampersands, Repair::EscapedNakedAmpersands),
-        ],
-        DocFamily::Json => &[(rung_reencode_utf8, Repair::ReencodedToUtf8)],
-    };
-
     // Sanitation runs *before* the parse rather than as a failure-triggered
     // fallback. feed-rs does not reject malformed lexis — it succeeds while
     // silently discarding the offending element, so a single naked `&` costs the
@@ -79,8 +71,36 @@ pub fn parse_with_ladder(bytes: &[u8]) -> Result<ParseSuccess, ParseFailure> {
     // is safe because each one is a byte-level no-op on well-formed input (spec
     // AC16, pinned by the conservativeness test in `sanitize.rs`): a well-formed
     // document comes through byte-identical and parses exactly as it would have.
-    let mut current = bytes.to_vec();
     let mut repairs = Vec::new();
+
+    // Rung 1 applies to both families, and it runs first because the family is
+    // only reliable once it has. `detect_family` reads the first non-whitespace
+    // *byte*, which a UTF-16 document does not begin with: UTF-16LE `{` is
+    // `7B 00` and classifies as JSON by accident of byte order, while UTF-16BE
+    // `{` is `00 7B` — `0x00` is not ASCII whitespace, so the same document
+    // classifies as XML and rung 3 then escapes a naked `&` that was inside a
+    // JSON string all along, which is the corruption the `DocFamily::Json` arm
+    // exists to prevent. Deciding the remaining rungs from the transcoded bytes
+    // makes the two byte orders agree, and generalizes: any document rung 1
+    // rewrites is classified from what it turned out to be rather than from
+    // what its encoding made it look like.
+    let (mut current, changed) = rung_reencode_utf8(bytes);
+    if changed {
+        let repair = Repair::ReencodedToUtf8;
+        tracing::debug!(?repair, "rss sanitation rung changed bytes");
+        repairs.push(repair);
+    }
+
+    // Rungs 2 and 3 repair XML lexis and would corrupt a JSON document (a naked
+    // `&` is legal inside a JSON string), so JSON climbs only the re-encode rung.
+    let family = detect_family(&current);
+    let rungs: &[Rung] = match family {
+        DocFamily::Xml => &[
+            (rung_strip_control_chars, Repair::StrippedControlChars),
+            (rung_escape_naked_ampersands, Repair::EscapedNakedAmpersands),
+        ],
+        DocFamily::Json => &[],
+    };
     for (rung, repair) in rungs {
         let (next, changed) = rung(&current);
         current = next;
@@ -108,6 +128,9 @@ pub fn parse_with_ladder(bytes: &[u8]) -> Result<ParseSuccess, ParseFailure> {
     // to `max_response_bytes`, and it is the only guard that can refuse a
     // document whose prolog the rungs mangle past recognition (pinned by
     // `a_mislabelled_utf16_documents_subset_is_refused_before_the_rungs_run`).
+    //
+    // Gated on the post-transcode family, like the rungs: a document that only
+    // looked like XML before rung 1 ran has no prolog to scan for.
     if family == DocFamily::Xml
         && let Err(reason) = refuse_internal_dtd(&current)
     {
@@ -367,6 +390,11 @@ struct Enclosure {
 /// Atom `rel="enclosure"` links or JSON Feed attachments — both of those stay in
 /// `links` (a JSON attachment arrives `rel`-less but carries a `media_type`,
 /// which is what distinguishes it from the item's own URL).
+///
+/// Only one attachment fits the `enclosure_*` columns; an entry may carry
+/// several, and [`attachments`] folds the rest into `extensions_json` from
+/// both places, so which one this picks decides the columns and never whether
+/// a file is recorded at all.
 fn enclosure(entry: &Entry) -> Enclosure {
     if let Some(mc) = entry
         .media
@@ -399,14 +427,19 @@ fn enclosure(entry: &Entry) -> Enclosure {
     }
 }
 
-/// Whatever the `feed-rs` model exposes beyond the pinned columns, as a compact
-/// JSON object with deterministic key order. `None` when nothing is present.
+/// The non-core fields the `feed-rs` model exposes beyond the pinned columns,
+/// as a compact JSON object with deterministic key order. `None` when none are
+/// present.
+///
+/// A named set rather than a catch-all: `attachments`, `source`, `rights`, and
+/// `language` are what the model carries and this projects. Unknown namespaces
+/// are dropped at parse time and can never appear here.
 fn extensions_json(entry: &Entry, enclosure_from_media: bool) -> Option<String> {
     let mut fields: BTreeMap<&str, Value> = BTreeMap::new();
 
-    let media = remaining_media(entry, enclosure_from_media);
-    if !media.is_empty() {
-        fields.insert("media", Value::Array(media));
+    let attached = attachments(entry, enclosure_from_media);
+    if !attached.is_empty() {
+        fields.insert("attachments", Value::Array(attached));
     }
     if let Some(source) = non_blank(entry.source.as_deref()) {
         fields.insert("source", Value::String(source.to_string()));
@@ -428,47 +461,45 @@ fn non_blank(s: Option<&str>) -> Option<&str> {
     s.map(str::trim).filter(|s| !s.is_empty())
 }
 
-/// Media objects minus the single content already surfaced as the enclosure.
-fn remaining_media(entry: &Entry, enclosure_from_media: bool) -> Vec<Value> {
+/// Every attachment the entry carries beyond the one already surfaced in the
+/// `enclosure_*` columns, from both of the places `feed-rs` keeps them.
+///
+/// One element per downloadable file, whatever dialect it arrived in, because
+/// that is the concept these rows are about. `feed-rs` folds RSS 2.0
+/// `<enclosure>` and MediaRSS into `media` but leaves Atom `rel="enclosure"`
+/// links and JSON Feed `attachments[]` in `links`, so reading only `media`
+/// would keep the second rendition of a podcast published as RSS and drop it
+/// for the same podcast published as JSON Feed — one episode in several audio
+/// formats being the JSON Feed spec's own example for that array. Both fold
+/// here, in one shape, so the dialect does not decide whether the file is
+/// recorded.
+///
+/// MediaRSS carries per-object metadata a link cannot (`title`, `description`,
+/// `thumbnails`, `duration_secs`), and one object may hold several renditions
+/// under a single set of it. Flattening copies that metadata onto each
+/// rendition rather than nesting them, so every element is self-describing and
+/// the array has one shape. An object whose renditions were all consumed — the
+/// enclosure's own, say — still yields an element carrying its metadata alone,
+/// so nothing the model exposes is dropped.
+///
+/// Order is the model's: media objects first, then attachment links, each in
+/// document order.
+fn attachments(entry: &Entry, enclosure_from_media: bool) -> Vec<Value> {
     let mut enclosure_still_to_skip = enclosure_from_media;
-    let mut objects = Vec::new();
+    let mut out = Vec::new();
 
     for object in &entry.media {
-        let mut contents = Vec::new();
-        for c in &object.content {
-            if enclosure_still_to_skip && c.url.is_some() {
-                enclosure_still_to_skip = false;
-                continue;
-            }
-            let mut one: BTreeMap<&str, Value> = BTreeMap::new();
-            if let Some(url) = &c.url {
-                one.insert("url", Value::String(url.to_string()));
-            }
-            if let Some(ct) = &c.content_type {
-                one.insert("content_type", Value::String(ct.to_string()));
-            }
-            if let Some(size) = c.size {
-                one.insert("size", Value::from(size));
-            }
-            if !one.is_empty() {
-                contents.push(json!(one));
-            }
-        }
-
-        let mut fields: BTreeMap<&str, Value> = BTreeMap::new();
-        if !contents.is_empty() {
-            fields.insert("content", Value::Array(contents));
-        }
+        let mut meta: BTreeMap<&str, Value> = BTreeMap::new();
         if let Some(title) = non_blank(object.title.as_ref().map(|t| t.content.as_str())) {
-            fields.insert("title", Value::String(title.to_string()));
+            meta.insert("title", Value::String(title.to_string()));
         }
         if let Some(description) =
             non_blank(object.description.as_ref().map(|t| t.content.as_str()))
         {
-            fields.insert("description", Value::String(description.to_string()));
+            meta.insert("description", Value::String(description.to_string()));
         }
         if !object.thumbnails.is_empty() {
-            fields.insert(
+            meta.insert(
                 "thumbnails",
                 Value::Array(
                     object
@@ -480,14 +511,56 @@ fn remaining_media(entry: &Entry, enclosure_from_media: bool) -> Vec<Value> {
             );
         }
         if let Some(duration) = object.duration {
-            fields.insert("duration_secs", Value::from(duration.as_secs()));
+            meta.insert("duration_secs", Value::from(duration.as_secs()));
         }
 
-        if !fields.is_empty() {
-            objects.push(json!(fields));
+        let mut rendered = 0;
+        for c in &object.content {
+            if enclosure_still_to_skip && c.url.is_some() {
+                enclosure_still_to_skip = false;
+                continue;
+            }
+            let mut one = meta.clone();
+            if let Some(url) = &c.url {
+                one.insert("url", Value::String(url.to_string()));
+            }
+            if let Some(ct) = &c.content_type {
+                one.insert("content_type", Value::String(ct.to_string()));
+            }
+            if let Some(size) = c.size {
+                one.insert("size", Value::from(size));
+            }
+            if !one.is_empty() {
+                out.push(json!(one));
+                rendered += 1;
+            }
+        }
+
+        if rendered == 0 && !meta.is_empty() {
+            out.push(json!(meta));
         }
     }
-    objects
+
+    // The link path surfaced its first attachment only when `media` had none to
+    // give, so that is exactly when one is skipped here.
+    let mut link_still_to_skip = !enclosure_from_media;
+    for link in entry.links.iter().filter(|l| is_attachment(l)) {
+        if link_still_to_skip {
+            link_still_to_skip = false;
+            continue;
+        }
+        let mut one: BTreeMap<&str, Value> = BTreeMap::new();
+        one.insert("url", Value::String(link.href.clone()));
+        if let Some(ct) = &link.media_type {
+            one.insert("content_type", Value::String(ct.clone()));
+        }
+        if let Some(size) = link.length {
+            one.insert("size", Value::from(size));
+        }
+        out.push(json!(one));
+    }
+
+    out
 }
 
 /// Parse and extract in one call — the entry point the engine uses.
@@ -775,6 +848,66 @@ mod tests {
         assert!(ok.repairs.is_empty(), "{:?}", ok.repairs);
     }
 
+    /// A JSON Feed with a BOM, in the requested byte order. JSON Feed 1.1
+    /// mandates UTF-8, so this is a non-conforming document — rescuing one
+    /// without corrupting it is what the ladder is for.
+    fn utf16_json_feed(big_endian: bool) -> Vec<u8> {
+        let text =
+            r#"{"version":"https://jsonfeed.org/version/1.1","title":"Fish & Chips","items":[]}"#;
+        let mut doc = if big_endian {
+            vec![0xFE, 0xFF]
+        } else {
+            vec![0xFF, 0xFE]
+        };
+        for unit in text.encode_utf16() {
+            let bytes = if big_endian {
+                unit.to_be_bytes()
+            } else {
+                unit.to_le_bytes()
+            };
+            doc.extend_from_slice(&bytes);
+        }
+        doc
+    }
+
+    /// The family the rungs are chosen from is read after rung 1, not before,
+    /// so both UTF-16 byte orders take the JSON path. Read from the raw bytes,
+    /// UTF-16BE `{` is `00 7B` — `0x00` is not ASCII whitespace, so the first
+    /// byte decides XML, and rung 3 then escapes a naked `&` that was inside a
+    /// JSON string, silently turning the title into `Fish &amp; Chips` while
+    /// recording a repair the document never needed.
+    #[test]
+    fn utf16be_json_feed_title_survives_the_ladder() {
+        let ok = parse_with_ladder(&utf16_json_feed(true)).unwrap();
+
+        assert_eq!(ok.feed.title.as_ref().unwrap().content, "Fish & Chips");
+        assert_eq!(ok.dialect, "json-feed-1.x", "took the JSON path");
+        assert_eq!(
+            ok.repairs,
+            vec![Repair::ReencodedToUtf8],
+            "transcoding is the only repair this document needs; an \
+             `EscapedNakedAmpersands` here is both the corruption and a repair \
+             note attributed to a document that needed none"
+        );
+        // The declared-dialect sniff still reads the *raw* bytes, where an
+        // ASCII marker interleaved with NULs is not found. Known gap, separate
+        // from the family decision fixed here; this pins today's answer so that
+        // closing it has to update this line.
+        assert_eq!(ok.dialect_declared, None);
+    }
+
+    /// The same document in the other byte order, which classifies correctly
+    /// today only because UTF-16LE `{` is `7B 00` and the first byte happens to
+    /// be the `{` itself. Pinned so the two orders are held to one answer.
+    #[test]
+    fn utf16le_json_feed_title_survives_the_ladder() {
+        let ok = parse_with_ladder(&utf16_json_feed(false)).unwrap();
+
+        assert_eq!(ok.feed.title.as_ref().unwrap().content, "Fish & Chips");
+        assert_eq!(ok.dialect, "json-feed-1.x", "took the JSON path");
+        assert_eq!(ok.repairs, vec![Repair::ReencodedToUtf8]);
+    }
+
     #[test]
     fn rss2_maps_per_field_mapping_table() {
         let doc = br#"<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:dc="http://purl.org/dc/elements/1.1/"><channel>
@@ -960,12 +1093,12 @@ mod tests {
 
     /// M1: the previous version of this test only asserted `.expect(...)`
     /// on the whole object, so a `<source>` alone (which never touches
-    /// `remaining_media`) satisfied it just as well as real leftover media
+    /// `attachments`) satisfied it just as well as a real leftover attachment
     /// would — the brief's most intricate rule went untested. This asserts
-    /// on the parsed JSON's actual keys instead, so `media` and `source`
+    /// on the parsed JSON's actual keys instead, so `attachments` and `source`
     /// can't stand in for each other.
     #[test]
-    fn extensions_json_media_key_is_only_leftover_media_beyond_the_enclosure() {
+    fn extensions_json_attachments_key_is_only_what_the_enclosure_left_over() {
         let doc = br#"<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/"><channel>
 <title>C</title><link>https://e.com</link><description>D</description>
 <item><guid>1</guid><title>T</title>
@@ -981,21 +1114,123 @@ mod tests {
         let obj = value.as_object().expect("extensions_json is a JSON object");
         assert_eq!(
             obj.keys().collect::<Vec<_>>(),
-            vec!["media"],
-            "only the leftover media, not source/rights/language: {ext}"
+            vec!["attachments"],
+            "only the leftover attachment, not source/rights/language: {ext}"
         );
-        let media = obj["media"].as_array().expect("media is an array");
-        assert_eq!(media.len(), 1, "the enclosure's own content is excluded");
+        let attachments = obj["attachments"]
+            .as_array()
+            .expect("attachments is an array");
         assert_eq!(
-            media[0]["content"][0]["url"], "https://e.com/b.jpg",
+            attachments.len(),
+            1,
+            "the enclosure's own content is excluded"
+        );
+        assert_eq!(
+            attachments[0]["url"], "https://e.com/b.jpg",
             "the *other* media:content survives, not the enclosure's: {ext}"
         );
+        assert_eq!(attachments[0]["content_type"], "image/jpeg");
+        assert_eq!(attachments[0]["size"], 2);
         assert_eq!(ext, serde_json::to_string(&value).unwrap(), "keys sorted");
     }
 
-    /// M1: `<source>` alone — with no media beyond the single enclosure —
+    /// The same two-attachment entry in a dialect whose extras `feed-rs` keeps
+    /// in `links` rather than `media`: one episode in two audio formats, the
+    /// JSON Feed spec's own example for the array. Reading only `media` kept
+    /// the second rendition for RSS and dropped it here, with nothing in any
+    /// column recording that it existed.
+    #[test]
+    fn json_feed_second_attachment_survives_in_extensions() {
+        let doc = br#"{"version":"https://jsonfeed.org/version/1.1","title":"C",
+"items":[{"id":"1","title":"Ep",
+"attachments":[{"url":"https://e.com/ep.mp3","mime_type":"audio/mpeg","size_in_bytes":7},
+{"url":"https://e.com/ep.m4a","mime_type":"audio/mp4","size_in_bytes":9}]}]}"#;
+        let parsed = parse_feed_document(doc, None).unwrap();
+        let it = &parsed.items[0];
+
+        assert_eq!(it.enclosure_url.as_deref(), Some("https://e.com/ep.mp3"));
+        let value: serde_json::Value =
+            serde_json::from_str(it.extensions_json.as_deref().expect("second attachment"))
+                .expect("valid JSON");
+        let attachments = value["attachments"]
+            .as_array()
+            .expect("attachments is an array");
+        assert_eq!(
+            attachments.len(),
+            1,
+            "only the one the columns did not take"
+        );
+        assert_eq!(attachments[0]["url"], "https://e.com/ep.m4a");
+        assert_eq!(attachments[0]["content_type"], "audio/mp4");
+        assert_eq!(attachments[0]["size"], 9);
+    }
+
+    /// Atom keeps its extra attachments in `links` too, so the same entry
+    /// published as Atom records the same set of files.
+    #[test]
+    fn atom_second_enclosure_link_survives_in_extensions() {
+        let doc = br#"<feed xmlns="http://www.w3.org/2005/Atom">
+<title>C</title><updated>2026-07-20T10:00:00Z</updated>
+<entry><id>1</id><title>Ep</title>
+<link rel="enclosure" href="https://e.com/ep.mp3" type="audio/mpeg" length="7"/>
+<link rel="enclosure" href="https://e.com/ep.m4a" type="audio/mp4" length="9"/>
+</entry></feed>"#;
+        let parsed = parse_feed_document(doc, None).unwrap();
+        let it = &parsed.items[0];
+
+        assert_eq!(it.enclosure_url.as_deref(), Some("https://e.com/ep.mp3"));
+        let value: serde_json::Value =
+            serde_json::from_str(it.extensions_json.as_deref().expect("second attachment"))
+                .expect("valid JSON");
+        let attachments = value["attachments"]
+            .as_array()
+            .expect("attachments is an array");
+        assert_eq!(attachments.len(), 1);
+        assert_eq!(attachments[0]["url"], "https://e.com/ep.m4a");
+        assert_eq!(attachments[0]["content_type"], "audio/mp4");
+        assert_eq!(attachments[0]["size"], 9);
+    }
+
+    /// When `media` supplies the enclosure, no attachment link was surfaced —
+    /// so every one of them is left over, not all but the first. Getting this
+    /// backwards would silently drop the first link of any entry carrying both
+    /// kinds.
+    #[test]
+    fn a_media_sourced_enclosure_leaves_every_attachment_link_over() {
+        let enclosure_link = |href: &str, media_type: &str| Link {
+            href: href.to_string(),
+            rel: Some("enclosure".to_string()),
+            media_type: Some(media_type.to_string()),
+            href_lang: None,
+            title: None,
+            length: None,
+        };
+        let entry = Entry {
+            links: vec![
+                enclosure_link("https://e.com/one.mp3", "audio/mpeg"),
+                enclosure_link("https://e.com/two.m4a", "audio/mp4"),
+            ],
+            ..Entry::default()
+        };
+        let folded = attachments(&entry, true);
+        assert_eq!(
+            folded.len(),
+            2,
+            "media took the columns, so both links remain"
+        );
+        assert_eq!(folded[0]["url"], "https://e.com/one.mp3");
+        assert_eq!(folded[1]["url"], "https://e.com/two.m4a");
+
+        // The same entry with no media to surface: the first link took the
+        // columns and only the second is left.
+        let folded = attachments(&entry, false);
+        assert_eq!(folded.len(), 1);
+        assert_eq!(folded[0]["url"], "https://e.com/two.m4a");
+    }
+
+    /// M1: `<source>` alone — with no attachment beyond the single enclosure —
     /// was meant to populate `extensions_json` with a `source` key and *no*
-    /// `media` key, distinguishing this from the media-key test above. But
+    /// `attachments` key, distinguishing this from the test above. But
     /// `entry.source` (the field this crate's `extensions_json` reads) is
     /// never actually assigned by feed-rs 2.4.0, for *any* dialect: there is
     /// no `.source =` anywhere under `feed-rs-2.4.0/src/parser/**` (checked
@@ -1011,19 +1246,19 @@ mod tests {
     /// mapping this crate's own code performs so the property is still
     /// covered if a future feed-rs starts populating the field.
     #[test]
-    fn extensions_json_source_key_present_without_a_media_key() {
+    fn extensions_json_source_key_present_without_an_attachments_key() {
         let entry = Entry {
             source: Some("Origin".to_string()),
             ..Entry::default()
         };
         let ext = extensions_json(&entry, false)
-            .expect("source populates extensions even with no leftover media");
+            .expect("source populates extensions even with no leftover attachment");
         let value: serde_json::Value = serde_json::from_str(&ext).expect("valid JSON");
         let obj = value.as_object().expect("extensions_json is a JSON object");
         assert_eq!(
             obj.keys().collect::<Vec<_>>(),
             vec!["source"],
-            "source only, no media key when nothing is left over: {ext}"
+            "source only, no attachments key when nothing is left over: {ext}"
         );
         assert_eq!(obj["source"], "Origin");
     }

--- a/crates/skardi/src/sources/providers/rss/sanitize.rs
+++ b/crates/skardi/src/sources/providers/rss/sanitize.rs
@@ -371,6 +371,11 @@ pub fn rung_escape_naked_ampersands(input: &[u8]) -> (Vec<u8>, bool) {
     (out, changed)
 }
 
+/// Longest run of leading `0` bytes `valid_reference_len` will skip in a
+/// numeric character reference before the significant-digit window applies —
+/// well beyond any real encoder's fixed-width padding.
+const MAX_LEADING_ZEROS: usize = 16;
+
 /// Byte length of the reference at the start of `rest` (which begins with `&`),
 /// or `None` when the `&` is naked or names an entity XML does not define.
 fn valid_reference_len(rest: &[u8]) -> Option<usize> {
@@ -383,25 +388,36 @@ fn valid_reference_len(rest: &[u8]) -> Option<usize> {
         }
     }
 
-    // `&#[0-9]{1,7};` or `&#x[0-9A-Fa-f]{1,6};` (XML allows only a lowercase `x`).
-    // The digit caps bound how far this scans looking for the terminating
-    // `;`, but they are a byte-count cap, not a leading-zero-aware one: a
-    // well-formed reference whose leading zeros push its digits past the cap
-    // (e.g. `&#000000169;`, 9 digits against the 7-digit window) is treated as
-    // unterminated within the window
-    // and its `&` gets escaped to `&amp;`, corrupting an otherwise-valid
-    // reference. Accepted tradeoff: a fixed, cheap-to-check cap over a
-    // leading-zero-stripping scan.
+    // Numeric references (XML allows only a lowercase `x`): a two-segment
+    // constant-bound scan. First a bounded run of leading `0` bytes
+    // (`MAX_LEADING_ZEROS`, well beyond any real encoder's fixed-width
+    // padding), then the significant-digit window — 7 decimal / 6 hex digits,
+    // from U+10FFFF being `1114111` decimal / `10FFFF` hex — then the
+    // terminating `;`. A reference with more leading zeros than the cap is
+    // still treated as naked and escaped: the scan bound remains, it is just
+    // leading-zero-aware now.
     let digits = tail.strip_prefix(b"#")?;
     let (body, max, is_digit): (&[u8], usize, fn(&u8) -> bool) = match digits.strip_prefix(b"x") {
         Some(hex) => (hex, 6, u8::is_ascii_hexdigit),
         None => (digits, 7, u8::is_ascii_digit),
     };
-    let n = body.iter().take(max).take_while(|b| is_digit(b)).count();
-    if n == 0 || body.get(n) != Some(&b';') {
+    let zeros = body
+        .iter()
+        .take(MAX_LEADING_ZEROS + 1)
+        .take_while(|&&b| b == b'0')
+        .count();
+    if zeros > MAX_LEADING_ZEROS {
         return None;
     }
-    Some(rest.len() - body.len() + n + 1)
+    let n = body[zeros..]
+        .iter()
+        .take(max)
+        .take_while(|b| is_digit(b))
+        .count();
+    if zeros + n == 0 || body.get(zeros + n) != Some(&b';') {
+        return None;
+    }
+    Some(rest.len() - body.len() + zeros + n + 1)
 }
 
 /// A rung: a pure byte transform reporting whether it changed anything.
@@ -428,6 +444,11 @@ mod tests {
             r#"<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><channel><title>t &amp; u</title></channel></rss>"#,
             r#"<rss version="2.0"><channel><description><![CDATA[a & b && c]]></description></channel></rss>"#,
             r#"<feed xmlns="http://www.w3.org/2005/Atom"><title>&#169; &#x2014; &lt;ok&gt;</title></feed>"#,
+            // Leading-zero numeric references pin the conservativeness
+            // contract over zero padding: the old fixed 7/6-digit window
+            // treated these as unterminated and escaped their `&`.
+            r#"<feed xmlns="http://www.w3.org/2005/Atom"><title>&#000000169;</title></feed>"#,
+            r#"<feed xmlns="http://www.w3.org/2005/Atom"><title>&#x0002014;</title></feed>"#,
             "<!-- a & naked amp in a comment --><rss version=\"2.0\"/>",
             "<?pi with & inside?><rss version=\"2.0\"/>",
             // All five predefined entities (the brief's own fixture list
@@ -468,6 +489,17 @@ mod tests {
         let (out, changed) = rung_escape_naked_ampersands(input);
         assert!(changed);
         assert_eq!(out, expect);
+    }
+
+    /// The leading-zero run is bounded (`MAX_LEADING_ZEROS`) so the reference
+    /// scan stays constant; beyond the cap the `&` is treated as naked and
+    /// escaped.
+    #[test]
+    fn references_with_more_leading_zeros_than_the_cap_are_escaped() {
+        let input = format!("<x>&#{}169;</x>", "0".repeat(MAX_LEADING_ZEROS + 1));
+        let (out, changed) = rung_escape_naked_ampersands(input.as_bytes());
+        assert!(changed);
+        assert!(String::from_utf8(out).unwrap().contains("&amp;#"));
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/rss/sanitize.rs
+++ b/crates/skardi/src/sources/providers/rss/sanitize.rs
@@ -9,6 +9,8 @@
 //! malformed lexis, it silently drops the offending element, so there is no
 //! per-rung parse failure for a retry loop to react to.
 
+use encoding_rs::{Encoding, UTF_8, UTF_16BE, UTF_16LE, WINDOWS_1252};
+
 /// Which document family a feed body belongs to, decided lexically.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DocFamily {
@@ -53,12 +55,12 @@ fn strip_utf8_bom(bytes: &[u8]) -> (&[u8], bool) {
 }
 
 /// A UTF-16 byte-order mark and the bytes after it, if present.
-fn utf16_bom(bytes: &[u8]) -> Option<(&'static encoding_rs::Encoding, &[u8])> {
+fn utf16_bom(bytes: &[u8]) -> Option<(&'static Encoding, &[u8])> {
     if let Some(rest) = bytes.strip_prefix(&[0xFF, 0xFE][..]) {
-        return Some((encoding_rs::UTF_16LE, rest));
+        return Some((UTF_16LE, rest));
     }
     if let Some(rest) = bytes.strip_prefix(&[0xFE, 0xFF][..]) {
-        return Some((encoding_rs::UTF_16BE, rest));
+        return Some((UTF_16BE, rest));
     }
     None
 }
@@ -207,10 +209,8 @@ pub fn rung_reencode_utf8(input: &[u8]) -> (Vec<u8>, bool) {
     // result would be `text` by construction.
     if let Ok(text) = std::str::from_utf8(body) {
         let declaration_misleads = xml_decl_encoding_label(body)
-            .and_then(|label| encoding_rs::Encoding::for_label(&label))
-            .is_some_and(|enc| {
-                enc != encoding_rs::UTF_8 && enc.decode_without_bom_handling(body).0 != text
-            });
+            .and_then(|label| Encoding::for_label(&label))
+            .is_some_and(|enc| enc != UTF_8 && enc.decode_without_bom_handling(body).0 != text);
         if declaration_misleads {
             return (rewrite_decl_encoding(text), true);
         }
@@ -220,10 +220,10 @@ pub fn rung_reencode_utf8(input: &[u8]) -> (Vec<u8>, bool) {
     // Not UTF-8. Trust the declared label unless it claims UTF-8 (a lie, since
     // the bytes just failed UTF-8 validation) — then sniff.
     let declared = xml_decl_encoding_label(body)
-        .and_then(|label| encoding_rs::Encoding::for_label(&label))
-        .filter(|enc| *enc != encoding_rs::UTF_8);
+        .and_then(|label| Encoding::for_label(&label))
+        .filter(|enc| *enc != UTF_8);
     // windows-1252 is the sniff fallback: it maps every byte, so decoding cannot fail.
-    let enc = declared.unwrap_or(encoding_rs::WINDOWS_1252);
+    let enc = declared.unwrap_or(WINDOWS_1252);
     let (text, _, _) = enc.decode(body);
     (rewrite_decl_encoding(&text), true)
 }

--- a/crates/skardi/src/sources/providers/rss/sanitize.rs
+++ b/crates/skardi/src/sources/providers/rss/sanitize.rs
@@ -1,0 +1,713 @@
+//! Sanitation ladder: conservative, byte-level repairs for feed documents that
+//! are *almost* well-formed.
+//!
+//! Each rung is a pure byte transform and, by contract (spec AC16), a byte-level
+//! no-op on well-formed input. `parse.rs` applies every applicable rung
+//! cumulatively and then parses the result *once* — it does not stop at the
+//! first rung whose output parses, and it does not retry per rung. See
+//! `parse_with_ladder`'s own doc for why: `feed-rs` does not error on
+//! malformed lexis, it silently drops the offending element, so there is no
+//! per-rung parse failure for a retry loop to react to.
+
+/// Which document family a feed body belongs to, decided lexically.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DocFamily {
+    Xml,
+    Json,
+}
+
+/// A repair that a rung applied, recorded in `feeds.conformance_notes`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Repair {
+    ReencodedToUtf8,
+    StrippedControlChars,
+    EscapedNakedAmpersands,
+}
+
+impl Repair {
+    /// Stable note string carried into `conformance_notes`.
+    pub fn note(&self) -> &'static str {
+        match self {
+            Repair::ReencodedToUtf8 => "sanitation: reencoded-to-utf8",
+            Repair::StrippedControlChars => "sanitation: stripped-control-chars",
+            Repair::EscapedNakedAmpersands => "sanitation: escaped-naked-ampersands",
+        }
+    }
+}
+
+const UTF8_BOM: &[u8] = &[0xEF, 0xBB, 0xBF];
+
+/// First index of `needle` in `haystack`.
+pub(super) fn find_sub(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return None;
+    }
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+fn strip_utf8_bom(bytes: &[u8]) -> (&[u8], bool) {
+    match bytes.strip_prefix(UTF8_BOM) {
+        Some(rest) => (rest, true),
+        None => (bytes, false),
+    }
+}
+
+/// A UTF-16 byte-order mark and the bytes after it, if present.
+fn utf16_bom(bytes: &[u8]) -> Option<(&'static encoding_rs::Encoding, &[u8])> {
+    if let Some(rest) = bytes.strip_prefix(&[0xFF, 0xFE][..]) {
+        return Some((encoding_rs::UTF_16LE, rest));
+    }
+    if let Some(rest) = bytes.strip_prefix(&[0xFE, 0xFF][..]) {
+        return Some((encoding_rs::UTF_16BE, rest));
+    }
+    None
+}
+
+/// Decide the document family: first non-whitespace byte `{` → JSON, else XML.
+/// Tolerates a leading byte-order mark.
+pub fn detect_family(bytes: &[u8]) -> DocFamily {
+    let body = match utf16_bom(bytes) {
+        Some((_, rest)) => rest,
+        None => strip_utf8_bom(bytes).0,
+    };
+    for &b in body {
+        if b.is_ascii_whitespace() {
+            continue;
+        }
+        return if b == b'{' {
+            DocFamily::Json
+        } else {
+            DocFamily::Xml
+        };
+    }
+    DocFamily::Xml
+}
+
+/// Refuse documents carrying an internal DTD subset (`<!DOCTYPE … [`), the
+/// entity-expansion (billion-laughs) class.
+pub fn refuse_internal_dtd(bytes: &[u8]) -> Result<(), String> {
+    const REFUSAL: &str = "internal DTD subset refused (entity-expansion guard)";
+
+    let body = strip_utf8_bom(bytes).0;
+    let mut i = 0;
+    while i < body.len() {
+        let rest = &body[i..];
+        if rest[0].is_ascii_whitespace() {
+            i += 1;
+            continue;
+        }
+        if rest[0] != b'<' {
+            i += 1;
+            continue;
+        }
+        // Comments and processing instructions may precede the doctype.
+        if let Some(skip) = skip_delimited(rest, b"<!--", b"-->") {
+            i += skip;
+            continue;
+        }
+        if rest.starts_with(b"<!--") {
+            return Ok(()); // unterminated comment: nothing further to inspect
+        }
+        if let Some(skip) = skip_delimited(rest, b"<?", b"?>") {
+            i += skip;
+            continue;
+        }
+        if rest.starts_with(b"<?") {
+            return Ok(());
+        }
+        if starts_with_ignore_ascii_case(rest, b"<!DOCTYPE") {
+            // Walk the declaration; `[` before its closing `>` opens a subset.
+            let mut j = "<!DOCTYPE".len();
+            let mut quote: Option<u8> = None;
+            while j < rest.len() {
+                let c = rest[j];
+                match quote {
+                    Some(q) if c == q => quote = None,
+                    Some(_) => {}
+                    None => match c {
+                        b'"' | b'\'' => quote = Some(c),
+                        b'[' => return Err(REFUSAL.to_string()),
+                        b'>' => break,
+                        _ => {}
+                    },
+                }
+                j += 1;
+            }
+            i += j + 1;
+            continue;
+        }
+        // Any other `<` starts the root element — the prolog is over.
+        return Ok(());
+    }
+    Ok(())
+}
+
+/// Whether `haystack` starts with `needle`, ASCII case-insensitively (e.g. a
+/// lowercase `<!doctype` must be recognized exactly like `<!DOCTYPE`).
+fn starts_with_ignore_ascii_case(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.len() >= needle.len() && haystack[..needle.len()].eq_ignore_ascii_case(needle)
+}
+
+/// Length to skip past a `open … close` region, if `rest` opens one and it terminates.
+fn skip_delimited(rest: &[u8], open: &[u8], close: &[u8]) -> Option<usize> {
+    if !rest.starts_with(open) {
+        return None;
+    }
+    find_sub(&rest[open.len()..], close).map(|p| open.len() + p + close.len())
+}
+
+/// Rung 1: normalize to UTF-8 — strip any BOM, honor the XML declaration's
+/// `encoding=` label, sniff when the declaration is absent or lying.
+pub fn rung_reencode_utf8(input: &[u8]) -> (Vec<u8>, bool) {
+    // A UTF-16 BOM is authoritative: decode wholesale.
+    if let Some((enc, rest)) = utf16_bom(input) {
+        let (text, _, _) = enc.decode(rest);
+        return (rewrite_decl_encoding(&text), true);
+    }
+
+    let (body, had_bom) = strip_utf8_bom(input);
+
+    // Already valid UTF-8. A missing declaration, or one that already says
+    // UTF-8, needs no repair beyond a leading BOM — that is what keeps the rung
+    // a byte-level no-op on well-formed input.
+    //
+    // A declaration naming some *other* encoding matters only when reading the
+    // body under that label would yield different text than reading it as
+    // UTF-8. That is tested directly: decode under the declared label and
+    // compare against the bytes as-is. Identical means every consumer gets the
+    // same characters either way, so the declaration is harmless and this rung
+    // must stay a byte-level no-op; differing means `feed-rs` would read
+    // something other than what the bytes say, so the token gets pointed at
+    // UTF-8 (the same thing the transcoding path below does).
+    //
+    // The direct comparison replaces a `!body.is_ascii() ||
+    // !enc.is_ascii_compatible()` proxy that was wrong in both directions
+    // across two review rounds. `Encoding::is_ascii_compatible`
+    // (encoding_rs-0.8.35/src/lib.rs:2928-2930) is `!(self == REPLACEMENT ||
+    // self == UTF_16BE || self == UTF_16LE || self == ISO_2022_JP)` — a
+    // hardcoded name list, not a test of whether ASCII survives decoding. It
+    // therefore over-triggered on ISO-2022-JP, which is on that list only
+    // because of its `ESC`/`SO`/`SI` sequences: pure-ASCII bytes decode
+    // byte-identically under it, so
+    // `<?xml encoding="ISO-2022-JP"?><x>plain ascii</x>` is truthfully declared
+    // yet was being rewritten and recorded a false `reencoded-to-utf8` note.
+    //
+    // One decode covers every case the proxy needed special-casing for, with no
+    // encoding named in the code: ASCII under a legacy label is identical (a
+    // no-op — and a very common real-feed shape, which is what the contract
+    // protects); a UTF-8 `café` under an `iso-8859-1` declaration differs
+    // (`cafÃ©`, so repair); UTF-16 and `replacement`-mapped labels over ASCII
+    // differ (repair); ISO-2022-JP carrying real escape sequences differs
+    // (repair). Costed at the 5 MiB `max_response_bytes` cap on an ASCII body
+    // under an `iso-8859-1` declaration: 283 µs against the old scan's 166 µs,
+    // and only on bodies that actually carry a non-UTF-8 declaration.
+    //
+    // `decode_without_bom_handling` because both BOM forms were already
+    // consumed above; the `UTF_8` short-circuit only avoids a decode whose
+    // result would be `text` by construction.
+    if let Ok(text) = std::str::from_utf8(body) {
+        let declaration_misleads = xml_decl_encoding_label(body)
+            .and_then(|label| encoding_rs::Encoding::for_label(&label))
+            .is_some_and(|enc| {
+                enc != encoding_rs::UTF_8 && enc.decode_without_bom_handling(body).0 != text
+            });
+        if declaration_misleads {
+            return (rewrite_decl_encoding(text), true);
+        }
+        return (body.to_vec(), had_bom);
+    }
+
+    // Not UTF-8. Trust the declared label unless it claims UTF-8 (a lie, since
+    // the bytes just failed UTF-8 validation) — then sniff.
+    let declared = xml_decl_encoding_label(body)
+        .and_then(|label| encoding_rs::Encoding::for_label(&label))
+        .filter(|enc| *enc != encoding_rs::UTF_8);
+    // windows-1252 is the sniff fallback: it maps every byte, so decoding cannot fail.
+    let enc = declared.unwrap_or(encoding_rs::WINDOWS_1252);
+    let (text, _, _) = enc.decode(body);
+    (rewrite_decl_encoding(&text), true)
+}
+
+/// The `encoding=` label from a leading XML declaration, as raw bytes.
+fn xml_decl_encoding_label(body: &[u8]) -> Option<Vec<u8>> {
+    if !body.starts_with(b"<?xml") {
+        return None;
+    }
+    let decl = &body[..find_sub(body, b"?>")?];
+    let mut j = find_sub(decl, b"encoding")? + "encoding".len();
+
+    while j < decl.len() && decl[j].is_ascii_whitespace() {
+        j += 1;
+    }
+    if decl.get(j) != Some(&b'=') {
+        return None;
+    }
+    j += 1;
+    while j < decl.len() && decl[j].is_ascii_whitespace() {
+        j += 1;
+    }
+    let quote = *decl.get(j)?;
+    if quote != b'"' && quote != b'\'' {
+        return None;
+    }
+    j += 1;
+
+    let start = j;
+    while j < decl.len() && decl[j] != quote {
+        j += 1;
+    }
+    if j >= decl.len() {
+        return None;
+    }
+    Some(decl[start..j].to_vec())
+}
+
+/// Point a transcoded document's declaration at UTF-8 so it stops lying.
+fn rewrite_decl_encoding(text: &str) -> Vec<u8> {
+    let unchanged = || text.as_bytes().to_vec();
+    if !text.as_bytes().starts_with(b"<?xml") {
+        return unchanged();
+    }
+    let Some(decl_end) = find_sub(text.as_bytes(), b"?>") else {
+        return unchanged();
+    };
+    let decl = &text[..decl_end];
+    let Some(pos) = decl.find("encoding") else {
+        return unchanged();
+    };
+
+    // `encoding` (ws)* `=` (ws)* quote value quote
+    let after = &decl[pos + "encoding".len()..];
+    let eq = match after.char_indices().find(|(_, c)| !c.is_whitespace()) {
+        Some((i, '=')) => i,
+        _ => return unchanged(),
+    };
+    let rest = &after[eq + 1..];
+    let (q_at, quote) = match rest.char_indices().find(|(_, c)| !c.is_whitespace()) {
+        Some((i, c @ ('"' | '\''))) => (i, c),
+        _ => return unchanged(),
+    };
+    let val_start = pos + "encoding".len() + eq + 1 + q_at + 1;
+    let Some(len) = text[val_start..].find(quote) else {
+        return unchanged();
+    };
+
+    let mut out = String::with_capacity(text.len() + "UTF-8".len());
+    out.push_str(&text[..val_start]);
+    out.push_str("UTF-8");
+    out.push_str(&text[val_start + len..]);
+    out.into_bytes()
+}
+
+/// Rung 2: drop bytes/characters that XML 1.0 forbids outright.
+pub fn rung_strip_control_chars(input: &[u8]) -> (Vec<u8>, bool) {
+    let mut out = Vec::with_capacity(input.len());
+    let mut changed = false;
+    let mut i = 0;
+    while i < input.len() {
+        let b = input[i];
+        // C0 controls other than tab, LF, CR.
+        if b < 0x20 && !matches!(b, b'\t' | b'\n' | b'\r') {
+            changed = true;
+            i += 1;
+            continue;
+        }
+        // U+FFFE / U+FFFF, the non-characters XML 1.0 also forbids.
+        if b == 0xEF
+            && input.get(i + 1) == Some(&0xBF)
+            && matches!(input.get(i + 2), Some(&0xBE) | Some(&0xBF))
+        {
+            changed = true;
+            i += 3;
+            continue;
+        }
+        out.push(b);
+        i += 1;
+    }
+    (out, changed)
+}
+
+/// Rung 3: escape ampersands that do not open a valid entity or character
+/// reference, leaving CDATA, comments, and processing instructions untouched.
+pub fn rung_escape_naked_ampersands(input: &[u8]) -> (Vec<u8>, bool) {
+    let mut out = Vec::with_capacity(input.len());
+    let mut changed = false;
+    let mut i = 0;
+    'scan: while i < input.len() {
+        let rest = &input[i..];
+
+        // Pass-through regions, verbatim. An unterminated region takes the tail.
+        for (open, close) in [
+            (&b"<![CDATA["[..], &b"]]>"[..]),
+            (&b"<!--"[..], &b"-->"[..]),
+            (&b"<?"[..], &b"?>"[..]),
+        ] {
+            if rest.starts_with(open) {
+                let end = skip_delimited(rest, open, close).unwrap_or(rest.len());
+                out.extend_from_slice(&rest[..end]);
+                i += end;
+                continue 'scan;
+            }
+        }
+
+        if rest[0] == b'&' {
+            match valid_reference_len(rest) {
+                Some(n) => {
+                    out.extend_from_slice(&rest[..n]);
+                    i += n;
+                }
+                None => {
+                    out.extend_from_slice(b"&amp;");
+                    i += 1;
+                    changed = true;
+                }
+            }
+            continue;
+        }
+
+        out.push(rest[0]);
+        i += 1;
+    }
+    (out, changed)
+}
+
+/// Byte length of the reference at the start of `rest` (which begins with `&`),
+/// or `None` when the `&` is naked or names an entity XML does not define.
+fn valid_reference_len(rest: &[u8]) -> Option<usize> {
+    debug_assert_eq!(rest[0], b'&');
+    let tail = &rest[1..];
+
+    for name in [&b"amp;"[..], b"lt;", b"gt;", b"apos;", b"quot;"] {
+        if tail.starts_with(name) {
+            return Some(1 + name.len());
+        }
+    }
+
+    // `&#[0-9]{1,7};` or `&#x[0-9A-Fa-f]{1,6};` (XML allows only a lowercase `x`).
+    // The digit caps bound how far this scans looking for the terminating
+    // `;`, but they are a byte-count cap, not a leading-zero-aware one: a
+    // well-formed reference whose leading zeros push its digits past the cap
+    // (e.g. `&#000000169;`, 9 digits against the 7-digit window) is treated as
+    // unterminated within the window
+    // and its `&` gets escaped to `&amp;`, corrupting an otherwise-valid
+    // reference. Accepted tradeoff: a fixed, cheap-to-check cap over a
+    // leading-zero-stripping scan.
+    let digits = tail.strip_prefix(b"#")?;
+    let (body, max, is_digit): (&[u8], usize, fn(&u8) -> bool) = match digits.strip_prefix(b"x") {
+        Some(hex) => (hex, 6, u8::is_ascii_hexdigit),
+        None => (digits, 7, u8::is_ascii_digit),
+    };
+    let n = body.iter().take(max).take_while(|b| is_digit(b)).count();
+    if n == 0 || body.get(n) != Some(&b';') {
+        return None;
+    }
+    Some(rest.len() - body.len() + n + 1)
+}
+
+/// A rung: a pure byte transform reporting whether it changed anything.
+#[cfg(test)]
+type RungFn = fn(&[u8]) -> (Vec<u8>, bool);
+
+/// The three rungs in ladder order, for the conservativeness contract test.
+#[cfg(test)]
+pub(crate) const RUNGS_FOR_TEST: [(&str, RungFn); 3] = [
+    ("reencode_utf8", rung_reencode_utf8),
+    ("strip_control_chars", rung_strip_control_chars),
+    ("escape_naked_ampersands", rung_escape_naked_ampersands),
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_rung_is_a_byte_level_noop_on_wellformed_input() {
+        // The conservativeness contract (spec AC16): includes CDATA with legal
+        // ampersands, predefined entities, and numeric character references.
+        let wellformed: &[&str] = &[
+            r#"<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><channel><title>t &amp; u</title></channel></rss>"#,
+            r#"<rss version="2.0"><channel><description><![CDATA[a & b && c]]></description></channel></rss>"#,
+            r#"<feed xmlns="http://www.w3.org/2005/Atom"><title>&#169; &#x2014; &lt;ok&gt;</title></feed>"#,
+            "<!-- a & naked amp in a comment --><rss version=\"2.0\"/>",
+            "<?pi with & inside?><rss version=\"2.0\"/>",
+            // All five predefined entities (the brief's own fixture list
+            // names them): `apos;`/`quot;` were the two `valid_reference_len`
+            // arms no test exercised before this.
+            r#"<x a='&apos;&quot;'>&apos; &quot;</x>"#,
+            // A legacy-but-truthful declaration over ASCII-only content: every
+            // one of these labels resolves to windows-1252, which agrees with
+            // UTF-8 below 0x80, so the document is correctly declared and the
+            // bytes need nothing. The battery used to declare UTF-8 or nothing
+            // at all in every fixture, which is how rung 1 came to rewrite
+            // these — the single most common real-feed prolog there is.
+            r#"<?xml version="1.0" encoding="us-ascii"?><rss version="2.0"><channel><title>t</title></channel></rss>"#,
+            r#"<?xml version="1.0" encoding="ISO-8859-1"?><rss version="2.0"><channel><title>t</title></channel></rss>"#,
+            r#"<?xml version="1.0" encoding="windows-1252"?><rss version="2.0"><channel><title>t</title></channel></rss>"#,
+            // ISO-2022-JP over pure ASCII. `is_ascii_compatible` is false for
+            // this encoding (encoding_rs-0.8.35/src/lib.rs:2928-2930 excludes it
+            // by name, for its ESC/SO/SI sequences), but ASCII decodes
+            // byte-identically under it, so this document is truthfully declared
+            // and must not be rewritten. The old `!enc.is_ascii_compatible()`
+            // proxy rewrote it and recorded a false `reencoded-to-utf8` note.
+            r#"<?xml version="1.0" encoding="ISO-2022-JP"?><rss version="2.0"><channel><title>t</title></channel></rss>"#,
+        ];
+        for doc in wellformed {
+            let b = doc.as_bytes();
+            for (name, rung) in RUNGS_FOR_TEST {
+                let (out, changed) = rung(b);
+                assert!(!changed, "rung {name} changed well-formed doc: {doc}");
+                assert_eq!(out, b, "rung {name} output differs on: {doc}");
+            }
+        }
+    }
+
+    #[test]
+    fn naked_and_undefined_ampersands_are_escaped_defined_ones_kept() {
+        let input = br#"<x a="M &nbsp; N">Fish & Chips &amp; more &#169;</x>"#;
+        let expect = br#"<x a="M &amp;nbsp; N">Fish &amp; Chips &amp; more &#169;</x>"#;
+        let (out, changed) = rung_escape_naked_ampersands(input);
+        assert!(changed);
+        assert_eq!(out, expect);
+    }
+
+    #[test]
+    fn trailing_ampersand_at_end_of_input_is_escaped_without_panicking() {
+        let input = b"<x>a &";
+        let (out, changed) = rung_escape_naked_ampersands(input);
+        assert!(changed);
+        assert_eq!(out, b"<x>a &amp;");
+    }
+
+    #[test]
+    fn latin1_bytes_reencode_to_utf8() {
+        // decl claims iso-8859-1 and the bytes are: caf<0xE9>
+        let mut doc = br#"<?xml version="1.0" encoding="iso-8859-1"?><x>caf"#.to_vec();
+        doc.push(0xE9);
+        doc.extend_from_slice(b"</x>");
+        let (out, changed) = rung_reencode_utf8(&doc);
+        assert!(changed);
+        let s = std::str::from_utf8(&out).unwrap();
+        assert!(s.contains("café"));
+        assert!(
+            !s.contains("iso-8859-1"),
+            "decl encoding token rewritten: {s}"
+        );
+    }
+
+    #[test]
+    fn lying_non_utf8_decl_over_valid_utf8_bytes_is_corrected() {
+        // decl claims iso-8859-1, but the bytes are already valid UTF-8 (café
+        // encoded as UTF-8's 2-byte é, not Latin-1's single byte) — a common
+        // real-world shape: content converted to UTF-8 without updating the
+        // declaration. Previously a byte-level no-op (per the old "whatever
+        // the decl claims" comment); now the decl is corrected in place.
+        let doc = "<?xml version=\"1.0\" encoding=\"iso-8859-1\"?><x>café</x>".as_bytes();
+        let (out, changed) = rung_reencode_utf8(doc);
+        assert!(changed);
+        let s = std::str::from_utf8(&out).unwrap();
+        assert!(s.contains("café"), "{s}");
+        assert!(
+            !s.contains("iso-8859-1"),
+            "decl encoding token rewritten: {s}"
+        );
+    }
+
+    #[test]
+    fn legacy_decl_over_ascii_only_content_is_a_noop() {
+        // The trigger is "decoding under the declared label changes the text":
+        // the same declaration is a lie over `café` (the test above) and the
+        // truth over ASCII, and only decoding can tell the two apart.
+        let ascii = r#"<?xml version="1.0" encoding="ISO-8859-1"?><x>plain ascii</x>"#.as_bytes();
+        let (out, changed) = rung_reencode_utf8(ascii);
+        assert!(!changed, "ASCII under a legacy label needs no repair");
+        assert_eq!(out, ascii);
+    }
+
+    #[test]
+    fn ascii_under_a_utf16_decl_is_still_repaired() {
+        // Decoding these ASCII bytes as the declared UTF-16 pairs them up into
+        // unrelated CJK, so the text changes and the declaration has to go. This
+        // is the case the ASCII no-op above must not swallow.
+        let doc = r#"<?xml version="1.0" encoding="utf-16"?><x>plain ascii</x>"#.as_bytes();
+        let (out, changed) = rung_reencode_utf8(doc);
+        assert!(changed);
+        assert_eq!(
+            out,
+            r#"<?xml version="1.0" encoding="UTF-8"?><x>plain ascii</x>"#.as_bytes()
+        );
+    }
+
+    #[test]
+    fn iso_2022_jp_carrying_real_escape_sequences_is_still_repaired() {
+        // The companion to the ISO-2022-JP entry in the no-op battery: that label
+        // is a no-op only because *ASCII* survives it. Once the body carries the
+        // escape sequences the encoding exists for, decoding changes the text
+        // (`\x1b$B$3$s$K$A$O\x1b(B` decodes to `こんにちは`), so the rung engages
+        // — decided by the bytes rather than by the encoding's name.
+        let mut doc = br#"<?xml version="1.0" encoding="ISO-2022-JP"?><x>"#.to_vec();
+        doc.extend_from_slice(b"\x1b$B$3$s$K$A$O\x1b(B");
+        doc.extend_from_slice(b"</x>");
+        let (out, changed) = rung_reencode_utf8(&doc);
+        assert!(changed, "escape-sequence body decodes to different text");
+        let s = std::str::from_utf8(&out).unwrap();
+        assert!(
+            !s.contains("ISO-2022-JP") && s.contains("UTF-8"),
+            "decl encoding token rewritten: {s}"
+        );
+        // Pinning what this branch actually does, which the predicate swap did
+        // not change: the bytes already passed UTF-8 validation, so it relabels
+        // the declaration and leaves the body alone rather than transcoding.
+        // The escape sequences survive as literal text under the new UTF-8
+        // label. Both the old `!enc.is_ascii_compatible()` proxy and the direct
+        // decode test select this same path for this input.
+        assert!(
+            s.contains('\x1b'),
+            "body relabeled, not transcoded, so ESC survives: {s:?}"
+        );
+        assert!(
+            !s.contains("こんにちは"),
+            "body is not transcoded here: {s:?}"
+        );
+    }
+
+    #[test]
+    fn utf8_decl_over_utf8_bytes_stays_a_noop() {
+        // The no-op contract for a decl that already tells the truth (or is
+        // absent) must survive the I3 fix above.
+        let doc = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><x>café</x>".as_bytes();
+        let (out, changed) = rung_reencode_utf8(doc);
+        assert!(!changed);
+        assert_eq!(out, doc);
+
+        let no_decl = "<x>café</x>".as_bytes();
+        let (out, changed) = rung_reencode_utf8(no_decl);
+        assert!(!changed);
+        assert_eq!(out, no_decl);
+    }
+
+    #[test]
+    fn bom_is_stripped() {
+        let mut doc = vec![0xEF, 0xBB, 0xBF];
+        doc.extend_from_slice(br#"<rss version="2.0"/>"#);
+        let (out, changed) = rung_reencode_utf8(&doc);
+        assert!(changed, "a leading BOM is a repair");
+        assert_eq!(out, br#"<rss version="2.0"/>"#);
+    }
+
+    #[test]
+    fn lying_utf8_decl_over_latin1_bytes_is_sniffed() {
+        // decl says utf-8 but the bytes are not valid UTF-8 → sniff and transcode.
+        let mut doc = br#"<?xml version="1.0" encoding="utf-8"?><x>caf"#.to_vec();
+        doc.push(0xE9);
+        doc.extend_from_slice(b"</x>");
+        assert!(
+            std::str::from_utf8(&doc).is_err(),
+            "fixture must be invalid UTF-8"
+        );
+        let (out, changed) = rung_reencode_utf8(&doc);
+        assert!(changed);
+        let s = std::str::from_utf8(&out).expect("output is valid UTF-8");
+        assert!(
+            s.contains("café"),
+            "sniffed transcode recovered the text: {s}"
+        );
+    }
+
+    #[test]
+    fn control_chars_stripped_tab_lf_cr_kept() {
+        let mut doc = b"<x>a".to_vec();
+        doc.push(0x08); // illegal in XML 1.0
+        doc.extend_from_slice(b"b\t c\n d\r e</x>");
+        let (out, changed) = rung_strip_control_chars(&doc);
+        assert!(changed);
+        assert_eq!(out, b"<x>ab\t c\n d\r e</x>");
+        assert!(!out.contains(&0x08), "0x08 removed");
+
+        // Tab/LF/CR alone are legal — byte-identical no-op.
+        let legal = b"<x>a\tb\nc\rd</x>";
+        let (out, changed) = rung_strip_control_chars(legal);
+        assert!(!changed, "tab/LF/CR are legal XML 1.0 characters");
+        assert_eq!(out, legal);
+    }
+
+    #[test]
+    fn u_fffe_and_u_ffff_are_stripped() {
+        let mut doc = b"<x>a".to_vec();
+        doc.extend_from_slice("\u{FFFE}".as_bytes());
+        doc.extend_from_slice(b"b");
+        doc.extend_from_slice("\u{FFFF}".as_bytes());
+        doc.extend_from_slice(b"c</x>");
+        let (out, changed) = rung_strip_control_chars(&doc);
+        assert!(changed);
+        assert_eq!(out, b"<x>abc</x>");
+    }
+
+    #[test]
+    fn internal_dtd_subset_refused() {
+        let doc = br#"<?xml version="1.0"?><!DOCTYPE lolz [ <!ENTITY lol "lol"> <!ENTITY lol2 "&lol;&lol;"> ]><lolz>&lol2;</lolz>"#;
+        let err = refuse_internal_dtd(doc).expect_err("billion-laughs prolog must be refused");
+        assert!(
+            err.contains("internal DTD subset refused"),
+            "error names the guard, got: {err}"
+        );
+        assert!(
+            err.contains("entity-expansion guard"),
+            "error names the class, got: {err}"
+        );
+    }
+
+    #[test]
+    fn plain_doctype_without_subset_not_refused() {
+        refuse_internal_dtd(b"<!DOCTYPE opml><opml version=\"2.0\"/>").unwrap();
+    }
+
+    #[test]
+    fn json_family_detected() {
+        assert_eq!(
+            detect_family(br#"{"version": "https://jsonfeed.org/version/1.1"}"#),
+            DocFamily::Json
+        );
+        // leading BOM + whitespace tolerated
+        let mut doc = vec![0xEF, 0xBB, 0xBF];
+        doc.extend_from_slice(b"  \r\n\t {\"version\": \"1.1\"}");
+        assert_eq!(detect_family(&doc), DocFamily::Json);
+
+        assert_eq!(detect_family(br#"<rss version="2.0"/>"#), DocFamily::Xml);
+        let mut xml = vec![0xEF, 0xBB, 0xBF];
+        xml.extend_from_slice(b"\n <?xml version=\"1.0\"?><feed/>");
+        assert_eq!(detect_family(&xml), DocFamily::Xml);
+    }
+
+    #[test]
+    fn cdata_and_comment_regions_pass_untouched_even_with_naked_amps() {
+        for doc in [
+            &br#"<x><![CDATA[Tom & Jerry && co]]></x>"#[..],
+            &b"<x><!-- Tom & Jerry --></x>"[..],
+            &b"<x><?php echo $a & $b; ?></x>"[..],
+        ] {
+            let (out, changed) = rung_escape_naked_ampersands(doc);
+            assert!(
+                !changed,
+                "CDATA/comment/PI region must pass untouched: {}",
+                String::from_utf8_lossy(doc)
+            );
+            assert_eq!(out, doc);
+        }
+    }
+
+    #[test]
+    fn repair_notes_are_the_contract_strings() {
+        assert_eq!(
+            Repair::ReencodedToUtf8.note(),
+            "sanitation: reencoded-to-utf8"
+        );
+        assert_eq!(
+            Repair::StrippedControlChars.note(),
+            "sanitation: stripped-control-chars"
+        );
+        assert_eq!(
+            Repair::EscapedNakedAmpersands.note(),
+            "sanitation: escaped-naked-ampersands"
+        );
+    }
+}

--- a/crates/skardi/src/sources/providers/rss/schema.rs
+++ b/crates/skardi/src/sources/providers/rss/schema.rs
@@ -1,0 +1,773 @@
+//! The Arrow surface of the `feeds` and `items` tables: the two schemas, the
+//! builders that turn parsed rows into `RecordBatch`es, and the one column
+//! rewrite the engine performs after a batch is built.
+//!
+//! Column order *is* the batch shape — the exec layer projects by index — so
+//! these schemas are the single source of truth for both, and the tests pin
+//! every name, type, and nullability against the plan's tables. No projection
+//! or filtering happens here; that is exec's job.
+
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock};
+
+use arrow::array::{
+    ArrayRef, ListBuilder, RecordBatch, StringArray, StringBuilder, TimestampMillisecondBuilder,
+    UInt16Builder, UInt32Array, UInt64Builder,
+};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
+
+use super::RSS_SURFACE_VERSION;
+use super::cache::FeedStatus;
+use super::parse::ItemRow;
+
+/// Position of `items.window_status`. The engine builds a window's batch once
+/// and re-labels it per serve (`fresh` / `revalidated` / `stale-error`), so this
+/// index is part of the module's contract — see [`with_window_status`].
+pub const WINDOW_STATUS_IDX: usize = 15;
+
+/// Schema-metadata key carrying [`RSS_SURFACE_VERSION`], so a batch that
+/// outlives its producer still names the surface generation it was built for.
+const SURFACE_VERSION_KEY: &str = "skardi.rss.surface_version";
+
+static ITEMS_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
+    Arc::new(
+        Schema::new(vec![
+            Field::new("feed", DataType::Utf8, false),
+            Field::new("feed_url", DataType::Utf8, false),
+            Field::new("guid", DataType::Utf8, false),
+            Field::new("title", DataType::Utf8, true),
+            Field::new("link", DataType::Utf8, true),
+            Field::new("author", DataType::Utf8, true),
+            Field::new(
+                "published",
+                DataType::Timestamp(TimeUnit::Millisecond, Some("UTC".into())),
+                true,
+            ),
+            Field::new(
+                "updated",
+                DataType::Timestamp(TimeUnit::Millisecond, Some("UTC".into())),
+                true,
+            ),
+            Field::new("content", DataType::Utf8, true),
+            Field::new("summary", DataType::Utf8, true),
+            Field::new(
+                "categories",
+                DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+                true,
+            ),
+            Field::new("enclosure_url", DataType::Utf8, true),
+            Field::new("enclosure_type", DataType::Utf8, true),
+            Field::new("enclosure_length", DataType::UInt64, true),
+            Field::new("position", DataType::UInt32, false),
+            Field::new("window_status", DataType::Utf8, false),
+            Field::new("extensions_json", DataType::Utf8, true),
+        ])
+        .with_metadata(surface_metadata()),
+    )
+});
+
+static FEEDS_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
+    Arc::new(
+        Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("url", DataType::Utf8, false),
+            Field::new("title", DataType::Utf8, true),
+            Field::new("site_url", DataType::Utf8, true),
+            Field::new("description", DataType::Utf8, true),
+            Field::new(
+                "last_fetch",
+                DataType::Timestamp(TimeUnit::Millisecond, Some("UTC".into())),
+                true,
+            ),
+            Field::new("last_status", DataType::Utf8, false),
+            Field::new("http_status", DataType::UInt16, true),
+            Field::new("last_error", DataType::Utf8, true),
+            Field::new("etag", DataType::Utf8, true),
+            Field::new("last_modified", DataType::Utf8, true),
+            Field::new("dialect", DataType::Utf8, true),
+            Field::new("dialect_declared", DataType::Utf8, true),
+            Field::new("conformance_notes", DataType::Utf8, true),
+            Field::new("item_count", DataType::UInt64, true),
+        ])
+        .with_metadata(surface_metadata()),
+    )
+});
+
+fn surface_metadata() -> HashMap<String, String> {
+    HashMap::from([(
+        SURFACE_VERSION_KEY.to_string(),
+        RSS_SURFACE_VERSION.to_string(),
+    )])
+}
+
+/// One `feeds` row, flat and owned so this module stays independent of the
+/// cache's and engine's own types.
+#[derive(Debug, Clone)]
+pub struct FeedsRow {
+    pub name: String,
+    pub url: String,
+    pub title: Option<String>,
+    pub site_url: Option<String>,
+    pub description: Option<String>,
+    pub last_fetch_ms: Option<i64>,
+    /// Typed rather than `&'static str` for the same reason
+    /// [`with_window_status`] takes a [`FeedStatus`]: [`FeedStatus`] owns this
+    /// column's domain and is the only place its strings are spelled, so a typo
+    /// cannot reach the column from here.
+    pub last_status: FeedStatus,
+    pub http_status: Option<u16>,
+    pub last_error: Option<String>,
+    pub etag: Option<String>,
+    pub last_modified: Option<String>,
+    pub dialect: Option<String>,
+    pub dialect_declared: Option<String>,
+    pub conformance_notes: Option<String>,
+    pub item_count: Option<u64>,
+}
+
+/// The 17-column `items` surface.
+pub fn items_schema() -> SchemaRef {
+    ITEMS_SCHEMA.clone()
+}
+
+/// The 15-column `feeds` surface.
+pub fn feeds_schema() -> SchemaRef {
+    FEEDS_SCHEMA.clone()
+}
+
+/// Encode one feed's window as an `items` batch.
+///
+/// `feed`/`feed_url` are constant for the batch (a partition is one feed), and
+/// `position` is the row's index in the window — the feed's own ordering, which
+/// is the only ordering a feed guarantees. `window_status` is filled from
+/// [`FeedStatus::Fresh`] (a batch is only ever built from a document that just
+/// parsed); serving a cached window re-labels it via [`with_window_status`].
+pub fn build_items_batch(feed: &str, feed_url: &str, items: &[ItemRow]) -> RecordBatch {
+    let rows = items.len();
+    let mut guid = StringBuilder::new();
+    let mut title = StringBuilder::new();
+    let mut link = StringBuilder::new();
+    let mut author = StringBuilder::new();
+    let mut published = TimestampMillisecondBuilder::new();
+    let mut updated = TimestampMillisecondBuilder::new();
+    let mut content = StringBuilder::new();
+    let mut summary = StringBuilder::new();
+    let mut categories = ListBuilder::new(StringBuilder::new());
+    let mut enclosure_url = StringBuilder::new();
+    let mut enclosure_type = StringBuilder::new();
+    let mut enclosure_length = UInt64Builder::new();
+    let mut extensions_json = StringBuilder::new();
+
+    for item in items {
+        guid.append_value(&item.guid);
+        title.append_option(item.title.as_deref());
+        link.append_option(item.link.as_deref());
+        author.append_option(item.author.as_deref());
+        published.append_option(item.published_ms);
+        updated.append_option(item.updated_ms);
+        content.append_option(item.content.as_deref());
+        summary.append_option(item.summary.as_deref());
+        // No categories is NULL, not `[]` — absence then reads the same as every
+        // other absent field on the row, which is what the column's declared
+        // nullability is for.
+        if item.categories.is_empty() {
+            categories.append_null();
+        } else {
+            for category in &item.categories {
+                categories.values().append_value(category);
+            }
+            categories.append(true);
+        }
+        enclosure_url.append_option(item.enclosure_url.as_deref());
+        enclosure_type.append_option(item.enclosure_type.as_deref());
+        enclosure_length.append_option(item.enclosure_length);
+        extensions_json.append_option(item.extensions_json.as_deref());
+    }
+
+    let columns: Vec<ArrayRef> = vec![
+        Arc::new(StringArray::from(vec![feed; rows])),
+        Arc::new(StringArray::from(vec![feed_url; rows])),
+        Arc::new(guid.finish()),
+        Arc::new(title.finish()),
+        Arc::new(link.finish()),
+        Arc::new(author.finish()),
+        Arc::new(published.finish().with_timezone("UTC")),
+        Arc::new(updated.finish().with_timezone("UTC")),
+        Arc::new(content.finish()),
+        Arc::new(summary.finish()),
+        Arc::new(categories.finish()),
+        Arc::new(enclosure_url.finish()),
+        Arc::new(enclosure_type.finish()),
+        Arc::new(enclosure_length.finish()),
+        Arc::new(UInt32Array::from_iter_values(0..rows as u32)),
+        Arc::new(StringArray::from(vec![fresh_label(); rows])),
+        Arc::new(extensions_json.finish()),
+    ];
+
+    RecordBatch::try_new(items_schema(), columns)
+        .expect("built columns match the items schema declared above")
+}
+
+/// The `window_status` label [`build_items_batch`] stamps.
+///
+/// [`FeedStatus::Fresh`] is one of the three statuses
+/// [`FeedStatus::window_status_str`] answers `Some` for, so the `expect` is
+/// discharged by that function's own match arms rather than by an assumption
+/// about a caller.
+fn fresh_label() -> &'static str {
+    FeedStatus::Fresh
+        .window_status_str()
+        .expect("FeedStatus::Fresh has a window_status label")
+}
+
+/// Re-label a window's freshness without rebuilding it, or `None` when
+/// `status` is one of the two that serve no window at all.
+///
+/// Takes a [`FeedStatus`] rather than a `&str` so a misspelled label
+/// (`stale_error` for `stale-error`) cannot compile: [`FeedStatus`] owns this
+/// domain and is the only place the strings are spelled. `None` covers
+/// [`FeedStatus::Never`] and [`FeedStatus::Error`], which have no label
+/// because a feed in either state has nothing to serve — that makes
+/// "relabelled with a status that isn't a window status" unrepresentable in
+/// the return value instead of something this function has to invent a label
+/// for.
+///
+/// Every other column and the schema are shared by `Arc`, so a `Some` costs
+/// one `status`-wide string array — cheap enough to run on every serve of a
+/// cached window.
+pub fn with_window_status(batch: &RecordBatch, status: FeedStatus) -> Option<RecordBatch> {
+    let label = status.window_status_str()?;
+    let mut columns = batch.columns().to_vec();
+    columns[WINDOW_STATUS_IDX] = Arc::new(StringArray::from(vec![label; batch.num_rows()]));
+    Some(
+        RecordBatch::try_new(batch.schema(), columns)
+            .expect("only window_status changed, and it stayed Utf8 with the same length"),
+    )
+}
+
+/// Encode feed health observations as a `feeds` batch.
+pub fn build_feeds_batch(rows: &[FeedsRow]) -> RecordBatch {
+    let mut name = StringBuilder::new();
+    let mut url = StringBuilder::new();
+    let mut title = StringBuilder::new();
+    let mut site_url = StringBuilder::new();
+    let mut description = StringBuilder::new();
+    let mut last_fetch = TimestampMillisecondBuilder::new();
+    let mut last_status = StringBuilder::new();
+    let mut http_status = UInt16Builder::new();
+    let mut last_error = StringBuilder::new();
+    let mut etag = StringBuilder::new();
+    let mut last_modified = StringBuilder::new();
+    let mut dialect = StringBuilder::new();
+    let mut dialect_declared = StringBuilder::new();
+    let mut conformance_notes = StringBuilder::new();
+    let mut item_count = UInt64Builder::new();
+
+    for row in rows {
+        name.append_value(&row.name);
+        url.append_value(&row.url);
+        title.append_option(row.title.as_deref());
+        site_url.append_option(row.site_url.as_deref());
+        description.append_option(row.description.as_deref());
+        last_fetch.append_option(row.last_fetch_ms);
+        last_status.append_value(row.last_status.as_str());
+        http_status.append_option(row.http_status);
+        last_error.append_option(row.last_error.as_deref());
+        etag.append_option(row.etag.as_deref());
+        last_modified.append_option(row.last_modified.as_deref());
+        dialect.append_option(row.dialect.as_deref());
+        dialect_declared.append_option(row.dialect_declared.as_deref());
+        conformance_notes.append_option(row.conformance_notes.as_deref());
+        item_count.append_option(row.item_count);
+    }
+
+    let columns: Vec<ArrayRef> = vec![
+        Arc::new(name.finish()),
+        Arc::new(url.finish()),
+        Arc::new(title.finish()),
+        Arc::new(site_url.finish()),
+        Arc::new(description.finish()),
+        Arc::new(last_fetch.finish().with_timezone("UTC")),
+        Arc::new(last_status.finish()),
+        Arc::new(http_status.finish()),
+        Arc::new(last_error.finish()),
+        Arc::new(etag.finish()),
+        Arc::new(last_modified.finish()),
+        Arc::new(dialect.finish()),
+        Arc::new(dialect_declared.finish()),
+        Arc::new(conformance_notes.finish()),
+        Arc::new(item_count.finish()),
+    ];
+
+    RecordBatch::try_new(feeds_schema(), columns)
+        .expect("built columns match the feeds schema declared above")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::array::{
+        Array, ListArray, StringArray, TimestampMillisecondArray, UInt16Array, UInt32Array,
+        UInt64Array,
+    };
+    use arrow::datatypes::{DataType, Field, TimeUnit};
+
+    use super::*;
+
+    const FEED: &str = "news";
+    const FEED_URL: &str = "https://example.com/feed.xml";
+
+    /// The bundled semantics overlay describes exactly these two schemas'
+    /// columns — no more, no fewer — and parses as a real `SemanticsFile`.
+    ///
+    /// Nothing else tests `docs/rss/semantics.yaml` at all, and it is the file an
+    /// agent reads when planning a query, so a drift between it and the surface
+    /// is a drift in what agents are told. Both directions matter: a column the
+    /// overlay omits is a column with no provenance, and a column the overlay
+    /// invents is a lookup that silently never matches. Two live examples this
+    /// would have caught — a stale pruning rule the overlay kept after the
+    /// implementation widened it, and a NULL-ability claim contradicted by a
+    /// corpus fixture — were both found by review instead.
+    #[test]
+    fn the_bundled_semantics_overlay_matches_the_two_schemas() {
+        use crate::semantics::{SEMANTICS_KIND, SemanticsFile};
+
+        // `CARGO_MANIFEST_DIR` is `crates/skardi`; the overlay ships at the
+        // repo root under `docs/`.
+        let path =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../docs/rss/semantics.yaml");
+        let text = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read the bundled overlay at {}: {e}", path.display()));
+        let file: SemanticsFile = serde_yaml::from_str(&text)
+            .unwrap_or_else(|e| panic!("the bundled overlay must parse as a SemanticsFile: {e}"));
+
+        assert_eq!(
+            file.kind.as_deref(),
+            Some(SEMANTICS_KIND),
+            "the overlay must declare `kind: semantics` or the loader skips it"
+        );
+
+        for (table, schema) in [("feeds", feeds_schema()), ("items", items_schema())] {
+            // The overlay's `name:` keys are fully-qualified and assume a source
+            // called `news`, which the file's own header documents.
+            let qualified = format!("news.main.{table}");
+            let source = file
+                .spec
+                .sources
+                .iter()
+                .find(|s| s.name == qualified)
+                .unwrap_or_else(|| panic!("the overlay must carry an entry for {qualified}"));
+            assert!(
+                source.description.is_some(),
+                "{qualified} needs a table-level description"
+            );
+
+            let described: Vec<&str> = source.columns.iter().map(|c| c.name.as_str()).collect();
+            let declared: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+
+            for name in &declared {
+                assert!(
+                    described.contains(name),
+                    "{qualified}.{name} is in the schema but has no description in the overlay"
+                );
+            }
+            for name in &described {
+                assert!(
+                    declared.contains(name),
+                    "the overlay describes {qualified}.{name}, which is not a column of that \
+                     table — an agent reading it would plan a query against nothing"
+                );
+            }
+            // Catches a duplicated column entry, which the two containment
+            // checks above would each pass.
+            assert_eq!(
+                described.len(),
+                declared.len(),
+                "{qualified}: the overlay lists {} columns for a {}-column table",
+                described.len(),
+                declared.len()
+            );
+        }
+    }
+
+    /// The expected types are restated here rather than shared with the
+    /// implementation on purpose: a helper used by both would let a wrong type
+    /// satisfy its own assertion.
+    fn ts_utc() -> DataType {
+        DataType::Timestamp(TimeUnit::Millisecond, Some("UTC".into()))
+    }
+
+    fn utf8_list() -> DataType {
+        DataType::List(Arc::new(Field::new("item", DataType::Utf8, true)))
+    }
+
+    fn assert_surface(schema: &SchemaRef, expected: &[(&str, DataType, bool)], count: usize) {
+        assert_eq!(expected.len(), count, "the test's own expectation list");
+        assert_eq!(schema.fields().len(), count, "column count");
+        for (idx, (name, data_type, nullable)) in expected.iter().enumerate() {
+            let field = schema.field(idx);
+            assert_eq!(field.name(), name, "column {idx} name");
+            assert_eq!(field.data_type(), data_type, "column {idx} `{name}` type");
+            assert_eq!(
+                field.is_nullable(),
+                *nullable,
+                "column {idx} `{name}` nullability"
+            );
+        }
+        // Spelled out rather than taken from the constant: the key is the
+        // wire-visible name, so a rename must fail here.
+        assert_eq!(
+            schema
+                .metadata()
+                .get("skardi.rss.surface_version")
+                .map(String::as_str),
+            Some("1"),
+            "surface-version metadata"
+        );
+    }
+
+    fn strings(batch: &RecordBatch, idx: usize) -> Vec<Option<&str>> {
+        batch
+            .column(idx)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap_or_else(|| panic!("column {idx} is not Utf8"))
+            .iter()
+            .collect()
+    }
+
+    fn two_items() -> Vec<ItemRow> {
+        vec![
+            ItemRow {
+                guid: "urn:uuid:1".into(),
+                title: Some("First post".into()),
+                link: Some("https://example.com/1".into()),
+                author: Some("Ada".into()),
+                published_ms: Some(1_700_000_000_000),
+                updated_ms: Some(1_700_000_060_000),
+                content: Some("# body".into()),
+                summary: Some("teaser".into()),
+                categories: vec!["rust".into(), "arrow".into()],
+                enclosure_url: Some("https://example.com/1.mp3".into()),
+                enclosure_type: Some("audio/mpeg".into()),
+                enclosure_length: Some(1024),
+                extensions_json: Some(r#"{"rights":"CC0"}"#.into()),
+            },
+            // Every optional absent: the null-propagation half of the round trip.
+            ItemRow {
+                guid: "urn:uuid:2".into(),
+                title: None,
+                link: None,
+                author: None,
+                published_ms: None,
+                updated_ms: None,
+                content: None,
+                summary: None,
+                categories: Vec::new(),
+                enclosure_url: None,
+                enclosure_type: None,
+                enclosure_length: None,
+                extensions_json: None,
+            },
+        ]
+    }
+
+    fn never_row() -> FeedsRow {
+        FeedsRow {
+            name: FEED.into(),
+            url: FEED_URL.into(),
+            title: None,
+            site_url: None,
+            description: None,
+            last_fetch_ms: None,
+            last_status: FeedStatus::Never,
+            http_status: None,
+            last_error: None,
+            etag: None,
+            last_modified: None,
+            dialect: None,
+            dialect_declared: None,
+            conformance_notes: None,
+            item_count: None,
+        }
+    }
+
+    #[test]
+    fn items_schema_matches_spec() {
+        let schema = items_schema();
+        let expected: Vec<(&str, DataType, bool)> = vec![
+            ("feed", DataType::Utf8, false),
+            ("feed_url", DataType::Utf8, false),
+            ("guid", DataType::Utf8, false),
+            ("title", DataType::Utf8, true),
+            ("link", DataType::Utf8, true),
+            ("author", DataType::Utf8, true),
+            ("published", ts_utc(), true),
+            ("updated", ts_utc(), true),
+            ("content", DataType::Utf8, true),
+            ("summary", DataType::Utf8, true),
+            ("categories", utf8_list(), true),
+            ("enclosure_url", DataType::Utf8, true),
+            ("enclosure_type", DataType::Utf8, true),
+            ("enclosure_length", DataType::UInt64, true),
+            ("position", DataType::UInt32, false),
+            ("window_status", DataType::Utf8, false),
+            ("extensions_json", DataType::Utf8, true),
+        ];
+        assert_surface(&schema, &expected, 17);
+        // The engine rewrites this column by index; a reorder must fail here
+        // rather than silently mislabel every row's freshness.
+        assert_eq!(schema.field(WINDOW_STATUS_IDX).name(), "window_status");
+    }
+
+    #[test]
+    fn feeds_schema_matches_spec() {
+        let expected: Vec<(&str, DataType, bool)> = vec![
+            ("name", DataType::Utf8, false),
+            ("url", DataType::Utf8, false),
+            ("title", DataType::Utf8, true),
+            ("site_url", DataType::Utf8, true),
+            ("description", DataType::Utf8, true),
+            ("last_fetch", ts_utc(), true),
+            ("last_status", DataType::Utf8, false),
+            ("http_status", DataType::UInt16, true),
+            ("last_error", DataType::Utf8, true),
+            ("etag", DataType::Utf8, true),
+            ("last_modified", DataType::Utf8, true),
+            ("dialect", DataType::Utf8, true),
+            ("dialect_declared", DataType::Utf8, true),
+            ("conformance_notes", DataType::Utf8, true),
+            ("item_count", DataType::UInt64, true),
+        ];
+        assert_surface(&feeds_schema(), &expected, 15);
+    }
+
+    #[test]
+    fn items_batch_round_trips_rows() {
+        let batch = build_items_batch(FEED, FEED_URL, &two_items());
+        assert_eq!(batch.schema(), items_schema());
+        assert_eq!(batch.num_rows(), 2);
+
+        assert_eq!(strings(&batch, 0), vec![Some(FEED), Some(FEED)]);
+        assert_eq!(strings(&batch, 1), vec![Some(FEED_URL), Some(FEED_URL)]);
+        assert_eq!(
+            strings(&batch, 2),
+            vec![Some("urn:uuid:1"), Some("urn:uuid:2")]
+        );
+        assert_eq!(strings(&batch, 3), vec![Some("First post"), None]);
+        assert_eq!(
+            strings(&batch, 4),
+            vec![Some("https://example.com/1"), None]
+        );
+        assert_eq!(strings(&batch, 5), vec![Some("Ada"), None]);
+
+        let published = batch
+            .column(6)
+            .as_any()
+            .downcast_ref::<TimestampMillisecondArray>()
+            .expect("published is Timestamp(ms)");
+        assert_eq!(
+            published.iter().collect::<Vec<_>>(),
+            vec![Some(1_700_000_000_000), None]
+        );
+        assert_eq!(
+            published.data_type(),
+            &ts_utc(),
+            "the array must carry the column's timezone, not a bare Timestamp"
+        );
+        let updated = batch
+            .column(7)
+            .as_any()
+            .downcast_ref::<TimestampMillisecondArray>()
+            .expect("updated is Timestamp(ms)");
+        assert_eq!(
+            updated.iter().collect::<Vec<_>>(),
+            vec![Some(1_700_000_060_000), None]
+        );
+
+        assert_eq!(strings(&batch, 8), vec![Some("# body"), None]);
+        assert_eq!(strings(&batch, 9), vec![Some("teaser"), None]);
+
+        let categories = batch
+            .column(10)
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("categories is a List");
+        let first = categories.value(0);
+        assert_eq!(
+            first
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("list items are Utf8")
+                .iter()
+                .collect::<Vec<_>>(),
+            vec![Some("rust"), Some("arrow")]
+        );
+        // NULL rather than `[]`: every other absent field is NULL, and that
+        // consistency is what makes the column's declared nullability mean
+        // something.
+        assert!(
+            categories.is_null(1),
+            "an item with no categories is NULL, not an empty list"
+        );
+
+        assert_eq!(
+            strings(&batch, 11),
+            vec![Some("https://example.com/1.mp3"), None]
+        );
+        assert_eq!(strings(&batch, 12), vec![Some("audio/mpeg"), None]);
+        let length = batch
+            .column(13)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .expect("enclosure_length is UInt64");
+        assert_eq!(length.iter().collect::<Vec<_>>(), vec![Some(1024), None]);
+
+        let position = batch
+            .column(14)
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .expect("position is UInt32");
+        assert_eq!(
+            position.iter().collect::<Vec<_>>(),
+            vec![Some(0), Some(1)],
+            "position is the row's index in the window"
+        );
+        assert_eq!(
+            strings(&batch, WINDOW_STATUS_IDX),
+            vec![Some("fresh"), Some("fresh")]
+        );
+        assert_eq!(strings(&batch, 16), vec![Some(r#"{"rights":"CC0"}"#), None]);
+    }
+
+    #[test]
+    fn with_window_status_swaps_only_column_15() {
+        let batch = build_items_batch(FEED, FEED_URL, &two_items());
+        let relabelled = with_window_status(&batch, FeedStatus::StaleError)
+            .expect("stale-error is a window status");
+
+        for idx in 0..batch.num_columns() {
+            if idx == WINDOW_STATUS_IDX {
+                continue;
+            }
+            assert!(
+                Arc::ptr_eq(batch.column(idx), relabelled.column(idx)),
+                "column {idx} was rebuilt instead of shared"
+            );
+        }
+        assert!(
+            Arc::ptr_eq(&batch.schema(), &relabelled.schema()),
+            "the schema was rebuilt instead of shared"
+        );
+        assert_eq!(
+            strings(&relabelled, WINDOW_STATUS_IDX),
+            vec![Some("stale-error"), Some("stale-error")]
+        );
+        assert_eq!(
+            strings(&batch, WINDOW_STATUS_IDX),
+            vec![Some("fresh"), Some("fresh")],
+            "the source batch must be untouched — it is the cached window"
+        );
+    }
+
+    #[test]
+    fn feeds_batch_round_trips() {
+        let observed = FeedsRow {
+            name: "blog".into(),
+            url: "https://blog.example.com/atom.xml".into(),
+            title: Some("The Blog".into()),
+            site_url: Some("https://blog.example.com/".into()),
+            description: Some("posts".into()),
+            last_fetch_ms: Some(1_700_000_000_000),
+            last_status: FeedStatus::Revalidated,
+            http_status: Some(304),
+            last_error: None,
+            etag: Some("\"abc\"".into()),
+            last_modified: Some("Wed, 21 Oct 2015 07:28:00 GMT".into()),
+            dialect: Some("atom".into()),
+            dialect_declared: Some("atom".into()),
+            conformance_notes: Some("sanitation: stripped-control-chars".into()),
+            item_count: Some(7),
+        };
+        let batch = build_feeds_batch(&[never_row(), observed]);
+        assert_eq!(batch.schema(), feeds_schema());
+        assert_eq!(batch.num_rows(), 2);
+
+        // Row 0 — never fetched: only identity and status are known.
+        assert_eq!(strings(&batch, 0), vec![Some(FEED), Some("blog")]);
+        assert_eq!(strings(&batch, 1)[0], Some(FEED_URL));
+        assert_eq!(strings(&batch, 6), vec![Some("never"), Some("revalidated")]);
+        for idx in [2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14] {
+            assert!(
+                batch.column(idx).is_null(0),
+                "column {idx} `{}` must be NULL before the first fetch",
+                batch.schema().field(idx).name()
+            );
+        }
+
+        // Row 1 — everything the engine can observe, round-tripped.
+        assert_eq!(strings(&batch, 2)[1], Some("The Blog"));
+        assert_eq!(strings(&batch, 3)[1], Some("https://blog.example.com/"));
+        assert_eq!(strings(&batch, 4)[1], Some("posts"));
+        let last_fetch = batch
+            .column(5)
+            .as_any()
+            .downcast_ref::<TimestampMillisecondArray>()
+            .expect("last_fetch is Timestamp(ms)");
+        assert_eq!(last_fetch.data_type(), &ts_utc());
+        assert_eq!(last_fetch.value(1), 1_700_000_000_000);
+        let http_status = batch
+            .column(7)
+            .as_any()
+            .downcast_ref::<UInt16Array>()
+            .expect("http_status is UInt16");
+        assert_eq!(http_status.value(1), 304);
+        assert_eq!(
+            strings(&batch, 8)[1],
+            None,
+            "a revalidated feed carries no error"
+        );
+        assert_eq!(strings(&batch, 9)[1], Some("\"abc\""));
+        assert_eq!(
+            strings(&batch, 10)[1],
+            Some("Wed, 21 Oct 2015 07:28:00 GMT")
+        );
+        assert_eq!(strings(&batch, 11)[1], Some("atom"));
+        assert_eq!(strings(&batch, 12)[1], Some("atom"));
+        assert_eq!(
+            strings(&batch, 13)[1],
+            Some("sanitation: stripped-control-chars")
+        );
+        let item_count = batch
+            .column(14)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .expect("item_count is UInt64");
+        assert_eq!(item_count.value(1), 7);
+    }
+
+    #[test]
+    fn empty_items_batch_has_zero_rows_17_cols() {
+        let batch = build_items_batch(FEED, FEED_URL, &[]);
+        assert_eq!(batch.num_rows(), 0);
+        assert_eq!(batch.num_columns(), 17);
+        assert_eq!(batch.schema(), items_schema());
+        // A feed can legitimately serve an empty window; re-labelling one must
+        // not be the path that panics.
+        let relabelled = with_window_status(&batch, FeedStatus::Revalidated)
+            .expect("revalidated is a window status");
+        assert_eq!(relabelled.num_rows(), 0);
+        assert_eq!(relabelled.num_columns(), 17);
+    }
+
+    /// The two statuses that serve zero rows have no `window_status` label, so
+    /// relabelling with one answers `None` rather than writing a string
+    /// outside the column's domain.
+    #[test]
+    fn with_window_status_refuses_the_zero_row_statuses() {
+        let batch = build_items_batch(FEED, FEED_URL, &two_items());
+        assert!(with_window_status(&batch, FeedStatus::Never).is_none());
+        assert!(with_window_status(&batch, FeedStatus::Error).is_none());
+    }
+}

--- a/docs/rss/semantics.yaml
+++ b/docs/rss/semantics.yaml
@@ -1,0 +1,274 @@
+# Bundled semantics overlay for a `type: rss` data source.
+#
+# Loading: this is an ordinary `kind: semantics` resource, discovered through
+# the standard mechanism (see docs/semantics.md) — drop it into
+# `<ctx_dir>/semantics/` (a directory scanned for *.yaml at one level), or
+# point at it explicitly with `--semantics <path>`. Note that defining both
+# `<ctx_dir>/semantics/` and `<ctx_dir>/semantics.yaml` is a hard error, so
+# pick one.
+#
+# The `name:` keys below are fully-qualified `catalog.schema.table` paths, and
+# the catalog segment is the data source's own `name:` from ctx.yaml. This file
+# assumes a source named `news`; rename `news.main.*` to match yours.
+#
+# Column descriptions carry the per-dialect provenance from the Field Mapping
+# table in docs/rss.md, so an agent inspecting the schema learns where each
+# value came from without reading provider source.
+
+kind: semantics
+
+metadata:
+  name: rss-semantics
+  version: 1.0.0
+
+spec:
+  sources:
+    - name: news.main.feeds
+      description: >-
+        Fetch health, one row per configured subscription, always — the table
+        stays total over the subscription list even for feeds that have never
+        been fetched. Reading THIS TABLE issues ZERO HTTP requests at any moment,
+        including right after a failure, so it is cheap by construction. This
+        is the authoritative signal for a feed that served no rows: absence has
+        no in-band carrier in `items`, so run the anti-join
+        `SELECT f.name, f.last_status, f.last_error FROM news.main.feeds f LEFT
+        JOIN news.main.items i ON i.feed = f.name WHERE i.feed IS NULL`
+        alongside any read where completeness matters. NOTE that the anti-join
+        DOES fetch: its `items` side has no `feed` predicate, so it is a full
+        scan and every subscription past its TTL is fetched — cheap after a scan
+        has warmed the cache, expensive cold. It can also report 'never' for a
+        feed that same query just fetched, since the two tables are scanned with
+        no ordering guarantee between them; re-read `feeds` on its own to
+        confirm. Absence alone is not a verdict: `last_status = 'fresh'` with
+        `item_count = 0` is a legitimately empty feed, `'error'` is a dead one,
+        and `'never'` means no scan has visited it yet — or that every scan so
+        far hit the scan deadline before reaching it, which writes no health
+        state at all. The subscription list is configuration and is not
+        SQL-mutable.
+      columns:
+        - name: name
+          description: >-
+            Subscription name from configuration, defaulting to the URL when
+            none was given. Unique across the source, and the value that appears
+            as `items.feed`.
+        - name: url
+          description: "The subscribed feed URL, exactly as configured."
+        - name: title
+          description: >-
+            The feed's own channel/feed title, populated once the feed has been
+            fetched successfully. NULL before that.
+        - name: site_url
+          description: >-
+            The feed's HTML alternate — the human-facing site the feed
+            describes, not the feed URL itself.
+        - name: description
+          description: "The feed's own channel/feed description, once fetched."
+        - name: last_fetch
+          description: >-
+            Time of the last fetch ATTEMPT, successful or not. NULL until a
+            first attempt. An aging value on an otherwise healthy feed means no
+            scan has visited it recently — fetches only ride on `items` scans.
+        - name: last_status
+          description: >-
+            Fetch health: 'never' (no attempt yet), 'fresh' (a full 200 parsed),
+            'revalidated' (a 304 confirmed the cached window), 'stale-error'
+            (the refresh failed and the previous window is still being served),
+            'error' (failed with no window to fall back on — zero rows in
+            `items`).
+        - name: http_status
+          description: >-
+            HTTP status of the last attempt. NULL when no status was ever
+            observed, e.g. a target refused by the egress policy before
+            connecting.
+        - name: last_error
+          description: >-
+            Why the last attempt failed, bounded at 512 characters (the
+            provider's MAX_ERROR_CHARS). TREAT AS FEED-AUTHORED TEXT: it may
+            quote a feed-supplied token that sat in a structural position — an
+            element or attribute name, a type/MIME string, a declared version
+            string, or the JSON member value that failed a type check — and the
+            512-char cap is the only bound on how long such a fragment is. It
+            does not quote what the provider reads as content (character data, a
+            title, a description, an entry body), even when the document fails
+            for an unrelated reason. The prefix names the stage: 'egress
+            blocked: …', 'parse failed at refused-internal-dtd: …', 'parse
+            failed at strict-parse: …', 'http status <n>', 'request timed out
+            after <n>s', 'response exceeded <n> bytes', 'too many redirects
+            (limit 5)', 'invalid feed url: …', 'transport error: …', or
+            'revalidated (304) but the cached window had already been
+            evicted …'.
+        - name: etag
+          description: >-
+            Stored ETag validator, sent as If-None-Match on the next refresh.
+            Process-lifetime state: a restart clears it, so the first scan after
+            a restart is a full 200 rather than a 304. Also NULL once the feed's
+            cached window has been evicted under the cache's 64 MiB window
+            budget — the validators live on the window, while `last_status` and
+            `item_count` survive on the health record, so this column reading
+            NULL beside a 'fresh' status means the next fetch is unconditional.
+        - name: last_modified
+          description: >-
+            Stored Last-Modified validator, sent as If-Modified-Since on the
+            next refresh. Same process-lifetime caveat as `etag`.
+        - name: dialect
+          description: >-
+            The dialect actually parsed: 'rss-0.9x', 'rss-1.0', 'rss-2.0',
+            'atom', or 'json-feed-1.x'. Note that 'atom' covers both Atom 1.0
+            and Atom 0.3 — use `dialect_declared` to tell them apart.
+        - name: dialect_declared
+          description: >-
+            What the document claimed, sniffed from its root element and version
+            attribute: 'rss-0.9' / 'rss-0.91' / 'rss-0.92' / 'rss-1.0' /
+            'rss-2.0' / 'atom-0.3' / 'atom-1.0' / 'json-feed-1' /
+            'json-feed-1.1', or 'unknown:<root element>'. Keeps the version
+            detail the parsed dialect collapses. A value of 'atom-0.3' with
+            `item_count = 0` is the known empty-parse case, not a fault. The
+            'unknown:' form is the XML fallback ONLY, and is capped at 512
+            characters because the root element name is feed-supplied: a JSON
+            document whose version marker is neither 1 nor 1.1 — version 2, say —
+            leaves this column NULL rather than reporting 'unknown:…'.
+        - name: conformance_notes
+          description: >-
+            JSON array of observations about the document; '[]' means clean and
+            NULL means never parsed. Note shapes: 'sanitation: reencoded-to-utf8'
+            / 'stripped-control-chars' / 'escaped-naked-ampersands' (repairs
+            that were actually applied), 'content-type-mismatch: served <type>,
+            parsed <family>', 'missing-required-field: <path>', and
+            'entries-without-identity: <n>' (entries dropped for having neither
+            an id nor a link). Deviations never reject a feed that parsed.
+        - name: item_count
+          description: >-
+            Entries in the currently cached window. NULL when no window was ever
+            built. A failed refresh leaves it describing the window still being
+            served, not the failed attempt — and after a 304 whose window had
+            already been evicted it describes a window that is gone, which is the
+            one shape where a non-NULL `item_count` sits beside `last_status =
+            'error'`.
+
+    - name: news.main.items
+      description: >-
+        The live window of every subscription, unioned, with `(feed, guid)` as
+        the item identity. Rows are fetched at scan time through a per-feed TTL
+        cache; each feed is an independent partition, so one dead feed degrades
+        alone rather than failing the scan. There is no history here — an entry
+        that scrolls out of a feed's window is gone unless a pipeline archived
+        it. Two caveats when completeness matters. (1) A bare `LIMIT` with no
+        `ORDER BY` serves a NONDETERMINISTIC subset of feeds: items have no
+        global order, the scan stops launching fetches once the limit is
+        satisfied, and the feeds it never launched are neither fetched nor
+        health-refreshed. Use `ORDER BY … LIMIT` (a Top-K consumes every
+        partition) or no `LIMIT`. (2) A feed that served zero rows leaves no
+        trace here at all — check `news.main.feeds` for it. Three predicate
+        shapes over `feed` or `feed_url` prune which feeds are fetched, and
+        nothing else does: equality against a literal (either operand order), a
+        non-negated `IN` list of literals AT ANY LENGTH, and a disjunction of
+        either of those over ONE of the two columns (`feed = 'a' OR feed = 'c'`
+        prunes to exactly those two). A disjunction mixing the two columns
+        (`feed = 'a' OR feed_url = '…'`) or containing any non-prunable branch
+        fetches everything. Everything else filters after the fetch — correct
+        rows, wasted requests.
+      columns:
+        - name: feed
+          description: >-
+            The subscription's configured name (`feeds.name`). Synthesized by
+            the provider, not a wire field. Equality, `IN` lists of any length,
+            and `OR` chains of either over this column alone prune the scan to
+            those feeds before any HTTP request. Names matching no subscription
+            contribute nothing rather than erroring.
+        - name: feed_url
+          description: >-
+            The subscribed feed URL. Provider-synthesized. Prunable by the same
+            three shapes as `feed`, but a disjunction may not MIX the two
+            columns. Two subscriptions may share a URL, and pruning on it visits
+            both.
+        - name: guid
+          description: >-
+            Stable item identity, unique within a feed. RSS 2.0 <guid> (falling
+            back to <link>), RSS 1.0 <link> (feed-rs does not read rdf:about),
+            Atom <id>, JSON Feed `id`. Feed-asserted and unverifiable, but
+            scoped by `feed`, so one feed cannot collide with another's items.
+            Entries with neither an id nor a link are dropped and counted in
+            `feeds.conformance_notes`.
+        - name: title
+          description: >-
+            Entry title. RSS 2.0/1.0 <title>, Atom <title> (text/html/xhtml
+            normalized), JSON Feed `title`.
+        - name: link
+          description: >-
+            The page a reader should follow. RSS 2.0/1.0 <link>, Atom <link
+            rel="alternate"> (first, else first link), JSON Feed `url`.
+            Feed-asserted: it can point anywhere, including at an attacker's
+            page.
+        - name: author
+          description: >-
+            RSS 2.0 <author> or dc:creator, RSS 1.0 dc:creator, Atom
+            <author><name>, JSON Feed `authors[0].name`.
+        - name: published
+          description: >-
+            Publication time, normalized to Timestamp(ms, UTC). RSS 2.0
+            <pubDate> (RFC 822), RSS 1.0 dc:date (ISO 8601), Atom <published>
+            (RFC 3339), JSON Feed `date_published`.
+        - name: updated
+          description: >-
+            Last-modified time, normalized to Timestamp(ms, UTC). Atom <updated>
+            (RFC 3339), JSON Feed `date_modified`. Neither RSS dialect has an
+            update element, but THE TWO DIFFER: feed-rs copies <pubDate> into
+            `updated` for RSS 2.0, so an RSS 2.0 item reads `updated =
+            published` and NEVER NULL, while RSS 1.0 really is NULL. So `WHERE
+            updated IS NULL` never matches an RSS 2.0 feed and `updated >
+            published` never matches one either — to find revised items,
+            restrict to `dialect IN ('atom', 'json-feed-1.x')`.
+        - name: content
+          description: >-
+            Full entry body as MARKDOWN, converted once at extraction. RSS
+            2.0/1.0 content:encoded, Atom <content>, JSON Feed `content_html` /
+            `content_text`. HTML-typed values are converted deterministically
+            and no HTML TAG survives as markup (script/style dropped, unknown
+            markup reduced to its text). That is narrower than "no raw HTML": an
+            attribute value's `<` survives unescaped, and a plain-text-typed
+            value (Atom type="text", JSON Feed `content_text`) passes through
+            BYTE-EXACT, so a feed declaring text can store a literal
+            `<script>…</script>`. UNTRUSTED FEED-AUTHORED TEXT either way —
+            disable raw HTML in any renderer and filter link schemes. The source
+            HTML is not retained. Chunkable with chunk('markdown', …).
+        - name: summary
+          description: >-
+            Short entry body as Markdown, same conversion as `content`. RSS
+            2.0/1.0 <description>, Atom <summary>, JSON Feed `summary`. Use
+            COALESCE(content, summary) when a feed carries only one of the two.
+        - name: categories
+          description: >-
+            Tags as a List<Utf8>. RSS 2.0 <category>*, RSS 1.0 dc:subject*, Atom
+            <category term>*, JSON Feed `tags[]`. An entry with no tags is NULL,
+            not an empty list — test it with `IS NULL`, not
+            `cardinality(categories) = 0`.
+        - name: enclosure_url
+          description: >-
+            URL of the entry's primary attachment (podcast audio, video). RSS
+            2.0 <enclosure url>, Atom <link rel="enclosure">, JSON Feed
+            `attachments[0]`. Stored, never fetched by Skardi.
+        - name: enclosure_type
+          description: "MIME type of the attachment named by `enclosure_url`."
+        - name: enclosure_length
+          description: "Size in bytes of the attachment, as the feed declares it."
+        - name: position
+          description: >-
+            Zero-based index of the row in the feed's own document order — the
+            only ordering a feed guarantees. Provider-synthesized.
+        - name: window_status
+          description: >-
+            In-band freshness of the window this row came from, so a consumer
+            never has to join `feeds` to know it is reading stale data. 'fresh'
+            (a full 200 just parsed), 'revalidated' (a 304 confirmed the cached
+            window), 'stale-error' (the refresh failed and this is the previous
+            window). WINDOW-level: identical on every row of one feed within one
+            scan. 'never' and 'error' produce zero rows and so can never appear
+            here — those feeds are visible only in `feeds`.
+        - name: extensions_json
+          description: >-
+            Non-core fields as a JSON object with deterministic key order, or
+            NULL when there are none. Bounded by what the feed-rs model exposes
+            — NOT a catch-all for arbitrary unknown namespaces, which are
+            dropped at parse time. Keys seen today: `media` (MediaRSS objects
+            beyond the one surfaced as the enclosure), `source`, `rights`,
+            `language`.

--- a/docs/rss/semantics.yaml
+++ b/docs/rss/semantics.yaml
@@ -133,9 +133,12 @@ spec:
             NULL means never parsed. Note shapes: 'sanitation: reencoded-to-utf8'
             / 'stripped-control-chars' / 'escaped-naked-ampersands' (repairs
             that were actually applied), 'content-type-mismatch: served <type>,
-            parsed <family>', 'missing-required-field: <path>', and
+            parsed <family>', 'missing-required-field: <path>',
             'entries-without-identity: <n>' (entries dropped for having neither
-            an id nor a link). Deviations never reject a feed that parsed.
+            an id nor a link), and 'duplicate-identity: <n>' (later entries
+            dropped because an earlier entry in the same document already
+            claimed the same guid — first occurrence in document order wins).
+            Deviations never reject a feed that parsed.
         - name: item_count
           description: >-
             Entries in the currently cached window. NULL when no window was ever

--- a/docs/rss/semantics.yaml
+++ b/docs/rss/semantics.yaml
@@ -249,7 +249,11 @@ spec:
           description: >-
             URL of the entry's primary attachment (podcast audio, video). RSS
             2.0 <enclosure url>, Atom <link rel="enclosure">, JSON Feed
-            `attachments[0]`. Stored, never fetched by Skardi.
+            `attachments[0]`. Stored, never fetched by Skardi. An entry may
+            carry SEVERAL attachments — one episode in several audio formats,
+            say — and only the first reaches these three columns; the rest are
+            in `extensions_json`'s `attachments` array, so read both when you
+            want them all.
         - name: enclosure_type
           description: "MIME type of the attachment named by `enclosure_url`."
         - name: enclosure_length
@@ -272,6 +276,14 @@ spec:
             Non-core fields as a JSON object with deterministic key order, or
             NULL when there are none. Bounded by what the feed-rs model exposes
             — NOT a catch-all for arbitrary unknown namespaces, which are
-            dropped at parse time. Keys seen today: `media` (MediaRSS objects
-            beyond the one surfaced as the enclosure), `source`, `rights`,
-            `language`.
+            dropped at parse time. Keys seen today: `attachments`, `source`,
+            `rights`, `language`. `attachments` is every attachment past the
+            one in the `enclosure_*` columns, one flat object per downloadable
+            file with `url` / `content_type` / `size`, and the dialect it came
+            in does not change that shape — MediaRSS and Atom/JSON Feed
+            attachment links both land here, so two renditions of one podcast
+            episode survive whether the feed is RSS or JSON Feed. MediaRSS
+            objects add `title`, `description`, `thumbnails`, and
+            `duration_secs` when they carry them, copied onto each of their
+            renditions; such an object whose renditions were all consumed
+            leaves an element with that metadata and no `url`.


### PR DESCRIPTION
Phase 2 of 4 stacked PRs splitting #175 (plan Tasks 5-10). Base: `rss-m1-phase1` (#180); retarget to `main` after #180 merges.

## Scope
- **Sanitation ladder**: encoding repair incl. a lying non-UTF-8 declaration over valid UTF-8 bytes, control-char stripping, internal-DTD refusal run case-insensitively on both raw and sanitized bytes (closes the restore-after-guard evasions)
- **HTML→Markdown** via htmd behind a lexical `MAX_HTML_DEPTH = 100` pre-scan: htmd's DOM walk recurses unboundedly, and a ~7 KB feed with 600 nested divs aborts the process on a 2 MiB Tokio stack; above the ceiling content degrades to tag-stripped text. The scanner survived eight distinct bypass attempts during review (stray close tags, `<!-->`, foreign-content self-closing tags, …) and is mutation-verified.
- **Dialect conformance + parse driver**: RSS 0.9x/1.0/2.0, Atom, JSON Feed; field extraction per the spec's Field Mapping table (MIME subtype compared case-insensitively)
- **Arrow schemas**: items (17 cols) / feeds (15 cols), `skardi.rss.surface_version` metadata, builders routed through the `FeedStatus` domain type
- **Per-feed TTL cache**: LRU-evicted windows, health observations structurally never evicted, HTTP validators bundled with the window they validate, bounded observation map
- `docs/rss/semantics.yaml` ships here because a schema test pins the overlay against both schemas

## Verification
148 rss tests (cumulative); featureless check clean; `cargo doc -D warnings` clean both configs; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)