### PR TITLE
feat(query-audit): extract the ledger crate + nullable identity columns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9552,6 +9552,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "skardi-query-audit"
+version = "0.5.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tokio-rusqlite",
+]
+
+[[package]]
 name = "skardi-server"
 version = "0.5.0"
 dependencies = [
@@ -9582,6 +9594,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "skardi",
+ "skardi-query-audit",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9670,6 +9670,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-rusqlite",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 [workspace]
 members = [ "crates/cli",
             "crates/skardi",
+            "crates/query-audit",
             "crates/server"]
 
 resolver = "2"

--- a/crates/query-audit/Cargo.toml
+++ b/crates/query-audit/Cargo.toml
@@ -9,7 +9,14 @@ anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 serde_json = { workspace = true }
 tokio-rusqlite = { workspace = true }
+# The pipeline-audit path (#213) bounds its ledger write with
+# `tokio::time::timeout` and reports a lost outcome through `tracing`. Both
+# arrived with that change while this crate was being extracted, so they are
+# declared here rather than inherited from the server that used to host the
+# module.
+tokio = { workspace = true, features = ["time"] }
+tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["rt", "macros"] }
+tokio = { workspace = true, features = ["rt", "macros", "time"] }

--- a/crates/query-audit/Cargo.toml
+++ b/crates/query-audit/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "skardi-query-audit"
+version.workspace = true
+edition.workspace = true
+description = "SQLite-backed durable audit ledger for /query — shared by the OSS server and downstream distributions"
+
+[dependencies]
+anyhow = "1.0"
+chrono = { version = "0.4", features = ["serde"] }
+serde_json = { workspace = true }
+tokio-rusqlite = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/query-audit/src/lib.rs
+++ b/crates/query-audit/src/lib.rs
@@ -68,7 +68,10 @@ pub(crate) const AUDIT_WRITE_TIMEOUT: Duration = Duration::from_secs(5);
 ///
 /// `skardi-cli` restates this cap under the same name (`run.rs`) because the
 /// CLI crate does not depend on this one; keep them in sync.
-pub(crate) const MAX_SESSION_ID_CHARS: usize = 200;
+/// `pub` because the handlers that enforce this bound now live in a
+/// different crate: `pub(crate)` was the right scope while this module was
+/// inside the server, and the extraction is what widened it.
+pub const MAX_SESSION_ID_CHARS: usize = 200;
 
 /// Error from [`bounded`] that keeps "the write timed out" distinguishable
 /// from "the write ran and failed" (e.g. `ConnectionClosed`). Only the
