### PR TITLE
feat(sources): Feishu source pack (milestone 5.4) — six tables, digit-string epoch + boolean-pushdown engine support

### DIFF
--- a/crates/skardi/src/sources/providers/open_connector/error.rs
+++ b/crates/skardi/src/sources/providers/open_connector/error.rs
@@ -257,6 +257,19 @@ pub enum OpenConnectorError {
         found: String,
     },
 
+    /// The declared has-more signal was absent or not a boolean. Guessing
+    /// either way could truncate or loop the scan; carries the JSON *kind*
+    /// only, never the value.
+    #[error(
+        "Open Connector pagination has-more signal at '{path}' on page {page} is {found}, \
+         expected a boolean"
+    )]
+    PaginationHasMoreInvalid {
+        path: String,
+        page: usize,
+        found: String,
+    },
+
     /// Pagination failed to advance: the gateway returned an already-seen
     /// cursor, which would loop the scan forever.
     #[error(

--- a/crates/skardi/src/sources/providers/open_connector/filters.rs
+++ b/crates/skardi/src/sources/providers/open_connector/filters.rs
@@ -50,8 +50,18 @@ pub enum ValueFormat {
     /// precision. Flooring widens a *lower* bound (a superset — safe under
     /// [`Fidelity::Inexact`] re-filtering); for an upper-bound provider
     /// parameter it would narrow the fetch and drop rows, so epoch-seconds
-    /// mappings are for lower-bound inputs (`ts_from`-style) only.
+    /// mappings are for lower-bound inputs (`ts_from`-style) only — the
+    /// pack loader REJECTS any other operator (and any fidelity but
+    /// Inexact) at load time. Pre-epoch instants clamp to `0`: still a
+    /// lower-bound superset, and providers with unsigned epoch inputs
+    /// (Feishu 400s a `-` sign) never see a negative.
     EpochSeconds,
+    /// [`ValueFormat::EpochSeconds`] rendered as a JSON *string* of decimal
+    /// digits, for providers whose strict input schemas type their epoch
+    /// inputs as strings (Feishu's `startTime`, `minLength: 1`) — a JSON
+    /// number there is a hard 400. Same flooring semantics, so the same
+    /// lower-bound-only rule applies.
+    EpochSecondsString,
 }
 
 /// One allowlisted pushdown rule: `column <operator> literal` → `input_field: literal`.
@@ -113,6 +123,39 @@ pub fn translate_filters(filters: &[Expr], mappings: &[FilterMapping]) -> Transl
 
 /// Translate one filter, returning `(input_field, value, fidelity)` on a match.
 fn translate_one(filter: &Expr, mappings: &[FilterMapping]) -> Option<(String, Value, Fidelity)> {
+    // DataFusion's simplifier rewrites boolean equality to the bare
+    // column (`completed = true` → `completed`) or its negation
+    // (`completed = false` → `NOT completed`) before pushdown, so an Eq
+    // mapping on a boolean column would otherwise never fire. Normalize
+    // both spellings back to the equality they mean.
+    //
+    // Invariant: these two arms fabricate a Boolean literal without
+    // checking the mapped column's declared type, because only a
+    // boolean-typed column can appear as a bare predicate in a
+    // type-checked DataFusion plan — an Eq mapping on a non-boolean
+    // column is reachable solely through the BinaryExpr arm below, where
+    // the literal comes from the query.
+    match filter {
+        Expr::Column(column) => {
+            let mapping = mappings.iter().find(|mapping| {
+                mapping.column == column.name && mapping.operator == Operator::Eq
+            })?;
+            let value = scalar_to_json(&ScalarValue::Boolean(Some(true)), mapping.value_format)?;
+            return Some((mapping.input_field.to_string(), value, mapping.fidelity));
+        }
+        Expr::Not(inner) => {
+            let Expr::Column(column) = inner.as_ref() else {
+                return None;
+            };
+            let mapping = mappings.iter().find(|mapping| {
+                mapping.column == column.name && mapping.operator == Operator::Eq
+            })?;
+            let value = scalar_to_json(&ScalarValue::Boolean(Some(false)), mapping.value_format)?;
+            return Some((mapping.input_field.to_string(), value, mapping.fidelity));
+        }
+        _ => {}
+    }
+
     let Expr::BinaryExpr(binary) = filter else {
         return None;
     };
@@ -184,25 +227,40 @@ fn scalar_to_json(literal: &ScalarValue, format: ValueFormat) -> Option<Value> {
         // Verbatim arms return None on purpose: the mapping declared no
         // timestamp spelling, so the predicate stays local rather than
         // being pushed in a guessed format.
+        // Epoch renderings clamp pre-epoch instants to 0 (see the
+        // ValueFormat docs): a negative would render with a `-` sign that
+        // strict digit-string schemas 400 on, failing the whole scan where
+        // no pushdown at all would have succeeded — and 0 is still a
+        // superset for the lower bounds these formats are restricted to.
         ScalarValue::TimestampSecond(Some(v), _) => match format {
             ValueFormat::Verbatim => None,
             ValueFormat::Rfc3339 => DateTime::from_timestamp(*v, 0).map(rfc3339),
-            ValueFormat::EpochSeconds => Some(Value::from(*v)),
+            ValueFormat::EpochSeconds => Some(Value::from((*v).max(0))),
+            ValueFormat::EpochSecondsString => Some(Value::from((*v).max(0).to_string())),
         },
         ScalarValue::TimestampMillisecond(Some(v), _) => match format {
             ValueFormat::Verbatim => None,
             ValueFormat::Rfc3339 => DateTime::from_timestamp_millis(*v).map(rfc3339),
-            ValueFormat::EpochSeconds => Some(Value::from(v.div_euclid(1000))),
+            ValueFormat::EpochSeconds => Some(Value::from(v.div_euclid(1000).max(0))),
+            ValueFormat::EpochSecondsString => {
+                Some(Value::from(v.div_euclid(1000).max(0).to_string()))
+            }
         },
         ScalarValue::TimestampMicrosecond(Some(v), _) => match format {
             ValueFormat::Verbatim => None,
             ValueFormat::Rfc3339 => DateTime::from_timestamp_micros(*v).map(rfc3339),
-            ValueFormat::EpochSeconds => Some(Value::from(v.div_euclid(1_000_000))),
+            ValueFormat::EpochSeconds => Some(Value::from(v.div_euclid(1_000_000).max(0))),
+            ValueFormat::EpochSecondsString => {
+                Some(Value::from(v.div_euclid(1_000_000).max(0).to_string()))
+            }
         },
         ScalarValue::TimestampNanosecond(Some(v), _) => match format {
             ValueFormat::Verbatim => None,
             ValueFormat::Rfc3339 => Some(rfc3339(DateTime::from_timestamp_nanos(*v))),
-            ValueFormat::EpochSeconds => Some(Value::from(v.div_euclid(1_000_000_000))),
+            ValueFormat::EpochSeconds => Some(Value::from(v.div_euclid(1_000_000_000).max(0))),
+            ValueFormat::EpochSecondsString => {
+                Some(Value::from(v.div_euclid(1_000_000_000).max(0).to_string()))
+            }
         },
         _ => None,
     }
@@ -254,6 +312,20 @@ mod tests {
             input_field: "ts_from",
             fidelity: Fidelity::Inexact,
             value_format: ValueFormat::EpochSeconds,
+        },
+        FilterMapping {
+            column: "create_time",
+            operator: Operator::GtEq,
+            input_field: "startTime",
+            fidelity: Fidelity::Inexact,
+            value_format: ValueFormat::EpochSecondsString,
+        },
+        FilterMapping {
+            column: "completed",
+            operator: Operator::Eq,
+            input_field: "completed",
+            fidelity: Fidelity::Inexact,
+            value_format: ValueFormat::Verbatim,
         },
     ];
 
