### PR TITLE
fix(udf): LargeUtf8 text columns in chunk/chunk_parts; document json_pack sub-ms truncation

### DIFF
--- a/crates/skardi/src/model/chunking/mod.rs
+++ b/crates/skardi/src/model/chunking/mod.rs
@@ -379,6 +379,30 @@ fn read_scalar_usize(udf: &str, arg: &ColumnarValue, name: &str) -> DfResult<usi
     Ok(n as usize)
 }
 
+/// Pre-flight for LargeUtf8 COLUMNS: chunk output flows through
+/// i32-offset builders (`StringBuilder`), whose offset overflow is a
+/// PANIC in arrow, not an error — and LargeUtf8 is the one layout whose
+/// contract makes >2 GiB legal input. Chunk output ≈ input bytes (more
+/// with overlap), so reject early with a real error instead of
+/// unwinding mid-batch. (A near-2 GiB Utf8 column plus overlap can
+/// still overflow — that exposure predates LargeUtf8 support and is
+/// shared with every i32-offset producer.) Offsets first-to-last, so a
+/// SLICED array counts its own bytes, not the whole buffer's. A free
+/// function over raw offsets so the boundary is unit-testable without a
+/// 2 GiB allocation.
+fn ensure_large_text_fits_i32(udf: &str, name: &str, offsets: &[i64]) -> DfResult<()> {
+    let total_bytes =
+        offsets.last().copied().unwrap_or_default() - offsets.first().copied().unwrap_or_default();
+    if total_bytes > i64::from(i32::MAX) {
+        return Err(DataFusionError::Execution(format!(
+            "{udf}: '{name}' carries more than 2 GiB of text in one batch; \
+             chunk output is built as 32-bit-offset Utf8 and cannot hold it — \
+             split the input into smaller batches"
+        )));
+    }
+    Ok(())
+}
+
 fn read_text_column<'a>(
     udf: &str,
     arg: &'a ColumnarValue,
