### PR TITLE
fix(build): pin Rust via rust-toolchain.toml to keep Docker and CI in lockstep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,12 +159,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler
       - name: Install Rust
-        # Version comes from rust-toolchain.toml. Components are listed here
-        # rather than in the toolchain file so the Docker build doesn't pull
-        # them: rustfmt for `cargo fmt`, llvm-tools-preview for coverage.
-        # Runners install fresh pinned toolchains with the minimal profile,
-        # which includes neither.
-        run: rustup toolchain install --component llvm-tools-preview,rustfmt
+        # Version comes from rust-toolchain.toml. Runners install the pinned
+        # toolchain with the minimal profile, and a bare `rustup toolchain
+        # install` ignores CLI --component flags in favor of the toolchain
+        # file's spec — so components must be added in a second command.
+        # Kept out of the toolchain file so the Docker build doesn't pull
+        # them: rustfmt is for `cargo fmt`, llvm-tools-preview for coverage.
+        run: |
+          rustup toolchain install
+          rustup component add rustfmt llvm-tools-preview
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: install nextest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,8 +159,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler
       - name: Install Rust
-        # Version comes from rust-toolchain.toml.
-        run: rustup toolchain install --component llvm-tools-preview
+        # Version comes from rust-toolchain.toml. Components are listed here
+        # rather than in the toolchain file so the Docker build doesn't pull
+        # them: rustfmt for `cargo fmt`, llvm-tools-preview for coverage.
+        # Runners install fresh pinned toolchains with the minimal profile,
+        # which includes neither.
+        run: rustup toolchain install --component llvm-tools-preview,rustfmt
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: install nextest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        # No toolchain argument: rustup installs the version pinned in
+        # rust-toolchain.toml, keeping CI in lockstep with the Docker build.
+        run: rustup toolchain install
       - uses: Swatinem/rust-cache@v2
       - name: Install protoc
         run: sudo apt-get install -y protobuf-compiler
@@ -157,7 +159,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler
       - name: Install Rust
-        run: rustup toolchain install stable --component llvm-tools-preview
+        # Version comes from rust-toolchain.toml.
+        run: rustup toolchain install --component llvm-tools-preview
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: install nextest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        # No toolchain argument: rustup installs the version pinned in
+        # rust-toolchain.toml, keeping CI in lockstep with the Docker build.
+        run: rustup toolchain install
 
       - name: Cache cargo registry
         uses: actions/cache@v4

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -62,7 +62,8 @@ jobs:
           echo "Next version: v${NEXT}-rc.${RC_NUM}"
 
       - name: Install Rust
-        run: rustup toolchain install stable
+        # Version comes from rust-toolchain.toml.
+        run: rustup toolchain install
 
       - name: Bump version in Cargo.toml and open PR
         id: pr

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -48,7 +48,8 @@ jobs:
           echo "Promoting $RC_TAG -> $OFFICIAL"
 
       - name: Install Rust
-        run: rustup toolchain install stable
+        # Version comes from rust-toolchain.toml.
+        run: rustup toolchain install
 
       - name: Bump version in Cargo.toml and open PR
         id: pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,8 +106,9 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - name: Install Rust
+        # Version comes from rust-toolchain.toml.
         run: |
-          rustup toolchain install stable
+          rustup toolchain install
           rustup target add ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2
@@ -273,7 +274,8 @@ jobs:
           sudo apt-get install -y protobuf-compiler
 
       - name: Install Rust
-        run: rustup toolchain install stable
+        # Version comes from rust-toolchain.toml.
+        run: rustup toolchain install
 
       - uses: Swatinem/rust-cache@v2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # Build stage
-FROM rust:1.94.0-slim AS builder
+# The Rust version is pinned by rust-toolchain.toml (copied in with the source),
+# which rustup honors even if this tag drifts. Keep the tag matching the pin so
+# the build uses the preinstalled toolchain instead of downloading one.
+FROM rust:1.96.1-slim AS builder
 
 RUN apt-get update && apt-get install -y \
     pkg-config \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,8 @@
+# Single source of truth for the Rust version used by local dev, CI, and the
+# Docker image build. rustup resolves this file automatically for any cargo or
+# rustup invocation inside the repo, so all environments build with the same
+# compiler. Keep the builder tag in Dockerfile in sync when bumping: a matching
+# tag only avoids a toolchain download at image-build time — correctness comes
+# from this file either way.
+[toolchain]
+channel = "1.96.1"


### PR DESCRIPTION
## Problem

The release Docker build failed with:

```
aws-smithy-observability@0.3.0 requires rustc 1.94.1
aws-smithy-runtime@1.12.0 requires rustc 1.94.1
...
```

The `aws-smithy-*` versions locked in `Cargo.lock` (pulled in by the S3/object-store support, #171) require rustc **1.94.1**, while the Dockerfile builder was pinned to `rust:1.94.0-slim` — one patch too old. CI never caught it because every workflow installs the floating `stable` toolchain, so only the release image build was exposed to the drift.

## Fix

Make the Rust version a single source of truth so Docker, CI, and local dev move together:

- **Add `rust-toolchain.toml`** pinning `1.96.1` (current stable, matches local dev). rustup resolves it for any cargo invocation in the repo — including inside the Docker build, since `COPY . .` brings the file in. The image therefore compiles with the pinned version even if the base-image tag drifts; the original failure mode can't recur.
- **Bump the Dockerfile builder** to `rust:1.96.1-slim`, with a comment noting the tag match only avoids a toolchain download — correctness comes from the toolchain file.
- **Switch all workflows** (`ci`, `docs`, `release`, `draft-release`, `promote-release`) from `dtolnay/rust-toolchain@stable` / `rustup toolchain install stable` to a bare `rustup toolchain install`, which installs the file-pinned version (rustup ≥ 1.28, standard on GitHub runners).

## Behavior change

CI no longer floats on latest stable. A future dependency MSRV bump will fail loudly in every job until `rust-toolchain.toml` is raised (a one-line change), instead of surfacing only at release time.

## Verification

- Full builder-stage `docker build` with `--build-arg FEATURES=rag` (the exact failing release step) completed successfully with the new image.
- `rustup show active-toolchain` in the repo resolves to `1.96.1 (overridden by rust-toolchain.toml)`.
- All workflow YAML validated; no `stable` installs or `dtolnay/rust-toolchain` references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)