@@ -616,6 +688,99 @@ mod tests {
             assert_eq!(
                 translated.inputs,
                 vec![("ts_from".to_string(), Value::from(1_767_225_600i64))],
+            );
+            assert_eq!(
+                translated.pushdown,
+                vec![TableProviderFilterPushDown::Inexact]
+            );
+        }
+    }
+
+    #[test]
+    fn simplified_boolean_predicates_normalize_back_to_equality() {
+        // DataFusion's simplifier hands pushdown `completed` instead of
+        // `completed = true` and `NOT completed` instead of
+        // `completed = false`; both must still reach the mapped input —
+        // otherwise a boolean Eq mapping is dead code.
+        let translated = translate_filters(&[col("completed")], MAPPINGS);
+        assert_eq!(
+            translated.inputs,
+            vec![("completed".to_string(), Value::from(true))]
+        );
+        assert_eq!(
+            translated.pushdown,
+            vec![TableProviderFilterPushDown::Inexact]
+        );
+
+        let translated = translate_filters(&[Expr::Not(Box::new(col("completed")))], MAPPINGS);
+        assert_eq!(
+            translated.inputs,
+            vec![("completed".to_string(), Value::from(false))]
+        );
+
+        // A bare column without an Eq mapping stays local — and NOT over
+        // anything but a bare column is never translated.
+        let translated = translate_filters(&[col("value")], MAPPINGS);
+        assert!(translated.inputs.is_empty());
+        assert_eq!(
+            translated.pushdown,
+            vec![TableProviderFilterPushDown::Unsupported]
+        );
+        let translated = translate_filters(&[Expr::Not(Box::new(gt("value", 5)))], MAPPINGS);
+        assert!(translated.inputs.is_empty());
+    }
+
+    #[test]
+    fn pre_epoch_instants_clamp_to_zero_never_a_signed_string() {
+        // `create_time >= '1965-01-01'` would otherwise render "-157766400"
+        // — not a digit string, so a strict provider schema (Feishu's
+        // startTime) 400s and the whole scan fails where no pushdown at
+        // all would have succeeded. Zero is still a superset for the
+        // lower bounds these formats are restricted to.
+        let filter = Expr::BinaryExpr(BinaryExpr::new(
+            Box::new(col("create_time")),
+            Operator::GtEq,
+            Box::new(Expr::Literal(
+                ScalarValue::TimestampMillisecond(Some(-157_766_400_000), Some("UTC".into())),
+                None,
+            )),
+        ));
+        let translated = translate_filters(&[filter], MAPPINGS);
+        assert_eq!(
+            translated.inputs,
+            vec![("startTime".to_string(), Value::from("0"))],
+        );
+        assert_eq!(
+            translated.pushdown,
+            vec![TableProviderFilterPushDown::Inexact]
+        );
+    }
+
+    #[test]
+    fn epoch_seconds_string_mappings_render_digit_strings() {
+        // Feishu-style startTime: same flooring semantics as epoch_seconds,
+        // but the provider's strict schema types the input as a STRING —
+        // the rendered literal must be a JSON string of digits, never a
+        // number.
+        let epoch_ms = 1_767_225_600_000i64; // 2026-01-01T00:00:00Z
+        for scalar in [
+            ScalarValue::TimestampSecond(Some(epoch_ms / 1000), None),
+            ScalarValue::TimestampMillisecond(Some(epoch_ms), Some("UTC".into())),
+            ScalarValue::TimestampMicrosecond(Some(epoch_ms * 1000), None),
+            ScalarValue::TimestampNanosecond(Some(epoch_ms * 1_000_000), None),
+            // Sub-second precision floors — widening the lower bound,
+            // which Inexact re-filtering trims back.
+            ScalarValue::TimestampMillisecond(Some(epoch_ms + 999), None),
+        ] {
+            let filter = Expr::BinaryExpr(BinaryExpr::new(
+                Box::new(col("create_time")),
+                Operator::GtEq,
+                Box::new(Expr::Literal(scalar, None)),
+            ));
+            let translated = translate_filters(&[filter], MAPPINGS);
+            assert_eq!(
+                translated.inputs,
+                vec![("startTime".to_string(), Value::from("1767225600"))],
             );
             assert_eq!(
                 translated.pushdown,

--- a/crates/skardi/src/sources/providers/open_connector/json_to_arrow.rs
+++ b/crates/skardi/src/sources/providers/open_connector/json_to_arrow.rs
@@ -41,6 +41,20 @@ pub enum FieldType {
     /// would silently misparse them as millis (dates in January 1970).
     /// Strictly integers: fractional or string values fail with their kind.
     TimestampSecondsUtc,
+    /// JSON string of decimal digits carrying epoch **milliseconds** ↔
+    /// Arrow Timestamp(Millisecond, UTC). For Feishu-style APIs whose
+    /// `create_time` / `update_time` fields are millisecond epochs
+    /// serialized as STRINGS (`"1609296809000"`) — neither an RFC 3339
+    /// string nor a JSON number, so [`FieldType::TimestampMillisUtc`]
+    /// rejects them. Strictly ASCII-digit strings: anything else fails
+    /// with its kind or a shape description, never parses as zero.
+    TimestampMillisStringUtc,
+    /// JSON string of decimal digits carrying epoch **seconds** ↔ Arrow
+    /// Timestamp(Millisecond, UTC) — the seconds-as-string sibling of
+    /// [`FieldType::TimestampMillisStringUtc`] (Feishu wiki
+    /// `obj_create_time`), with the same strict digit-string rule and the
+    /// same overflow guard as [`FieldType::TimestampSecondsUtc`].
+    TimestampSecondsStringUtc,
     /// JSON array of strings ↔ Arrow List\<Utf8\>.
     Utf8List,
     /// JSON array of objects, each contributing the string under the given
@@ -63,7 +77,10 @@ impl FieldType {
             Self::UInt64 => DataType::UInt64,
             Self::Float64 => DataType::Float64,
             Self::Utf8 | Self::Json => DataType::Utf8,
-            Self::TimestampMillisUtc | Self::TimestampSecondsUtc => {
+            Self::TimestampMillisUtc
+            | Self::TimestampSecondsUtc
+            | Self::TimestampMillisStringUtc
+            | Self::TimestampSecondsStringUtc => {
                 DataType::Timestamp(TimeUnit::Millisecond, Some("UTC".into()))
             }
             Self::Utf8List | Self::Utf8ListFromObjectKey(_) => {
@@ -81,6 +98,8 @@ impl FieldType {
             Self::Utf8 => "string",
             Self::TimestampMillisUtc => "RFC 3339 timestamp or epoch millis",
             Self::TimestampSecondsUtc => "epoch-seconds timestamp",
+            Self::TimestampMillisStringUtc => "epoch-millis digit string",
+            Self::TimestampSecondsStringUtc => "epoch-seconds digit string",
             Self::Utf8List => "array of strings",
             Self::Utf8ListFromObjectKey(_) => "array of objects each carrying a string key",
             Self::Json => "any JSON value",
@@ -318,6 +337,24 @@ impl RowConverter {
                 )?)
                 .with_timezone("UTC"),
             )),
+            FieldType::TimestampMillisStringUtc => Ok(Arc::new(
+                TimestampMillisecondArray::from(collect_cells_described(
+                    &cells,
+                    spec,
+                    |v| parse_epoch_digit_string(v, 1),
+                    fail,
+                )?)
+                .with_timezone("UTC"),
+            )),
+            FieldType::TimestampSecondsStringUtc => Ok(Arc::new(
+                TimestampMillisecondArray::from(collect_cells_described(
+                    &cells,
+                    spec,
+                    |v| parse_epoch_digit_string(v, 1000),
+                    fail,
+                )?)
+                .with_timezone("UTC"),
+            )),
             FieldType::Utf8List => self.convert_string_list(field, &cells, page, None),
             FieldType::Utf8ListFromObjectKey(key) => {
                 self.convert_string_list(field, &cells, page, Some(key))
@@ -484,6 +521,25 @@ where
         }
     }
     Ok(out)
+}
+
+/// Digit-string epoch → epoch millis at the given scale (1 for
+/// millis-valued strings, 1000 for seconds-valued strings). Only
+/// non-empty ASCII-digit strings convert — an arbitrary string is shape
+/// drift and must fail with a description, never parse as zero.
+fn parse_epoch_digit_string(value: &Value, scale: i64) -> Result<i64, String> {
+    let Some(text) = value.as_str() else {
+        return Err(json_kind(value).to_string());
+    };
+    if text.is_empty() || !text.bytes().all(|b| b.is_ascii_digit()) {
+        return Err("a non-epoch string".to_string());
+    }
+    let epoch: i64 = text
+        .parse()
+        .map_err(|_| "an epoch out of range for millisecond timestamps".to_string())?;
+    epoch
+        .checked_mul(scale)
+        .ok_or_else(|| "an epoch out of range for millisecond timestamps".to_string())
 }
 
 /// RFC 3339 string or epoch-millis number → epoch millis.
@@ -918,6 +974,100 @@ mod tests {
                     err,
                     OpenConnectorError::ConversionFailed { found: ref f, ref expected, .. }
                         if f == found && expected == "epoch-seconds timestamp"
+                ),
+                "got {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn epoch_digit_strings_convert_at_both_scales_and_reject_other_shapes() {
+        // Feishu-style timestamps are DIGIT STRINGS — millis for im
+        // (`create_time: "1609296809000"`), seconds for wiki
+        // (`obj_create_time: "1642402790"`). Each variant converts only
+        // non-empty ASCII-digit strings; numbers, RFC 3339 strings, and
+        // arbitrary text fail with their kind or shape — never parse as
+        // zero.
+        let converter = RowConverter::new(&[
+            FieldMapping {
+                name: "create_time",
+                path: "create_time",
+                field_type: FieldType::TimestampMillisStringUtc,
+                nullable: true,
+            },
+            FieldMapping {
+                name: "obj_create_time",
+                path: "obj_create_time",
+                field_type: FieldType::TimestampSecondsStringUtc,
+                nullable: true,
+            },
+        ])
+        .unwrap();
+
+        let batch = converter
+            .convert(
+                &[
+                    serde_json::json!({
+                        "create_time": "1735689600000", // 2025-01-01T00:00:00Z
+                        "obj_create_time": "1735689600",
+                    }),
+                    serde_json::json!({"create_time": null}),
+                ],
+                1,
+            )
+            .unwrap();
+        for column in [0, 1] {
+            let ts = batch
+                .column(column)
+                .as_any()
+                .downcast_ref::<TimestampMillisecondArray>()
+                .unwrap();
+            assert_eq!(ts.value(0), 1_735_689_600_000);
+            assert!(ts.is_null(1), "null and absent keys stay NULL");
+        }
+
+        for (bad, found, expected) in [
+            // A JSON number is the OTHER spelling — accepting it here
+            // would blur the two variants' contracts.
+            (
+                serde_json::json!({"create_time": 1735689600000_i64}),
+                "number",
+                "epoch-millis digit string",
+            ),
+            (
+                serde_json::json!({"create_time": "2025-01-01T00:00:00Z"}),
+                "a non-epoch string",
+                "epoch-millis digit string",
+            ),
+            (
+                serde_json::json!({"create_time": ""}),
+                "a non-epoch string",
+                "epoch-millis digit string",
+            ),
+            (
+                serde_json::json!({"obj_create_time": "-5"}),
+                "a non-epoch string",
+                "epoch-seconds digit string",
+            ),
+            // Overflow is its own diagnosis, at both the parse and the
+            // seconds→millis scale step.
+            (
+                serde_json::json!({"obj_create_time": "99999999999999999999"}),
+                "an epoch out of range for millisecond timestamps",
+                "epoch-seconds digit string",
+            ),
+            (
+                serde_json::json!({"obj_create_time": i64::MAX.to_string()}),
+                "an epoch out of range for millisecond timestamps",
+                "epoch-seconds digit string",
+            ),
+        ] {
+            let err = converter.convert(&[bad], 1).unwrap_err();
+            assert!(
+                matches!(
+                    err,
+                    OpenConnectorError::ConversionFailed { found: ref f, expected: ref e, .. }
+                        if f == found && e == expected
                 ),
                 "got {err}"
             );

--- a/crates/skardi/src/sources/providers/open_connector/packs/feishu.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/feishu.rs
@@ -1,0 +1,1039 @@
+//! Feishu source pack: stable relational contracts over the Open Connector
+//! `feishu.*` read actions (OAuth user_access_token, cursor pagination).
+//!
+//! **The wire contract is Open Connector's HYBRID shape.** Every feishu
+//! list executor rebuilds the pagination envelope — camelCase `$.items` /
+//! `$.pageToken` / `$.hasMore`, with the provider's `page_token`
+//! normalized to a null `pageToken` at end-of-collection — while passing
+//! the Feishu API's item objects through RAW (`optionalObjectArray(...)`
+//! / `Array.isArray(...)` in the executors, no per-item rebuild). Rows
+//! therefore keep Feishu's snake_case keys and its epoch-digit-STRING
+//! timestamps: millis for im and tasks (`create_time: "1609296809000"`,
+//! `completed_at: "1780322529638"`), seconds for wiki
+//! (`obj_create_time: "1642402790"`) — the reason
+//! `TimestampMillisStringUtc` / `TimestampSecondsStringUtc` exist.
+//! Inputs are Open Connector's camelCase strict schemas (`pageSize`,
+//! `pageToken` with `minLength: 1`, `chatId`, …). Everything below is
+//! reconciled against a live gateway (v1.3.3) and the OC provider
+//! source.
+//!
+//! Design decisions, per the integration design spec and the source-pack
+//! admission gate:
+//!
+//! - **Cursor pagination on every table** (`pageToken` in, top-level
+//!   `$.pageToken` out; page size 100 for chats/chat_members/tasks, 50
+//!   for wiki — and 50 for `messages`, whose REAL wire cap is 50 despite
+//!   the schema's declared 100: Feishu hard-fails larger values with
+//!   99992402, live-verified 2026-08-04), with `$.hasMore` declared as
+//!   the AUTHORITATIVE
+//!   termination signal (`has_more_path`). That is a live-verification
+//!   correction, not a nicety: Feishu's wiki space listing answers its
+//!   final page with `has_more: false` beside a NON-empty `page_token`
+//!   (`"0||…"`, captured 2026-08-04), so the null-token spelling alone
+//!   would refetch a finished scan and die as `PaginationLoop`. With the
+//!   signal declared, `hasMore: true` without a usable token is contract
+//!   drift (`PaginationCursorInvalid`), a non-boolean signal is
+//!   `PaginationHasMoreInvalid` — never a silent truncation. No feishu
+//!   executor filters fetched pages, so the signals are undamaged.
+//! - **Orderings are pinned for cursor stability**: `chats` and
+//!   `messages` pin `sortType: ByCreateTimeAsc` because the API's
+//!   activity-ordered default reshuffles rows mid-scan (skips and
+//!   duplicates across pages); creation order is immutable.
+//! - **`messages` is chat history**: `containerIdType` pinned to `chat`
+//!   (threads are a different action), the chat itself a required
+//!   binding resource — the per-container shape Notion's
+//!   `block_children` established. One filter pushes: `create_time >=`
+//!   → `startTime`, inclusive epoch seconds typed as a digit STRING in
+//!   the strict schema (the reason `ValueFormat::EpochSecondsString`
+//!   exists), `Inexact` so DataFusion re-trims the floored bound.
+//!   `endTime` is deliberately unmapped: it is EXCLUSIVE, and flooring
+//!   an upper bound drops rows.
+//! - **`tasks` pins `type: my_tasks`** (the executor default, declared
+//!   rather than inherited) and omits the action's `completed` input —
+//!   Feishu's state=all. Live rows (2026-08-04) carry NO `completed`
+//!   boolean: completion is `status` (todo|done) plus `completed_at`,
+//!   whose "not completed" spelling is the digit string "0" (epoch-zero
+//!   sentinel, documented at the column). The `completed` input is
+//!   therefore deliberately unmapped — a `status` string cannot render
+//!   into a boolean input without a value transform the filter engine
+//!   deliberately lacks, and a mapping on an always-NULL draft column
+//!   would have re-trimmed every row to zero.
+//! - **`wiki_nodes` lists ONE level** (children of `parentNodeToken`,
+//!   space root when omitted) — the action's own shape; full-tree
+//!   traversal is client-side recursion, documented in the pack doc.
+//! - **In-band provider errors never reach rows**: executors throw on
+//!   Feishu's non-zero `code` envelope, so the gateway returns a failure
+//!   envelope and `error_path` is `None` for every table.
+//! - **Fingerprints are pinned** from the live capture
+//!   (`fixtures/feishu/contracts/`), but the gateway declares every
+//!   item schema LOOSE (`additionalProperties: true`, zero declared
+//!   properties) — so ALL mapped columns ride passthrough outside the
+//!   fingerprint gate, and the coverage-gap pin records that honestly.
+//!   Column truth is therefore settled ONLY by real rows, and ALL SIX
+//!   tables are reconciled against a live workspace (2026-08-04; every
+//!   fixture is a redacted live capture). What the pass changed: chats
+//!   gained `chat_mode`/`chat_status`; tasks lost the nonexistent
+//!   `completed` boolean for `status`/`completed_at`; wiki tables
+//!   gained `open_sharing`/`creator`/`url`; messages' page size dropped
+//!   to the real 50 cap. Two operational findings the pack doc records:
+//!   reading messages under the user identity requires the
+//!   `im:message:readonly` (or `im:message` /
+//!   `im:message.history:readonly`) scope — the `get_as_user` scopes
+//!   the gateway's actions declare are NOT honored for this path
+//!   (99991679 names the real set) — plus the app's bot capability
+//!   (232025). `message_position` (a digit string on every live row) is
+//!   deliberately unmapped: no public Feishu doc pins its semantics.
+//!   Live e2e evidence: 86 messages over two real cursor pages with
+//!   zero duplicate ids; the `create_time >=` pushdown narrowing a
+//!   live scan; wiki's non-empty final token terminating cleanly.
+
+use std::sync::OnceLock;
+
+use crate::sources::providers::open_connector::error::OpenConnectorError;
+use crate::sources::providers::open_connector::source_pack::SourcePack;
+
+use super::loader;
+
+static PACK: OnceLock<Result<SourcePack, String>> = OnceLock::new();
+
+/// The Feishu pack, parsed once from the embedded YAML asset.
+pub fn pack() -> Result<&'static SourcePack, OpenConnectorError> {
+    loader::builtin("feishu.yaml", include_str!("feishu.yaml"), &PACK)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sources::hierarchy::HierarchyLevel;
+    use crate::sources::providers::open_connector::action_registry::fingerprint_schema;
+    use crate::sources::providers::open_connector::json_to_arrow::RowConverter;
+    use crate::sources::providers::open_connector::row_path::RowPath;
+    use crate::sources::providers::open_connector::source_pack::SourcePackTable;
+    use crate::sources::providers::open_connector::testutil::{
+        EnvVarGuard, MockGateway, MockResponse, discovery_ok, envelope_ok,
+        fingerprint_uncovered_columns,
+    };
+    use crate::sources::providers::open_connector::{
+        OpenConnectorConfig, OpenConnectorGateways, register_open_connector_tables,
+        register_open_connector_udtfs,
+    };
+    use arrow::array::{Array, BooleanArray, StringArray, TimestampMillisecondArray};
+    use arrow::record_batch::RecordBatch;
+    use datafusion::prelude::SessionContext;
+    use serde_json::{Value, json};
+
+    /// Look up a table by short name; the assets are test-pinned to parse.
+    fn table(short: &str) -> &'static SourcePackTable {
+        pack()
+            .expect("embedded asset is test-pinned to parse")
+            .tables
+            .iter()
+            .find(|t| t.id.rsplit('.').next() == Some(short))
+            .unwrap_or_else(|| panic!("table {short}"))
+    }
+
+    /// Discovery serving the live-captured contracts, so every mock
+    /// registration exercises the fingerprint gate's pass side.
+    fn feishu_discovery(path: &str) -> MockResponse {
+        let output_schema = if path.ends_with("feishu.list_chats") {
+            include_str!("fixtures/feishu/contracts/list_chats.json")
+        } else if path.ends_with("feishu.list_messages") {
+            include_str!("fixtures/feishu/contracts/list_messages.json")
+        } else if path.ends_with("feishu.list_chat_members") {
+            include_str!("fixtures/feishu/contracts/list_chat_members.json")
+        } else if path.ends_with("feishu.list_tasks") {
+            include_str!("fixtures/feishu/contracts/list_tasks.json")
+        } else if path.ends_with("feishu.list_wiki_spaces") {
+            include_str!("fixtures/feishu/contracts/list_wiki_spaces.json")
+        } else if path.ends_with("feishu.list_wiki_nodes") {
+            include_str!("fixtures/feishu/contracts/list_wiki_nodes.json")
+        } else {
+            r#"{"type": "object"}"#
+        };
+        MockResponse::ok(&discovery_ok("{}", output_schema, true, None))
+    }
+
+    // ── Contract tests: bundled fixtures are the build-time conversion
+    // contract (null-bearing, nested, empty, extra upstream fields, and a
+    // schema mismatch per the admission gate). DRAFT status: synthetic,
+    // re-derived from live captures in the real-data phase. ─────────────
+
+    fn convert_fixture(table: &SourcePackTable, fixture: &str) -> RecordBatch {
+        let page: Value = serde_json::from_str(fixture).expect("fixture parses");
+        let rows = RowPath::parse(table.row_path)
+            .expect("row path")
+            .rows(&page, 1)
+            .expect("row array");
+        RowConverter::new(table.fields)
+            .expect("converter")
+            .convert(rows, 1)
+            .expect("fixture converts")
+    }
+
+    fn utf8<'a>(batch: &'a RecordBatch, name: &str) -> &'a StringArray {
+        batch
+            .column_by_name(name)
+            .unwrap_or_else(|| panic!("column {name}"))
+            .as_any()
+            .downcast_ref()
+            .expect("Utf8 column")
+    }
+
+    fn boolean<'a>(batch: &'a RecordBatch, name: &str) -> &'a BooleanArray {
+        batch
+            .column_by_name(name)
+            .unwrap_or_else(|| panic!("column {name}"))
+            .as_any()
+            .downcast_ref()
+            .expect("Boolean column")
+    }
+
+    fn millis<'a>(batch: &'a RecordBatch, name: &str) -> &'a TimestampMillisecondArray {
+        batch
+            .column_by_name(name)
+            .unwrap_or_else(|| panic!("column {name}"))
+            .as_any()
+            .downcast_ref()
+            .expect("Timestamp column")
+    }
+
+    #[test]
+    fn chats_fixture_converts_live_shapes() {
+        // Redacted live capture (2026-08-04): an assistant chat without an
+        // owner, an internal group with an EMPTY description, and a topic
+        // chat.
+        let batch = convert_fixture(table("chats"), include_str!("fixtures/feishu/chats.json"));
+        assert_eq!(batch.num_rows(), 3);
+        assert_eq!(utf8(&batch, "id").value(0), "oc_0001");
+        // The assistant chat carries no owner_id at all — absence lands as
+        // SQL NULL while its neighbors keep theirs.
+        assert!(utf8(&batch, "owner_id").is_null(0));
+        assert!(!utf8(&batch, "owner_id").is_null(1));
+        // An empty description is DATA, preserved verbatim, never coerced
+        // to NULL.
+        assert_eq!(utf8(&batch, "description").value(1), "");
+        assert_eq!(utf8(&batch, "chat_mode").value(2), "topic");
+        assert_eq!(utf8(&batch, "chat_status").value(0), "normal");
+        assert!(boolean(&batch, "external").value(0));
+        assert!(!boolean(&batch, "external").value(1));
+    }
+
+    #[test]
+    fn messages_fixture_converts_digit_string_times_and_nested_content() {
+        // Redacted live capture (2026-08-04), one row per verified field
+        // family: a system message (empty-string sender ids — data, not
+        // NULL), a reply (root_id), a topic-group message (thread_id),
+        // and an @-mention (mentions array).
+        let batch = convert_fixture(
+            table("messages"),
+            include_str!("fixtures/feishu/messages.json"),
+        );
+        assert_eq!(batch.num_rows(), 4);
+        assert_eq!(utf8(&batch, "id").value(0), "om_0002");
+        // Epoch-millis digit strings become real timestamps.
+        assert_eq!(millis(&batch, "create_time").value(0), 1_593_441_000_000);
+        // body.content stays the provider's own JSON-encoded string, whose
+        // inner shape varies by msg_type (a system template here).
+        let content: Value =
+            serde_json::from_str(utf8(&batch, "content").value(0)).expect("valid inner JSON");
+        assert!(content.get("template").is_some(), "system-message payload");
+        // sender survives as opaque JSON; a system message's sender ids
+        // are EMPTY STRINGS on the wire, preserved verbatim.
+        let sender: Value =
+            serde_json::from_str(utf8(&batch, "sender").value(0)).expect("valid JSON");
+        assert_eq!(sender["sender_type"], "");
+        assert_eq!(
+            serde_json::from_str::<Value>(utf8(&batch, "sender").value(1)).unwrap()["sender_type"],
+            "user"
+        );
+        // Reply / thread / mention fields: absent on most rows (SQL NULL),
+        // real on the rows that carry them.
+        assert!(utf8(&batch, "root_id").is_null(0));
+        assert_eq!(utf8(&batch, "root_id").value(1), "om_0005");
+        assert_eq!(utf8(&batch, "thread_id").value(2), "omt_0009");
+        assert!(utf8(&batch, "mentions").is_null(0));
+        let mentions: Value =
+            serde_json::from_str(utf8(&batch, "mentions").value(3)).expect("valid JSON");
+        assert_eq!(mentions[0]["key"], "@_user_1");
+    }
+
+    #[test]
+    fn tasks_fixture_converts_status_and_the_epoch_zero_sentinel() {
+        // Redacted live capture (2026-08-04): completion is `status`
+        // (todo|done) plus `completed_at` — there is NO `completed`
+        // boolean on the wire, which is why that draft column is gone.
+        let batch = convert_fixture(table("tasks"), include_str!("fixtures/feishu/tasks.json"));
+        assert_eq!(batch.num_rows(), 3);
+        assert_eq!(utf8(&batch, "status").value(0), "todo");
+        assert_eq!(utf8(&batch, "status").value(2), "done");
+        // Feishu spells "not completed" as "0" — the epoch-zero sentinel
+        // the YAML documents; a done task carries a real instant.
+        assert_eq!(millis(&batch, "completed_at").value(0), 0);
+        assert_eq!(millis(&batch, "completed_at").value(2), 1_780_322_529_638);
+        assert_eq!(millis(&batch, "created_at").value(0), 1_775_202_331_888);
+        // No fixture row carries a `due` key at all (the live pass saw it
+        // on 2 of 9 rows; none survived the redacted subset) — ABSENT
+        // decodes to SQL NULL; the column itself is doc-derived, as the
+        // YAML notes. members survive as opaque JSON.
+        assert!(utf8(&batch, "due").is_null(0));
+        let members: Value =
+            serde_json::from_str(utf8(&batch, "members").value(0)).expect("valid JSON");
+        assert!(members.is_array());
+    }
+
+    #[test]
+    fn fixtures_stay_redacted_one_json_level_deep() {
+        // Round-2 review blind spot: real member names survived inside the
+        // JSON-encoded `body.content` payload — strings one decode level
+        // BELOW the outer tree the redaction pass walked. Two tripwires:
+        // no CJK text anywhere in any feishu fixture (the live workspace's
+        // real names were Chinese), and every membership entry inside a
+        // decoded message payload is a `member-NNNN` placeholder.
+        let fixtures = [
+            (
+                "chat_members",
+                include_str!("fixtures/feishu/chat_members.json"),
+            ),
+            ("chats", include_str!("fixtures/feishu/chats.json")),
+            (
+                "chats_type_mismatch",
+                include_str!("fixtures/feishu/chats_type_mismatch.json"),
+            ),
+            ("messages", include_str!("fixtures/feishu/messages.json")),
+            ("tasks", include_str!("fixtures/feishu/tasks.json")),
+            (
+                "wiki_nodes",
+                include_str!("fixtures/feishu/wiki_nodes.json"),
+            ),
+            (
+                "wiki_spaces",
+                include_str!("fixtures/feishu/wiki_spaces.json"),
+            ),
+        ];
+        for (name, text) in fixtures {
+            assert!(
+                !text.chars().any(|c| ('\u{4e00}'..='\u{9fff}').contains(&c)),
+                "{name}.json: CJK text survived redaction"
+            );
+        }
+
+        let messages: Value =
+            serde_json::from_str(include_str!("fixtures/feishu/messages.json")).expect("json");
+        let mut audited = 0;
+        for item in messages["items"].as_array().expect("items") {
+            let Some(content) = item["body"]["content"].as_str() else {
+                continue;
+            };
+            let Ok(inner) = serde_json::from_str::<Value>(content) else {
+                continue;
+            };
+            for key in ["from_user", "to_chatters"] {
+                let Some(entries) = inner.get(key).and_then(Value::as_array) else {
+                    continue;
+                };
+                for entry in entries {
+                    let member = entry.as_str().unwrap_or_default();
+                    let placeholder = member
+                        .strip_prefix("member-")
+                        .is_some_and(|d| !d.is_empty() && d.bytes().all(|b| b.is_ascii_digit()));
+                    assert!(
+                        placeholder,
+                        "messages.json: '{member}' in {key} is not a member-NNNN placeholder"
+                    );
+                    audited += 1;
+                }
+            }
+        }
+        assert!(audited >= 3, "the audit reached the nested payloads");
+    }
+
+    #[test]
+    fn wiki_nodes_fixture_converts_epoch_second_strings() {
+        // Redacted live capture (2026-08-04).
+        let batch = convert_fixture(
+            table("wiki_nodes"),
+            include_str!("fixtures/feishu/wiki_nodes.json"),
+        );
+        assert_eq!(batch.num_rows(), 3);
+        // Epoch-SECONDS digit strings scale to millis.
+        assert_eq!(
+            millis(&batch, "obj_create_time").value(0),
+            1_636_114_726_000
+        );
+        assert!(!boolean(&batch, "has_child").value(0));
+        // Feishu spells "no parent" as the empty string — that is data,
+        // preserved verbatim, not coerced to NULL.
+        assert_eq!(utf8(&batch, "parent_node_token").value(0), "");
+        assert!(utf8(&batch, "creator").value(0).starts_with("ou_"));
+        assert!(utf8(&batch, "url").value(0).starts_with("https://"));
+    }
+
+    #[test]
+    fn chat_members_and_wiki_spaces_fixtures_convert() {
+        let members = convert_fixture(
+            table("chat_members"),
+            include_str!("fixtures/feishu/chat_members.json"),
+        );
+        // Redacted live capture (2026-08-04): the wire carries exactly the
+        // four mapped columns, every one populated.
+        assert_eq!(members.num_rows(), 2);
+        assert_eq!(utf8(&members, "member_id").value(0), "ou_0003");
+        assert_eq!(utf8(&members, "member_id_type").value(0), "open_id");
+        assert!(!utf8(&members, "name").is_null(1));
+
+        let spaces = convert_fixture(
+            table("wiki_spaces"),
+            include_str!("fixtures/feishu/wiki_spaces.json"),
+        );
+        // Redacted live capture (2026-08-04): note the envelope carries a
+        // NON-empty pageToken beside hasMore:false — the shape the
+        // has_more_path termination exists for, pinned end to end by
+        // `wiki_spaces_terminate_on_has_more_false_despite_a_token`.
+        assert_eq!(spaces.num_rows(), 1);
+        assert_eq!(utf8(&spaces, "space_id").value(0), "700000038");
+        assert_eq!(utf8(&spaces, "open_sharing").value(0), "closed");
+    }
+
+    #[test]
+    fn chats_mismatch_fixture_fails_with_the_targeted_error() {
+        // Admission-gate schema-mismatch fixture: a number where Utf8 is
+        // declared fails with the full row-scoped identity, never a quiet
+        // null and never the offending value.
+        let page: Value =
+            serde_json::from_str(include_str!("fixtures/feishu/chats_type_mismatch.json"))
+                .expect("fixture parses");
+        let t = table("chats");
+        let rows = RowPath::parse(t.row_path)
+            .expect("row path")
+            .rows(&page, 1)
+            .expect("row array");
+        let err = RowConverter::new(t.fields)
+            .expect("converter")
+            .convert(rows, 1)
+            .expect_err("a number where Utf8 is declared must fail conversion");
+        match err {
+            OpenConnectorError::ConversionFailed {
+                column,
+                page,
+                row,
+                found,
+                ..
+            } => {
+                assert_eq!(column, "id");
+                assert_eq!(page, 1);
+                assert_eq!(row, 1, "the valid first row converts");
+                assert_eq!(found, "number");
+            }
+            other => panic!("expected ConversionFailed, got {other}"),
+        }
+    }
+
+    #[test]
+    fn pinned_fingerprints_match_the_reconciled_contracts() {
+        // Pin <-> captured-contract lock through the SAME function
+        // registration uses; the mismatch output is also how pins are
+        // (re)taken after an upstream upgrade.
+        let contracts = [
+            (
+                "chats",
+                include_str!("fixtures/feishu/contracts/list_chats.json"),
+            ),
+            (
+                "messages",
+                include_str!("fixtures/feishu/contracts/list_messages.json"),
+            ),
+            (
+                "chat_members",
+                include_str!("fixtures/feishu/contracts/list_chat_members.json"),
+            ),
+            (
+                "tasks",
+                include_str!("fixtures/feishu/contracts/list_tasks.json"),
+            ),
+            (
+                "wiki_spaces",
+                include_str!("fixtures/feishu/contracts/list_wiki_spaces.json"),
+            ),
+            (
+                "wiki_nodes",
+                include_str!("fixtures/feishu/contracts/list_wiki_nodes.json"),
+            ),
+        ];
+        let mut mismatches = Vec::new();
+        for (short, contract) in contracts {
+            let schema: Value = serde_json::from_str(contract).expect("contract fixture parses");
+            let actual = fingerprint_schema(Some(&schema));
+            let t = table(short);
+            if t.expected_fingerprint != Some(actual.as_str()) {
+                mismatches.push(format!(
+                    "{}: pinned {:?}, contract fixture hashes to {actual}",
+                    t.id, t.expected_fingerprint
+                ));
+            }
+        }
+        assert!(mismatches.is_empty(), "{}", mismatches.join("\n"));
+    }
+
+    #[test]
+    fn fingerprint_coverage_gap_is_pinned() {
+        // The gateway declares every feishu items schema LOOSE (zero
+        // declared properties, additionalProperties: true), so EVERY
+        // mapped column of EVERY table rides passthrough — outside the
+        // fingerprint gate, drift surfacing at scan time per conversion
+        // rules. Pinned so any change is a conscious decision; the
+        // real-data phase is what actually vouches for these columns.
+        for short in [
+            "chats",
+            "messages",
+            "chat_members",
+            "tasks",
+            "wiki_spaces",
+            "wiki_nodes",
+        ] {
+            let t = table(short);
+            let contract = match short {
+                "chats" => include_str!("fixtures/feishu/contracts/list_chats.json"),
+                "messages" => include_str!("fixtures/feishu/contracts/list_messages.json"),
+                "chat_members" => include_str!("fixtures/feishu/contracts/list_chat_members.json"),
+                "tasks" => include_str!("fixtures/feishu/contracts/list_tasks.json"),
+                "wiki_spaces" => include_str!("fixtures/feishu/contracts/list_wiki_spaces.json"),
+                "wiki_nodes" => include_str!("fixtures/feishu/contracts/list_wiki_nodes.json"),
+                other => panic!("table {other}"),
+            };
+            let all_columns: Vec<&str> = t.fields.iter().map(|f| f.name).collect();
+            assert_eq!(
+                fingerprint_uncovered_columns(contract, t.row_path, t.fields),
+                all_columns,
+                "every {short} column is expected to be uncovered (loose item schema)"
+            );
+        }
+    }
+
+    // ── Integration: the pack against a mock gateway, end to end. ───────
+
+    fn feishu_config(token_env: &str, tables: &str) -> OpenConnectorConfig {
+        // Resources are declared only where a table requires them;
+        // sending one to a binding without that table trips the
+        // undeclared-resource guard.
+        let resource = if tables.contains("messages") {
+            "resource: { containerId: oc_root }"
+        } else if tables.contains("chat_members") {
+            "resource: { chatId: oc_root }"
+        } else if tables.contains("wiki_nodes") {
+            "resource: { spaceId: sp_root }"
+        } else {
+            ""
+        };
+        serde_yaml::from_str(&format!(
+            r#"
+runtime_token_env: {token_env}
+bindings:
+  - name: ws
+    source_pack: feishu
+    {resource}
+    tables: [{tables}]
+"#
+        ))
+        .expect("config parses")
+    }
+
+    async fn setup_with_gateway(
+        gateway: MockGateway,
+        token_env: &'static str,
+        tables: &str,
+    ) -> (MockGateway, SessionContext) {
+        let _token = EnvVarGuard::set(token_env, "test-token");
+        let gateways = OpenConnectorGateways::default();
+        let mut ctx = SessionContext::new();
+        register_open_connector_tables(
+            &mut ctx,
+            "saas",
+            &gateway.url,
+            Some(&feishu_config(token_env, tables)),
+            false,
+            HierarchyLevel::Catalog,
+            Some(&gateways),
+        )
+        .await
+        .expect("gateway registration succeeds");
+        register_open_connector_udtfs(&ctx, gateways).expect("UDTF registration succeeds");
+        (gateway, ctx)
+    }
+
+    async fn collect(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch> {
+        ctx.sql(sql)
+            .await
+            .expect("plan")
+            .collect()
+            .await
+            .expect("collect")
+    }
+
+    fn ids_of(batches: &[RecordBatch]) -> Vec<String> {
+        batches
+            .iter()
+            .flat_map(|batch| {
+                let ids = batch
+                    .column_by_name("id")
+                    .expect("id column")
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .expect("Utf8 ids")
+                    .clone();
+                (0..ids.len()).map(move |i| ids.value(i).to_string())
+            })
+            .collect()
+    }
+
+    fn execute_inputs(gateway: &MockGateway) -> Vec<Value> {
+        gateway
+            .requests()
+            .into_iter()
+            .filter(|r| r.method == "POST")
+            .map(|r| {
+                serde_json::from_str::<Value>(&r.body).expect("request body is JSON")["input"]
+                    .clone()
+            })
+            .collect()
+    }
+
+    fn chat_row(id: &str) -> Value {
+        json!({"chat_id": id, "name": id})
+    }
+
+    #[tokio::test]
+    async fn chats_cursor_scan_pins_ordering_and_pages_with_null_token_termination() {
+        // Two-page cursor scan pinning CHATS' wire declarations: no
+        // pageToken on page 1, the stub's token afterwards, pageSize 100
+        // and the ByCreateTimeAsc pin on every request, null-token
+        // termination, row identity across pages.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return feishu_discovery(&req.path);
+            }
+            if req.method == "POST" && req.path == "/v1/actions/feishu.list_chats" {
+                let body: Value = serde_json::from_str(&req.body).unwrap_or_default();
+                let page = match body["input"].get("pageToken").and_then(Value::as_str) {
+                    None => json!({"items": [chat_row("oc-1"), chat_row("oc-2")],
+                                    "pageToken": "tok-2", "hasMore": true}),
+                    Some("tok-2") => json!({"items": [chat_row("oc-3")],
+                                             "pageToken": null, "hasMore": false}),
+                    Some(other) => return MockResponse::new(400, &format!("bad token {other}")),
+                };
+                return MockResponse::ok(&envelope_ok(&page.to_string()));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (gateway, ctx) =
+            setup_with_gateway(gateway, "SKARDI_TEST_OC_FEISHU_CHATS", "chats").await;
+
+        let batches = collect(&ctx, "SELECT id FROM saas.ws.chats ORDER BY id").await;
+        assert_eq!(ids_of(&batches), vec!["oc-1", "oc-2", "oc-3"]);
+
+        let inputs = execute_inputs(&gateway);
+        assert_eq!(inputs.len(), 2, "two cursor pages");
+        assert!(inputs[0].get("pageToken").is_none(), "{}", inputs[0]);
+        assert_eq!(inputs[1]["pageToken"], "tok-2");
+        for input in &inputs {
+            assert_eq!(input["pageSize"], 100, "page-size hint: {input}");
+            assert_eq!(
+                input["sortType"], "ByCreateTimeAsc",
+                "ordering pin: {input}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn messages_push_start_time_as_digit_string_with_pinned_container() {
+        // The messages table's whole wire declaration in one scan: the
+        // chat container pin + resource forwarding, the ByCreateTimeAsc
+        // pin, and the create_time >= pushdown rendered as EPOCH-SECONDS
+        // DIGIT STRING under the strict schema — plus the no-pushdown
+        // guard (requests carry exactly the declared inputs).
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return feishu_discovery(&req.path);
+            }
+            if req.method == "POST" && req.path == "/v1/actions/feishu.list_messages" {
+                return MockResponse::ok(&envelope_ok(
+                    &json!({"items": [
+                        {"message_id": "om-1", "create_time": "1735689600000"},
+                        {"message_id": "om-2", "create_time": "1704067200000"}],
+                        "pageToken": null, "hasMore": false})
+                    .to_string(),
+                ));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (gateway, ctx) =
+            setup_with_gateway(gateway, "SKARDI_TEST_OC_FEISHU_MSGS", "messages").await;
+
+        let batches = collect(
+            &ctx,
+            "SELECT id FROM saas.ws.messages \
+             WHERE create_time >= TIMESTAMP '2025-01-01T00:00:00Z'",
+        )
+        .await;
+        // Inexact pushdown: DataFusion re-trims, so only the matching row
+        // survives even though the stub returned both.
+        assert_eq!(ids_of(&batches), vec!["om-1"]);
+
+        let inputs = execute_inputs(&gateway);
+        assert_eq!(inputs.len(), 1);
+        let input = &inputs[0];
+        assert_eq!(input["containerIdType"], "chat", "container kind pin");
+        assert_eq!(input["containerId"], "oc_root", "resource forwarded");
+        assert_eq!(input["sortType"], "ByCreateTimeAsc");
+        assert_eq!(
+            input["pageSize"], 50,
+            "Feishu's im/v1/messages caps page_size at 50 on the wire \
+             (99992402 above it), despite the schema's declared 100"
+        );
+        assert_eq!(
+            input["startTime"], "1735689600",
+            "epoch seconds as a digit STRING, not a number"
+        );
+        let mut keys: Vec<&str> = input
+            .as_object()
+            .expect("input object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            vec![
+                "containerId",
+                "containerIdType",
+                "pageSize",
+                "sortType",
+                "startTime"
+            ],
+            "exactly the declared inputs, nothing else"
+        );
+    }
+
+    #[tokio::test]
+    async fn tasks_pin_their_population_and_keep_status_predicates_local() {
+        // The action HAS a `completed` boolean input, but real rows carry
+        // `status` (todo|done) and no boolean — so nothing is mapped and a
+        // status predicate must run entirely in DataFusion while the
+        // request carries exactly the pins and pagination, nothing else.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return feishu_discovery(&req.path);
+            }
+            if req.method == "POST" && req.path == "/v1/actions/feishu.list_tasks" {
+                return MockResponse::ok(&envelope_ok(
+                    &json!({"items": [
+                        {"guid": "t-1", "status": "done"},
+                        {"guid": "t-2", "status": "todo"}],
+                        "pageToken": null, "hasMore": false})
+                    .to_string(),
+                ));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (gateway, ctx) =
+            setup_with_gateway(gateway, "SKARDI_TEST_OC_FEISHU_TASKS", "tasks").await;
+
+        let batches = collect(&ctx, "SELECT guid FROM saas.ws.tasks WHERE status = 'done'").await;
+        let guids: Vec<String> = batches
+            .iter()
+            .flat_map(|b| {
+                let col = b
+                    .column_by_name("guid")
+                    .expect("guid")
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .expect("Utf8")
+                    .clone();
+                (0..col.len()).map(move |i| col.value(i).to_string())
+            })
+            .collect();
+        assert_eq!(guids, vec!["t-1"], "status filtering happened locally");
+
+        let input = &execute_inputs(&gateway)[0];
+        assert_eq!(input["type"], "my_tasks", "population pin");
+        let mut keys: Vec<&str> = input
+            .as_object()
+            .expect("input object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            vec!["pageSize", "type"],
+            "the status predicate is not pushed and no `completed` input is invented"
+        );
+        assert_eq!(input["pageSize"], 100, "declared page size rides the wire");
+    }
+
+    #[tokio::test]
+    async fn wiki_spaces_terminate_on_has_more_false_despite_a_token() {
+        // The live wire shape this pack's has_more_path exists for
+        // (captured 2026-08-04): Feishu wiki answers the FINAL page with
+        // hasMore:false but a NON-empty pageToken ("0||…"). Null-token
+        // termination alone would refetch that token and fail as a
+        // PaginationLoop; the has-more signal must end the scan after one
+        // request.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return feishu_discovery(&req.path);
+            }
+            if req.method == "POST" && req.path == "/v1/actions/feishu.list_wiki_spaces" {
+                return MockResponse::ok(&envelope_ok(
+                    &json!({"items": [{"space_id": "700000038", "name": "s"}],
+                             "pageToken": "0||7000000000000000001", "hasMore": false})
+                    .to_string(),
+                ));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (gateway, ctx) =
+            setup_with_gateway(gateway, "SKARDI_TEST_OC_FEISHU_WIKI_HM", "wiki_spaces").await;
+
+        let batches = collect(&ctx, "SELECT space_id FROM saas.ws.wiki_spaces").await;
+        assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 1);
+        let inputs = execute_inputs(&gateway);
+        assert_eq!(
+            inputs.len(),
+            1,
+            "hasMore:false ended the scan; the non-empty token was never refetched"
+        );
+        assert_eq!(
+            inputs[0]["pageSize"], 50,
+            "declared page size rides the wire"
+        );
+    }
+
+    #[tokio::test]
+    async fn wiki_nodes_forward_required_and_optional_resources() {
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return feishu_discovery(&req.path);
+            }
+            if req.method == "POST" && req.path == "/v1/actions/feishu.list_wiki_nodes" {
+                return MockResponse::ok(&envelope_ok(
+                    &json!({"items": [{"node_token": "wik-1", "has_child": false}],
+                             "pageToken": null, "hasMore": false})
+                    .to_string(),
+                ));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let _token = EnvVarGuard::set("SKARDI_TEST_OC_FEISHU_WIKI", "test-token");
+        let config: OpenConnectorConfig = serde_yaml::from_str(
+            r#"
+runtime_token_env: SKARDI_TEST_OC_FEISHU_WIKI
+bindings:
+  - name: ws
+    source_pack: feishu
+    resource: { spaceId: sp-1, parentNodeToken: wikcn-parent }
+    tables: [wiki_nodes]
+"#,
+        )
+        .expect("config parses");
+        let gateways = OpenConnectorGateways::default();
+        let mut ctx = SessionContext::new();
+        register_open_connector_tables(
+            &mut ctx,
+            "saas",
+            &gateway.url,
+            Some(&config),
+            false,
+            HierarchyLevel::Catalog,
+            Some(&gateways),
+        )
+        .await
+        .expect("registration succeeds");
+
+        let batches = collect(&ctx, "SELECT node_token FROM saas.ws.wiki_nodes").await;
+        assert_eq!(batches[0].num_rows(), 1);
+        let input = &execute_inputs(&gateway)[0];
+        assert_eq!(input["spaceId"], "sp-1", "required resource forwarded");
+        assert_eq!(
+            input["parentNodeToken"], "wikcn-parent",
+            "optional resource forwarded when configured"
+        );
+        // Page size honors the wiki maximum, not the im maximum.
+        assert_eq!(input["pageSize"], 50);
+    }
+
+    #[tokio::test]
+    async fn missing_required_resource_fails_before_any_http() {
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let _token = EnvVarGuard::set("SKARDI_TEST_OC_FEISHU_NO_RES", "test-token");
+        let config: OpenConnectorConfig = serde_yaml::from_str(
+            r#"
+runtime_token_env: SKARDI_TEST_OC_FEISHU_NO_RES
+bindings:
+  - name: ws
+    source_pack: feishu
+    tables: [messages]
+"#,
+        )
+        .expect("config parses");
+        let mut ctx = SessionContext::new();
+        let gateways = OpenConnectorGateways::default();
+        let err = register_open_connector_tables(
+            &mut ctx,
+            "saas",
+            &gateway.url,
+            Some(&config),
+            false,
+            HierarchyLevel::Catalog,
+            Some(&gateways),
+        )
+        .await
+        .expect_err("missing containerId must fail registration");
+        assert!(err.to_string().contains("containerId"), "{err}");
+        assert!(
+            gateway.requests().iter().all(|r| r.path == "/v1/health"),
+            "resource enforcement precedes discovery"
+        );
+    }
+
+    #[tokio::test]
+    async fn limit_stops_cursor_pagination_early() {
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return feishu_discovery(&req.path);
+            }
+            if req.method == "POST" && req.path == "/v1/actions/feishu.list_chats" {
+                // Every page advertises another; only LIMIT can stop this.
+                return MockResponse::ok(&envelope_ok(
+                    &json!({"items": [chat_row("oc-1"), chat_row("oc-2")],
+                             "pageToken": "again", "hasMore": true})
+                    .to_string(),
+                ));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (gateway, ctx) =
+            setup_with_gateway(gateway, "SKARDI_TEST_OC_FEISHU_LIMIT", "chats").await;
+
+        let batches = collect(&ctx, "SELECT id FROM saas.ws.chats LIMIT 2").await;
+        assert_eq!(ids_of(&batches).len(), 2);
+        assert_eq!(
+            execute_inputs(&gateway).len(),
+            1,
+            "one page satisfied LIMIT"
+        );
+    }
+
+    #[tokio::test]
+    async fn udtf_parity_for_chat_members() {
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return feishu_discovery(&req.path);
+            }
+            if req.method == "POST" && req.path == "/v1/actions/feishu.list_chat_members" {
+                return MockResponse::ok(&envelope_ok(
+                    &json!({"items": [{"member_id": "ou-9", "name": "Ada"}],
+                             "pageToken": null, "hasMore": false})
+                    .to_string(),
+                ));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (gateway, ctx) =
+            setup_with_gateway(gateway, "SKARDI_TEST_OC_FEISHU_UDTF", "chat_members").await;
+
+        let from_table = collect(&ctx, "SELECT member_id, name FROM saas.ws.chat_members").await;
+        assert_eq!(
+            execute_inputs(&gateway)[0]["pageSize"],
+            100,
+            "declared page size rides the wire"
+        );
+        let from_udtf = collect(
+            &ctx,
+            "SELECT member_id, name FROM open_connector_query('saas', 'feishu.chat_members', \
+             '{\"chatId\":\"oc_root\"}')",
+        )
+        .await;
+        assert_eq!(from_table[0].schema(), from_udtf[0].schema());
+        assert_eq!(
+            arrow::util::pretty::pretty_format_batches(&from_table)
+                .unwrap()
+                .to_string(),
+            arrow::util::pretty::pretty_format_batches(&from_udtf)
+                .unwrap()
+                .to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn drifted_contract_fails_registration_not_the_scan() {
+        // The pin's refusal side: a gateway whose discovered output schema
+        // differs from the captured contract is refused at REGISTRATION,
+        // table and action named. (Every other e2e proves the pass side
+        // via feishu_discovery's captured contracts.)
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return MockResponse::ok(&discovery_ok("{}", r#"{"type": "object"}"#, true, None));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let _token = EnvVarGuard::set("SKARDI_TEST_OC_FEISHU_DRIFT", "test-token");
+        let mut ctx = SessionContext::new();
+        let gateways = OpenConnectorGateways::default();
+        let err = register_open_connector_tables(
+            &mut ctx,
+            "saas",
+            &gateway.url,
+            Some(&feishu_config("SKARDI_TEST_OC_FEISHU_DRIFT", "chats")),
+            false,
+            HierarchyLevel::Catalog,
+            Some(&gateways),
+        )
+        .await
+        .expect_err("a drifted contract must fail registration");
+        let message = err.to_string();
+        assert!(
+            message.contains("feishu.chats")
+                && message.contains("feishu.list_chats")
+                && message.contains("fingerprint mismatch"),
+            "table, action, and cause are named: {message}"
+        );
+    }
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/feishu.yaml
+++ b/crates/skardi/src/sources/providers/open_connector/packs/feishu.yaml
@@ -1,0 +1,228 @@
+# Feishu source pack. Wire contract is Open Connector's HYBRID shape,
+# reconciled against a live gateway (v1.3.3): every list executor
+# rebuilds the pagination ENVELOPE (camelCase `$.items` / `$.pageToken` /
+# `$.hasMore`, with `page_token` absent-or-empty normalized to a null
+# `pageToken` at end-of-collection) while passing the Feishu API's item
+# objects through RAW — snake_case keys, timestamps as epoch DIGIT
+# STRINGS (millis for im and tasks, seconds for wiki), the reason the
+# timestamp_*_string_utc column types exist. Inputs are camelCase strict
+# (`pageSize` / `pageToken` / `chatId`; `additionalProperties: false`).
+# Design rationale lives in the module docs of packs/feishu.rs.
+#
+# COLUMN STATUS: item schemas are declared LOOSE by the gateway (empty
+# properties + additionalProperties), so every column below rides
+# passthrough and none is protected by the fingerprint gate — real rows
+# are the only column truth. tasks / wiki_spaces / wiki_nodes are
+# reconciled against a live workspace (2026-08-04): tasks carry
+# status/completed_at (no `completed` boolean), wiki spaces answer the
+# final page with a NON-empty pageToken and hasMore:false (the reason
+# has_more_path exists). chats, chat_members, and messages are
+# live-verified too: chats gained chat_mode/chat_status from the pass;
+# messages' real page_size cap is 50 (99992402 above it) and reading
+# them under the user identity requires the im:message:readonly (or
+# im:message / im:message.history:readonly) scope — the get_as_user
+# scopes the gateway declares are NOT honored for this path (99991679).
+# `message_position` (a digit string on every row) is deliberately
+# unmapped: it appears in no public Feishu doc we could pin semantics
+# to.
+kind: pack
+pack: feishu
+version: 1
+
+tables:
+  chats:
+    action: feishu.list_chats
+    row_path: "$.items"
+    fingerprint: 51dcd0f7fe1efb4437ee71cf62e9991b535e5d0bc71a3b9998a96b090b4e6cd3
+    pagination:
+      strategy: cursor
+      cursor_input: pageToken
+      next_cursor_path: "$.pageToken"
+      page_size_input: pageSize
+      page_size: 100
+      has_more_path: "$.hasMore"
+    # ByCreateTimeAsc is the STABLE ordering. The API default
+    # (ByActiveTimeDesc) reshuffles rows whenever a chat receives a
+    # message mid-scan, which can skip or duplicate chats across cursor
+    # pages — creation order is immutable.
+    fixed_inputs:
+      sortType: ByCreateTimeAsc
+    columns:
+      - { name: id, path: chat_id, type: utf8, nullable: false }
+      - { name: name, path: name, type: utf8, nullable: true }
+      - { name: description, path: description, type: utf8, nullable: true }
+      - { name: owner_id, path: owner_id, type: utf8, nullable: true }
+      - { name: owner_id_type, path: owner_id_type, type: utf8, nullable: true }
+      - { name: external, path: external, type: boolean, nullable: true }
+      - { name: tenant_key, path: tenant_key, type: utf8, nullable: true }
+      - { name: avatar, path: avatar, type: utf8, nullable: true }
+      - { name: chat_mode, path: chat_mode, type: utf8, nullable: true }
+      - { name: chat_status, path: chat_status, type: utf8, nullable: true }
+
+  messages:
+    action: feishu.list_messages
+    row_path: "$.items"
+    fingerprint: 51dcd0f7fe1efb4437ee71cf62e9991b535e5d0bc71a3b9998a96b090b4e6cd3
+    pagination:
+      strategy: cursor
+      cursor_input: pageToken
+      next_cursor_path: "$.pageToken"
+      page_size_input: pageSize
+      # 50, NOT the schema's declared max of 100: Feishu's im/v1/messages
+      # caps page_size at 50 and hard-fails larger values (99992402,
+      # live-verified 2026-08-04) — the gateway's declared maximum is
+      # wrong on the wire.
+      page_size: 50
+      has_more_path: "$.hasMore"
+    # containerIdType is pinned to `chat`: this table IS chat history
+    # (thread listing is a different action, list_thread_messages).
+    # ByCreateTimeAsc for the same cursor-stability reason as chats —
+    # and it makes the startTime lower-bound pushdown coherent with the
+    # scan direction.
+    fixed_inputs:
+      containerIdType: chat
+      sortType: ByCreateTimeAsc
+    resources:
+      required: [containerId]
+    filters:
+      # Lower bound only: startTime is inclusive epoch seconds (a digit
+      # STRING in the strict schema — the reason epoch_seconds_string
+      # exists). Flooring widens the fetch; Inexact re-filtering trims.
+      # endTime is deliberately unmapped: it is EXCLUSIVE and flooring an
+      # upper bound would drop rows.
+      - { column: create_time, op: gt_eq, input: startTime, fidelity: inexact, format: epoch_seconds_string }
+    columns:
+      - { name: id, path: message_id, type: utf8, nullable: false }
+      - { name: chat_id, path: chat_id, type: utf8, nullable: true }
+      - { name: msg_type, path: msg_type, type: utf8, nullable: true }
+      - { name: create_time, path: create_time, type: timestamp_ms_string_utc, nullable: true }
+      - { name: update_time, path: update_time, type: timestamp_ms_string_utc, nullable: true }
+      - { name: deleted, path: deleted, type: boolean, nullable: true }
+      - { name: updated, path: updated, type: boolean, nullable: true }
+      - { name: root_id, path: root_id, type: utf8, nullable: true }
+      - { name: parent_id, path: parent_id, type: utf8, nullable: true }
+      - { name: thread_id, path: thread_id, type: utf8, nullable: true }
+      # sender carries id/id_type/sender_type/tenant_key — a small stable
+      # object, kept opaque; mentions is an array of user references.
+      - { name: sender, path: sender, type: json, nullable: true }
+      # body.content is Feishu's message payload: itself a JSON-encoded
+      # string whose inner schema varies BY msg_type — opaque by design,
+      # searchable as text.
+      - { name: content, path: body.content, type: utf8, nullable: true }
+      - { name: mentions, path: mentions, type: json, nullable: true }
+      # DOC-DERIVED: no captured row carries upper_message_id (it appears
+      # only on merge-forwarded messages) — under this pack's loose-schema
+      # doctrine that means zero evidence trail; kept because the Feishu
+      # message resource documents it, typed utf8 like every other id.
+      - { name: upper_message_id, path: upper_message_id, type: utf8, nullable: true }
+
+  chat_members:
+    action: feishu.list_chat_members
+    row_path: "$.items"
+    fingerprint: 51dcd0f7fe1efb4437ee71cf62e9991b535e5d0bc71a3b9998a96b090b4e6cd3
+    pagination:
+      strategy: cursor
+      cursor_input: pageToken
+      next_cursor_path: "$.pageToken"
+      page_size_input: pageSize
+      page_size: 100
+      has_more_path: "$.hasMore"
+    resources:
+      required: [chatId]
+    columns:
+      - { name: member_id, path: member_id, type: utf8, nullable: false }
+      - { name: member_id_type, path: member_id_type, type: utf8, nullable: true }
+      - { name: name, path: name, type: utf8, nullable: true }
+      - { name: tenant_key, path: tenant_key, type: utf8, nullable: true }
+
+  tasks:
+    action: feishu.list_tasks
+    row_path: "$.items"
+    fingerprint: f8d062dc87c010a03a76e6b1b0bc252f2de8b7004365042422de3f89b13f6382
+    pagination:
+      strategy: cursor
+      cursor_input: pageToken
+      next_cursor_path: "$.pageToken"
+      page_size_input: pageSize
+      page_size: 100
+      has_more_path: "$.hasMore"
+    # `my_tasks` is the executor's default; pinned explicitly so the
+    # table's population is declared, not inherited. Omitting the
+    # action's `completed` input returns tasks in BOTH states — the
+    # state=all default. The input is deliberately unmapped as a filter:
+    # real rows carry NO `completed` boolean (live-verified 2026-08-04 —
+    # completion is `status: todo|done` plus `completed_at`), and a
+    # string-enum column cannot render into a boolean input without a
+    # value transform the engine deliberately lacks.
+    fixed_inputs:
+      type: my_tasks
+    columns:
+      - { name: guid, path: guid, type: utf8, nullable: false }
+      - { name: summary, path: summary, type: utf8, nullable: true }
+      - { name: description, path: description, type: utf8, nullable: true }
+      - { name: status, path: status, type: utf8, nullable: true }
+      - { name: created_at, path: created_at, type: timestamp_ms_string_utc, nullable: true }
+      - { name: updated_at, path: updated_at, type: timestamp_ms_string_utc, nullable: true }
+      # Feishu spells "not completed" as the digit string "0", which
+      # decodes to 1970-01-01T00:00:00Z — filter on `status = 'done'`
+      # rather than on this column's epoch-zero sentinel.
+      - { name: completed_at, path: completed_at, type: timestamp_ms_string_utc, nullable: true }
+      # DOC-DERIVED shape: the live pass saw `due` on 2 of 9 rows, but no
+      # row with it survived the redacted fixture subset — the column has
+      # no fixture evidence; kept opaque json per the documented resource.
+      - { name: due, path: due, type: json, nullable: true }
+      - { name: members, path: members, type: json, nullable: true }
+      - { name: url, path: url, type: utf8, nullable: true }
+
+  wiki_spaces:
+    action: feishu.list_wiki_spaces
+    row_path: "$.items"
+    fingerprint: e6b2676fbe15e20f408f30c5d2f4aafee1cd628c434f699f1520f780fc940a6a
+    pagination:
+      strategy: cursor
+      cursor_input: pageToken
+      next_cursor_path: "$.pageToken"
+      page_size_input: pageSize
+      page_size: 50
+      has_more_path: "$.hasMore"
+    columns:
+      - { name: space_id, path: space_id, type: utf8, nullable: false }
+      - { name: name, path: name, type: utf8, nullable: true }
+      - { name: description, path: description, type: utf8, nullable: true }
+      - { name: space_type, path: space_type, type: utf8, nullable: true }
+      - { name: visibility, path: visibility, type: utf8, nullable: true }
+      - { name: open_sharing, path: open_sharing, type: utf8, nullable: true }
+
+  wiki_nodes:
+    action: feishu.list_wiki_nodes
+    row_path: "$.items"
+    fingerprint: e6b2676fbe15e20f408f30c5d2f4aafee1cd628c434f699f1520f780fc940a6a
+    pagination:
+      strategy: cursor
+      cursor_input: pageToken
+      next_cursor_path: "$.pageToken"
+      page_size_input: pageSize
+      page_size: 50
+      has_more_path: "$.hasMore"
+    # One level per scan: the action lists the children of ONE parent
+    # (space root when parentNodeToken is omitted) — same shape as
+    # Notion's block_children. Full-tree traversal is a client-side
+    # recursion, documented in the pack doc.
+    resources:
+      required: [spaceId]
+      optional: [parentNodeToken]
+    columns:
+      - { name: node_token, path: node_token, type: utf8, nullable: false }
+      - { name: obj_token, path: obj_token, type: utf8, nullable: true }
+      - { name: obj_type, path: obj_type, type: utf8, nullable: true }
+      - { name: title, path: title, type: utf8, nullable: true }
+      - { name: parent_node_token, path: parent_node_token, type: utf8, nullable: true }
+      - { name: node_type, path: node_type, type: utf8, nullable: true }
+      - { name: origin_node_token, path: origin_node_token, type: utf8, nullable: true }
+      - { name: has_child, path: has_child, type: boolean, nullable: true }
+      - { name: obj_create_time, path: obj_create_time, type: timestamp_s_string_utc, nullable: true }
+      - { name: obj_edit_time, path: obj_edit_time, type: timestamp_s_string_utc, nullable: true }
+      - { name: node_create_time, path: node_create_time, type: timestamp_s_string_utc, nullable: true }
+      - { name: owner, path: owner, type: utf8, nullable: true }
+      - { name: creator, path: creator, type: utf8, nullable: true }
+      - { name: url, path: url, type: utf8, nullable: true }

--- a/crates/skardi/src/sources/providers/open_connector/packs/feishu.yaml
+++ b/crates/skardi/src/sources/providers/open_connector/packs/feishu.yaml
@@ -146,8 +146,9 @@ tables:
       page_size_input: pageSize
       page_size: 100
       has_more_path: "$.hasMore"
-    # `my_tasks` is the executor's default; pinned explicitly so the
-    # table's population is declared, not inherited. Omitting the
+    # `my_tasks` is the ONLY value Feishu accepts (1470400 for
+    # assigned/created/followed — field-verified), pinned explicitly so
+    # the table's population is declared, not inherited. Omitting the
     # action's `completed` input returns tasks in BOTH states — the
     # state=all default. The input is deliberately unmapped as a filter:
     # real rows carry NO `completed` boolean (live-verified 2026-08-04 —

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/feishu/chat_members.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/feishu/chat_members.json
@@ -1,0 +1,18 @@
+{
+  "items": [
+    {
+      "member_id": "ou_0003",
+      "member_id_type": "open_id",
+      "name": "Redacted name",
+      "tenant_key": "t-0001"
+    },
+    {
+      "member_id": "ou_0006",
+      "member_id_type": "open_id",
+      "name": "Redacted name",
+      "tenant_key": "t-0001"
+    }
+  ],
+  "hasMore": false,
+  "pageToken": null
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/feishu/chats.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/feishu/chats.json
@@ -1,0 +1,40 @@
+{
+  "items": [
+    {
+      "avatar": "https://img.example/avatar.png",
+      "chat_id": "oc_0001",
+      "chat_mode": "group",
+      "chat_status": "normal",
+      "description": "Redacted description",
+      "external": true,
+      "name": "Redacted name",
+      "tenant_key": "t-0001"
+    },
+    {
+      "avatar": "https://img.example/avatar.png",
+      "chat_id": "oc_0002",
+      "chat_mode": "group",
+      "chat_status": "normal",
+      "description": "",
+      "external": false,
+      "name": "Redacted name",
+      "owner_id": "ou_0003",
+      "owner_id_type": "open_id",
+      "tenant_key": "t-0001"
+    },
+    {
+      "avatar": "https://img.example/avatar.png",
+      "chat_id": "oc_0004",
+      "chat_mode": "topic",
+      "chat_status": "normal",
+      "description": "Redacted description",
+      "external": true,
+      "name": "Redacted name",
+      "owner_id": "ou_0005",
+      "owner_id_type": "open_id",
+      "tenant_key": "t-0001"
+    }
+  ],
+  "hasMore": false,
+  "pageToken": null
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/feishu/chats_type_mismatch.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/feishu/chats_type_mismatch.json
@@ -1,0 +1,14 @@
+{
+  "items": [
+    {
+      "chat_id": "oc_ok",
+      "name": "fine"
+    },
+    {
+      "chat_id": 12345,
+      "name": "broken"
+    }
+  ],
+  "hasMore": false,
+  "pageToken": null
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/feishu/contracts/list_chat_members.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/feishu/contracts/list_chat_members.json
@@ -1,0 +1,37 @@
+{
+  "type": "object",
+  "properties": {
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": true,
+        "description": "A raw Feishu IM object."
+      },
+      "description": "The objects returned on this page."
+    },
+    "hasMore": {
+      "type": "boolean",
+      "description": "Whether another page is available."
+    },
+    "pageToken": {
+      "anyOf": [
+        {
+          "type": "string",
+          "description": "The token for the next page."
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "items",
+    "hasMore",
+    "pageToken"
+  ],
+  "description": "A normalized page of Feishu IM objects."
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/feishu/contracts/list_chats.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/feishu/contracts/list_chats.json
@@ -1,0 +1,37 @@
+{
+  "type": "object",
+  "properties": {
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": true,
+        "description": "A raw Feishu IM object."
+      },
+      "description": "The objects returned on this page."
+    },
+    "hasMore": {
+      "type": "boolean",
+      "description": "Whether another page is available."
+    },
+    "pageToken": {
+      "anyOf": [
+        {
+          "type": "string",
+          "description": "The token for the next page."
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "items",
+    "hasMore",
+    "pageToken"
+  ],
+  "description": "A normalized page of Feishu IM objects."
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/feishu/contracts/list_messages.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/feishu/contracts/list_messages.json
@@ -1,0 +1,37 @@
+{
+  "type": "object",
+  "properties": {
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": true,
+        "description": "A raw Feishu IM object."
+      },
+      "description": "The objects returned on this page."
+    },
+    "hasMore": {
+      "type": "boolean",
+      "description": "Whether another page is available."
+    },
+    "pageToken": {
+      "anyOf": [
+        {
+          "type": "string",
+          "description": "The token for the next page."
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "items",
+    "hasMore",
+    "pageToken"
+  ],
+  "description": "A normalized page of Feishu IM objects."
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/feishu/contracts/list_tasks.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/feishu/contracts/list_tasks.json
@@ -1,0 +1,37 @@
+{
+  "type": "object",
+  "properties": {
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": true,
+        "description": "A Feishu task object."
+      },
+      "description": "The returned task objects."
+    },
+    "hasMore": {
+      "type": "boolean",
+      "description": "Whether another page is available."
+    },
+    "pageToken": {
+      "anyOf": [
+        {
+          "type": "string",
+          "description": "The token for the next page."
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "items",
+    "hasMore",
+    "pageToken"
+  ],
+  "description": "A normalized page of tasks."
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/feishu/contracts/list_wiki_nodes.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/feishu/contracts/list_wiki_nodes.json
@@ -1,0 +1,37 @@
+{
+  "type": "object",
+  "properties": {
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": true,
+        "description": "A Feishu Wiki object."
+      },
+      "description": "The items returned on this page."
+    },
+    "hasMore": {
+      "type": "boolean",
+      "description": "Whether another page is available."
+    },
+    "pageToken": {
+      "anyOf": [
+        {
+          "type": "string",
+          "description": "The token for the next page."
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "items",
+    "hasMore",
+    "pageToken"
+  ],
+  "description": "A normalized Wiki page."
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/feishu/contracts/list_wiki_spaces.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/feishu/contracts/list_wiki_spaces.json
@@ -1,0 +1,37 @@
+{
+  "type": "object",
+  "properties": {
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": true,
+        "description": "A Feishu Wiki object."
+      },
+      "description": "The items returned on this page."
+    },
+    "hasMore": {
+      "type": "boolean",
+      "description": "Whether another page is available."
+    },
+    "pageToken": {
+      "anyOf": [
+        {
+          "type": "string",
+          "description": "The token for the next page."
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "items",
+    "hasMore",
+    "pageToken"
+  ],
+  "description": "A normalized Wiki page."
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/feishu/messages.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/feishu/messages.json
@@ -1,0 +1,95 @@
+{
+  "items": [
+    {
+      "body": {
+        "content": "{\"template\": \"{to_chatters} joined {group_name}\", \"from_user\": [], \"to_chatters\": [\"member-0001\"], \"divider_text\": {}}"
+      },
+      "chat_id": "oc_0001",
+      "create_time": "1593441000000",
+      "deleted": false,
+      "message_id": "om_0002",
+      "message_position": "0",
+      "msg_type": "system",
+      "sender": {
+        "id": "",
+        "id_type": "",
+        "sender_type": "",
+        "tenant_key": "t-0001"
+      },
+      "update_time": "1593441000000",
+      "updated": false
+    },
+    {
+      "body": {
+        "content": "{\"text\": \"Redacted text\"}"
+      },
+      "chat_id": "oc_0003",
+      "create_time": "1681116000000",
+      "deleted": false,
+      "message_id": "om_0004",
+      "message_position": "6",
+      "msg_type": "text",
+      "parent_id": "om_0005",
+      "root_id": "om_0005",
+      "sender": {
+        "id": "ou_0006",
+        "id_type": "open_id",
+        "sender_type": "user",
+        "tenant_key": "t-0001"
+      },
+      "update_time": "1681116000000",
+      "updated": false
+    },
+    {
+      "body": {
+        "content": "{\"template\": \"{to_chatters} joined {group_name}\", \"from_user\": [\"member-0002\"], \"to_chatters\": [\"member-0003\"], \"divider_text\": {}}"
+      },
+      "chat_id": "oc_0007",
+      "create_time": "1631153000000",
+      "deleted": false,
+      "message_id": "om_0008",
+      "message_position": "0",
+      "msg_type": "system",
+      "sender": {
+        "id": "",
+        "id_type": "",
+        "sender_type": "",
+        "tenant_key": "t-0001"
+      },
+      "thread_id": "omt_0009",
+      "thread_message_position": "-1",
+      "update_time": "1631153000000",
+      "updated": false
+    },
+    {
+      "body": {
+        "content": "{\"text\": \"Redacted text\"}"
+      },
+      "chat_id": "oc_0010",
+      "create_time": "1775204000000",
+      "deleted": false,
+      "mentions": [
+        {
+          "id": "ou_0011",
+          "id_type": "open_id",
+          "key": "@_user_1",
+          "name": "Redacted",
+          "tenant_key": "t-0001"
+        }
+      ],
+      "message_id": "om_0012",
+      "message_position": "10",
+      "msg_type": "text",
+      "sender": {
+        "id": "ou_0013",
+        "id_type": "open_id",
+        "sender_type": "user",
+        "tenant_key": "t-0001"
+      },
+      "update_time": "1775204100000",
+      "updated": true
+    }
+  ],
+  "hasMore": false,
+  "pageToken": null
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/feishu/tasks.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/feishu/tasks.json
@@ -1,0 +1,230 @@
+{
+  "hasMore": false,
+  "items": [
+    {
+      "completed_at": "0",
+      "created_at": "1775202331888",
+      "creator": {
+        "id": "ou_0001",
+        "type": "user"
+      },
+      "dependencies": [],
+      "description": "Redacted description",
+      "extra": "",
+      "guid": "guid-0002",
+      "is_milestone": false,
+      "members": [
+        {
+          "id": "ou_0003",
+          "role": "assignee",
+          "type": "user"
+        },
+        {
+          "id": "ou_0001",
+          "role": "follower",
+          "type": "user"
+        },
+        {
+          "id": "ou_0003",
+          "role": "follower",
+          "type": "user"
+        }
+      ],
+      "mode": 2,
+      "origin": {
+        "href": {
+          "title": "Redacted title",
+          "url": "https://example.feishu.cn/wiki/redacted"
+        },
+        "platform_i18n_name": {
+          "de_de": "",
+          "en_us": "",
+          "es_es": "",
+          "fr_fr": "",
+          "it_it": "",
+          "ja_jp": "",
+          "ko_kr": "",
+          "ru_ru": "",
+          "th_th": "",
+          "zh_cn": "",
+          "zh_hk": "",
+          "zh_tw": ""
+        }
+      },
+      "parent_task_guid": "",
+      "repeat_rule": "",
+      "source": 1,
+      "status": "todo",
+      "subtask_count": 0,
+      "summary": "Redacted summary",
+      "task_id": "70004",
+      "tasklists": [],
+      "updated_at": "1775202339871",
+      "url": "https://applink.feishu.cn/client/todo/detail?guid=guid-0002"
+    },
+    {
+      "completed_at": "0",
+      "created_at": "1775201978764",
+      "creator": {
+        "id": "ou_0001",
+        "type": "user"
+      },
+      "dependencies": [],
+      "description": "Redacted description",
+      "extra": "",
+      "guid": "guid-0006",
+      "is_milestone": false,
+      "members": [
+        {
+          "id": "ou_0003",
+          "role": "assignee",
+          "type": "user"
+        },
+        {
+          "id": "ou_0007",
+          "role": "assignee",
+          "type": "user"
+        },
+        {
+          "id": "ou_0001",
+          "role": "follower",
+          "type": "user"
+        },
+        {
+          "id": "ou_0003",
+          "role": "follower",
+          "type": "user"
+        },
+        {
+          "id": "ou_0007",
+          "role": "follower",
+          "type": "user"
+        }
+      ],
+      "mode": 2,
+      "origin": {
+        "href": {
+          "title": "Redacted title",
+          "url": "https://example.feishu.cn/wiki/redacted"
+        },
+        "platform_i18n_name": {
+          "de_de": "",
+          "en_us": "",
+          "es_es": "",
+          "fr_fr": "",
+          "it_it": "",
+          "ja_jp": "",
+          "ko_kr": "",
+          "ru_ru": "",
+          "th_th": "",
+          "zh_cn": "",
+          "zh_hk": "",
+          "zh_tw": ""
+        }
+      },
+      "parent_task_guid": "",
+      "repeat_rule": "",
+      "source": 1,
+      "status": "todo",
+      "subtask_count": 0,
+      "summary": "Redacted summary",
+      "task_id": "70008",
+      "tasklists": [],
+      "updated_at": "1775204093319",
+      "url": "https://applink.feishu.cn/client/todo/detail?guid=guid-0006"
+    },
+    {
+      "agent_task_status": 4,
+      "completed_at": "1780322529638",
+      "created_at": "1768661318224",
+      "creator": {
+        "id": "ou_0021",
+        "type": "user"
+      },
+      "dependencies": [],
+      "description": "Redacted description",
+      "extra": "",
+      "guid": "guid-0022",
+      "is_milestone": false,
+      "members": [
+        {
+          "id": "ou_0023",
+          "role": "assignee",
+          "type": "user"
+        },
+        {
+          "id": "ou_0001",
+          "role": "assignee",
+          "type": "user"
+        },
+        {
+          "id": "ou_0003",
+          "role": "assignee",
+          "type": "user"
+        },
+        {
+          "id": "ou_0024",
+          "role": "assignee",
+          "type": "user"
+        },
+        {
+          "id": "ou_0023",
+          "role": "follower",
+          "type": "user"
+        },
+        {
+          "id": "ou_0021",
+          "role": "follower",
+          "type": "user"
+        },
+        {
+          "id": "ou_0024",
+          "role": "follower",
+          "type": "user"
+        },
+        {
+          "id": "ou_0003",
+          "role": "follower",
+          "type": "user"
+        }
+      ],
+      "mode": 2,
+      "origin": {
+        "href": {
+          "title": "Redacted title",
+          "url": "https://example.feishu.cn/wiki/redacted"
+        },
+        "platform_i18n_name": {
+          "de_de": "",
+          "en_us": "",
+          "es_es": "",
+          "fr_fr": "",
+          "it_it": "",
+          "ja_jp": "",
+          "ko_kr": "",
+          "ru_ru": "",
+          "th_th": "",
+          "zh_cn": "",
+          "zh_hk": "",
+          "zh_tw": ""
+        }
+      },
+      "parent_task_guid": "",
+      "repeat_rule": "",
+      "source": 1,
+      "status": "done",
+      "subtask_count": 0,
+      "summary": "Redacted summary",
+      "task_id": "70012",
+      "tasklists": [
+        {
+          "section_guid": "guid-0025",
+          "tasklist_guid": "guid-0026"
+        }
+      ],
+      "updated_at": "1780322532309",
+      "url": "https://applink.feishu.cn/client/todo/detail?guid=guid-0022"
+    }
+  ],
+  "pageToken": null
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/feishu/wiki_nodes.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/feishu/wiki_nodes.json
@@ -1,0 +1,60 @@
+{
+  "items": [
+    {
+      "creator": "ou_0003",
+      "has_child": false,
+      "node_create_time": "1636114726",
+      "node_token": "wikcn0039",
+      "node_type": "origin",
+      "obj_create_time": "1636114726",
+      "obj_edit_time": "1636114726",
+      "obj_token": "wikcn0040",
+      "obj_type": "doc",
+      "origin_node_token": "wikcn0039",
+      "origin_space_id": "700000038",
+      "owner": "ou_0003",
+      "parent_node_token": "",
+      "space_id": "700000038",
+      "title": "Redacted title",
+      "url": "https://example.feishu.cn/wiki/redacted"
+    },
+    {
+      "creator": "ou_0003",
+      "has_child": true,
+      "node_create_time": "1636114726",
+      "node_token": "wikcn0041",
+      "node_type": "origin",
+      "obj_create_time": "1636114726",
+      "obj_edit_time": "1636114726",
+      "obj_token": "wikcn0042",
+      "obj_type": "doc",
+      "origin_node_token": "wikcn0041",
+      "origin_space_id": "700000038",
+      "owner": "ou_0003",
+      "parent_node_token": "",
+      "space_id": "700000038",
+      "title": "Redacted title",
+      "url": "https://example.feishu.cn/wiki/redacted"
+    },
+    {
+      "creator": "ou_0003",
+      "has_child": true,
+      "node_create_time": "1636114726",
+      "node_token": "wikcn0043",
+      "node_type": "origin",
+      "obj_create_time": "1636114726",
+      "obj_edit_time": "1636114726",
+      "obj_token": "wikcn0044",
+      "obj_type": "doc",
+      "origin_node_token": "wikcn0043",
+      "origin_space_id": "700000038",
+      "owner": "ou_0003",
+      "parent_node_token": "",
+      "space_id": "700000038",
+      "title": "Redacted title",
+      "url": "https://example.feishu.cn/wiki/redacted"
+    }
+  ],
+  "hasMore": false,
+  "pageToken": null
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/feishu/wiki_spaces.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/feishu/wiki_spaces.json
@@ -1,0 +1,14 @@
+{
+  "items": [
+    {
+      "description": "Redacted description",
+      "name": "Redacted name",
+      "open_sharing": "closed",
+      "space_id": "700000038",
+      "space_type": "team",
+      "visibility": "private"
+    }
+  ],
+  "hasMore": false,
+  "pageToken": "0||7000000000000000001"
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/loader.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/loader.rs
@@ -187,6 +187,34 @@ fn validate_table(table: &SourcePackTable) -> Result<(), String> {
                 filter.column, filter.operator
             ));
         }
+        // Epoch renderings floor sub-second precision, which only ever
+        // WIDENS a lower bound; under any other operator the floored
+        // literal compares at a different instant and the provider drops
+        // rows that Inexact re-filtering cannot recover — and under Exact,
+        // DataFusion never re-filters the widened fetch at all. Both rules
+        // enforced here so the drift is a load failure, not silent row
+        // loss (the ValueFormat docs state the same contract).
+        if matches!(
+            filter.value_format,
+            ValueFormat::EpochSeconds | ValueFormat::EpochSecondsString
+        ) {
+            if !matches!(filter.operator, Operator::Gt | Operator::GtEq) {
+                return Err(format!(
+                    "{id}: filter on '{}' renders as flooring epoch seconds, which is only \
+                     sound for lower bounds — operator {:?} would drop rows; declare gt/gt_eq \
+                     or use the rfc3339 format",
+                    filter.column, filter.operator
+                ));
+            }
+            if filter.fidelity != Fidelity::Inexact {
+                return Err(format!(
+                    "{id}: filter on '{}' floors sub-second literals into a WIDER fetch, so it \
+                     must be declared inexact (DataFusion re-filters locally); exact would \
+                     surface rows the predicate excludes",
+                    filter.column
+                ));
+            }
+        }
     }
     for required in table.required_resources {
         if table.optional_resources.contains(required) {
@@ -318,6 +346,8 @@ fn convert_column(table_id: &str, doc: ColumnDoc) -> Result<FieldMapping, String
         (ColumnType::Utf8, None) => FieldType::Utf8,
         (ColumnType::TimestampMsUtc, None) => FieldType::TimestampMillisUtc,
         (ColumnType::TimestampSUtc, None) => FieldType::TimestampSecondsUtc,
+        (ColumnType::TimestampMsStringUtc, None) => FieldType::TimestampMillisStringUtc,
+        (ColumnType::TimestampSStringUtc, None) => FieldType::TimestampSecondsStringUtc,
         (ColumnType::Utf8List, None) => FieldType::Utf8List,
         (ColumnType::Json, None) => FieldType::Json,
     };
@@ -346,6 +376,7 @@ fn convert_filter(doc: FilterDoc) -> FilterMapping {
             FormatDoc::Verbatim => ValueFormat::Verbatim,
             FormatDoc::Rfc3339 => ValueFormat::Rfc3339,
             FormatDoc::EpochSeconds => ValueFormat::EpochSeconds,
+            FormatDoc::EpochSecondsString => ValueFormat::EpochSecondsString,
         },
     }
 }
@@ -426,6 +457,8 @@ enum PaginationDoc {
         #[serde(default)]
         page_size_input: Option<String>,
         page_size: u32,
+        #[serde(default)]
+        has_more_path: Option<String>,
     },
 }
 
@@ -450,11 +483,13 @@ impl PaginationDoc {
                 next_cursor_path,
                 page_size_input,
                 page_size,
+                has_more_path,
             } => PaginationStrategy::Cursor {
                 cursor_param: leak_str(cursor_input),
                 next_cursor_path: leak_str(next_cursor_path),
                 page_size_param: page_size_input.map(leak_str),
                 page_size,
+                has_more_path: has_more_path.map(leak_str),
             },
         }
     }
@@ -489,6 +524,10 @@ enum ColumnType {
     TimestampMsUtc,
     #[serde(rename = "timestamp_s_utc")]
     TimestampSUtc,
+    #[serde(rename = "timestamp_ms_string_utc")]
+    TimestampMsStringUtc,
+    #[serde(rename = "timestamp_s_string_utc")]
+    TimestampSStringUtc,
     #[serde(rename = "utf8_list")]
     Utf8List,
     #[serde(rename = "utf8_list_from_object_key")]
@@ -612,6 +651,8 @@ enum FormatDoc {
     Rfc3339,
     #[serde(rename = "epoch_seconds")]
     EpochSeconds,
+    #[serde(rename = "epoch_seconds_string")]
+    EpochSecondsString,
 }
 
 #[cfg(test)]
@@ -628,6 +669,7 @@ mod tests {
             ("github.yaml", include_str!("github.yaml")),
             ("slack.yaml", include_str!("slack.yaml")),
             ("notion.yaml", include_str!("notion.yaml")),
+            ("feishu.yaml", include_str!("feishu.yaml")),
         ] {
             // parse_pack performs the full structural + cross-field
             // validation pass itself; parsing IS the gate.
@@ -724,6 +766,54 @@ tables:
         ))
         .unwrap_err();
         assert!(err.contains("only"), "{err}");
+    }
+
+    #[test]
+    fn epoch_formats_are_lower_bound_inexact_only() {
+        // Flooring widens LOWER bounds only; any other operator (or an
+        // Exact claim over the widened fetch) drops or surfaces wrong
+        // rows silently — so both are load failures, not runtime hazards.
+        let base = |filter: &str| {
+            format!(
+                r#"
+kind: pack
+pack: demo
+version: 1
+tables:
+  items:
+    action: demo.list
+    row_path: "$.items"
+    pagination: {{ strategy: page_number, page_input: page, page_size_input: perPage, page_size: 10 }}
+    columns:
+      - {{ name: created, path: created, type: timestamp_ms_utc, nullable: true }}
+    filters:
+{filter}
+"#
+            )
+        };
+        let err = parse_pack(&base(
+            "      - { column: created, op: eq, input: at, fidelity: inexact, format: epoch_seconds }",
+        ))
+        .unwrap_err();
+        assert!(
+            err.contains("only") && err.contains("lower bounds"),
+            "{err}"
+        );
+
+        // (The YAML op enum admits only eq/gt/gt_eq today, so eq is the one
+        // declarable non-lower-bound operator; the validation still guards
+        // any future upper-bound additions.)
+        let err = parse_pack(&base(
+            "      - { column: created, op: gt_eq, input: since, fidelity: exact, format: epoch_seconds }",
+        ))
+        .unwrap_err();
+        assert!(err.contains("inexact"), "{err}");
+
+        // The sound shape — Feishu's startTime — still loads.
+        parse_pack(&base(
+            "      - { column: created, op: gt_eq, input: since, fidelity: inexact, format: epoch_seconds_string }",
+        ))
+        .expect("lower-bound inexact epoch mapping is legal");
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/open_connector/packs/mod.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/mod.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod loader;
 
+pub mod feishu;
 pub mod github;
 pub mod mock;
 pub mod notion;

--- a/crates/skardi/src/sources/providers/open_connector/pagination.rs
+++ b/crates/skardi/src/sources/providers/open_connector/pagination.rs
@@ -62,6 +62,19 @@ pub enum PaginationStrategy {
         page_size_param: Option<&'static str>,
         /// Page size to request (ignored when `page_size_param` is None).
         page_size: u32,
+        /// Row-path-style location of the provider's authoritative
+        /// has-more boolean (e.g. Feishu's `$.hasMore`). Some providers
+        /// return a NON-empty cursor on the final page and signal the end
+        /// only here — Feishu's wiki `list_spaces` answers `has_more:
+        /// false` with `page_token: "0||…"`, so null-cursor termination
+        /// alone would refetch and fail as a `PaginationLoop`. When
+        /// declared: `false` ends the scan regardless of the cursor;
+        /// `true` requires a usable cursor, and its absence is contract
+        /// drift (`PaginationCursorInvalid`), never a quiet stop. A
+        /// non-boolean value fails as `PaginationHasMoreInvalid`. When
+        /// absent, the cursor's null/empty/missing spellings terminate as
+        /// before.
+        has_more_path: Option<&'static str>,
     },
     /// One request, one page: no pagination inputs are injected and the scan
     /// completes after the first response. Used by `open_connector_scan`,
@@ -87,6 +100,8 @@ pub struct Pagination {
     total_pages_path: Option<RowPath>,
     /// Pre-parsed raw-page-size path (PageNumber only).
     raw_page_size_path: Option<RowPath>,
+    /// Pre-parsed has-more path (Cursor only, when declared).
+    has_more_path: Option<RowPath>,
 }
 
 impl PaginationStrategy {
@@ -95,9 +110,14 @@ impl PaginationStrategy {
     pub fn validate(&self) -> Result<(), OpenConnectorError> {
         match self {
             PaginationStrategy::Cursor {
-                next_cursor_path, ..
+                next_cursor_path,
+                has_more_path,
+                ..
             } => {
                 RowPath::parse(next_cursor_path)?;
+                if let Some(path) = has_more_path {
+                    RowPath::parse(path)?;
+                }
             }
             PaginationStrategy::PageNumber {
                 total_pages_path,
@@ -159,6 +179,13 @@ impl Pagination {
             } => Some(RowPath::parse(path)?),
             _ => None,
         };
+        let has_more_path = match &strategy {
+            PaginationStrategy::Cursor {
+                has_more_path: Some(path),
+                ..
+            } => Some(RowPath::parse(path)?),
+            _ => None,
+        };
         Ok(Self {
             strategy,
             page: 1,
@@ -167,6 +194,7 @@ impl Pagination {
             cursor_path,
             total_pages_path,
             raw_page_size_path,
+            has_more_path,
         })
     }
 
@@ -267,6 +295,37 @@ impl Pagination {
                 Ok(more)
             }
             PaginationStrategy::Cursor { .. } => {
+                // The authoritative has-more signal, when the pack declares
+                // one, is consulted FIRST: some providers return a non-empty
+                // cursor on the final page (Feishu wiki spaces answer
+                // `has_more: false` with `page_token: "0||…"`), so the
+                // cursor's spellings alone would refetch a finished scan.
+                if let Some(path) = &self.has_more_path {
+                    let has_more = match path.extract(envelope, self.page) {
+                        Ok(Value::Bool(b)) => *b,
+                        Ok(other) => {
+                            return Err(OpenConnectorError::PaginationHasMoreInvalid {
+                                path: path.as_str().to_string(),
+                                page: self.page,
+                                found: json_kind(other).to_string(),
+                            });
+                        }
+                        // The pack declared the signal; a page without it is
+                        // contract drift, not a quiet stop or continue.
+                        Err(OpenConnectorError::RowPathNotFound { .. }) => {
+                            return Err(OpenConnectorError::PaginationHasMoreInvalid {
+                                path: path.as_str().to_string(),
+                                page: self.page,
+                                found: "absent".to_string(),
+                            });
+                        }
+                        Err(e) => return Err(e),
+                    };
+                    if !has_more {
+                        return Ok(false);
+                    }
+                }
+
                 let path = self.cursor_path.as_ref().ok_or_else(|| {
                     OpenConnectorError::InvalidRowPath {
                         path: "<cursor>".to_string(),
@@ -297,6 +356,17 @@ impl Pagination {
                 };
 
                 let Some(next) = next else {
+                    // With a declared has-more signal saying `true`, a missing
+                    // cursor is drift — stopping here would silently truncate
+                    // the scan the provider says is unfinished.
+                    if self.has_more_path.is_some() {
+                        return Err(OpenConnectorError::PaginationCursorInvalid {
+                            path: path.as_str().to_string(),
+                            page: self.page,
+                            found: "null, empty, or absent while the has-more signal is true"
+                                .to_string(),
+                        });
+                    }
                     return Ok(false);
                 };
                 if !self.seen_tokens.insert(next.clone()) {
@@ -333,6 +403,7 @@ mod tests {
             next_cursor_path: "$.next_cursor",
             page_size_param: Some("limit"),
             page_size: 50,
+            has_more_path: None,
         })
         .unwrap()
     }
@@ -344,6 +415,7 @@ mod tests {
             next_cursor_path: "not-a-path",
             page_size_param: None,
             page_size: 50,
+            has_more_path: None,
         })
         .unwrap_err();
         assert!(matches!(err, OpenConnectorError::InvalidRowPath { .. }));
@@ -356,6 +428,7 @@ mod tests {
             next_cursor_path: "$.a..b",
             page_size_param: None,
             page_size: 50,
+            has_more_path: None,
         };
         assert!(matches!(
             bad.validate(),
@@ -526,6 +599,7 @@ mod tests {
             next_cursor_path: "$.meta.next",
             page_size_param: None,
             page_size: 50,
+            has_more_path: None,
         })
         .unwrap();
         let err = pagination
@@ -543,9 +617,95 @@ mod tests {
             next_cursor_path: "$.meta.next",
             page_size_param: None,
             page_size: 50,
+            has_more_path: None,
         })
         .unwrap();
         assert!(!pagination.advance(&json!({"other": 1}), 50).unwrap());
+    }
+
+    /// A cursor strategy with a declared has-more signal.
+    fn cursor_with_has_more() -> Pagination {
+        Pagination::new(PaginationStrategy::Cursor {
+            cursor_param: "pageToken",
+            next_cursor_path: "$.pageToken",
+            page_size_param: Some("pageSize"),
+            page_size: 50,
+            has_more_path: Some("$.hasMore"),
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn has_more_false_terminates_even_with_a_nonempty_cursor() {
+        // The Feishu wiki shape this field exists for: the final page still
+        // carries a non-empty page token ("0||…"), and only has_more says
+        // the scan is over. Null-cursor termination alone would refetch and
+        // trip the loop guard.
+        let mut pagination = cursor_with_has_more();
+        assert!(
+            !pagination
+                .advance(
+                    &json!({"hasMore": false, "pageToken": "0||7027059242666328066"}),
+                    1
+                )
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn has_more_true_continues_with_the_cursor() {
+        let mut pagination = cursor_with_has_more();
+        assert!(
+            pagination
+                .advance(&json!({"hasMore": true, "pageToken": "tok-2"}), 50)
+                .unwrap()
+        );
+        let mut input = Map::new();
+        pagination.apply(&mut input);
+        assert_eq!(input.get("pageToken"), Some(&Value::from("tok-2")));
+    }
+
+    #[test]
+    fn has_more_true_without_a_cursor_is_drift_not_termination() {
+        // The provider says more pages exist but hands nothing to follow —
+        // stopping would silently truncate a scan the signal says is
+        // unfinished.
+        for envelope in [
+            json!({"hasMore": true, "pageToken": null}),
+            json!({"hasMore": true}),
+        ] {
+            let mut pagination = cursor_with_has_more();
+            let err = pagination.advance(&envelope, 50).unwrap_err();
+            assert!(
+                matches!(
+                    err,
+                    OpenConnectorError::PaginationCursorInvalid { ref found, .. }
+                        if found.contains("has-more")
+                ),
+                "got {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn non_boolean_or_absent_has_more_fails_with_its_kind() {
+        // The pack declared the signal, so a page without a usable one is
+        // contract drift — guessing either way could truncate or loop.
+        for (envelope, found) in [
+            (json!({"hasMore": "yes", "pageToken": "t"}), "a string"),
+            (json!({"hasMore": 1, "pageToken": "t"}), "a number"),
+            (json!({"pageToken": "t"}), "absent"),
+        ] {
+            let mut pagination = cursor_with_has_more();
+            let err = pagination.advance(&envelope, 50).unwrap_err();
+            assert!(
+                matches!(
+                    err,
+                    OpenConnectorError::PaginationHasMoreInvalid { found: ref f, .. } if f == found
+                ),
+                "for {envelope}: got {err}"
+            );
+        }
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/open_connector/source_pack.rs
+++ b/crates/skardi/src/sources/providers/open_connector/source_pack.rs
@@ -137,6 +137,7 @@ impl SourcePackRegistry {
             super::packs::github::pack()?,
             super::packs::notion::pack()?,
             super::packs::slack::pack()?,
+            super::packs::feishu::pack()?,
         ] {
             packs.insert(pack.name, pack);
         }

--- a/crates/skardi/src/sources/providers/open_connector/table.rs
+++ b/crates/skardi/src/sources/providers/open_connector/table.rs
@@ -226,6 +226,7 @@ mod tests {
             next_cursor_path: "not-a-path",
             page_size_param: None,
             page_size: 50,
+            has_more_path: None,
         });
         let err = OpenConnectorTableProvider::new(
             offline_client(),
@@ -254,6 +255,7 @@ mod tests {
             next_cursor_path: "$.next_cursor",
             page_size_param: None,
             page_size: 50,
+            has_more_path: None,
         });
         OpenConnectorTableProvider::new(
             offline_client(),

--- a/docs/open-connector-feishu.md
+++ b/docs/open-connector-feishu.md
@@ -1,0 +1,151 @@
+# Feishu Source Pack
+
+The built-in `feishu` source pack exposes a Feishu user's own workspace —
+chats and their messages and members, tasks, and wiki spaces/nodes — as
+stable SQL tables through an
+[Open Connector gateway](open-connector.md). Feishu credentials are an
+OAuth **user_access_token** obtained through the gateway's OAuth flow
+against a user-provided Feishu custom app; Skardi holds only the gateway
+runtime token. Visibility is exactly the authorizing user's: their chats,
+their tasks, the wiki they can read.
+
+**The wire contract is Open Connector's HYBRID shape**: every feishu list
+executor rebuilds the pagination envelope (camelCase `$.items` /
+`$.pageToken` / `$.hasMore`, with the provider's `page_token` normalized
+to a null `pageToken` at end-of-collection) while passing the Feishu
+API's item objects through **raw** — snake_case keys, and timestamps as
+epoch **digit strings** (milliseconds for im, seconds for wiki), which is
+what the `timestamp_ms_string_utc` / `timestamp_s_string_utc` column
+types decode. Reconciled against a live gateway (v1.3.3).
+
+> **Live-verified (2026-08-04):** all six tables are reconciled against
+> a real workspace end to end — registration through live discovery,
+> real scans (86 messages over two real cursor pages, zero duplicate
+> ids; `create_time >=` pushdown narrowing a live scan; wiki's
+> non-empty final token terminating cleanly), and every mapped column
+> non-NULL on real rows. The gateway declares every feishu items schema
+> loose (no declared properties), so no column is protected by the
+> fingerprint gate — real rows are the column truth, and the bundled
+> fixtures are redacted live captures.
+
+## Binding
+
+```yaml
+spec:
+  data_sources:
+    - name: saas
+      type: open_connector
+      connection_string: http://open-connector:3000
+      hierarchy_level: catalog
+
+      open_connector:
+        runtime_token_env: OPEN_CONNECTOR_TOKEN
+        bindings:
+          - name: team               # schema name in SQL
+            source_pack: feishu
+            tables: [chats, tasks, wiki_spaces]
+          - name: standup            # per-chat binding for chat history
+            source_pack: feishu
+            resource:
+              containerId: oc_a1b2c3d4e5f6   # chat_id from the chats table
+            tables: [messages]
+```
+
+```sql
+SELECT name, external FROM saas.team.chats ORDER BY name;
+
+SELECT content, create_time
+FROM saas.standup.messages
+WHERE create_time >= TIMESTAMP '2026-07-01T00:00:00Z'
+  AND msg_type = 'text'
+ORDER BY create_time;
+
+-- The same definition, ad hoc, without a binding:
+SELECT member_id, name
+FROM open_connector_query('saas', 'feishu.chat_members',
+                          '{"chatId":"oc_a1b2c3d4e5f6"}');
+```
+
+## Tables
+
+| Table | Action | Resources | Pagination | Filter pushdown |
+|---|---|---|---|---|
+| `chats` | `feishu.list_chats` | — | cursor, 100/page | — |
+| `messages` | `feishu.list_messages` | `containerId` (required) | cursor, 50/page | `create_time >=` → `startTime` (inexact) |
+| `chat_members` | `feishu.list_chat_members` | `chatId` (required) | cursor, 100/page | — |
+| `tasks` | `feishu.list_tasks` | — | cursor, 100/page | — |
+| `wiki_spaces` | `feishu.list_wiki_spaces` | — | cursor, 50/page | — |
+| `wiki_nodes` | `feishu.list_wiki_nodes` | `spaceId` (required), `parentNodeToken` (optional) | cursor, 50/page | — |
+
+Design notes:
+
+- **`chats` and `messages` pin `sortType: ByCreateTimeAsc`** — the API's
+  activity-ordered default reshuffles rows while a scan pages, which can
+  skip or duplicate rows; creation order is immutable, so the cursor is
+  stable.
+- **`messages` is chat history for ONE chat** (`containerIdType` pinned
+  to `chat`; per-chat binding, the shape Notion's `block_children`
+  established). The `create_time >=` pushdown renders inclusive epoch
+  seconds as a digit string (`startTime`); `endTime` is deliberately
+  unmapped — it is exclusive, and flooring an upper bound would drop
+  rows. `body.content` maps to the `content` column as the provider's
+  own JSON-encoded payload text (its inner schema varies by `msg_type`).
+- **`tasks` pins `type: my_tasks`** and always omits the `completed`
+  input — Feishu's spelling of a state=all listing. Nothing pushes it:
+  real rows carry no `completed` boolean (completion on the wire is
+  `status: todo|done` plus `completed_at`), so filter on `status`
+  locally.
+- **`wiki_nodes` lists ONE level**: the children of `parentNodeToken`,
+  or the space root when omitted. Walking a whole space is client-side
+  recursion over `has_child` / `node_token`.
+- No table declares `error_path`: the gateway's executors consume
+  Feishu's in-band `code != 0` envelope and return a failure envelope
+  themselves.
+
+## Authorization and visibility
+
+The gateway's feishu provider uses the OAuth authorization-code flow
+(`authTypes: ["oauth2"]`) against a Feishu custom app the operator
+creates. Rows are the authorizing user's view — a chat the user left or
+a wiki space they cannot read is simply absent, not an error.
+
+Operational findings from the live verification, all three of which the
+Feishu console gates independently of each other:
+
+- The `messages` table requires the **`im:message:readonly`** scope (or
+  `im:message` / `im:message.history:readonly`) — the
+  `im:message.*.get_as_user` scopes the gateway's action metadata
+  declares are NOT honored for the user-identity read path (Feishu
+  99991679 names the real set).
+- The im tables additionally require the app's **bot capability**
+  (Feishu 232025), even though every read runs as the user.
+- Feishu's `im/v1/messages` caps `page_size` at **50** on the wire
+  (99992402 above it) despite the gateway schema declaring 100 — the
+  pack requests 50.
+- Upstream gateway caveat: its authorization URL requests the union of
+  ALL feishu actions' scopes with no narrowing surface, which Feishu
+  rejects (20027) unless the app enables every one — deployments should
+  expect to narrow the provider's scope list until upstream grows a
+  config-level override.
+
+Filed upstream (oomol-lab/open-connector) from this verification pass:
+[#267](https://github.com/oomol-lab/open-connector/issues/267)
+(scope-union OAuth URL),
+[#268](https://github.com/oomol-lab/open-connector/issues/268)
+(get_as_user scopes not honored for user-identity reads),
+[#269](https://github.com/oomol-lab/open-connector/issues/269)
+(declared pageSize 100 vs the wire's 50 cap, fix in
+[PR #271](https://github.com/oomol-lab/open-connector/pull/271)), and
+[#270](https://github.com/oomol-lab/open-connector/issues/270)
+(wiki's non-empty final page_token beside has_more:false).
+
+`message_position` (a digit string on every live message row) is
+deliberately unmapped: no public Feishu documentation pins its
+semantics.
+
+## Rate limits and freshness
+
+Feishu applies per-app and per-user QPS limits; the client's bounded
+retry/backoff handles transient 429/5xx envelopes. Scans fetch pages on
+demand and stop early under `LIMIT`; completed scans are cached per the
+scan cache's usual keying (binding, table, pushed inputs, LIMIT).

--- a/docs/open-connector-feishu.md
+++ b/docs/open-connector-feishu.md
@@ -41,14 +41,30 @@ spec:
       open_connector:
         runtime_token_env: OPEN_CONNECTOR_TOKEN
         bindings:
+          # The three tables that need NO resource — a first ctx can only
+          # cover these; the other three each require an id you get by
+          # querying chats / wiki_spaces first, then coming back.
           - name: team               # schema name in SQL
             source_pack: feishu
             tables: [chats, tasks, wiki_spaces]
+          # Each of the remaining tables needs one resource, so each
+          # needs its own binding — adding them to `team` fails startup
+          # with `missing required resource input`.
           - name: standup            # per-chat binding for chat history
             source_pack: feishu
             resource:
               containerId: oc_a1b2c3d4e5f6   # chat_id from the chats table
             tables: [messages]
+          - name: standup_members
+            source_pack: feishu
+            resource:
+              chatId: oc_a1b2c3d4e5f6        # chat_id from the chats table
+            tables: [chat_members]
+          - name: handbook
+            source_pack: feishu
+            resource:
+              spaceId: "7034502641455497244" # space_id from wiki_spaces
+            tables: [wiki_nodes]
 ```
 
 ```sql
@@ -90,8 +106,10 @@ Design notes:
   unmapped — it is exclusive, and flooring an upper bound would drop
   rows. `body.content` maps to the `content` column as the provider's
   own JSON-encoded payload text (its inner schema varies by `msg_type`).
-- **`tasks` pins `type: my_tasks`** and always omits the `completed`
-  input — Feishu's spelling of a state=all listing. Nothing pushes it:
+- **`tasks` sends `type: my_tasks`** — the only value Feishu accepts
+  (`1470400: Invalid Param 'type'. Only 'my_tasks' is supported.` for
+  `assigned`/`created`/`followed`), not a tunable choice — and always
+  omits the `completed` input, Feishu's spelling of a state=all listing. Nothing pushes it:
   real rows carry no `completed` boolean (completion on the wire is
   `status: todo|done` plus `completed_at`), so filter on `status`
   locally.
@@ -109,6 +127,22 @@ The gateway's feishu provider uses the OAuth authorization-code flow
 creates. Rows are the authorizing user's view — a chat the user left or
 a wiki space they cannot read is simply absent, not an error.
 
+**Gateway version is a floor, not a fact**: the six actions this pack
+needs were added to Open Connector after older mid-2025 builds (which
+expose only docs/bitable feishu actions); a too-old gateway fails
+registration with `action 'feishu.list_chats' was not found`, which
+reads like a typo but means "upgrade the gateway". Self-check before
+going further:
+
+```bash
+curl -s -H "Authorization: Bearer $OPEN_CONNECTOR_TOKEN" \
+  "$GATEWAY/v1/actions?service=feishu&limit=500" \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); \
+    ids=[i['id'] for i in d['data']['items']]; print(len(ids)); \
+    print([n for n in ['feishu.list_chats','feishu.list_messages','feishu.list_chat_members','feishu.list_tasks','feishu.list_wiki_spaces','feishu.list_wiki_nodes'] if n not in ids])"
+# expect: a few hundred actions, then an empty list []
+```
+
 Operational findings from the live verification, all three of which the
 Feishu console gates independently of each other:
 
@@ -123,10 +157,46 @@ Feishu console gates independently of each other:
   (99992402 above it) despite the gateway schema declaring 100 — the
   pack requests 50.
 - Upstream gateway caveat: its authorization URL requests the union of
-  ALL feishu actions' scopes with no narrowing surface, which Feishu
-  rejects (20027) unless the app enables every one — deployments should
-  expect to narrow the provider's scope list until upstream grows a
-  config-level override.
+  ALL feishu actions' scopes with no narrowing surface — measured at
+  164 scopes on the live authorize URL, including destructive write
+  scopes, to read six tables — which Feishu rejects (20027) unless the
+  app enables every one. Until upstream grows a config-level override
+  ([#267](https://github.com/oomol-lab/open-connector/issues/267)),
+  narrow `feishuOAuthScopes` in the gateway's
+  `src/providers/feishu/definition.ts` to what these tables need:
+
+  ```ts
+  const feishuOAuthScopes = [
+    "offline_access",
+    "im:chat:read",                       // chats
+    "im:chat.members:read",               // chat_members
+    "im:message:readonly",                // messages (next three also messages)
+    "im:message.group_msg:get_as_user",
+    "im:message.p2p_msg:get_as_user",
+    "im:message.reactions:read",
+    "task:task:read",                     // tasks
+    "wiki:space:retrieve",                // wiki_spaces
+    "wiki:node:retrieve",                 // wiki_nodes
+  ];
+  ```
+
+  The Feishu console bulk-imports scopes, so enabling them is one paste:
+
+  ```json
+  {"scopes":{"tenant":[],"user":["offline_access","im:chat:read","im:chat.members:read",
+  "im:message:readonly","im:message.group_msg:get_as_user","im:message.p2p_msg:get_as_user",
+  "im:message.reactions:read","task:task:read","wiki:space:retrieve","wiki:node:retrieve"]}}
+  ```
+
+- Zero-trust corporate VPNs (aTrust / EasyConnect class) that map
+  external domains into `198.18.0.0/15` trip the gateway's egress guard
+  BEFORE any request leaves the process: the OAuth exchange fails in
+  tens of milliseconds with only `oauth_token_exchange_failed` and no
+  resolved address — the speed is the tell. The guard checks reserved
+  ranges unconditionally (`OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK` cannot
+  open them, and it does not reach provider egress at all); tracked
+  upstream as
+  [#275](https://github.com/oomol-lab/open-connector/issues/275).
 
 Filed upstream (oomol-lab/open-connector) from this verification pass:
 [#267](https://github.com/oomol-lab/open-connector/issues/267)

--- a/docs/open-connector.md
+++ b/docs/open-connector.md
@@ -21,7 +21,9 @@ gateway **runtime token**.
 > tables are gated on upstream cursor support), and
 > [Notion](open-connector-notion.md) (users, pages, data sources, block
 > children — dynamic-schema rows are gated on binding-time schema
-> freeze). Further provider packs (Jira, …) ship one pack per release per the
+> freeze), and [Feishu](open-connector-feishu.md) (chats, messages,
+> chat members, tasks, wiki — live-verified against a real workspace).
+> Further provider packs (Jira, …) ship one pack per release per the
 > [design spec](superpowers/specs/2026-07-11-open-connector-integration-design.md);
 > a source is advertised as supported only once its pack passes the
 > admission gate there.
@@ -260,6 +262,13 @@ already run. Cursor pagination that stops advancing fails as a detected
 loop instead of spinning forever; a continuation cursor of the wrong JSON
 type fails the scan as itself (only an absent, `null`, or empty-string
 cursor means end-of-collection — anything else would silently truncate).
+A pack may additionally declare `has_more_path` for providers whose FINAL
+page carries a non-empty cursor beside an explicit has-more flag (Feishu's
+wiki listings): the flag is then consulted first and is MANDATORY on every
+page — a page without it fails as contract drift rather than guessing.
+Declare it only for providers that always emit the signal; for the
+omit-when-false pattern (Slack's `response_metadata`), leave it undeclared
+and let the cursor spellings terminate the scan.
 Conversion errors report the action, row
 path, page, row, column, and expected type — with the offending JSON
 *kind*, never the value.

--- a/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
+++ b/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
@@ -284,7 +284,28 @@ event carrying the scan identity and error.
       with row identity, per-table search filter pins with an
       exactly-the-declared-inputs guard, blockId resource forwarding +
       pre-HTTP enforcement, LIMIT early-stop, UDTF parity).
-- [ ] 5.4 Later waves per the design rollout (Google Workspace, Discord, Feishu, HubSpot, Jira, …) through the source-pack admission gate
+- [x] 5.4 Feishu pack (OAuth user token, cursor pagination, hybrid wire shape — normalized envelope with raw snake_case items): chats, messages, chat_members, tasks, wiki_spaces, wiki_nodes.
+      Live contract reconciliation (gateway v1.3.3; all six input sets
+      validated to the credential wall, then all six tables verified against a
+      REAL workspace end to end on 2026-08-04 — the loose items schemas make
+      real rows the only column truth, and every fixture is a redacted live
+      capture). The live pass caught three contract defects no mock could:
+      tasks' `completed` boolean does not exist on the wire (status/
+      completed_at do; the draft column + pushdown are gone), Feishu wiki
+      answers its final page with `has_more:false` beside a NON-empty
+      `page_token` (new Cursor `has_more_path` engine field, authoritative
+      termination, both failure arms typed), and `im/v1/messages` caps
+      page_size at 50 on the wire against a declared max of 100. Engine
+      extensions: `timestamp_ms_string_utc`/`timestamp_s_string_utc` column
+      types, `epoch_seconds_string` filter format, simplified-boolean pushdown
+      normalization, `has_more_path`. Live e2e evidence: registration through
+      LIVE discovery; 86 messages over two real cursor pages, zero duplicate
+      ids; `create_time >=` pushdown narrowing a live scan to 15 rows; every
+      mapped column of every table non-NULL on real rows. Verification: 285
+      tests (`cargo test -p skardi --lib sources::providers::open_connector`,
+      post-merge with 5.3), 17 pack-scoped (`… packs::feishu`), 842 full
+      library suite.
+- [ ] 5.5 Later waves per the design rollout (Google Workspace, Discord, HubSpot, Jira, …) through the source-pack admission gate
 
 **Gate for each pack** (from the design spec): complete terminating pagination,
 deterministic schema, read-only allowlist, documented authz/rate limits,


### PR DESCRIPTION
## Summary

Milestone 5.4: the **Feishu source pack** — six tables over the `feishu.*` read actions (OAuth user_access_token), the chat-history-first wave: `chats`, `messages`, `chat_members`, `tasks`, `wiki_spaces`, `wiki_nodes`.

**Draft until the real-workspace verification (skill phase 4) lands.** The gateway declares every feishu items schema loose (zero declared properties), so no column is protected by the fingerprint gate — the coverage-gap pin records all columns as passthrough-only, and column truth can only be settled by scanning real rows. The spec entry stays unticked and the fixtures are marked synthetic drafts until that pass replaces them with redacted live captures.

## Wire contract (live-reconciled, gateway v1.3.3)

- 396 feishu actions enumerated live; the six chosen actions' contracts captured verbatim to `fixtures/feishu/contracts/` and fingerprint-pinned.
- Executor source read end to end: the feishu list executors rebuild the pagination **envelope** (camelCase `$.items` / `$.pageToken` — provider `page_token` normalized to null at end — / `$.hasMore`) while passing item objects through **raw** (snake_case, epoch digit-string timestamps). No post-pagination filtering anywhere, so cursor termination is undamaged; in-band `code != 0` is consumed by the executors → `error_path: None` for every table.
- All six tables' exact generated input sets validated to the credential wall (calibrated 400 `invalid_input` vs 403 `authorization_failed`, default connection).

## Design decisions

- **Cursor stability**: `chats`/`messages` pin `sortType: ByCreateTimeAsc` — the activity-ordered default reshuffles rows mid-scan (skips/duplicates); creation order is immutable.
- **`messages` is per-chat history**: `containerIdType` pinned to `chat`, the chat a required `containerId` binding resource (the `block_children` shape). One pushdown: `create_time >=` → `startTime`, inclusive epoch seconds rendered as a **digit string** under the strict schema, `Inexact`. `endTime` deliberately unmapped: exclusive + flooring = dropped rows.
- **`tasks`** pins `type: my_tasks` (declared, not inherited) and omits `completed` — Feishu's state=all; `completed` equality pushes Inexact.
- **`wiki_nodes` lists one level** (children of optional `parentNodeToken`, space root default); full-tree traversal is documented client-side recursion.

## Engine extensions (each backward-compatible, engine-level tested)

- `FieldType::TimestampMillisStringUtc` / `TimestampSecondsStringUtc` (`timestamp_ms_string_utc` / `timestamp_s_string_utc`): Feishu's epochs are digit STRINGS (im millis, wiki seconds) — neither existing timestamp type accepts them. Strict digit-string rule; overflow keeps its own diagnosis.
- `ValueFormat::EpochSecondsString` (`epoch_seconds_string`): epoch-seconds flooring rendered as a JSON string for schemas that TYPE epoch inputs as strings (`startTime`, minLength 1) — a number there is a hard 400.
- **Simplified-boolean pushdown normalization**: DataFusion's simplifier hands pushdown `completed` / `NOT completed` instead of `= true/false`, so boolean Eq mappings were unreachable; `translate_one` now normalizes both spellings back to the equality they mean.

## Verification

- `cargo test -p skardi --lib` → **822 passed** (16 new pack tests + 3 engine tests).
- Pack tests: fixture conversions (nulls/omissions/nesting/extras + admission-gate schema mismatch), fingerprint sync + coverage-gap pins, two-page cursor e2e with ordering pin and null-token termination, digit-string filter pushdown e2e (exact declared inputs, nothing else), required+optional resource forwarding, pre-HTTP resource enforcement, LIMIT early stop, UDTF parity, drift refusal.
- Note the shared pins: chats/messages/chat_members share one declared envelope schema (identical hash), as do the two wiki tables — the same shared-contract situation as Notion's search tables, recorded in the module doc.

## Remaining before ready-for-review

Phase-4 real-data pass against a live Feishu workspace (needs an operator-created Feishu custom app + OAuth authorization through the gateway): per-table scans through skardi-server, both-direction diff of real row keys vs mapped columns, fixture re-derivation as redacted live captures, then spec tick with counted verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Phase-4 real-workspace verification (update, 2026-08-04)

Live pass against a real Feishu workspace (OAuth user token via the gateway's authorization-code flow; gateway v1.3.3). **tasks / wiki_spaces / wiki_nodes are now fully verified; the three im tables remain drafts pending the test app's bot capability.**

**Two contract defects caught by real rows (the reason this phase exists):**

1. **`tasks` had an always-NULL draft column with a pushdown on it.** Real rows carry no `completed` boolean — completion is `status` (todo|done) + `completed_at`, whose "not completed" spelling is the digit string `"0"` (epoch-zero sentinel, documented at the column). The Inexact pushdown on that column would have re-trimmed **every** row to zero. Dropped the column and mapping, mapped `status` instead; the action's `completed` input stays deliberately unmapped (a status string cannot render into a boolean input without a value transform the engine deliberately lacks).
2. **Feishu wiki answers its final page with `has_more: false` beside a NON-empty `page_token`** (`"0||…"`; page 2 returns an empty page with yet another non-empty token). Null-token cursor termination therefore refetches a finished scan and dies as `PaginationLoop`. New engine field **`has_more_path`** on the Cursor strategy (optional, backward-compatible): when declared it is the authoritative termination; `hasMore: true` without a usable token fails as `PaginationCursorInvalid`, a non-boolean signal as the new `PaginationHasMoreInvalid`. Declared on all six feishu tables; 4 engine tests plus a live-shape e2e pin both sides.

**Live evidence (skardi-server → real gateway → real workspace):**
- Registration passes the fingerprint gate against LIVE discovery for all bound tables.
- `tasks`: 9 real rows (6 todo / 3 done); **every mapped column non-NULL somewhere** (`due` on 2 of 9 rows); `GROUP BY status` + sentinel check: done → real 2026 instants, todo → 1970-01-01 sentinel exactly as documented.
- `wiki_spaces`: completes in ONE request on the real `hasMore:false` + non-empty-token page — the scan that previously would have looped.
- `wiki_nodes`: 3 real nodes; epoch-second digit strings decode to real instants (2021-11-05T12:18:46Z); required `spaceId` resource forwarded; gains `creator`/`url` columns from live reconciliation (`wiki_spaces` gains `open_sharing`).
- Fixtures for the three verified tables are now **redacted live captures** (ids/names/urls synthetic, structure and envelope verbatim — including the non-empty final pageToken).

**Remaining before ready-for-review:** the im tables (`chats`/`messages`/`chat_members`) — Feishu gates im APIs on the app's **bot capability** (error 232025) independently of OAuth scopes. Once enabled on the test app, the same live pass completes for them.

**Upstream notes (to file on oomol-lab/open-connector):** (a) OAuth authorization URLs request the union of ALL ~400 feishu actions' scopes with no config-level narrowing — Feishu rejects the request (20027) unless the app enables every one; verified locally with a narrowed scope list. (b) wiki executors pass Feishu's non-empty final `page_token` through instead of normalizing it to the null the envelope contract implies.

Full suite: `cargo test -p skardi --lib` → **827 passed**.

### Update: chats / chat_members verified; messages page_size corrected (1d780ae)

Bot capability enabled on the test app unblocked the im probes. **Five of six tables are now fully live-verified end to end** (registration through live discovery + engine scans + redacted-live-capture fixtures): `chats` (8 real chats; gains `chat_mode`/`chat_status` from reconciliation; the assistant chat legitimately lacks `owner_id` — nullable proven live), `chat_members` (wire carries exactly the four mapped columns), plus the previously verified `tasks`/`wiki_spaces`/`wiki_nodes`.

Third live-only contract defect caught: **Feishu's `im/v1/messages` caps `page_size` at 50 on the wire** (99992402 above it) while the gateway schema declares a maximum of 100 — corrected to 50, pinned by the e2e.

`messages` rows remain the one unverified surface: with all OAuth scopes granted AND bot capability on, reads still answer 99991679 — Feishu's third gate, **tenant-admin approval of the high-sensitivity `im:message.*.get_as_user` permissions**, pending on the test app. Once approved, the same live pass completes and this PR leaves draft.

### Final: all six tables live-verified — ready for review (f82d1de)

`messages` cleared its last gate (the `im:message:readonly` scope — see the pack doc's operational findings for why the gateway-declared `get_as_user` scopes are not what this path needs). Live e2e: **86 messages over two real cursor pages, zero duplicate ids (2020→2026)**; `create_time >= startTime` pushdown narrowing a live scan to 15 rows; field-family coverage across 8 real chats (replies' `root_id`/`parent_id`, a topic group's `thread_id`, an @-mention's `mentions`, system messages' empty-string sender ids); fixture re-derived as a redacted live capture with one row per family. Third wire-vs-schema defect recorded: `im/v1/messages` caps `page_size` at 50 (99992402) against a declared max of 100 — corrected and pinned.

Milestone 5.4 ticks with counted verification: 270 open_connector tests / 17 pack-scoped / 827 full suite. Every fixture in the pack is now a redacted live capture.