@@ -399,32 +423,7 @@ fn read_text_column<'a>(
                 return Ok(view_arr.iter().collect());
             }
             if let Some(large_arr) = arr.as_any().downcast_ref::<LargeStringArray>() {
-                // Pre-flight: chunk output flows through i32-offset
-                // builders (`StringBuilder`), whose offset overflow is a
-                // PANIC in arrow, not an error — and LargeUtf8 is the one
-                // layout whose contract makes >2 GiB legal input. Chunk
-                // output ≈ input bytes (more with overlap), so reject
-                // early with a real error instead of unwinding mid-batch.
-                // (A near-2 GiB Utf8 column plus overlap can still
-                // overflow — that exposure predates LargeUtf8 support and
-                // is shared with every i32-offset producer.)
-                let total_bytes = large_arr
-                    .value_offsets()
-                    .last()
-                    .copied()
-                    .unwrap_or_default()
-                    - large_arr
-                        .value_offsets()
-                        .first()
-                        .copied()
-                        .unwrap_or_default();
-                if total_bytes > i64::from(i32::MAX) {
-                    return Err(DataFusionError::Execution(format!(
-                        "{udf}: '{name}' carries more than 2 GiB of text in one batch; \
-                         chunk output is built as 32-bit-offset Utf8 and cannot hold it — \
-                         split the input into smaller batches"
-                    )));
-                }
+                ensure_large_text_fits_i32(udf, name, large_arr.value_offsets())?;
                 return Ok(large_arr.iter().collect());
             }
             let str_arr = arr.as_any().downcast_ref::<StringArray>().ok_or_else(|| {
@@ -664,6 +663,119 @@ mod tests {
         assert_eq!(list.len(), 2);
         assert!(list_at(list, 0).len() >= 3);
         assert!(list.is_null(1), "null in → null out");
+    }
+
+    #[test]
+    fn utf8view_text_columns_and_scalars_chunk_like_utf8() {
+        // The view arm (DataFusion 52 carries computed string expressions
+        // as view arrays/scalars) — column with a null, then the scalar.
+        let texts = StringViewArray::from(vec![Some("a".repeat(250)), None]);
+        let result = udf()
+            .invoke_with_args(make_args(vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("character".to_string()))),
+                ColumnarValue::Array(Arc::new(texts)),
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(100))),
+            ]))
+            .unwrap();
+        let arr = match result {
+            ColumnarValue::Array(a) => a,
+            _ => panic!("expected array"),
+        };
+        let list = arr.as_any().downcast_ref::<ListArray>().unwrap();
+        assert!(list_at(list, 0).len() >= 3);
+        assert!(list.is_null(1), "null in → null out");
+
+        // LargeUtf8 and Utf8View SCALARS: a literal must never be
+        // stricter than a column.
+        for scalar in [
+            ScalarValue::LargeUtf8(Some("b".repeat(150))),
+            ScalarValue::Utf8View(Some("b".repeat(150))),
+        ] {
+            let result = udf()
+                .invoke_with_args(make_args(vec![
+                    ColumnarValue::Scalar(ScalarValue::Utf8(Some("character".to_string()))),
+                    ColumnarValue::Scalar(scalar),
+                    ColumnarValue::Scalar(ScalarValue::Int64(Some(100))),
+                ]))
+                .unwrap();
+            let arr = match result {
+                ColumnarValue::Array(a) => a,
+                _ => panic!("expected array"),
+            };
+            let list = arr.as_any().downcast_ref::<ListArray>().unwrap();
+            assert_eq!(list_at(list, 0).len(), 2);
+        }
+
+        // Typed NULL scalars of every string layout → a NULL list row.
+        for scalar in [
+            ScalarValue::Utf8(None),
+            ScalarValue::LargeUtf8(None),
+            ScalarValue::Utf8View(None),
+        ] {
+            let result = udf()
+                .invoke_with_args(make_args(vec![
+                    ColumnarValue::Scalar(ScalarValue::Utf8(Some("character".to_string()))),
+                    ColumnarValue::Scalar(scalar),
+                    ColumnarValue::Scalar(ScalarValue::Int64(Some(100))),
+                ]))
+                .unwrap();
+            let arr = match result {
+                ColumnarValue::Array(a) => a,
+                _ => panic!("expected array"),
+            };
+            let list = arr.as_any().downcast_ref::<ListArray>().unwrap();
+            assert!(list.is_null(0), "typed NULL text → NULL list");
+        }
+    }
+
+    #[test]
+    fn non_string_text_arguments_name_the_accepted_layouts() {
+        // Column of the wrong type → the array-arm diagnostic.
+        let err = udf()
+            .invoke_with_args(make_args(vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("character".to_string()))),
+                ColumnarValue::Array(Arc::new(arrow::array::Int64Array::from(vec![1, 2]))),
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(100))),
+            ]))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("must be a string column (Utf8, LargeUtf8, or Utf8View)"),
+            "{err}"
+        );
+
+        // Scalar of the wrong type → the scalar-arm diagnostic.
+        let err = udf()
+            .invoke_with_args(make_args(vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("character".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(7))),
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(100))),
+            ]))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("must be a string (Utf8, LargeUtf8, or Utf8View)"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn the_two_gib_preflight_boundary_is_exact() {
+        // Raw offsets, so the boundary is pinned without a 2 GiB
+        // allocation: exactly i32::MAX passes, one past fails, and a
+        // SLICED array (non-zero first offset) counts its own bytes.
+        let max = i64::from(i32::MAX);
+        assert!(ensure_large_text_fits_i32("chunk", "text", &[0, max]).is_ok());
+        let err = ensure_large_text_fits_i32("chunk", "text", &[0, max + 1])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("more than 2 GiB"), "{err}");
+        assert!(err.contains("split the input"), "the fix is named: {err}");
+        // Slice: 10 bytes into a huge buffer — the slice's own span is
+        // what counts.
+        assert!(ensure_large_text_fits_i32("chunk", "text", &[max, max + 10]).is_ok());
+        // Empty offsets: nothing to overflow.
+        assert!(ensure_large_text_fits_i32("chunk", "text", &[]).is_ok());
     }
 
     #[test]