@@ -129,7 +132,10 @@ async fn bounded<T>(
 /// the statement, so it is logged rather than surfaced: the row simply stays
 /// `started` and the next startup reconciles it to `unknown`. No-op when
 /// auditing is off. Callers pass `app_state.query_audit.as_deref()`.
-pub(crate) async fn finish_audit(
+/// `pub` for the same reason as [`MAX_SESSION_ID_CHARS`] — the ad-hoc and
+/// pipeline handlers both stamp their terminal outcome through this, and they
+/// are no longer in this crate.
+pub async fn finish_audit(
     store: Option<&QueryAuditStore>,
     audit_id: Option<&str>,
     status: QueryAuditStatus,

--- a/crates/query-audit/src/lib.rs
+++ b/crates/query-audit/src/lib.rs
@@ -46,7 +46,12 @@ const INIT_SCHEMA_SQL: &str = "CREATE TABLE IF NOT EXISTS query_audit (
     statement_kind TEXT NOT NULL,
     status         TEXT NOT NULL,
     row_count      INTEGER,
-    error          TEXT
+    error          TEXT,
+    request_id     TEXT,
+    org_id         TEXT,
+    workspace_id   TEXT,
+    user_id        TEXT,
+    run_id         TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_query_audit_session_created
     ON query_audit (session_id, created_at DESC);
@@ -54,6 +59,42 @@ CREATE INDEX IF NOT EXISTS idx_query_audit_created
     ON query_audit (created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_query_audit_status
     ON query_audit (status);";
+
+/// The five identity columns, in order. `CREATE TABLE IF NOT EXISTS` cannot
+/// retrofit an existing table, so [`ensure_identity_columns`] reconciles the
+/// live schema on every open — additive, idempotent, and a no-op on fresh
+/// databases.
+const IDENTITY_COLUMNS: [&str; 5] = ["request_id", "org_id", "workspace_id", "user_id", "run_id"];
+
+fn ensure_identity_columns(conn: &rusqlite::Connection) -> SqlResult<()> {
+    let mut stmt = conn.prepare("PRAGMA table_info(query_audit)")?;
+    let existing: std::collections::HashSet<String> = stmt
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<std::result::Result<_, _>>()?;
+    for col in IDENTITY_COLUMNS {
+        if !existing.contains(col) {
+            conn.execute(
+                &format!("ALTER TABLE query_audit ADD COLUMN {col} TEXT"),
+                [],
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// Who ran the statement, when the distribution knows. Every field optional:
+/// the OSS single-user server records none of them; an authenticated
+/// distribution (e.g. an engine fronted by an identity-minting gateway)
+/// fills what its envelope carries. Nullable columns, never a fork — the
+/// same table remains readable by the same tooling either way.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct QueryIdentity {
+    pub request_id: Option<String>,
+    pub org_id: Option<String>,
+    pub workspace_id: Option<String>,
+    pub user_id: Option<String>,
+    pub run_id: Option<String>,
+}
 
 /// Outcome of an audited statement.
 ///
@@ -125,6 +166,7 @@ impl QueryAuditStore {
             conn.pragma_update(None, "journal_mode", "WAL")?;
             conn.pragma_update(None, "synchronous", "FULL")?;
             conn.execute_batch(INIT_SCHEMA_SQL)?;
+            ensure_identity_columns(conn)?;
             Ok(())
         })
         .await
@@ -152,6 +194,7 @@ impl QueryAuditStore {
             .context("Failed to open in-memory query-audit db")?;
         conn.call(|conn| -> SqlResult<()> {
             conn.execute_batch(INIT_SCHEMA_SQL)?;
+            ensure_identity_columns(conn)?;
             Ok(())
         })
         .await
@@ -184,6 +227,21 @@ impl QueryAuditStore {
         max_rows: usize,
         statement_kind: &str,
     ) -> Result<String> {
+        self.record_started_for(sql, ai_context, max_rows, statement_kind, None)
+            .await
+    }
+
+    /// [`record_started`], carrying the caller's identity when the
+    /// distribution has one. `None` fields land as NULL — the OSS server
+    /// always passes `None` for the whole thing.
+    pub async fn record_started_for(
+        &self,
+        sql: &str,
+        ai_context: Option<&Value>,
+        max_rows: usize,
+        statement_kind: &str,
+        identity: Option<&QueryIdentity>,
+    ) -> Result<String> {
         let id = new_id();
         let created_at = chrono::Utc::now().to_rfc3339();
         // `session_id` is denormalised out of the context object so the index
@@ -196,14 +254,16 @@ impl QueryAuditStore {
         let sql = sql.to_string();
         let statement_kind = statement_kind.to_string();
         let row_id = id.clone();
+        let identity = identity.cloned().unwrap_or_default();
 
         self.conn
             .call(move |conn| -> SqlResult<()> {
                 conn.execute(
                     "INSERT INTO query_audit
                         (id, created_at, sql, ai_context, session_id, max_rows,
-                         statement_kind, status)
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                         statement_kind, status,
+                         request_id, org_id, workspace_id, user_id, run_id)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
                     params![
                         row_id,
                         created_at,
@@ -213,6 +273,11 @@ impl QueryAuditStore {
                         max_rows as i64,
                         statement_kind,
                         QueryAuditStatus::Started.as_str(),
+                        identity.request_id,
+                        identity.org_id,
+                        identity.workspace_id,
+                        identity.user_id,
+                        identity.run_id,
                     ],
                 )?;
                 Ok(())
@@ -303,7 +368,8 @@ impl QueryAuditStore {
             .call(move |conn| -> SqlResult<Option<Value>> {
                 let mut stmt = conn.prepare(
                     "SELECT id, created_at, finished_at, sql, ai_context, session_id,
-                            max_rows, statement_kind, status, row_count, error
+                            max_rows, statement_kind, status, row_count, error,
+                            request_id, org_id, workspace_id, user_id, run_id
                        FROM query_audit WHERE id = ?1",
                 )?;
                 let row = stmt
@@ -321,6 +387,11 @@ impl QueryAuditStore {
                             "status": row.get::<_, String>(8)?,
                             "row_count": row.get::<_, Option<i64>>(9)?,
                             "error": row.get::<_, Option<String>>(10)?,
+                            "request_id": row.get::<_, Option<String>>(11)?,
+                            "org_id": row.get::<_, Option<String>>(12)?,
+                            "workspace_id": row.get::<_, Option<String>>(13)?,
+                            "user_id": row.get::<_, Option<String>>(14)?,
+                            "run_id": row.get::<_, Option<String>>(15)?,
                         }))
                     })
                     .ok();
@@ -432,6 +503,81 @@ fn new_id() -> String {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// The identity columns exist for downstream distributions whose caller
+    /// is authenticated (the cloud engine's envelope): five nullable columns,
+    /// written when the caller supplies them, NULL otherwise. OSS rows leave
+    /// them empty — same table, same file, same tooling.
+    #[tokio::test]
+    async fn identity_travels_when_supplied_and_is_null_otherwise() {
+        let store = QueryAuditStore::open_in_memory().await.unwrap();
+        let identity = QueryIdentity {
+            request_id: Some("req-9c41".into()),
+            org_id: Some("acme".into()),
+            workspace_id: Some("ws-core".into()),
+            user_id: Some("user:acme/alice".into()),
+            run_id: None,
+        };
+        let with_id = store
+            .record_started_for("SELECT 1", None, 10, "Query", Some(&identity))
+            .await
+            .unwrap();
+        let record = store.get(&with_id).await.unwrap().unwrap();
+        assert_eq!(record["request_id"], json!("req-9c41"));
+        assert_eq!(record["org_id"], json!("acme"));
+        assert_eq!(record["workspace_id"], json!("ws-core"));
+        assert_eq!(record["user_id"], json!("user:acme/alice"));
+        assert!(record["run_id"].is_null());
+
+        let anon = store
+            .record_started("SELECT 2", None, 10, "Query")
+            .await
+            .unwrap();
+        let record = store.get(&anon).await.unwrap().unwrap();
+        for col in ["request_id", "org_id", "workspace_id", "user_id", "run_id"] {
+            assert!(record[col].is_null(), "OSS rows leave {col} NULL");
+        }
+    }
+
+    /// A database created by a pre-identity binary gains the columns on open,
+    /// idempotently — `CREATE TABLE IF NOT EXISTS` alone cannot retrofit an
+    /// existing table, so open() must reconcile the live schema.
+    #[tokio::test]
+    async fn an_old_database_gains_the_identity_columns_on_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("audit.db");
+        {
+            // Simulate the pre-identity schema exactly.
+            let conn = Connection::open(&path).await.unwrap();
+            conn.call(|conn| -> SqlResult<()> {
+                conn.execute_batch(
+                    "CREATE TABLE query_audit (
+                        id TEXT PRIMARY KEY, created_at TEXT NOT NULL,
+                        finished_at TEXT, sql TEXT NOT NULL, ai_context TEXT,
+                        session_id TEXT, max_rows INTEGER NOT NULL,
+                        statement_kind TEXT NOT NULL, status TEXT NOT NULL,
+                        row_count INTEGER, error TEXT);",
+                )?;
+                conn.execute(
+                    "INSERT INTO query_audit (id, created_at, sql, max_rows, statement_kind, status)
+                     VALUES ('old-row', '2026-01-01T00:00:00Z', 'SELECT 0', 1, 'Query', 'succeeded')",
+                    [],
+                )?;
+                Ok(())
+            })
+            .await
+            .unwrap();
+            conn.close().await.unwrap();
+        }
+
+        // Open twice: the migration must be idempotent.
+        for _ in 0..2 {
+            let store = QueryAuditStore::open(&path).await.unwrap();
+            let record = store.get("old-row").await.unwrap().unwrap();
+            assert_eq!(record["sql"], json!("SELECT 0"), "old rows survive");
+            assert!(record["user_id"].is_null(), "old rows read NULL identity");
+        }
+    }
 
     #[tokio::test]
     async fn records_sql_ai_context_and_outcome() {

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -63,6 +63,7 @@ base64 = "0.22"
 thiserror = "1.0"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "sync", "time"] }
 tokio-rusqlite = { workspace = true }
+skardi-query-audit = { path = "../query-audit" }
 tower = { workspace = true }
 tower-http = { workspace = true, features = ["fs", "trace", "cors"] }
 tracing = { workspace = true }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -7,7 +7,10 @@ pub mod logging;
 pub mod metrics;
 pub mod optimizer_registry;
 pub mod pipeline_handlers;
-pub mod query_audit;
+// Extracted to its own crate so downstream distributions (the cloud engine)
+// can adopt the SAME ledger — file format, flags, semantics — without
+// depending on this whole server crate. The old path keeps working.
+pub use skardi_query_audit as query_audit;
 pub mod query_handlers;
 pub mod remote_storage;
 pub mod response;


### PR DESCRIPTION
Extracts `query_audit` into `crates/query-audit` (`skardi-query-audit`, re-exported under the old path — zero call-site changes) and adds five nullable identity columns (`request_id`, `org_id`, `workspace_id`, `user_id`, `run_id`) with `record_started_for(..., Option<&QueryIdentity>)`.

**Why:** the cloud engine (skardi-cloud) is required by its design to adopt this ledger *wholesale* — same file format, same `--query-audit-db` flags, same fail-closed semantics — with its caller identity in nullable columns rather than a forked store ("upstreamed, not forked"). The extraction is what makes that possible without dragging the whole server crate into its dependency tree; the columns are what its envelope fills. OSS behavior is byte-identical: `record_started` passes `None`, rows read NULL.

Existing databases migrate on open (`PRAGMA table_info` + additive `ALTER`s, idempotent — `CREATE TABLE IF NOT EXISTS` alone cannot retrofit a live table); covered by an old-schema fixture test.

Tests: skardi-query-audit 9/9 (migration, double-open idempotence, NULL-for-OSS-rows); skardi-server 168/168 single-threaded (the parallel run trips a pre-existing env-race flake in `auth::layer::tests::build_better_auth_respects_auth_base_url` — unrelated, it reads process env that neighbouring tests mutate).

Consumed by skardi-cloud's E5 (`/query` endpoint) PR, which pins this branch's rev and bumps to main's after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)