--- a/crates/skardi/src/model/chunking/mod.rs
+++ b/crates/skardi/src/model/chunking/mod.rs
@@ -64,7 +64,8 @@ impl ChunkingRegistry {
     /// chunk(mode, text, size [, overlap]) -> List<Utf8>
     /// ```
     /// - `mode`: `'character'` or `'markdown'`
-    /// - `text`: `Utf8` literal, scalar subquery, or column
+    /// - `text`: string literal, scalar subquery, or column — any string
+    ///   layout (`Utf8`, `LargeUtf8`, `Utf8View`)
     /// - `size`: target max chunk length (characters), positive integer literal
     /// - `overlap`: optional characters of overlap between adjacent chunks; must be `< size`
     pub fn register_chunk_udf(self: &Arc<Self>, ctx: &mut SessionContext) {
@@ -389,42 +390,49 @@ fn read_text_column<'a>(
         // arrays/scalars (the same reality open_connector/filters.rs
         // handles), LargeUtf8 columns arrive from large-string sources,
         // and the scalar arm below already accepts all three spellings —
-        // a text COLUMN must not be stricter than a text LITERAL.
+        // a text COLUMN must not be stricter than a text LITERAL. Each
+        // arm is `iter().collect()`: all three arrow string arrays yield
+        // `Option<&str>` with identical null/offset behavior, and one
+        // spelling keeps the arms from diverging.
         ColumnarValue::Array(arr) => {
             if let Some(view_arr) = arr.as_any().downcast_ref::<StringViewArray>() {
-                return Ok((0..view_arr.len())
-                    .map(|i| {
-                        if view_arr.is_null(i) {
-                            None
-                        } else {
-                            Some(view_arr.value(i))
-                        }
-                    })
-                    .collect());
+                return Ok(view_arr.iter().collect());
             }
             if let Some(large_arr) = arr.as_any().downcast_ref::<LargeStringArray>() {
-                return Ok((0..large_arr.len())
-                    .map(|i| {
-                        if large_arr.is_null(i) {
-                            None
-                        } else {
-                            Some(large_arr.value(i))
-                        }
-                    })
-                    .collect());
+                // Pre-flight: chunk output flows through i32-offset
+                // builders (`StringBuilder`), whose offset overflow is a
+                // PANIC in arrow, not an error — and LargeUtf8 is the one
+                // layout whose contract makes >2 GiB legal input. Chunk
+                // output ≈ input bytes (more with overlap), so reject
+                // early with a real error instead of unwinding mid-batch.
+                // (A near-2 GiB Utf8 column plus overlap can still
+                // overflow — that exposure predates LargeUtf8 support and
+                // is shared with every i32-offset producer.)
+                let total_bytes = large_arr
+                    .value_offsets()
+                    .last()
+                    .copied()
+                    .unwrap_or_default()
+                    - large_arr
+                        .value_offsets()
+                        .first()
+                        .copied()
+                        .unwrap_or_default();
+                if total_bytes > i64::from(i32::MAX) {
+                    return Err(DataFusionError::Execution(format!(
+                        "{udf}: '{name}' carries more than 2 GiB of text in one batch; \
+                         chunk output is built as 32-bit-offset Utf8 and cannot hold it — \
+                         split the input into smaller batches"
+                    )));
+                }
+                return Ok(large_arr.iter().collect());
             }
             let str_arr = arr.as_any().downcast_ref::<StringArray>().ok_or_else(|| {
-                DataFusionError::Execution(format!("{udf}: '{name}' must be a Utf8 column"))
+                DataFusionError::Execution(format!(
+                    "{udf}: '{name}' must be a string column (Utf8, LargeUtf8, or Utf8View)"
+                ))
             })?;
-            Ok((0..str_arr.len())
-                .map(|i| {
-                    if str_arr.is_null(i) {
-                        None
-                    } else {
-                        Some(str_arr.value(i))
-                    }
-                })
-                .collect())
+            Ok(str_arr.iter().collect())
         }
         ColumnarValue::Scalar(ScalarValue::Utf8(Some(s)))
         | ColumnarValue::Scalar(ScalarValue::LargeUtf8(Some(s)))
@@ -433,7 +441,7 @@ fn read_text_column<'a>(
             ScalarValue::Utf8(None) | ScalarValue::LargeUtf8(None) | ScalarValue::Utf8View(None),
         ) => Ok(vec![None]),
         _ => Err(DataFusionError::Execution(format!(
-            "{udf}: '{name}' must be Utf8"
+            "{udf}: '{name}' must be a string (Utf8, LargeUtf8, or Utf8View)"
         ))),
     }
 }

--- a/crates/skardi/src/model/chunking/mod.rs
+++ b/crates/skardi/src/model/chunking/mod.rs
@@ -26,8 +26,8 @@
 use std::sync::Arc;
 
 use arrow::array::{
-    Array, ArrayRef, Int32Builder, ListBuilder, StringArray, StringBuilder, StringViewArray,
-    StructBuilder,
+    Array, ArrayRef, Int32Builder, LargeStringArray, ListBuilder, StringArray, StringBuilder,
+    StringViewArray, StructBuilder,
 };
 use arrow::datatypes::{DataType, Field, Fields};
 use datafusion::common::Result as DfResult;
@@ -384,10 +384,12 @@ fn read_text_column<'a>(
     name: &str,
 ) -> DfResult<Vec<Option<&'a str>>> {
     match arg {
-        // Utf8View included alongside the classic layouts: DataFusion 52
-        // carries computed string expressions as view arrays/scalars (the
-        // same reality open_connector/filters.rs handles), and a text
-        // column fed through a CAST or concat must not fail the split.
+        // Utf8View and LargeUtf8 included alongside the classic layout:
+        // DataFusion 52 carries computed string expressions as view
+        // arrays/scalars (the same reality open_connector/filters.rs
+        // handles), LargeUtf8 columns arrive from large-string sources,
+        // and the scalar arm below already accepts all three spellings —
+        // a text COLUMN must not be stricter than a text LITERAL.
         ColumnarValue::Array(arr) => {
             if let Some(view_arr) = arr.as_any().downcast_ref::<StringViewArray>() {
                 return Ok((0..view_arr.len())
@@ -396,6 +398,17 @@ fn read_text_column<'a>(
                             None
                         } else {
                             Some(view_arr.value(i))
+                        }
+                    })
+                    .collect());
+            }
+            if let Some(large_arr) = arr.as_any().downcast_ref::<LargeStringArray>() {
+                return Ok((0..large_arr.len())
+                    .map(|i| {
+                        if large_arr.is_null(i) {
+                            None
+                        } else {
+                            Some(large_arr.value(i))
                         }
                     })
                     .collect());
@@ -620,6 +633,29 @@ mod tests {
         assert!(list_at(list, 0).len() >= 3); // 250 chars / 100 → ≥3
         assert_eq!(list_at(list, 1).len(), 1); // 50 chars fits in one
         assert!(list.is_null(2)); // null in → null out
+    }
+
+    #[test]
+    fn large_utf8_text_column_chunks_like_utf8() {
+        // A text COLUMN must not be stricter than a text LITERAL: the
+        // scalar arm accepts LargeUtf8, so the array arm must too
+        // (large-string sources hand DataFusion LargeUtf8 columns).
+        let texts = LargeStringArray::from(vec![Some("a".repeat(250)), None]);
+        let result = udf()
+            .invoke_with_args(make_args(vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("character".to_string()))),
+                ColumnarValue::Array(Arc::new(texts)),
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(100))),
+            ]))
+            .unwrap();
+        let arr = match result {
+            ColumnarValue::Array(a) => a,
+            _ => panic!("expected array"),
+        };
+        let list = arr.as_any().downcast_ref::<ListArray>().unwrap();
+        assert_eq!(list.len(), 2);
+        assert!(list_at(list, 0).len() >= 3);
+        assert!(list.is_null(1), "null in → null out");
     }
 
     #[test]

--- a/crates/skardi/src/util/json_pack.rs
+++ b/crates/skardi/src/util/json_pack.rs
@@ -171,11 +171,13 @@ fn scalar_to_value(scalar: &ScalarValue) -> DFResult<Value> {
                 )
             })
         })?,
-        // Sub-millisecond precision is TRUNCATED (floor division), by
-        // design: the contract is epoch milliseconds, and micro/nano
-        // inputs give up their remainder. Asymmetric with the Second arm
-        // above on purpose — narrowing can overflow and must be checked,
-        // widening cannot.
+        // Sub-millisecond precision is dropped by FLOOR division
+        // (`div_euclid`, rounds toward -inf — a pre-epoch instant rounds
+        // EARLIER, never toward zero: -1500us becomes -2ms), by design:
+        // the contract is epoch milliseconds, and micro/nano inputs give
+        // up their remainder. Asymmetric with the Second arm above on
+        // purpose — narrowing can overflow and must be checked, widening
+        // cannot.
         ScalarValue::TimestampMicrosecond(v, _) => {
             v.map_or(Value::Null, |us| Value::from(us.div_euclid(1000)))
         }
@@ -317,7 +319,9 @@ mod tests {
                    's',  arrow_cast(1735689600, 'Timestamp(Second, None)'), \
                    'us', arrow_cast(1735689600000001, 'Timestamp(Microsecond, None)'), \
                    'ns', arrow_cast(1735689600000000001, 'Timestamp(Nanosecond, None)'), \
-                   'neg', arrow_cast(-1500, 'Timestamp(Millisecond, None)')) AS m",
+                   'neg', arrow_cast(-1500, 'Timestamp(Millisecond, None)'), \
+                   'neg_us', arrow_cast(-1500, 'Timestamp(Microsecond, None)'), \
+                   'neg_ns', arrow_cast(-1500, 'Timestamp(Nanosecond, None)')) AS m",
             )
             .await
             .unwrap()
@@ -334,6 +338,12 @@ mod tests {
         assert_eq!(row["us"], 1_735_689_600_000_i64, "micros floor toward −∞");
         assert_eq!(row["ns"], 1_735_689_600_000_i64, "nanos floor toward −∞");
         assert_eq!(row["neg"], -1500_i64, "pre-epoch instants keep their sign");
+        // The negative micro/nano contract, pinned by value: floor rounds
+        // pre-epoch instants EARLIER (-1500µs → -2ms), never toward zero
+        // (truncation would give -1ms). The comment at the conversion says
+        // "floor"; this is what keeps it honest.
+        assert_eq!(row["neg_us"], -2_i64, "pre-epoch micros floor toward −∞");
+        assert_eq!(row["neg_ns"], -1_i64, "pre-epoch nanos floor toward −∞");
     }
 
     /// A seconds timestamp too large for a millis i64 refuses with a

--- a/crates/skardi/src/util/json_pack.rs
+++ b/crates/skardi/src/util/json_pack.rs
@@ -171,6 +171,11 @@ fn scalar_to_value(scalar: &ScalarValue) -> DFResult<Value> {
                 )
             })
         })?,
+        // Sub-millisecond precision is TRUNCATED (floor division), by
+        // design: the contract is epoch milliseconds, and micro/nano
+        // inputs give up their remainder. Asymmetric with the Second arm
+        // above on purpose — narrowing can overflow and must be checked,
+        // widening cannot.
         ScalarValue::TimestampMicrosecond(v, _) => {
             v.map_or(Value::Null, |us| Value::from(us.div_euclid(1000)))
         }

--- a/docs/chunk.md
+++ b/docs/chunk.md
@@ -24,7 +24,7 @@ chunk(mode, text, size [, overlap]) -> List<Utf8>
 | Argument | Type | Description |
 |----------|------|-------------|
 | `mode` | string literal | Splitter to use. Supported: `'character'`, `'markdown'`. |
-| `text` | `Utf8` | The text to split. May be a literal, a scalar subquery, or a column reference. `NULL` rows pass through unchanged. |
+| `text` | string (`Utf8`, `LargeUtf8`, or `Utf8View`) | The text to split. May be a literal, a scalar subquery, or a column reference — any Arrow string layout. `NULL` rows pass through unchanged. |
 | `size` | integer literal | Target maximum chunk length in characters. Must be `> 0`. |
 | `overlap` | integer literal | Optional. Characters of overlap between adjacent chunks. Must be strictly less than `size`. Defaults to `0`. |
 


### PR DESCRIPTION
Two findings from the skardi-cloud etl-generator review ([skardi-cloud#232 round 4](https://github.com/SkardiLabs/skardi-cloud/pull/232)) that belong in this repo now that #193 landed the UDFs here:

1. **`read_text_column` accepted `LargeUtf8` as a scalar but rejected it as a column** — the array arm downcast only `StringArray`/`StringViewArray`, so a `LargeUtf8` content column failed at job run time with "must be a Utf8 column". A text column must not be stricter than a text literal; `LargeStringArray` joins the downcast chain, with a regression test (split + null passthrough).

2. **`json_pack`'s micro/nano timestamp arms silently floor-divide to epoch milliseconds.** The truncation is by design (the contract is epoch ms) but was undocumented and read as asymmetric against the Second arm's overflow check. The comment now states both: sub-ms precision is deliberately dropped, and only the widening direction needs the overflow guard.

## Verification

- 18 `model::chunking` tests (`--features chunking`), 9 `util::json_pack` tests, clippy clean.
- skardi-cloud's `skardi-etl` will repin to the rev containing this fix (its vendored UDF copies are being deleted in #232 now that #193 is merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)