### PR TITLE
feat(graph): milestone 2 — Neo4j backend over Bolt, read-mode proven at registration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -695,6 +695,42 @@ jobs:
         if: always()
         run: docker rm -f skardi-age || true
 
+      # Neo4j gives the graph provider's Bolt path the same real
+      # coverage — the milestone-2 backend, incl. the registration
+      # read-mode proof, which only a real server can answer.
+      - name: Start Neo4j for graph live tests
+        run: |
+          docker run -d --name skardi-neo4j \
+            -p 127.0.0.1:17687:7687 -p 127.0.0.1:17474:7474 \
+            -e NEO4J_AUTH=neo4j/skardineo4j \
+            neo4j:5
+          for i in $(seq 1 90); do
+            if curl -sf http://127.0.0.1:17474 >/dev/null 2>&1; then
+              echo "neo4j ready after ${i}s"
+              break
+            fi
+            if [ "$i" = "90" ]; then
+              echo "neo4j failed to become ready"
+              docker logs skardi-neo4j
+              exit 1
+            fi
+            sleep 1
+          done
+          # The HTTP port answers before Bolt finishes auth setup; give
+          # the server a moment to open Bolt too.
+          sleep 5
+
+      - name: Execute graph Neo4j live tests
+        env:
+          SKARDI_NEO4J_LIVE_URL: bolt://neo4j:skardineo4j@127.0.0.1:17687
+        run: |
+          cargo llvm-cov --no-report nextest --all-features \
+            -E 'binary(graph_neo4j_live)' --no-tests=fail -- --ignored
+
+      - name: Stop Neo4j
+        if: always()
+        run: docker rm -f skardi-neo4j || true
+
       - name: Generate coverage report (lcov)
         run: cargo llvm-cov report --lcov --output-path lcov.info
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -661,7 +661,13 @@ jobs:
       # the AgeClient/register_graph_source code is exercised ONLY by the
       # graph_age_live suite, which self-skips without this backend (the
       # PR #203 codecov report showed client.rs at 11% for exactly that
-      # reason). Same docker-run pattern as MinIO above.
+      # reason). Docker-run like MinIO above, but the readiness poll must
+      # go over TCP: the postgres entrypoint runs a TEMPORARY
+      # unix-socket-only server for initdb, so a socket-side pg_isready
+      # can answer "ready" during bootstrap while the real server is
+      # still seconds away — an intermittent red on the whole coverage
+      # job. The bootstrap server never listens on TCP, so -h 127.0.0.1
+      # can only succeed against the real one.
       - name: Start Apache AGE for graph live tests
         run: |
           docker run -d --name skardi-age \
@@ -669,7 +675,7 @@ jobs:
             -e POSTGRES_PASSWORD=skardiage \
             apache/age
           for i in $(seq 1 30); do
-            if docker exec skardi-age pg_isready -U postgres >/dev/null 2>&1; then
+            if docker exec skardi-age pg_isready -h 127.0.0.1 -U postgres >/dev/null 2>&1; then
               echo "age ready after ${i}s"
               break
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -657,6 +657,44 @@ jobs:
         if: always()
         run: docker rm -f skardi-minio || true
 
+      # Apache AGE gives the graph provider's Postgres path real coverage —
+      # the AgeClient/register_graph_source code is exercised ONLY by the
+      # graph_age_live suite, which self-skips without this backend (the
+      # PR #203 codecov report showed client.rs at 11% for exactly that
+      # reason). Same docker-run pattern as MinIO above.
+      - name: Start Apache AGE for graph live tests
+        run: |
+          docker run -d --name skardi-age \
+            -p 127.0.0.1:15432:5432 \
+            -e POSTGRES_PASSWORD=skardiage \
+            apache/age
+          for i in $(seq 1 30); do
+            if docker exec skardi-age pg_isready -U postgres >/dev/null 2>&1; then
+              echo "age ready after ${i}s"
+              break
+            fi
+            if [ "$i" = "30" ]; then
+              echo "apache/age failed to become ready"
+              docker logs skardi-age
+              exit 1
+            fi
+            sleep 1
+          done
+
+      - name: Execute graph AGE live tests
+        env:
+          SKARDI_AGE_LIVE_URL: postgres://postgres:skardiage@127.0.0.1:15432/postgres
+        # `--no-tests=fail`: if the suite is ever renamed out of the
+        # filter's reach, fail loudly instead of reporting success having
+        # run nothing (the documents S3 step's discipline).
+        run: |
+          cargo llvm-cov --no-report nextest --all-features \
+            -E 'binary(graph_age_live)' --no-tests=fail -- --ignored
+
+      - name: Stop Apache AGE
+        if: always()
+        run: docker rm -f skardi-age || true
+
       - name: Generate coverage report (lcov)
         run: cargo llvm-cov report --lcov --output-path lcov.info
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -670,10 +670,15 @@ jobs:
       # can only succeed against the real one.
       - name: Start Apache AGE for graph live tests
         run: |
+          # PINNED: AGE is the one dependency whose exact behavior this
+          # module encodes (agtype_out spellings, the bare Infinity
+          # token, ag_label.kind values, the PREPARE requirement) — an
+          # upstream :latest rebuild must not move those under an
+          # unrelated PR.
           docker run -d --name skardi-age \
             -p 127.0.0.1:15432:5432 \
             -e POSTGRES_PASSWORD=skardiage \
-            apache/age
+            apache/age:release_PG16_1.6.0
           for i in $(seq 1 30); do
             if docker exec skardi-age pg_isready -h 127.0.0.1 -U postgres >/dev/null 2>&1; then
               echo "age ready after ${i}s"
@@ -690,6 +695,9 @@ jobs:
       - name: Execute graph AGE live tests
         env:
           SKARDI_AGE_LIVE_URL: postgres://postgres:skardiage@127.0.0.1:15432/postgres
+          # Arms the suite's self-skip into a hard failure here: CI is
+          # where nine silent skips would otherwise read as green.
+          SKARDI_AGE_LIVE_REQUIRED: "1"
         # `--no-tests=fail`: if the suite is ever renamed out of the
         # filter's reach, fail loudly instead of reporting success having
         # run nothing (the documents S3 step's discipline).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2932,6 +2932,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-functions-json"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3ce789cf93834ff0303811ce4080a5c349311fad52e3924ad26f933f59189f3"
+dependencies = [
+ "datafusion",
+ "jiter",
+ "log",
+ "paste",
+]
+
+[[package]]
 name = "datafusion-functions-nested"
 version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5415,6 +5427,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "inherent"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5541,6 +5562,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
 dependencies = [
  "jiff-tzdb",
+]
+
+[[package]]
+name = "jiter"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1bee9e536db8cbaac14af3d9bfb4abb81d2f31fe2e5d7772be78074ce08a08"
+dependencies = [
+ "ahash 0.8.12",
+ "bitvec",
+ "lexical-parse-float",
+ "num-bigint",
+ "num-traits",
+ "pyo3",
+ "smallvec",
 ]
 
 [[package]]
@@ -6658,6 +6694,15 @@ checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -8118,6 +8163,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
+name = "pyo3"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
+dependencies = [
+ "indoc",
+ "libc",
+ "memoffset",
+ "num-bigint",
+ "num-traits",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
+dependencies = [
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "quad-rand"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9486,6 +9594,7 @@ dependencies = [
  "datafusion",
  "datafusion-common",
  "datafusion-federation",
+ "datafusion-functions-json",
  "datafusion-table-providers",
  "derivative",
  "encoding_rs",
@@ -10265,6 +10374,12 @@ dependencies = [
  "libc",
  "xattr",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -11169,6 +11284,12 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3332,6 +3332,9 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+dependencies = [
+ "tokio",
+]
 
 [[package]]
 name = "deadpool-runtime"
@@ -6922,6 +6925,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
+name = "mutants"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0287524726960e07b119cebd01678f852f147742ae0d925e6a520dca956126"
+
+[[package]]
 name = "mysql-common-derive"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7051,6 +7060,54 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "neo4rs"
+version = "0.9.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b433ba6b38f863f3f1db1cd2b99da742c5db961d7fec9553663331b5db3bc453"
+dependencies = [
+ "backon",
+ "bytes",
+ "chrono",
+ "chrono-tz",
+ "deadpool 0.12.3",
+ "delegate",
+ "futures",
+ "log",
+ "neo4rs-macros",
+ "neo4rs_include_snippet",
+ "pastey",
+ "pin-project-lite",
+ "rustls 0.23.41",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "url",
+]
+
+[[package]]
+name = "neo4rs-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a0d57c55d2d1dc62a2b1d16a0a1079eb78d67c36bdf468d582ab4482ec7002"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "neo4rs_include_snippet"
+version = "0.9.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79f62dfc17e5e779bfed003d02e9ef4ecdb7b25fb9d37f7e60f3f730d9a62726"
+dependencies = [
+ "unsynn",
+]
 
 [[package]]
 name = "never-say-never"
@@ -7635,6 +7692,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "path_abs"
@@ -9499,6 +9562,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shadow_counted"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65da48d447333cebe1aadbdd3662f3ba56e76e67f53bc46f3dd5f67c74629d6b"
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9616,6 +9685,7 @@ dependencies = [
  "mongodb",
  "mysql_async",
  "ndarray 0.17.2",
+ "neo4rs",
  "num_cpus",
  "object_store",
  "ort",
@@ -11306,6 +11376,17 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "unsynn"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd574186a61b234717745ee569f9323def8ac863c2e4b512a25d3b0ec39322fc"
+dependencies = [
+ "mutants",
+ "proc-macro2",
+ "shadow_counted",
+]
 
 [[package]]
 name = "untrusted"

--- a/crates/skardi/Cargo.toml
+++ b/crates/skardi/Cargo.toml
@@ -169,6 +169,14 @@ uuid = { workspace = true }
 # instead of a homegrown twin. Registered via graph::register_graph_udtfs
 # — note it also installs ->/->>/? operator rewrites session-wide.
 datafusion-functions-json = "0.52"
+# Graph milestone 2: the Neo4j Bolt driver. Pinned to the 0.9 RC because
+# the access-mode spike (graph-engine-bypass §Milestone 2) found 0.8.0
+# has NO read-mode channel at all, while the RC's `execute_read` sends
+# Bolt `mode: "r"` on auto-commit RUN — the enforcement channel this
+# milestone rides. Default features only: `unstable-bolt-protocol-impl-v2`
+# stays OFF (its explicit-transaction BEGIN never carries the mode, so it
+# would ADD surface without adding enforcement).
+neo4rs = "0.9.0-rc.10"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/crates/skardi/Cargo.toml
+++ b/crates/skardi/Cargo.toml
@@ -82,11 +82,13 @@ tracing = { workspace = true }
 # pipeline
 log = { workspace = true }
 regex = { workspace = true }
-# preserve_order is LOAD-BEARING: json_pack's argument-order-is-object-order
-# contract (and the etl golden bundles' byte determinism) rides on
-# serde_json::Map preserving insertion order. Without the explicit feature
-# it held only through transitive unification (bson enables it) — a dep
-# change away from silently becoming lexicographic.
+# preserve_order is LOAD-BEARING for TWO consumers: json_pack's
+# argument-order-is-object-order contract (and the etl golden bundles'
+# byte determinism), and the graph module's declared-columns JSON — whose
+# object order IS the positional binding to the Cypher RETURN clause
+# (trimming this feature would silently re-sort declared columns
+# lexicographically and mis-map same-typed columns). Without the explicit
+# feature it held only through transitive unification (bson enables it).
 serde_json = { workspace = true, features = ["preserve_order"] }
 serde_yaml = { workspace = true }
 # model
@@ -162,6 +164,10 @@ thiserror = "2.0"
 tokio-rusqlite = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
+# The design's NAMED dependency for graph `properties` extraction
+# (graph-engine-bypass §Schema handling): ecosystem json_get family
+# instead of a homegrown twin. Registered via graph::register_graph_udtfs
+# — note it also installs ->/->>/? operator rewrites session-wide.
 datafusion-functions-json = "0.52"
 
 [dev-dependencies]

--- a/crates/skardi/Cargo.toml
+++ b/crates/skardi/Cargo.toml
@@ -162,6 +162,7 @@ thiserror = "2.0"
 tokio-rusqlite = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
+datafusion-functions-json = "0.52"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/crates/skardi/src/sources/providers/graph/client.rs
+++ b/crates/skardi/src/sources/providers/graph/client.rs
@@ -121,6 +121,50 @@ pub trait GraphClient: Send + Sync + std::fmt::Debug {
     ) -> Result<Vec<(String, String)>, GraphError>;
 }
 
+/// Cancellation safety for the hand-rolled transaction: [`AgeClient::execute`]
+/// manages BEGIN/ROLLBACK manually (rollback must precede DEALLOCATE on
+/// the same session — sqlx's `Transaction` guard cannot order that), and
+/// the cost of going manual is that NOTHING rolls back if the scan
+/// future is dropped mid-transaction — DataFusion drops scan streams on
+/// client disconnect, plan short-circuits, and sibling-partition errors,
+/// and sqlx's pool return path never rolls back (it pings). A connection
+/// returned `idle in transaction` mostly self-heals on reuse, but it
+/// holds a snapshot while idle and a cancellation burst can pin every
+/// pooled session. This guard closes it: if dropped while ARMED, the
+/// connection is moved into a spawned task that rolls back and only then
+/// returns it to the pool; the clean path defuses and runs its ordered
+/// cleanup inline.
+struct OpenTxnGuard {
+    conn: Option<sqlx::pool::PoolConnection<sqlx::Postgres>>,
+}
+
+impl OpenTxnGuard {
+    fn conn(&mut self) -> &mut sqlx::PgConnection {
+        self.conn.as_mut().expect("armed until defused")
+    }
+
+    fn defuse(mut self) -> sqlx::pool::PoolConnection<sqlx::Postgres> {
+        self.conn.take().expect("defused exactly once")
+    }
+}
+
+impl Drop for OpenTxnGuard {
+    fn drop(&mut self) {
+        if let Some(mut conn) = self.conn.take() {
+            // Drop is sync; the rollback needs the runtime. Execution
+            // always runs inside tokio here — the fallback (no runtime:
+            // plain drop, sqlx pings a possibly-in-transaction session
+            // back into the pool) is only reachable from exotic test
+            // harnesses.
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                handle.spawn(async move {
+                    let _ = conn.execute("ROLLBACK").await;
+                });
+            }
+        }
+    }
+}
+
 /// Apache AGE over the workspace's sqlx-postgres stack.
 #[derive(Debug)]
 pub struct AgeClient {
@@ -295,18 +339,26 @@ impl GraphClient for AgeClient {
             // where DEALLOCATE itself is refused, while rollback does NOT
             // clear session-level prepared statements. Rollback-then-
             // deallocate is the only order that cleans up after backend
-            // errors.
-            let mut conn = self
-                .pool
-                .acquire()
-                .await
-                .map_err(|e| map_query_error(&source, bounds, &e))?;
+            // errors. The [`OpenTxnGuard`] covers what MANUAL cannot: a
+            // scan future dropped mid-transaction still rolls back before
+            // the connection re-enters the pool.
+            let mut guard = OpenTxnGuard {
+                conn: Some(
+                    self.pool
+                        .acquire()
+                        .await
+                        .map_err(|e| map_query_error(&source, bounds, &e))?,
+                ),
+            };
             // The security boundary: the SERVER refuses writes in a read
             // transaction, whatever slipped past the keyword guard.
-            conn.execute("BEGIN TRANSACTION READ ONLY")
+            guard
+                .conn()
+                .execute("BEGIN TRANSACTION READ ONLY")
                 .await
                 .map_err(|e| backend_error(&source, &e))?;
             let collected: Result<Vec<GraphRow>, GraphError> = async {
+                let conn = guard.conn();
                 // Server-side: runaway traversals die in the backend, not
                 // in a client that gave up waiting.
                 conn.execute(
@@ -363,12 +415,16 @@ impl GraphClient for AgeClient {
                 Ok(rows)
             }
             .await;
+            // The clean path reclaims the connection — from here the
+            // guard's drop no longer fires and cleanup runs inline, in
+            // its required order.
+            let mut conn = guard.defuse();
             // ROLLBACK unconditionally and FIRST: it clears an aborted
             // transaction (making the DEALLOCATE below executable) and a
             // read-only transaction had nothing to undo anyway. Its
             // RESULT is checked LAST — an early `?` here would skip the
             // DEALLOCATE below and leak the statement on the very success
-            // path this cleanup exists for (round-4 follow-up finding).
+            // path this cleanup exists for.
             let rollback = conn.execute("ROLLBACK").await;
             let mut dealloc = Ok(Default::default());
             if let Some(name) = &prepared {
@@ -390,12 +446,14 @@ impl GraphClient for AgeClient {
             dealloc.map_err(|e| backend_error(&source, &e))?;
             Ok(rows)
         };
-        // Residual, stated: the client-side timeout below ABANDONS the
-        // future mid-flight — no DEALLOCATE can run on that path. It only
-        // fires when the backend outlived its own statement_timeout by 5s
-        // (i.e. stopped answering), and sqlx tears down a connection
-        // dropped mid-query rather than pooling it, so nothing
-        // accumulates there either.
+        // Residual, stated: the client-side timeout below (and any drop
+        // of the scan future) ABANDONS the run mid-flight. The OPEN
+        // TRANSACTION is covered — [`OpenTxnGuard`] rolls it back before
+        // the connection re-enters the pool — but no DEALLOCATE runs on
+        // that path. Acceptable: the prepared names are per-call unique
+        // (never reused), the timeout arm only fires when the backend
+        // outlived its own statement_timeout by 5s, and sqlx tears down
+        // a connection dropped mid-query rather than pooling it.
         // Client-side wrap: the server timeout is authoritative, this one
         // covers a backend that stops answering entirely. saturating_add:
         // the config caps the timeout, but arithmetic here must not be
@@ -532,8 +590,9 @@ fn build_cypher_sql(
     }
 }
 
-/// A dollar-quote tag that provably does not occur in `text`: extend a
-/// base tag with a counter until absent — no escape rules to get wrong.
+/// A dollar-quote tag that provably does not occur in `text`: pick the
+/// first `$skqN$` suffix the text does not contain — no escape rules to
+/// get wrong.
 fn dollar_tag(text: &str) -> String {
     // The collision test runs against `text + "$"`, not `text`: the
     // closing delimiter starts with `$`, so a query ENDING in the tag's
@@ -541,14 +600,32 @@ fn dollar_tag(text: &str) -> String {
     // the full tag at the text/closing-tag boundary and would close the
     // literal early. Appending the `$` makes the check cover exactly the
     // stream Postgres scans.
+    //
+    // ONE pass: collect the tag-shaped substrings actually present, then
+    // take the first free suffix — a probe stuffed with `$skq$ $skq1$ …`
+    // costs one scan, not one scan per collision.
     let probe = format!("{text}$");
-    let mut tag = "$skq$".to_string();
-    let mut n = 0u32;
-    while probe.contains(&tag) {
-        n += 1;
-        tag = format!("$skq{n}$");
+    let mut base_used = false;
+    let mut used: std::collections::HashSet<u32> = std::collections::HashSet::new();
+    for (i, _) in probe.match_indices("$skq") {
+        let rest = &probe[i + "$skq".len()..];
+        if let Some(end) = rest.find('$') {
+            let digits = &rest[..end];
+            if digits.is_empty() {
+                base_used = true;
+            } else if let Ok(n) = digits.parse::<u32>() {
+                used.insert(n);
+            }
+        }
     }
-    tag
+    if !base_used {
+        return "$skq$".to_string();
+    }
+    let mut n = 1u32;
+    while used.contains(&n) {
+        n += 1;
+    }
+    format!("$skq{n}$")
 }
 
 fn read_env(source: &str, field: &str, env: &str) -> Result<String, GraphError> {

--- a/crates/skardi/src/sources/providers/graph/client.rs
+++ b/crates/skardi/src/sources/providers/graph/client.rs
@@ -127,6 +127,14 @@ impl AgeClient {
         })
     }
 
+    /// The pool, for the live leak-regression test ONLY (the
+    /// `pg_prepared_statements` sweep is session-local, so it must run
+    /// on the very sessions `execute` used). Not API.
+    #[doc(hidden)]
+    pub fn pool_for_tests(&self) -> &PgPool {
+        &self.pool
+    }
+
     /// The `cypher()` invocation, spoken over the SIMPLE query protocol —
     /// three AGE realities verified live make this the one sound
     /// spelling:
@@ -223,8 +231,11 @@ impl GraphClient for AgeClient {
 
             // Stream (simple protocol — see build_sql) and cap:
             // max_rows + 1 proves the overflow without buffering past it.
-            let mut rows: Vec<GraphRow> = Vec::new();
-            {
+            // The collection runs as an INNER block so every early exit
+            // (row cap, malformed cell, wire error) still reaches the
+            // DEALLOCATE below.
+            let collected: Result<Vec<GraphRow>, GraphError> = async {
+                let mut rows: Vec<GraphRow> = Vec::new();
                 let mut stream = tx.fetch_many(sqlx::raw_sql(&sql));
                 while let Some(step) = stream.next().await {
                     let step = step.map_err(|e| map_query_error(&source, bounds, &e))?;
@@ -257,14 +268,25 @@ impl GraphClient for AgeClient {
                     }
                     rows.push(values);
                 }
+                Ok(rows)
             }
+            .await;
             if let Some(name) = &prepared {
-                // Targeted DEALLOCATE (never ALL — sqlx's own statement
-                // cache lives on the same connection).
-                tx.execute(format!("DEALLOCATE {name}").as_str())
-                    .await
-                    .map_err(|e| backend_error(&source, &e))?;
+                // On EVERY exit, success or error: prepared statements are
+                // SESSION-level — rollback does not clear them, the
+                // pid+seq names never reuse, and skipping this on an
+                // error path would monotonically accumulate statements on
+                // the pooled connection. Best-effort on the error path
+                // (the original error stays the one reported); a failed
+                // DEALLOCATE on the success path is itself an error.
+                // Targeted, never ALL — sqlx's own statement cache lives
+                // on the same connection.
+                let dealloc = tx.execute(format!("DEALLOCATE {name}").as_str()).await;
+                if collected.is_ok() {
+                    dealloc.map_err(|e| backend_error(&source, &e))?;
+                }
             }
+            let rows = collected?;
             // Read-only: rollback returns the connection with nothing to
             // undo either way.
             tx.rollback()
@@ -272,6 +294,12 @@ impl GraphClient for AgeClient {
                 .map_err(|e| backend_error(&source, &e))?;
             Ok(rows)
         };
+        // Residual, stated: the client-side timeout below ABANDONS the
+        // future mid-flight — no DEALLOCATE can run on that path. It only
+        // fires when the backend outlived its own statement_timeout by 5s
+        // (i.e. stopped answering), and sqlx tears down a connection
+        // dropped mid-query rather than pooling it, so nothing
+        // accumulates there either.
         // Client-side wrap: the server timeout is authoritative, this one
         // covers a backend that stops answering entirely.
         let rows = tokio::time::timeout(bounds.timeout + Duration::from_secs(5), run)

--- a/crates/skardi/src/sources/providers/graph/client.rs
+++ b/crates/skardi/src/sources/providers/graph/client.rs
@@ -62,8 +62,9 @@ pub trait GraphClient: Send + Sync + std::fmt::Debug {
 
     /// Label roster for `graph_schema`: one `(label, kind)` row per
     /// label, kinds `vertex` / `edge`. Names only — never property
-    /// values (design §Agent and LLM interaction).
-    async fn labels(&self) -> Result<Vec<(String, String)>, GraphError>;
+    /// values (design §Agent and LLM interaction). Bounded like every
+    /// other query — "every query is bounded" has no catalog exemption.
+    async fn labels(&self, bounds: QueryBounds) -> Result<Vec<(String, String)>, GraphError>;
 }
 
 /// Apache AGE over the workspace's sqlx-postgres stack.
@@ -310,37 +311,70 @@ impl GraphClient for AgeClient {
         Ok(futures::stream::iter(rows.into_iter().map(Ok)).boxed())
     }
 
-    async fn labels(&self) -> Result<Vec<(String, String)>, GraphError> {
-        // ag_catalog is the exact source for labels; AGE's own catch-all
-        // labels (`_ag_label_vertex` / `_ag_label_edge`) are implementation
-        // noise for an agent and are filtered.
-        let rows = sqlx::query(
-            "SELECT l.name, l.kind::text \
-             FROM ag_catalog.ag_label l \
-             JOIN ag_catalog.ag_graph g ON g.graphid = l.graph \
-             WHERE g.name = $1 AND l.name NOT LIKE '\\_ag\\_label\\_%' \
-             ORDER BY l.name",
-        )
-        .bind(&self.graph_name)
-        .fetch_all(&self.pool)
-        .await
-        .map_err(|e| backend_error(&self.source_name, &e))?;
-        rows.into_iter()
-            .map(|row| {
-                let name: String = row
-                    .try_get(0)
-                    .map_err(|e| backend_error(&self.source_name, &e))?;
-                let kind: String = row
-                    .try_get(1)
-                    .map_err(|e| backend_error(&self.source_name, &e))?;
-                let kind = match kind.as_str() {
-                    "v" => "vertex".to_string(),
-                    "e" => "edge".to_string(),
-                    other => other.to_string(),
-                };
-                Ok((name, kind))
-            })
-            .collect()
+    async fn labels(&self, bounds: QueryBounds) -> Result<Vec<(String, String)>, GraphError> {
+        // Same bounds discipline as execute — a catalog read against a
+        // wedged backend must not hang forever, and the design's "every
+        // query is bounded" makes no catalog exemption: READ ONLY
+        // transaction, server-side statement_timeout, row cap, and the
+        // client-side wrap.
+        let source = self.source_name.clone();
+        let run = async {
+            let mut tx = self
+                .pool
+                .begin()
+                .await
+                .map_err(|e| backend_error(&source, &e))?;
+            sqlx::query("SET TRANSACTION READ ONLY")
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| backend_error(&source, &e))?;
+            sqlx::query(&format!(
+                "SET LOCAL statement_timeout = '{}ms'",
+                bounds.timeout.as_millis()
+            ))
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| backend_error(&source, &e))?;
+            // ag_catalog is the exact source for labels; AGE's own
+            // catch-all labels (`_ag_label_vertex` / `_ag_label_edge`)
+            // are implementation noise for an agent and are filtered.
+            let rows = sqlx::query(
+                "SELECT l.name, l.kind::text \
+                 FROM ag_catalog.ag_label l \
+                 JOIN ag_catalog.ag_graph g ON g.graphid = l.graph \
+                 WHERE g.name = $1 AND l.name NOT LIKE '\\_ag\\_label\\_%' \
+                 ORDER BY l.name",
+            )
+            .bind(&self.graph_name)
+            .fetch_all(&mut *tx)
+            .await
+            .map_err(|e| map_query_error(&source, bounds, &e))?;
+            if rows.len() > bounds.max_rows {
+                return Err(GraphError::RowCapExceeded {
+                    max_rows: bounds.max_rows,
+                });
+            }
+            tx.rollback()
+                .await
+                .map_err(|e| backend_error(&source, &e))?;
+            rows.into_iter()
+                .map(|row| {
+                    let name: String = row.try_get(0).map_err(|e| backend_error(&source, &e))?;
+                    let kind: String = row.try_get(1).map_err(|e| backend_error(&source, &e))?;
+                    let kind = match kind.as_str() {
+                        "v" => "vertex".to_string(),
+                        "e" => "edge".to_string(),
+                        other => other.to_string(),
+                    };
+                    Ok((name, kind))
+                })
+                .collect()
+        };
+        tokio::time::timeout(bounds.timeout + Duration::from_secs(5), run)
+            .await
+            .map_err(|_| GraphError::Timeout {
+                seconds: bounds.timeout.as_secs(),
+            })?
     }
 }
 

--- a/crates/skardi/src/sources/providers/graph/client.rs
+++ b/crates/skardi/src/sources/providers/graph/client.rs
@@ -24,7 +24,7 @@ use futures::StreamExt;
 use futures::stream::BoxStream;
 use serde_json::Value;
 use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions};
-use sqlx::{Either, Executor, Row};
+use sqlx::{Connection, Either, Executor, Row};
 
 use super::error::{GraphError, json_kind};
 use super::value::parse_agtype;
@@ -131,11 +131,18 @@ pub trait GraphClient: Send + Sync + std::fmt::Debug {
 /// returned `idle in transaction` mostly self-heals on reuse, but it
 /// holds a snapshot while idle and a cancellation burst can pin every
 /// pooled session. This guard closes it: if dropped while ARMED, the
-/// connection is moved into a spawned task that rolls back and only then
-/// returns it to the pool; the clean path defuses and runs its ordered
-/// cleanup inline.
+/// connection is moved into a spawned task that rolls back AND
+/// deallocates the call's prepared statement, and only then returns it
+/// to the pool; the clean path defuses and runs its ordered cleanup
+/// inline. The DEALLOCATE matters as much as the rollback: the guard is
+/// what RESCUES the connection back into the pool, so without it every
+/// cancelled parameterized query would strand one session-level
+/// `skq_p_*` statement permanently — monotonic growth on long-lived
+/// sessions, the exact failure the live leak sweep exists to prevent.
 struct OpenTxnGuard {
     conn: Option<sqlx::pool::PoolConnection<sqlx::Postgres>>,
+    /// The per-call PREPARE name, armed as soon as it is known.
+    prepared: Option<String>,
 }
 
 impl OpenTxnGuard {
@@ -151,14 +158,21 @@ impl OpenTxnGuard {
 impl Drop for OpenTxnGuard {
     fn drop(&mut self) {
         if let Some(mut conn) = self.conn.take() {
-            // Drop is sync; the rollback needs the runtime. Execution
+            let prepared = self.prepared.take();
+            // Drop is sync; the cleanup needs the runtime. Execution
             // always runs inside tokio here — the fallback (no runtime:
             // plain drop, sqlx pings a possibly-in-transaction session
             // back into the pool) is only reachable from exotic test
             // harnesses.
             if let Ok(handle) = tokio::runtime::Handle::try_current() {
                 handle.spawn(async move {
+                    // ROLLBACK first (clears an aborted transaction, where
+                    // DEALLOCATE is refused), then drop the statement —
+                    // the same order the clean path uses.
                     let _ = conn.execute("ROLLBACK").await;
+                    if let Some(name) = prepared {
+                        let _ = conn.execute(format!("DEALLOCATE {name}").as_str()).await;
+                    }
                 });
             }
         }
@@ -205,6 +219,47 @@ impl AgeClient {
             let pass = read_env(source_name, "password_env", env)?;
             options = options.password(&pass);
         }
+        // PREFLIGHT on a single direct connection, before any pool
+        // exists: sqlx treats an `after_connect` error as a failed
+        // attempt and RETRIES until acquire_timeout, discarding the
+        // underlying cause — a bad search_path or a missing AGE would
+        // surface as a 30-second "pool timed out" pointing at pool
+        // sizing. Running the same per-connection setup here first means
+        // auth failures, setup failures, and the graph probe all fail
+        // FAST with their real, named error (the eager-fail contract in
+        // mod.rs's docstring).
+        {
+            let mut conn = sqlx::postgres::PgConnection::connect_with(&options)
+                .await
+                .map_err(|e| backend_error(source_name, &e))?;
+            per_connection_setup(&mut conn)
+                .await
+                .map_err(|e| backend_error(source_name, &e))?;
+            // The graph name gets the same eager treatment as the URL
+            // and the credential: a typo would otherwise fail LATE and
+            // split — per-query raw backend errors on cypher_query, and
+            // zero rows WITHOUT error on graph_schema (the catalog join
+            // just misses), which an agent reads as "this graph is
+            // empty".
+            let exists: Option<i32> =
+                sqlx::query_scalar("SELECT 1 FROM ag_catalog.ag_graph WHERE name = $1")
+                    .bind(graph_name)
+                    .fetch_optional(&mut conn)
+                    .await
+                    .map_err(|e| backend_error(source_name, &e))?;
+            if exists.is_none() {
+                return Err(GraphError::InvalidConfig {
+                    name: source_name.to_string(),
+                    reason: format!(
+                        "graph '{graph_name}' does not exist in this database \
+                         (ag_catalog.ag_graph has no such entry; create it with \
+                         SELECT create_graph(...) or fix graph_name)"
+                    ),
+                });
+            }
+        }
+        // Lazy pool: the preflight above already proved the environment,
+        // so the pool's own connections dial on demand.
         let pool = PgPoolOptions::new()
             .max_connections(max_connections)
             // Queueing on a saturated pool is bounded by the SAME knob
@@ -213,42 +268,13 @@ impl AgeClient {
             // driver failure after possibly LONGER than the configured
             // bound ("every query is bounded" covers the queue too).
             .acquire_timeout(acquire_timeout)
-            .after_connect(|conn, _meta| {
-                Box::pin(async move {
-                    // Per-connection, not per-query: LOAD is connection
-                    // state, and ag_catalog on the search path is what
-                    // makes `agtype` and `cypher()` resolvable.
-                    conn.execute("LOAD 'age'; SET search_path = ag_catalog, \"$user\", public;")
-                        .await?;
-                    Ok(())
-                })
-            })
-            .connect_with(options)
-            .await
-            .map_err(|e| backend_error(source_name, &e))?;
-        // The graph name gets the same eager treatment as the URL and
-        // the credential: a typo would otherwise fail LATE and split —
-        // per-query raw backend errors on cypher_query, and zero rows
-        // WITHOUT error on graph_schema (the catalog join just misses),
-        // which an agent reads as "this graph is empty". The connect
-        // already paid the round-trip; this check makes the eager-fail
-        // docstring true as written.
-        let exists: Option<i32> =
-            sqlx::query_scalar("SELECT 1 FROM ag_catalog.ag_graph WHERE name = $1")
-                .bind(graph_name)
-                .fetch_optional(&pool)
-                .await
-                .map_err(|e| backend_error(source_name, &e))?;
-        if exists.is_none() {
-            return Err(GraphError::InvalidConfig {
-                name: source_name.to_string(),
-                reason: format!(
-                    "graph '{graph_name}' does not exist in this database \
-                     (ag_catalog.ag_graph has no such entry; create it with \
-                     SELECT create_graph(...) or fix graph_name)"
-                ),
-            });
-        }
+            .after_connect(|conn, _meta| Box::pin(per_connection_setup(conn)))
+            .connect_lazy_with(options);
+        tracing::debug!(
+            source = source_name,
+            graph = graph_name,
+            "graph source connected"
+        );
         Ok(Self {
             pool,
             graph_name: graph_name.to_string(),
@@ -264,7 +290,30 @@ impl AgeClient {
     pub fn pool_for_tests(&self) -> &PgPool {
         &self.pool
     }
+}
 
+/// Per-connection session state, shared by the registration preflight
+/// and the pool's `after_connect` hook so the two can never drift.
+///
+/// `LOAD 'age'` is BEST-EFFORT, deliberately: Postgres restricts LOAD
+/// of a library outside `$libdir/plugins` to superusers (AGE installs
+/// to `$libdir/age.so`), so requiring it would force every graph source
+/// onto a superuser credential — the exact opposite of the design's
+/// least-privilege recommendation, and it would put the module's ONLY
+/// enforcing layer (the backend READ ONLY transaction) behind maximum
+/// privilege. The supported deployment (the official apache/age image)
+/// ships `shared_preload_libraries = age`, where the LOAD is a no-op;
+/// where AGE is genuinely absent, the registration preflight's
+/// `ag_catalog.ag_graph` probe is what fails, with a named error. The
+/// search_path, by contrast, is required state — its failure is real.
+async fn per_connection_setup(conn: &mut sqlx::PgConnection) -> Result<(), sqlx::Error> {
+    let _ = conn.execute("LOAD 'age'").await;
+    conn.execute("SET search_path = ag_catalog, \"$user\", public")
+        .await?;
+    Ok(())
+}
+
+impl AgeClient {
     /// The `cypher()` invocation, spoken over the SIMPLE query protocol —
     /// three AGE realities verified live make this the one sound
     /// spelling:
@@ -330,6 +379,19 @@ impl GraphClient for AgeClient {
         };
         let (sql, prepared) = self.build_sql(cypher, params, arity, fetch);
         let source = self.source_name.clone();
+        let started = std::time::Instant::now();
+        // Acquire OUTSIDE the client-side timeout window: acquire and
+        // execution are sequential costs, and acquire_timeout already
+        // bounds the queue with its own typed PoolTimedOut mapping.
+        // Sharing one window would let 25s of pool contention leave a
+        // 30s statement 10s of budget — reported as the query's timeout
+        // with the server-side bound (the authoritative one) mostly
+        // unspent.
+        let acquired = self
+            .pool
+            .acquire()
+            .await
+            .map_err(|e| map_query_error(&source, bounds, &e))?;
         let run = async {
             // A MANUAL transaction on an explicitly acquired connection,
             // not sqlx's Transaction guard: cleanup must be able to
@@ -340,15 +402,11 @@ impl GraphClient for AgeClient {
             // clear session-level prepared statements. Rollback-then-
             // deallocate is the only order that cleans up after backend
             // errors. The [`OpenTxnGuard`] covers what MANUAL cannot: a
-            // scan future dropped mid-transaction still rolls back before
-            // the connection re-enters the pool.
+            // scan future dropped mid-transaction still rolls back AND
+            // deallocates before the connection re-enters the pool.
             let mut guard = OpenTxnGuard {
-                conn: Some(
-                    self.pool
-                        .acquire()
-                        .await
-                        .map_err(|e| map_query_error(&source, bounds, &e))?,
-                ),
+                conn: Some(acquired),
+                prepared: prepared.clone(),
             };
             // The security boundary: the SERVER refuses writes in a read
             // transaction, whatever slipped past the keyword guard.
@@ -446,23 +504,29 @@ impl GraphClient for AgeClient {
             dealloc.map_err(|e| backend_error(&source, &e))?;
             Ok(rows)
         };
-        // Residual, stated: the client-side timeout below (and any drop
-        // of the scan future) ABANDONS the run mid-flight. The OPEN
-        // TRANSACTION is covered — [`OpenTxnGuard`] rolls it back before
-        // the connection re-enters the pool — but no DEALLOCATE runs on
-        // that path. Acceptable: the prepared names are per-call unique
-        // (never reused), the timeout arm only fires when the backend
-        // outlived its own statement_timeout by 5s, and sqlx tears down
-        // a connection dropped mid-query rather than pooling it.
-        // Client-side wrap: the server timeout is authoritative, this one
-        // covers a backend that stops answering entirely. saturating_add:
-        // the config caps the timeout, but arithmetic here must not be
-        // the thing that panics if that invariant ever moves.
+        // The client-side timeout (and any drop of the scan future)
+        // ABANDONS the run mid-flight; [`OpenTxnGuard`] then rolls the
+        // open transaction back AND deallocates this call's prepared
+        // statement before the connection re-enters the pool — the
+        // guard is what RESCUES the session, so it must also be what
+        // cleans it. The wrap covers only the transaction body (acquire
+        // happened above, bounded by its own acquire_timeout), so the
+        // server-side statement_timeout keeps its full budget and stays
+        // the authoritative bound; this one covers a backend that stops
+        // answering entirely. saturating_add: the config caps the
+        // timeout, but arithmetic here must not be the thing that panics
+        // if that invariant ever moves.
         let rows = tokio::time::timeout(bounds.timeout.saturating_add(Duration::from_secs(5)), run)
             .await
             .map_err(|_| GraphError::Timeout {
                 seconds: bounds.timeout.as_secs(),
             })??;
+        tracing::debug!(
+            source = %self.source_name,
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            rows = rows.len(),
+            "cypher_query executed"
+        );
         Ok(futures::stream::iter(rows.into_iter().map(Ok)).boxed())
     }
 
@@ -491,17 +555,26 @@ impl GraphClient for AgeClient {
                 .begin()
                 .await
                 .map_err(|e| backend_error(&source, &e))?;
-            sqlx::query("SET TRANSACTION READ ONLY")
-                .execute(&mut *tx)
+            // Same protocol discipline as execute(): the SETs ride the
+            // SIMPLE protocol as constant text. `sqlx::query` would take
+            // the extended protocol and plant a server-side prepared
+            // statement in the per-connection cache — keyed on the
+            // interpolated text, so each distinct timeout value would
+            // cache another copy on every pooled session.
+            (&mut *tx)
+                .execute("SET TRANSACTION READ ONLY")
                 .await
                 .map_err(|e| backend_error(&source, &e))?;
-            sqlx::query(&format!(
-                "SET LOCAL statement_timeout = '{}ms'",
-                bounds.timeout.as_millis()
-            ))
-            .execute(&mut *tx)
-            .await
-            .map_err(|e| backend_error(&source, &e))?;
+            (&mut *tx)
+                .execute(
+                    format!(
+                        "SET LOCAL statement_timeout = '{}ms'",
+                        bounds.timeout.as_millis()
+                    )
+                    .as_str(),
+                )
+                .await
+                .map_err(|e| backend_error(&source, &e))?;
             // ag_catalog is the exact source for labels; AGE's own
             // catch-all labels (`_ag_label_vertex` / `_ag_label_edge`)
             // are implementation noise for an agent and are filtered.
@@ -525,6 +598,7 @@ impl GraphClient for AgeClient {
             tx.rollback()
                 .await
                 .map_err(|e| backend_error(&source, &e))?;
+            tracing::debug!(source = %source, labels = rows.len(), "graph_schema catalog read");
             rows.into_iter()
                 .map(|row| {
                     let name: String = row.try_get(0).map_err(|e| backend_error(&source, &e))?;

--- a/crates/skardi/src/sources/providers/graph/client.rs
+++ b/crates/skardi/src/sources/providers/graph/client.rs
@@ -1,0 +1,390 @@
+//! The backend abstraction (design §Backend abstraction) and its
+//! milestone-1 implementation: [`AgeClient`] — Apache AGE, openCypher
+//! inside Postgres.
+//!
+//! One deliberate deviation from the design text, recorded here: the
+//! design named `tokio-postgres`; this implementation rides **sqlx**,
+//! because the workspace already ships sqlx-postgres for the relational
+//! Postgres provider — one Postgres stack beats two (same TLS, same
+//! pooling, same error surface).
+//!
+//! Read-only is backend-enforced: every call runs inside a Postgres
+//! `READ ONLY` transaction — the keyword guard upstream is UX, this is
+//! the boundary. Every call is bounded: `statement_timeout` server-side
+//! plus a client-side wrap, and a row cap enforced while streaming, so a
+//! whole-graph `RETURN` fails loudly at `max_rows + 1` instead of
+//! buffering the world.
+
+use std::time::Duration;
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use futures::stream::BoxStream;
+use serde_json::Value;
+use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions};
+use sqlx::{Either, Executor, Row};
+
+use super::error::{GraphError, json_kind};
+use super::value::parse_agtype;
+
+/// Per-query operational bounds (design §Security and operational
+/// bounds), carried per source.
+#[derive(Debug, Clone, Copy)]
+pub struct QueryBounds {
+    pub timeout: Duration,
+    pub max_rows: usize,
+}
+
+/// One result row: one JSON value per declared column.
+pub type GraphRow = Vec<Value>;
+/// The stream `execute` returns. Milestone 1 implementations may buffer
+/// internally up to `max_rows` — the trait shape is what must not change
+/// (design §Backend abstraction).
+pub type GraphRowStream = BoxStream<'static, Result<GraphRow, GraphError>>;
+
+/// What a backend must provide. Hides AGE (Postgres wire) vs Neo4j Bolt
+/// vs Kuzu details behind one seam.
+#[async_trait]
+pub trait GraphClient: Send + Sync + std::fmt::Debug {
+    /// Run read-only Cypher inside a backend-enforced read transaction,
+    /// bounded by `bounds`. `arity` is the declared column count — AGE's
+    /// `cypher()` call must declare its result arity, which is why the
+    /// declared-columns mode is required on this backend.
+    async fn execute(
+        &self,
+        cypher: &str,
+        params: &Value,
+        arity: usize,
+        bounds: QueryBounds,
+    ) -> Result<GraphRowStream, GraphError>;
+
+    /// Label roster for `graph_schema`: one `(label, kind)` row per
+    /// label, kinds `vertex` / `edge`. Names only — never property
+    /// values (design §Agent and LLM interaction).
+    async fn labels(&self) -> Result<Vec<(String, String)>, GraphError>;
+}
+
+/// Apache AGE over the workspace's sqlx-postgres stack.
+#[derive(Debug)]
+pub struct AgeClient {
+    pool: PgPool,
+    graph_name: String,
+    source_name: String,
+    /// Uniquifies per-call PREPARE names (see [`Self::build_sql`]) so
+    /// pooled-connection reuse can never collide.
+    prepare_seq: AtomicU64,
+}
+
+impl AgeClient {
+    /// Connect a pool whose every connection has AGE loaded and
+    /// `ag_catalog` on the search path. Credentials arrive as env-var
+    /// NAMES (values never in YAML); when set they override whatever the
+    /// URL carries.
+    pub async fn connect(
+        source_name: &str,
+        connection_string: &str,
+        graph_name: &str,
+        username_env: Option<&str>,
+        password_env: Option<&str>,
+    ) -> Result<Self, GraphError> {
+        let mut options: PgConnectOptions =
+            connection_string
+                .parse()
+                .map_err(|e: sqlx::Error| GraphError::InvalidConfig {
+                    name: source_name.to_string(),
+                    reason: format!("connection_string does not parse: {e}"),
+                })?;
+        if let Some(env) = username_env {
+            let user = read_env(source_name, "username_env", env)?;
+            options = options.username(&user);
+        }
+        if let Some(env) = password_env {
+            let pass = read_env(source_name, "password_env", env)?;
+            options = options.password(&pass);
+        }
+        let pool = PgPoolOptions::new()
+            .max_connections(4)
+            .after_connect(|conn, _meta| {
+                Box::pin(async move {
+                    // Per-connection, not per-query: LOAD is connection
+                    // state, and ag_catalog on the search path is what
+                    // makes `agtype` and `cypher()` resolvable.
+                    conn.execute("LOAD 'age'; SET search_path = ag_catalog, \"$user\", public;")
+                        .await?;
+                    Ok(())
+                })
+            })
+            .connect_with(options)
+            .await
+            .map_err(|e| backend_error(source_name, &e))?;
+        Ok(Self {
+            pool,
+            graph_name: graph_name.to_string(),
+            source_name: source_name.to_string(),
+            prepare_seq: AtomicU64::new(0),
+        })
+    }
+
+    /// The `cypher()` invocation, spoken over the SIMPLE query protocol —
+    /// three AGE realities verified live make this the one sound
+    /// spelling:
+    ///
+    /// - `cypher()`'s params argument must be a prepared-statement
+    ///   parameter (AGE rejects a constant with "third argument … must be
+    ///   a parameter"), so a parameterized call rides the documented
+    ///   `PREPARE name(agtype) AS …; EXECUTE name('…');` pattern — with a
+    ///   per-call unique name so pooled connections never collide.
+    /// - `::text` on agtype is AGE's scalar-only cast (a vertex fails
+    ///   with "unsupported argument agtype"), and for scalars it strips
+    ///   JSON quoting. The simple protocol instead delivers every column
+    ///   through `agtype_out` — the uniform annotated-JSON text the
+    ///   decoder expects.
+    /// - Everything is constant SQL text: the graph name is
+    ///   identifier-validated at config load AND quote-escaped (belt and
+    ///   braces); the caller's Cypher rides a dollar-quoted string whose
+    ///   tag provably does not occur in it; params are serde_json-encoded
+    ///   and single-quote-escaped — values cannot break out of the
+    ///   serialization.
+    ///
+    /// Returns the statement batch and the prepared name to DEALLOCATE
+    /// (when params were bound).
+    fn build_sql(&self, cypher: &str, params: &Value, arity: usize) -> (String, Option<String>) {
+        let tag = dollar_tag(cypher);
+        let graph = self.graph_name.replace('\'', "''");
+        let cols: Vec<String> = (0..arity)
+            .map(|i| format!("c{i} ag_catalog.agtype"))
+            .collect();
+        let outs: Vec<String> = (0..arity).map(|i| format!("c{i}")).collect();
+        let has_params = params.as_object().is_some_and(|m| !m.is_empty());
+        if has_params {
+            let name = format!(
+                "skq_p_{}_{}",
+                std::process::id(),
+                self.prepare_seq.fetch_add(1, Ordering::Relaxed)
+            );
+            let literal = params.to_string().replace('\'', "''");
+            let batch = format!(
+                "PREPARE {name}(ag_catalog.agtype) AS \
+                 SELECT {} FROM ag_catalog.cypher('{graph}', {tag}{cypher}{tag}, $1) \
+                 AS t({}); \
+                 EXECUTE {name}('{literal}');",
+                outs.join(", "),
+                cols.join(", ")
+            );
+            (batch, Some(name))
+        } else {
+            (
+                format!(
+                    "SELECT {} FROM ag_catalog.cypher('{graph}', {tag}{cypher}{tag}) \
+                     AS t({})",
+                    outs.join(", "),
+                    cols.join(", ")
+                ),
+                None,
+            )
+        }
+    }
+}
+
+#[async_trait]
+impl GraphClient for AgeClient {
+    async fn execute(
+        &self,
+        cypher: &str,
+        params: &Value,
+        arity: usize,
+        bounds: QueryBounds,
+    ) -> Result<GraphRowStream, GraphError> {
+        let (sql, prepared) = self.build_sql(cypher, params, arity);
+        let source = self.source_name.clone();
+        let run = async {
+            let mut tx = self
+                .pool
+                .begin()
+                .await
+                .map_err(|e| backend_error(&source, &e))?;
+            // The security boundary: the SERVER refuses writes in a read
+            // transaction, whatever slipped past the keyword guard.
+            sqlx::query("SET TRANSACTION READ ONLY")
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| backend_error(&source, &e))?;
+            // Server-side: runaway traversals die in the backend, not in
+            // a client that gave up waiting.
+            sqlx::query(&format!(
+                "SET LOCAL statement_timeout = '{}ms'",
+                bounds.timeout.as_millis()
+            ))
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| backend_error(&source, &e))?;
+
+            // Stream (simple protocol — see build_sql) and cap:
+            // max_rows + 1 proves the overflow without buffering past it.
+            let mut rows: Vec<GraphRow> = Vec::new();
+            {
+                let mut stream = tx.fetch_many(sqlx::raw_sql(&sql));
+                while let Some(step) = stream.next().await {
+                    let step = step.map_err(|e| map_query_error(&source, bounds, &e))?;
+                    // PREPARE contributes a rowless result; only rows count.
+                    let Either::Right(row) = step else { continue };
+                    if rows.len() >= bounds.max_rows {
+                        return Err(GraphError::RowCapExceeded {
+                            max_rows: bounds.max_rows,
+                        });
+                    }
+                    let row_idx = rows.len();
+                    let mut values = Vec::with_capacity(arity);
+                    for col in 0..arity {
+                        // Unchecked: simple-protocol cells are agtype_out
+                        // text, whose OID sqlx cannot map to String.
+                        let text: Option<String> = row
+                            .try_get_unchecked(col)
+                            .map_err(|e| backend_error(&source, &e))?;
+                        let value = match text {
+                            None => Value::Null,
+                            Some(t) => {
+                                parse_agtype(&t).map_err(|reason| GraphError::MalformedCell {
+                                    row: row_idx,
+                                    column: col,
+                                    reason,
+                                })?
+                            }
+                        };
+                        values.push(value);
+                    }
+                    rows.push(values);
+                }
+            }
+            if let Some(name) = &prepared {
+                // Targeted DEALLOCATE (never ALL — sqlx's own statement
+                // cache lives on the same connection).
+                tx.execute(format!("DEALLOCATE {name}").as_str())
+                    .await
+                    .map_err(|e| backend_error(&source, &e))?;
+            }
+            // Read-only: rollback returns the connection with nothing to
+            // undo either way.
+            tx.rollback()
+                .await
+                .map_err(|e| backend_error(&source, &e))?;
+            Ok(rows)
+        };
+        // Client-side wrap: the server timeout is authoritative, this one
+        // covers a backend that stops answering entirely.
+        let rows = tokio::time::timeout(bounds.timeout + Duration::from_secs(5), run)
+            .await
+            .map_err(|_| GraphError::Timeout {
+                seconds: bounds.timeout.as_secs(),
+            })??;
+        Ok(futures::stream::iter(rows.into_iter().map(Ok)).boxed())
+    }
+
+    async fn labels(&self) -> Result<Vec<(String, String)>, GraphError> {
+        // ag_catalog is the exact source for labels; AGE's own catch-all
+        // labels (`_ag_label_vertex` / `_ag_label_edge`) are implementation
+        // noise for an agent and are filtered.
+        let rows = sqlx::query(
+            "SELECT l.name, l.kind::text \
+             FROM ag_catalog.ag_label l \
+             JOIN ag_catalog.ag_graph g ON g.graphid = l.graph \
+             WHERE g.name = $1 AND l.name NOT LIKE '\\_ag\\_label\\_%' \
+             ORDER BY l.name",
+        )
+        .bind(&self.graph_name)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| backend_error(&self.source_name, &e))?;
+        rows.into_iter()
+            .map(|row| {
+                let name: String = row
+                    .try_get(0)
+                    .map_err(|e| backend_error(&self.source_name, &e))?;
+                let kind: String = row
+                    .try_get(1)
+                    .map_err(|e| backend_error(&self.source_name, &e))?;
+                let kind = match kind.as_str() {
+                    "v" => "vertex".to_string(),
+                    "e" => "edge".to_string(),
+                    other => other.to_string(),
+                };
+                Ok((name, kind))
+            })
+            .collect()
+    }
+}
+
+/// A dollar-quote tag that provably does not occur in `text`: extend a
+/// base tag with a counter until absent — no escape rules to get wrong.
+fn dollar_tag(text: &str) -> String {
+    let mut tag = "$skq$".to_string();
+    let mut n = 0u32;
+    while text.contains(&tag) {
+        n += 1;
+        tag = format!("$skq{n}$");
+    }
+    tag
+}
+
+fn read_env(source: &str, field: &str, env: &str) -> Result<String, GraphError> {
+    std::env::var(env).map_err(|_| GraphError::InvalidConfig {
+        name: source.to_string(),
+        reason: format!("{field}: ${env} is not set in this environment"),
+    })
+}
+
+fn backend_error(source: &str, e: &sqlx::Error) -> GraphError {
+    let code = match e {
+        sqlx::Error::Database(db) => db.code().map(|c| c.to_string()),
+        _ => None,
+    };
+    GraphError::backend(source, code.as_deref().unwrap_or("io"), &e.to_string())
+}
+
+/// Postgres cancels a statement-timeout overrun with SQLSTATE 57014 —
+/// surface it as the typed timeout, not a generic backend error.
+fn map_query_error(source: &str, bounds: QueryBounds, e: &sqlx::Error) -> GraphError {
+    if let sqlx::Error::Database(db) = e
+        && db.code().as_deref() == Some("57014")
+    {
+        return GraphError::Timeout {
+            seconds: bounds.timeout.as_secs(),
+        };
+    }
+    backend_error(source, e)
+}
+
+/// Numeric `params` mapping (design §SQL surface): a JSON number with no
+/// fraction or exponent binds as Integer; with either, as Float — write
+/// `1.0` to force Float. serde_json preserves the distinction (`is_i64`
+/// vs `is_f64`), so validation is a kind check, not a coercion.
+pub fn validate_params(params: &Value) -> Result<(), GraphError> {
+    match params {
+        Value::Object(_) => Ok(()),
+        other => Err(GraphError::InvalidParams {
+            found: json_kind(other).to_string(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dollar_tags_never_collide_with_the_text() {
+        assert_eq!(dollar_tag("MATCH (n) RETURN n"), "$skq$");
+        let hostile = "RETURN '$skq$ $skq1$'";
+        let tag = dollar_tag(hostile);
+        assert!(!hostile.contains(&tag), "{tag}");
+    }
+
+    #[test]
+    fn params_must_be_an_object() {
+        assert!(validate_params(&serde_json::json!({"a": 1})).is_ok());
+        let err = validate_params(&serde_json::json!([1])).unwrap_err();
+        assert!(err.to_string().contains("an array"), "{err}");
+    }
+}

--- a/crates/skardi/src/sources/providers/graph/client.rs
+++ b/crates/skardi/src/sources/providers/graph/client.rs
@@ -92,10 +92,13 @@ pub trait GraphClient: Send + Sync + std::fmt::Debug {
     /// Run read-only Cypher inside a backend-enforced read transaction,
     /// bounded by `bounds`. `arity` is the declared column count — AGE's
     /// `cypher()` call must declare its result arity, which is why the
-    /// declared-columns mode is required on this backend. `limit` is a
-    /// SQL LIMIT pushed to the CONSUMPTION side: the client stops reading
-    /// after that many rows (a clean early stop, not an error — the row
-    /// cap stays the loud overflow signal for uncapped scans).
+    /// declared-columns mode is required on this backend. `limit` is
+    /// pushed BOTH ways: into the statement as a real SQL LIMIT
+    /// (min(limit, max_rows + 1), so the backend and the wire are
+    /// bounded even when the caller passes none — an overflow costs
+    /// max_rows + 1 rows, not a full scan plus a drain) AND enforced at
+    /// consumption as defense in depth. Hitting `limit` is a clean early
+    /// stop; the row cap stays the loud overflow signal.
     async fn execute(
         &self,
         cypher: &str,
@@ -211,13 +214,20 @@ impl AgeClient {
     ///
     /// Returns the statement batch and the prepared name to DEALLOCATE
     /// (when params were bound).
-    fn build_sql(&self, cypher: &str, params: &Value, arity: usize) -> (String, Option<String>) {
+    fn build_sql(
+        &self,
+        cypher: &str,
+        params: &Value,
+        arity: usize,
+        fetch: usize,
+    ) -> (String, Option<String>) {
         build_cypher_sql(
             &self.graph_name,
             self.prepare_seq.fetch_add(1, Ordering::Relaxed),
             cypher,
             params,
             arity,
+            fetch,
         )
     }
 }
@@ -232,7 +242,19 @@ impl GraphClient for AgeClient {
         bounds: QueryBounds,
         limit: Option<usize>,
     ) -> Result<GraphRowStream, GraphError> {
-        let (sql, prepared) = self.build_sql(cypher, params, arity);
+        // The fetch bound rides the OUTER statement as a real SQL LIMIT
+        // (never inside the Cypher text): the backend and the wire are
+        // bounded even when the caller passes no limit, a RowCapExceeded
+        // costs max_rows + 1 rows instead of a full scan plus a full
+        // drain before ROLLBACK, and the consumption-side checks below
+        // stay as defense in depth. Same formula as labels(): a SQL
+        // LIMIT at or under the cap is a clean stop; otherwise fetch one
+        // past the cap to PROVE an overflow.
+        let fetch = match limit {
+            Some(l) if l <= bounds.max_rows => l,
+            _ => bounds.max_rows.saturating_add(1),
+        };
+        let (sql, prepared) = self.build_sql(cypher, params, arity, fetch);
         let source = self.source_name.clone();
         let run = async {
             // A MANUAL transaction on an explicitly acquired connection,
@@ -446,6 +468,7 @@ fn build_cypher_sql(
     cypher: &str,
     params: &Value,
     arity: usize,
+    fetch: usize,
 ) -> (String, Option<String>) {
     let tag = dollar_tag(cypher);
     let graph = graph_name.replace('\'', "''");
@@ -460,7 +483,7 @@ fn build_cypher_sql(
         let batch = format!(
             "PREPARE {name}(ag_catalog.agtype) AS \
              SELECT {} FROM ag_catalog.cypher('{graph}', {tag}{cypher}{tag}, $1) \
-             AS t({}); \
+             AS t({}) LIMIT {fetch}; \
              EXECUTE {name}('{literal}');",
             outs.join(", "),
             cols.join(", ")
@@ -470,7 +493,7 @@ fn build_cypher_sql(
         (
             format!(
                 "SELECT {} FROM ag_catalog.cypher('{graph}', {tag}{cypher}{tag}) \
-                 AS t({})",
+                 AS t({}) LIMIT {fetch}",
                 outs.join(", "),
                 cols.join(", ")
             ),
@@ -482,9 +505,16 @@ fn build_cypher_sql(
 /// A dollar-quote tag that provably does not occur in `text`: extend a
 /// base tag with a counter until absent — no escape rules to get wrong.
 fn dollar_tag(text: &str) -> String {
+    // The collision test runs against `text + "$"`, not `text`: the
+    // closing delimiter starts with `$`, so a query ENDING in the tag's
+    // interior (e.g. `RETURN $skq` with a parameter named `skq`) forms
+    // the full tag at the text/closing-tag boundary and would close the
+    // literal early. Appending the `$` makes the check cover exactly the
+    // stream Postgres scans.
+    let probe = format!("{text}$");
     let mut tag = "$skq$".to_string();
     let mut n = 0u32;
-    while text.contains(&tag) {
+    while probe.contains(&tag) {
         n += 1;
         tag = format!("$skq{n}$");
     }
@@ -542,6 +572,25 @@ mod tests {
         let hostile = "RETURN '$skq$ $skq1$'";
         let tag = dollar_tag(hostile);
         assert!(!hostile.contains(&tag), "{tag}");
+
+        // The BOUNDARY case: a query ending in the tag's interior forms
+        // the full tag against the closing delimiter's leading `$` —
+        // `RETURN $skq` + `$…` would close `$skq$…$skq$` early. The probe
+        // must scan text+"$", exactly the stream Postgres sees.
+        let boundary = "RETURN $skq";
+        let tag = dollar_tag(boundary);
+        assert_ne!(tag, "$skq$", "boundary composition must bump the tag");
+        assert!(!format!("{boundary}$").contains(&tag), "{tag}");
+        let (sql, _) = build_cypher_sql("kg", 0, boundary, &serde_json::json!({}), 1, 11);
+        // The emitted literal parses as ONE dollar-quoted string: the
+        // closing tag is found exactly once past the opening.
+        let open = sql.find(&tag).expect("opening tag");
+        let close = sql[open + tag.len()..].find(&tag).expect("closing tag");
+        assert_eq!(
+            &sql[open + tag.len()..open + tag.len() + close],
+            boundary,
+            "the whole query is the literal body: {sql}"
+        );
     }
 
     #[test]
@@ -552,14 +601,17 @@ mod tests {
             "MATCH (n) RETURN n.a, n.b",
             &serde_json::json!({}),
             2,
+            101,
         );
         assert!(prepared.is_none(), "no params → nothing to DEALLOCATE");
         assert!(
             sql.starts_with("SELECT c0, c1 FROM ag_catalog.cypher('kg', $skq$"),
             "{sql}"
         );
+        // The fetch bound is a REAL SQL LIMIT on the outer statement —
+        // the backend and the wire are bounded even with no caller LIMIT.
         assert!(
-            sql.ends_with("AS t(c0 ag_catalog.agtype, c1 ag_catalog.agtype)"),
+            sql.ends_with("AS t(c0 ag_catalog.agtype, c1 ag_catalog.agtype) LIMIT 101"),
             "{sql}"
         );
         assert!(!sql.contains("PREPARE"), "{sql}");
@@ -573,6 +625,11 @@ mod tests {
             "MATCH (n) WHERE n.x = $x RETURN n",
             &serde_json::json!({"x": 1}),
             1,
+            5,
+        );
+        assert!(
+            sql.contains("ag_catalog.agtype) LIMIT 5;"),
+            "the PREPARE body carries the fetch LIMIT: {sql}"
         );
         let name = prepared.expect("params → PREPARE name to DEALLOCATE");
         assert!(name.starts_with("skq_p_"), "{name}");
@@ -598,10 +655,11 @@ mod tests {
             "RETURN $s",
             &serde_json::json!({"s": "O'Brien '; DROP TABLE x; --"}),
             1,
+            10,
         );
         assert!(sql.contains("O''Brien ''; DROP TABLE x; --"), "{sql}");
 
-        let (sql, _) = build_cypher_sql("g'name", 0, "RETURN 1", &serde_json::json!({}), 1);
+        let (sql, _) = build_cypher_sql("g'name", 0, "RETURN 1", &serde_json::json!({}), 1, 10);
         assert!(sql.contains("cypher('g''name'"), "{sql}");
     }
 

--- a/crates/skardi/src/sources/providers/graph/client.rs
+++ b/crates/skardi/src/sources/providers/graph/client.rs
@@ -313,11 +313,12 @@ impl GraphClient for AgeClient {
             .await;
             // ROLLBACK unconditionally and FIRST: it clears an aborted
             // transaction (making the DEALLOCATE below executable) and a
-            // read-only transaction had nothing to undo anyway.
+            // read-only transaction had nothing to undo anyway. Its
+            // RESULT is checked LAST — an early `?` here would skip the
+            // DEALLOCATE below and leak the statement on the very success
+            // path this cleanup exists for (round-4 follow-up finding).
             let rollback = conn.execute("ROLLBACK").await;
-            if collected.is_ok() {
-                rollback.map_err(|e| backend_error(&source, &e))?;
-            }
+            let mut dealloc = Ok(Default::default());
             if let Some(name) = &prepared {
                 // On EVERY exit: prepared statements are SESSION-level,
                 // the pid+seq names never reuse, and skipping this on an
@@ -328,12 +329,14 @@ impl GraphClient for AgeClient {
                 // failed DEALLOCATE on the success path is itself an
                 // error. Targeted, never ALL — sqlx's own statement cache
                 // lives on the same connection.
-                let dealloc = conn.execute(format!("DEALLOCATE {name}").as_str()).await;
-                if collected.is_ok() {
-                    dealloc.map_err(|e| backend_error(&source, &e))?;
-                }
+                dealloc = conn.execute(format!("DEALLOCATE {name}").as_str()).await;
             }
-            collected
+            let rows = collected?;
+            // Success path only, and only AFTER both cleanups ran:
+            // rollback failure first (it happened first), then dealloc.
+            rollback.map_err(|e| backend_error(&source, &e))?;
+            dealloc.map_err(|e| backend_error(&source, &e))?;
+            Ok(rows)
         };
         // Residual, stated: the client-side timeout below ABANDONS the
         // future mid-flight — no DEALLOCATE can run on that path. It only

--- a/crates/skardi/src/sources/providers/graph/client.rs
+++ b/crates/skardi/src/sources/providers/graph/client.rs
@@ -144,6 +144,7 @@ impl AgeClient {
         username_env: Option<&str>,
         password_env: Option<&str>,
         max_connections: u32,
+        acquire_timeout: Duration,
     ) -> Result<Self, GraphError> {
         let mut options: PgConnectOptions =
             connection_string
@@ -162,6 +163,12 @@ impl AgeClient {
         }
         let pool = PgPoolOptions::new()
             .max_connections(max_connections)
+            // Queueing on a saturated pool is bounded by the SAME knob
+            // as the query itself — sqlx's 30s default is unrelated to
+            // query_timeout_seconds and would surface as a generic
+            // driver failure after possibly LONGER than the configured
+            // bound ("every query is bounded" covers the queue too).
+            .acquire_timeout(acquire_timeout)
             .after_connect(|conn, _meta| {
                 Box::pin(async move {
                     // Per-connection, not per-query: LOAD is connection
@@ -175,6 +182,29 @@ impl AgeClient {
             .connect_with(options)
             .await
             .map_err(|e| backend_error(source_name, &e))?;
+        // The graph name gets the same eager treatment as the URL and
+        // the credential: a typo would otherwise fail LATE and split —
+        // per-query raw backend errors on cypher_query, and zero rows
+        // WITHOUT error on graph_schema (the catalog join just misses),
+        // which an agent reads as "this graph is empty". The connect
+        // already paid the round-trip; this check makes the eager-fail
+        // docstring true as written.
+        let exists: Option<i32> =
+            sqlx::query_scalar("SELECT 1 FROM ag_catalog.ag_graph WHERE name = $1")
+                .bind(graph_name)
+                .fetch_optional(&pool)
+                .await
+                .map_err(|e| backend_error(source_name, &e))?;
+        if exists.is_none() {
+            return Err(GraphError::InvalidConfig {
+                name: source_name.to_string(),
+                reason: format!(
+                    "graph '{graph_name}' does not exist in this database \
+                     (ag_catalog.ag_graph has no such entry; create it with \
+                     SELECT create_graph(...) or fix graph_name)"
+                ),
+            });
+        }
         Ok(Self {
             pool,
             graph_name: graph_name.to_string(),
@@ -270,7 +300,7 @@ impl GraphClient for AgeClient {
                 .pool
                 .acquire()
                 .await
-                .map_err(|e| backend_error(&source, &e))?;
+                .map_err(|e| map_query_error(&source, bounds, &e))?;
             // The security boundary: the SERVER refuses writes in a read
             // transaction, whatever slipped past the keyword guard.
             conn.execute("BEGIN TRANSACTION READ ONLY")
@@ -529,11 +559,17 @@ fn read_env(source: &str, field: &str, env: &str) -> Result<String, GraphError> 
 }
 
 fn backend_error(source: &str, e: &sqlx::Error) -> GraphError {
-    let code = match e {
-        sqlx::Error::Database(db) => db.code().map(|c| c.to_string()),
-        _ => None,
+    // db.message(), never e.to_string(), for database errors: Postgres
+    // errors carry `position` and statement context — the caller's
+    // Cypher, i.e. values — and sqlx's Display dropping them today is
+    // an implementation detail of sqlx, not a guarantee of ours. Taking
+    // message() makes the "query text never flows into errors" rule
+    // THIS module's own (the 300-byte cap remains as backstop only).
+    let (code, message) = match e {
+        sqlx::Error::Database(db) => (db.code().map(|c| c.to_string()), db.message().to_string()),
+        _ => (None, e.to_string()),
     };
-    GraphError::backend(source, code.as_deref().unwrap_or("io"), &e.to_string())
+    GraphError::backend(source, code.as_deref().unwrap_or("io"), &message)
 }
 
 /// Postgres cancels a statement-timeout overrun with SQLSTATE 57014 —
@@ -542,6 +578,12 @@ fn map_query_error(source: &str, bounds: QueryBounds, e: &sqlx::Error) -> GraphE
     if let sqlx::Error::Database(db) = e
         && db.code().as_deref() == Some("57014")
     {
+        return GraphError::Timeout {
+            seconds: bounds.timeout.as_secs(),
+        };
+    }
+    // A pool-acquire timeout is the queueing flavor of the same bound.
+    if matches!(e, sqlx::Error::PoolTimedOut) {
         return GraphError::Timeout {
             seconds: bounds.timeout.as_secs(),
         };

--- a/crates/skardi/src/sources/providers/graph/client.rs
+++ b/crates/skardi/src/sources/providers/graph/client.rs
@@ -81,6 +81,7 @@ pub type GraphRowStream = BoxStream<'static, Result<GraphRow, GraphError>>;
 ///     async fn labels(
 ///         &self,
 ///         _bounds: QueryBounds,
+///         _limit: Option<usize>,
 ///     ) -> Result<Vec<(String, String)>, GraphError> {
 ///         Ok(vec![("Person".into(), "vertex".into())])
 ///     }
@@ -107,8 +108,14 @@ pub trait GraphClient: Send + Sync + std::fmt::Debug {
     /// Label roster for `graph_schema`: one `(label, kind)` row per
     /// label, kinds `vertex` / `edge`. Names only — never property
     /// values (design §Agent and LLM interaction). Bounded like every
-    /// other query — "every query is bounded" has no catalog exemption.
-    async fn labels(&self, bounds: QueryBounds) -> Result<Vec<(String, String)>, GraphError>;
+    /// other query — "every query is bounded" has no catalog exemption —
+    /// and `limit` is the SQL LIMIT, pushed into the catalog fetch as a
+    /// clean early stop.
+    async fn labels(
+        &self,
+        bounds: QueryBounds,
+        limit: Option<usize>,
+    ) -> Result<Vec<(String, String)>, GraphError>;
 }
 
 /// Apache AGE over the workspace's sqlx-postgres stack.
@@ -255,35 +262,43 @@ impl GraphClient for AgeClient {
         let (sql, prepared) = self.build_sql(cypher, params, arity);
         let source = self.source_name.clone();
         let run = async {
-            let mut tx = self
+            // A MANUAL transaction on an explicitly acquired connection,
+            // not sqlx's Transaction guard: cleanup must be able to
+            // ROLLBACK FIRST and then DEALLOCATE on the SAME session — a
+            // backend error (invalid Cypher, runtime error,
+            // statement_timeout) puts the transaction in aborted state,
+            // where DEALLOCATE itself is refused, while rollback does NOT
+            // clear session-level prepared statements. Rollback-then-
+            // deallocate is the only order that cleans up after backend
+            // errors.
+            let mut conn = self
                 .pool
-                .begin()
+                .acquire()
                 .await
                 .map_err(|e| backend_error(&source, &e))?;
             // The security boundary: the SERVER refuses writes in a read
             // transaction, whatever slipped past the keyword guard.
-            sqlx::query("SET TRANSACTION READ ONLY")
-                .execute(&mut *tx)
+            conn.execute("BEGIN TRANSACTION READ ONLY")
                 .await
                 .map_err(|e| backend_error(&source, &e))?;
-            // Server-side: runaway traversals die in the backend, not in
-            // a client that gave up waiting.
-            sqlx::query(&format!(
-                "SET LOCAL statement_timeout = '{}ms'",
-                bounds.timeout.as_millis()
-            ))
-            .execute(&mut *tx)
-            .await
-            .map_err(|e| backend_error(&source, &e))?;
-
-            // Stream (simple protocol — see build_sql) and cap:
-            // max_rows + 1 proves the overflow without buffering past it.
-            // The collection runs as an INNER block so every early exit
-            // (row cap, malformed cell, wire error) still reaches the
-            // DEALLOCATE below.
             let collected: Result<Vec<GraphRow>, GraphError> = async {
+                // Server-side: runaway traversals die in the backend, not
+                // in a client that gave up waiting.
+                conn.execute(
+                    format!(
+                        "SET LOCAL statement_timeout = '{}ms'",
+                        bounds.timeout.as_millis()
+                    )
+                    .as_str(),
+                )
+                .await
+                .map_err(|e| backend_error(&source, &e))?;
+
+                // Stream (simple protocol — see build_sql) and cap:
+                // max_rows + 1 proves the overflow without buffering past
+                // it.
                 let mut rows: Vec<GraphRow> = Vec::new();
-                let mut stream = tx.fetch_many(sqlx::raw_sql(&sql));
+                let mut stream = conn.fetch_many(sqlx::raw_sql(&sql));
                 while let Some(step) = stream.next().await {
                     let step = step.map_err(|e| map_query_error(&source, bounds, &e))?;
                     // PREPARE contributes a rowless result; only rows count.
@@ -323,28 +338,29 @@ impl GraphClient for AgeClient {
                 Ok(rows)
             }
             .await;
+            // ROLLBACK unconditionally and FIRST: it clears an aborted
+            // transaction (making the DEALLOCATE below executable) and a
+            // read-only transaction had nothing to undo anyway.
+            let rollback = conn.execute("ROLLBACK").await;
+            if collected.is_ok() {
+                rollback.map_err(|e| backend_error(&source, &e))?;
+            }
             if let Some(name) = &prepared {
-                // On EVERY exit, success or error: prepared statements are
-                // SESSION-level — rollback does not clear them, the
-                // pid+seq names never reuse, and skipping this on an
+                // On EVERY exit: prepared statements are SESSION-level,
+                // the pid+seq names never reuse, and skipping this on an
                 // error path would monotonically accumulate statements on
                 // the pooled connection. Best-effort on the error path
-                // (the original error stays the one reported); a failed
-                // DEALLOCATE on the success path is itself an error.
-                // Targeted, never ALL — sqlx's own statement cache lives
-                // on the same connection.
-                let dealloc = tx.execute(format!("DEALLOCATE {name}").as_str()).await;
+                // (the original error stays the one reported — and when
+                // the PREPARE itself failed there is nothing to drop); a
+                // failed DEALLOCATE on the success path is itself an
+                // error. Targeted, never ALL — sqlx's own statement cache
+                // lives on the same connection.
+                let dealloc = conn.execute(format!("DEALLOCATE {name}").as_str()).await;
                 if collected.is_ok() {
                     dealloc.map_err(|e| backend_error(&source, &e))?;
                 }
             }
-            let rows = collected?;
-            // Read-only: rollback returns the connection with nothing to
-            // undo either way.
-            tx.rollback()
-                .await
-                .map_err(|e| backend_error(&source, &e))?;
-            Ok(rows)
+            collected
         };
         // Residual, stated: the client-side timeout below ABANDONS the
         // future mid-flight — no DEALLOCATE can run on that path. It only
@@ -353,8 +369,10 @@ impl GraphClient for AgeClient {
         // dropped mid-query rather than pooling it, so nothing
         // accumulates there either.
         // Client-side wrap: the server timeout is authoritative, this one
-        // covers a backend that stops answering entirely.
-        let rows = tokio::time::timeout(bounds.timeout + Duration::from_secs(5), run)
+        // covers a backend that stops answering entirely. saturating_add:
+        // the config caps the timeout, but arithmetic here must not be
+        // the thing that panics if that invariant ever moves.
+        let rows = tokio::time::timeout(bounds.timeout.saturating_add(Duration::from_secs(5)), run)
             .await
             .map_err(|_| GraphError::Timeout {
                 seconds: bounds.timeout.as_secs(),
@@ -362,12 +380,24 @@ impl GraphClient for AgeClient {
         Ok(futures::stream::iter(rows.into_iter().map(Ok)).boxed())
     }
 
-    async fn labels(&self, bounds: QueryBounds) -> Result<Vec<(String, String)>, GraphError> {
+    async fn labels(
+        &self,
+        bounds: QueryBounds,
+        limit: Option<usize>,
+    ) -> Result<Vec<(String, String)>, GraphError> {
         // Same bounds discipline as execute — a catalog read against a
         // wedged backend must not hang forever, and the design's "every
         // query is bounded" makes no catalog exemption: READ ONLY
         // transaction, server-side statement_timeout, row cap, and the
-        // client-side wrap.
+        // client-side wrap. The cap and the SQL LIMIT both ride the
+        // query's own LIMIT clause, so at most max_rows + 1 label rows
+        // ever cross the wire — never the whole catalog first.
+        let fetch = match limit {
+            // A SQL LIMIT at or under the cap is a clean early stop.
+            Some(l) if l <= bounds.max_rows => l,
+            // Otherwise fetch one past the cap to PROVE an overflow.
+            _ => bounds.max_rows.saturating_add(1),
+        };
         let source = self.source_name.clone();
         let run = async {
             let mut tx = self
@@ -394,13 +424,14 @@ impl GraphClient for AgeClient {
                  FROM ag_catalog.ag_label l \
                  JOIN ag_catalog.ag_graph g ON g.graphid = l.graph \
                  WHERE g.name = $1 AND l.name NOT LIKE '\\_ag\\_label\\_%' \
-                 ORDER BY l.name",
+                 ORDER BY l.name LIMIT $2",
             )
             .bind(&self.graph_name)
+            .bind(i64::try_from(fetch).unwrap_or(i64::MAX))
             .fetch_all(&mut *tx)
             .await
             .map_err(|e| map_query_error(&source, bounds, &e))?;
-            if rows.len() > bounds.max_rows {
+            if limit.is_none_or(|l| l > bounds.max_rows) && rows.len() > bounds.max_rows {
                 return Err(GraphError::RowCapExceeded {
                     max_rows: bounds.max_rows,
                 });
@@ -421,7 +452,7 @@ impl GraphClient for AgeClient {
                 })
                 .collect()
         };
-        tokio::time::timeout(bounds.timeout + Duration::from_secs(5), run)
+        tokio::time::timeout(bounds.timeout.saturating_add(Duration::from_secs(5)), run)
             .await
             .map_err(|_| GraphError::Timeout {
                 seconds: bounds.timeout.as_secs(),

--- a/crates/skardi/src/sources/providers/graph/client.rs
+++ b/crates/skardi/src/sources/providers/graph/client.rs
@@ -166,6 +166,18 @@ impl Drop for OpenTxnGuard {
             // harnesses.
             if let Ok(handle) = tokio::runtime::Handle::try_current() {
                 handle.spawn(async move {
+                    // NOTE: this ROLLBACK queues BEHIND the statement
+                    // still running on this session, so the connection
+                    // does not return to the pool until the server-side
+                    // statement_timeout expires (up to
+                    // query_timeout_seconds — measured ~23s in review).
+                    // A burst of cancellations can therefore pin every
+                    // pooled session for that long, with new queries
+                    // queueing on acquire_timeout — bounded, but not
+                    // prompt. Cancelling the running query first
+                    // (pg_cancel_backend from a second connection) is
+                    // the fix if that ever bites.
+                    //
                     // ROLLBACK first (clears an aborted transaction, where
                     // DEALLOCATE is refused), then drop the statement —
                     // the same order the clean path uses.

--- a/crates/skardi/src/sources/providers/graph/client.rs
+++ b/crates/skardi/src/sources/providers/graph/client.rs
@@ -95,8 +95,8 @@ pub struct SchemaRow {
 ///         Ok(futures::stream::iter(rows.into_iter().map(Ok)).boxed())
 ///     }
 ///
-///     fn requires_declared_columns(&self) -> bool {
-///         false
+///     fn declared_columns_requirement(&self) -> Option<&'static str> {
+///         None
 ///     }
 ///
 ///     async fn schema(
@@ -139,11 +139,13 @@ pub trait GraphClient: Send + Sync + std::fmt::Debug {
         limit: Option<usize>,
     ) -> Result<GraphRowStream, GraphError>;
 
-    /// Whether `execute` refuses `columns: None`. True exactly when the
-    /// backend's wire call must declare its result arity up front (AGE's
-    /// `cypher()`); the UDTF turns this into a targeted plan-time error
-    /// instead of a late execution failure.
-    fn requires_declared_columns(&self) -> bool;
+    /// Why `execute` would refuse `columns: None`, if it would: `Some`
+    /// carries the backend's own explanation (AGE: its `cypher()` must
+    /// declare arity, and binding is positional), which the UDTF renders
+    /// into the targeted plan-time error — so shared code never
+    /// hardcodes one backend's contract. `None` means the JSON-`record`
+    /// fallback is available.
+    fn declared_columns_requirement(&self) -> Option<&'static str>;
 
     /// Catalog roster for `graph_schema`: one row per label (kinds
     /// `vertex` / `edge`), and — where the backend's catalog knows them —
@@ -151,7 +153,9 @@ pub trait GraphClient: Send + Sync + std::fmt::Debug {
     /// type(s). Names and types only, never property values (design
     /// §Agent and LLM interaction). Bounded like every other query —
     /// "every query is bounded" has no catalog exemption — and `limit`
-    /// is pushed into the catalog fetch as a clean early stop.
+    /// is honored as a clean early stop, pushed as deep as the backend
+    /// allows (AGE: into the catalog SQL; Neo4j: applied after the
+    /// bounded procedure fetch, since procedure rows flatten 1-to-many).
     async fn schema(
         &self,
         bounds: QueryBounds,
@@ -447,22 +451,22 @@ impl GraphClient for AgeClient {
         // (i.e. stopped answering), and sqlx tears down a connection
         // dropped mid-query rather than pooling it, so nothing
         // accumulates there either.
-        // Client-side wrap: the server timeout is authoritative, this one
-        // covers a backend that stops answering entirely. saturating_add:
-        // the config caps the timeout, but arithmetic here must not be
-        // the thing that panics if that invariant ever moves.
-        let rows = tokio::time::timeout(bounds.timeout.saturating_add(Duration::from_secs(5)), run)
-            .await
-            .map_err(|_| GraphError::Timeout {
-                seconds: bounds.timeout.as_secs(),
-            })??;
+        let rows = bounded(bounds.timeout, run).await?;
         Ok(futures::stream::iter(rows.into_iter().map(Ok)).boxed())
     }
 
-    fn requires_declared_columns(&self) -> bool {
+    fn declared_columns_requirement(&self) -> Option<&'static str> {
         // AGE's `cypher()` call must declare its result arity — the
-        // JSON-record fallback cannot exist on this backend.
-        true
+        // JSON-record fallback cannot exist on this backend. The text
+        // also carries the positional-binding warning, because omitting
+        // columns and mis-ordering them are the same caller mistake
+        // family on this backend.
+        Some(
+            "'columns' is required on the age backend — declare the output columns \
+             IN THE SAME ORDER AS YOUR RETURN CLAUSE (the binding is positional; \
+             two same-typed columns declared out of order swap silently), \
+             e.g. '{\"name\": \"string\", \"n\": \"node\"}'",
+        )
     }
 
     async fn schema(
@@ -547,11 +551,7 @@ impl GraphClient for AgeClient {
                 })
                 .collect()
         };
-        tokio::time::timeout(bounds.timeout.saturating_add(Duration::from_secs(5)), run)
-            .await
-            .map_err(|_| GraphError::Timeout {
-                seconds: bounds.timeout.as_secs(),
-            })?
+        bounded(bounds.timeout, run).await
     }
 }
 
@@ -618,11 +618,30 @@ fn dollar_tag(text: &str) -> String {
     tag
 }
 
-fn read_env(source: &str, field: &str, env: &str) -> Result<String, GraphError> {
+/// Env-var credential lookup, shared by every backend client so the
+/// error wording (env-var NAME only, never a value) cannot drift per
+/// backend.
+pub(super) fn read_env(source: &str, field: &str, env: &str) -> Result<String, GraphError> {
     std::env::var(env).map_err(|_| GraphError::InvalidConfig {
         name: source.to_string(),
         reason: format!("{field}: ${env} is not set in this environment"),
     })
+}
+
+/// The client-side timeout wrap, shared by every backend client: the
+/// SERVER-side timeout (statement_timeout / tx_timeout) is
+/// authoritative; this covers a backend that stops answering entirely.
+/// saturating_add: the config caps the timeout, but arithmetic here must
+/// not be the thing that panics if that invariant ever moves.
+pub(super) async fn bounded<T>(
+    timeout: Duration,
+    fut: impl Future<Output = Result<T, GraphError>>,
+) -> Result<T, GraphError> {
+    tokio::time::timeout(timeout.saturating_add(Duration::from_secs(5)), fut)
+        .await
+        .map_err(|_| GraphError::Timeout {
+            seconds: timeout.as_secs(),
+        })?
 }
 
 fn backend_error(source: &str, e: &sqlx::Error) -> GraphError {

--- a/crates/skardi/src/sources/providers/graph/client.rs
+++ b/crates/skardi/src/sources/providers/graph/client.rs
@@ -46,18 +46,62 @@ pub type GraphRowStream = BoxStream<'static, Result<GraphRow, GraphError>>;
 
 /// What a backend must provide. Hides AGE (Postgres wire) vs Neo4j Bolt
 /// vs Kuzu details behind one seam.
+///
+/// # Example
+/// ```
+/// use async_trait::async_trait;
+/// use futures::StreamExt;
+/// use serde_json::Value;
+/// use skardi::sources::providers::graph::client::{
+///     GraphClient, GraphRowStream, QueryBounds,
+/// };
+/// use skardi::sources::providers::graph::error::GraphError;
+///
+/// /// A canned backend, the shape tests use.
+/// #[derive(Debug)]
+/// struct Fixed(Vec<Vec<Value>>);
+///
+/// #[async_trait]
+/// impl GraphClient for Fixed {
+///     async fn execute(
+///         &self,
+///         _cypher: &str,
+///         _params: &Value,
+///         _arity: usize,
+///         _bounds: QueryBounds,
+///         limit: Option<usize>,
+///     ) -> Result<GraphRowStream, GraphError> {
+///         let mut rows = self.0.clone();
+///         if let Some(l) = limit {
+///             rows.truncate(l);
+///         }
+///         Ok(futures::stream::iter(rows.into_iter().map(Ok)).boxed())
+///     }
+///
+///     async fn labels(
+///         &self,
+///         _bounds: QueryBounds,
+///     ) -> Result<Vec<(String, String)>, GraphError> {
+///         Ok(vec![("Person".into(), "vertex".into())])
+///     }
+/// }
+/// ```
 #[async_trait]
 pub trait GraphClient: Send + Sync + std::fmt::Debug {
     /// Run read-only Cypher inside a backend-enforced read transaction,
     /// bounded by `bounds`. `arity` is the declared column count — AGE's
     /// `cypher()` call must declare its result arity, which is why the
-    /// declared-columns mode is required on this backend.
+    /// declared-columns mode is required on this backend. `limit` is a
+    /// SQL LIMIT pushed to the CONSUMPTION side: the client stops reading
+    /// after that many rows (a clean early stop, not an error — the row
+    /// cap stays the loud overflow signal for uncapped scans).
     async fn execute(
         &self,
         cypher: &str,
         params: &Value,
         arity: usize,
         bounds: QueryBounds,
+        limit: Option<usize>,
     ) -> Result<GraphRowStream, GraphError>;
 
     /// Label roster for `graph_schema`: one `(label, kind)` row per
@@ -89,6 +133,7 @@ impl AgeClient {
         graph_name: &str,
         username_env: Option<&str>,
         password_env: Option<&str>,
+        max_connections: u32,
     ) -> Result<Self, GraphError> {
         let mut options: PgConnectOptions =
             connection_string
@@ -106,7 +151,7 @@ impl AgeClient {
             options = options.password(&pass);
         }
         let pool = PgPoolOptions::new()
-            .max_connections(4)
+            .max_connections(max_connections)
             .after_connect(|conn, _meta| {
                 Box::pin(async move {
                     // Per-connection, not per-query: LOAD is connection
@@ -205,6 +250,7 @@ impl GraphClient for AgeClient {
         params: &Value,
         arity: usize,
         bounds: QueryBounds,
+        limit: Option<usize>,
     ) -> Result<GraphRowStream, GraphError> {
         let (sql, prepared) = self.build_sql(cypher, params, arity);
         let source = self.source_name.clone();
@@ -242,6 +288,11 @@ impl GraphClient for AgeClient {
                     let step = step.map_err(|e| map_query_error(&source, bounds, &e))?;
                     // PREPARE contributes a rowless result; only rows count.
                     let Either::Right(row) = step else { continue };
+                    // A SQL LIMIT is a clean early stop — enough rows is
+                    // success, unlike the cap below.
+                    if limit.is_some_and(|l| rows.len() >= l) {
+                        break;
+                    }
                     if rows.len() >= bounds.max_rows {
                         return Err(GraphError::RowCapExceeded {
                             max_rows: bounds.max_rows,

--- a/crates/skardi/src/sources/providers/graph/client.rs
+++ b/crates/skardi/src/sources/providers/graph/client.rs
@@ -27,7 +27,7 @@ use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions};
 use sqlx::{Either, Executor, Row};
 
 use super::error::{GraphError, json_kind};
-use super::value::parse_agtype;
+use super::value::{DeclaredColumn, parse_agtype};
 
 /// Per-query operational bounds (design §Security and operational
 /// bounds), carried per source.
@@ -37,12 +37,28 @@ pub struct QueryBounds {
     pub max_rows: usize,
 }
 
-/// One result row: one JSON value per declared column.
+/// One result row: one JSON value per declared column (or a single
+/// whole-record JSON object in the fallback mode).
 pub type GraphRow = Vec<Value>;
 /// The stream `execute` returns. Milestone 1 implementations may buffer
 /// internally up to `max_rows` — the trait shape is what must not change
 /// (design §Backend abstraction).
 pub type GraphRowStream = BoxStream<'static, Result<GraphRow, GraphError>>;
+
+/// One `graph_schema` row: a label or relationship type, and — where the
+/// backend's catalog carries them (Neo4j, Kuzu; never AGE, which is
+/// schema-optional) — one property name and its type(s) per row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaRow {
+    pub label: String,
+    /// `vertex` or `edge`.
+    pub kind: String,
+    /// Property NAME — never a value (design §Agent and LLM interaction).
+    pub property: Option<String>,
+    /// The backend's type name(s) for the property, `|`-joined when the
+    /// catalog reports several.
+    pub property_type: Option<String>,
+}
 
 /// What a backend must provide. Hides AGE (Postgres wire) vs Neo4j Bolt
 /// vs Kuzu details behind one seam.
@@ -53,9 +69,10 @@ pub type GraphRowStream = BoxStream<'static, Result<GraphRow, GraphError>>;
 /// use futures::StreamExt;
 /// use serde_json::Value;
 /// use skardi::sources::providers::graph::client::{
-///     GraphClient, GraphRowStream, QueryBounds,
+///     GraphClient, GraphRowStream, QueryBounds, SchemaRow,
 /// };
 /// use skardi::sources::providers::graph::error::GraphError;
+/// use skardi::sources::providers::graph::value::DeclaredColumn;
 ///
 /// /// A canned backend, the shape tests use.
 /// #[derive(Debug)]
@@ -67,7 +84,7 @@ pub type GraphRowStream = BoxStream<'static, Result<GraphRow, GraphError>>;
 ///         &self,
 ///         _cypher: &str,
 ///         _params: &Value,
-///         _arity: usize,
+///         _columns: Option<&[DeclaredColumn]>,
 ///         _bounds: QueryBounds,
 ///         limit: Option<usize>,
 ///     ) -> Result<GraphRowStream, GraphError> {
@@ -78,47 +95,68 @@ pub type GraphRowStream = BoxStream<'static, Result<GraphRow, GraphError>>;
 ///         Ok(futures::stream::iter(rows.into_iter().map(Ok)).boxed())
 ///     }
 ///
-///     async fn labels(
+///     fn requires_declared_columns(&self) -> bool {
+///         false
+///     }
+///
+///     async fn schema(
 ///         &self,
 ///         _bounds: QueryBounds,
 ///         _limit: Option<usize>,
-///     ) -> Result<Vec<(String, String)>, GraphError> {
-///         Ok(vec![("Person".into(), "vertex".into())])
+///     ) -> Result<Vec<SchemaRow>, GraphError> {
+///         Ok(vec![SchemaRow {
+///             label: "Person".into(),
+///             kind: "vertex".into(),
+///             property: None,
+///             property_type: None,
+///         }])
 ///     }
 /// }
 /// ```
 #[async_trait]
 pub trait GraphClient: Send + Sync + std::fmt::Debug {
     /// Run read-only Cypher inside a backend-enforced read transaction,
-    /// bounded by `bounds`. `arity` is the declared column count — AGE's
-    /// `cypher()` call must declare its result arity, which is why the
-    /// declared-columns mode is required on this backend. `limit` is
-    /// pushed BOTH ways: into the statement as a real SQL LIMIT
-    /// (min(limit, max_rows + 1), so the backend and the wire are
-    /// bounded even when the caller passes none — an overflow costs
-    /// max_rows + 1 rows, not a full scan plus a drain) AND enforced at
+    /// bounded by `bounds`.
+    ///
+    /// `columns` carries the caller's declared columns — how they BIND is
+    /// per backend: AGE binds positionally (its `cypher()` call declares
+    /// arity, all it gives us), Neo4j binds BY NAME to the Bolt record's
+    /// field names. `None` is the JSON-`record` fallback (whole record as
+    /// one JSON object per row) — backends whose wire needs a declared
+    /// arity refuse it (see [`Self::requires_declared_columns`]).
+    ///
+    /// `limit` is pushed as far down as the backend allows (AGE: a real
+    /// SQL LIMIT of min(limit, max_rows + 1); Neo4j: bounded stream
+    /// consumption over Bolt's incremental PULL) AND enforced at
     /// consumption as defense in depth. Hitting `limit` is a clean early
     /// stop; the row cap stays the loud overflow signal.
     async fn execute(
         &self,
         cypher: &str,
         params: &Value,
-        arity: usize,
+        columns: Option<&[DeclaredColumn]>,
         bounds: QueryBounds,
         limit: Option<usize>,
     ) -> Result<GraphRowStream, GraphError>;
 
-    /// Label roster for `graph_schema`: one `(label, kind)` row per
-    /// label, kinds `vertex` / `edge`. Names only — never property
-    /// values (design §Agent and LLM interaction). Bounded like every
-    /// other query — "every query is bounded" has no catalog exemption —
-    /// and `limit` is the SQL LIMIT, pushed into the catalog fetch as a
-    /// clean early stop.
-    async fn labels(
+    /// Whether `execute` refuses `columns: None`. True exactly when the
+    /// backend's wire call must declare its result arity up front (AGE's
+    /// `cypher()`); the UDTF turns this into a targeted plan-time error
+    /// instead of a late execution failure.
+    fn requires_declared_columns(&self) -> bool;
+
+    /// Catalog roster for `graph_schema`: one row per label (kinds
+    /// `vertex` / `edge`), and — where the backend's catalog knows them —
+    /// one row per (label, property) with the property's name and
+    /// type(s). Names and types only, never property values (design
+    /// §Agent and LLM interaction). Bounded like every other query —
+    /// "every query is bounded" has no catalog exemption — and `limit`
+    /// is pushed into the catalog fetch as a clean early stop.
+    async fn schema(
         &self,
         bounds: QueryBounds,
         limit: Option<usize>,
-    ) -> Result<Vec<(String, String)>, GraphError>;
+    ) -> Result<Vec<SchemaRow>, GraphError>;
 }
 
 /// Apache AGE over the workspace's sqlx-postgres stack.
@@ -268,10 +306,23 @@ impl GraphClient for AgeClient {
         &self,
         cypher: &str,
         params: &Value,
-        arity: usize,
+        columns: Option<&[DeclaredColumn]>,
         bounds: QueryBounds,
         limit: Option<usize>,
     ) -> Result<GraphRowStream, GraphError> {
+        // Positional binding: AGE's `cypher()` declares arity and nothing
+        // else, so only the COUNT of declared columns reaches the SQL.
+        // The UDTF already refuses the fallback on this backend
+        // (`requires_declared_columns`); this is the defense in depth.
+        let Some(declared) = columns else {
+            return Err(GraphError::InvalidColumns {
+                reason: "the age backend requires declared columns (its cypher() call \
+                         must declare its result arity)"
+                    .to_string(),
+                accepted: super::value::ACCEPTED_TYPES,
+            });
+        };
+        let arity = declared.len();
         // The fetch bound rides the OUTER statement as a real SQL LIMIT
         // (never inside the Cypher text): the backend and the wire are
         // bounded even when the caller passes no limit, a RowCapExceeded
@@ -408,11 +459,17 @@ impl GraphClient for AgeClient {
         Ok(futures::stream::iter(rows.into_iter().map(Ok)).boxed())
     }
 
-    async fn labels(
+    fn requires_declared_columns(&self) -> bool {
+        // AGE's `cypher()` call must declare its result arity — the
+        // JSON-record fallback cannot exist on this backend.
+        true
+    }
+
+    async fn schema(
         &self,
         bounds: QueryBounds,
         limit: Option<usize>,
-    ) -> Result<Vec<(String, String)>, GraphError> {
+    ) -> Result<Vec<SchemaRow>, GraphError> {
         // Same bounds discipline as execute — a catalog read against a
         // wedged backend must not hang forever, and the design's "every
         // query is bounded" makes no catalog exemption: READ ONLY
@@ -476,7 +533,17 @@ impl GraphClient for AgeClient {
                         "e" => "edge".to_string(),
                         other => other.to_string(),
                     };
-                    Ok((name, kind))
+                    // Names only, structurally: `ag_catalog` records label
+                    // names and kinds and nothing else (AGE is
+                    // schema-optional) — property discovery would mean
+                    // scanning data, deliberately not done (design §Agent
+                    // and LLM interaction).
+                    Ok(SchemaRow {
+                        label: name,
+                        kind,
+                        property: None,
+                        property_type: None,
+                    })
                 })
                 .collect()
         };

--- a/crates/skardi/src/sources/providers/graph/client.rs
+++ b/crates/skardi/src/sources/providers/graph/client.rs
@@ -212,40 +212,13 @@ impl AgeClient {
     /// Returns the statement batch and the prepared name to DEALLOCATE
     /// (when params were bound).
     fn build_sql(&self, cypher: &str, params: &Value, arity: usize) -> (String, Option<String>) {
-        let tag = dollar_tag(cypher);
-        let graph = self.graph_name.replace('\'', "''");
-        let cols: Vec<String> = (0..arity)
-            .map(|i| format!("c{i} ag_catalog.agtype"))
-            .collect();
-        let outs: Vec<String> = (0..arity).map(|i| format!("c{i}")).collect();
-        let has_params = params.as_object().is_some_and(|m| !m.is_empty());
-        if has_params {
-            let name = format!(
-                "skq_p_{}_{}",
-                std::process::id(),
-                self.prepare_seq.fetch_add(1, Ordering::Relaxed)
-            );
-            let literal = params.to_string().replace('\'', "''");
-            let batch = format!(
-                "PREPARE {name}(ag_catalog.agtype) AS \
-                 SELECT {} FROM ag_catalog.cypher('{graph}', {tag}{cypher}{tag}, $1) \
-                 AS t({}); \
-                 EXECUTE {name}('{literal}');",
-                outs.join(", "),
-                cols.join(", ")
-            );
-            (batch, Some(name))
-        } else {
-            (
-                format!(
-                    "SELECT {} FROM ag_catalog.cypher('{graph}', {tag}{cypher}{tag}) \
-                     AS t({})",
-                    outs.join(", "),
-                    cols.join(", ")
-                ),
-                None,
-            )
-        }
+        build_cypher_sql(
+            &self.graph_name,
+            self.prepare_seq.fetch_add(1, Ordering::Relaxed),
+            cypher,
+            params,
+            arity,
+        )
     }
 }
 
@@ -460,6 +433,49 @@ impl GraphClient for AgeClient {
     }
 }
 
+/// Render the `cypher()` invocation batch (see [`AgeClient::build_sql`]
+/// for the protocol constraints that shape it). A free function so the
+/// exact SQL text — quote doubling, dollar tags, arity columns, the
+/// PREPARE/EXECUTE split — is pinned by unit tests without a pool.
+fn build_cypher_sql(
+    graph_name: &str,
+    seq: u64,
+    cypher: &str,
+    params: &Value,
+    arity: usize,
+) -> (String, Option<String>) {
+    let tag = dollar_tag(cypher);
+    let graph = graph_name.replace('\'', "''");
+    let cols: Vec<String> = (0..arity)
+        .map(|i| format!("c{i} ag_catalog.agtype"))
+        .collect();
+    let outs: Vec<String> = (0..arity).map(|i| format!("c{i}")).collect();
+    let has_params = params.as_object().is_some_and(|m| !m.is_empty());
+    if has_params {
+        let name = format!("skq_p_{}_{seq}", std::process::id());
+        let literal = params.to_string().replace('\'', "''");
+        let batch = format!(
+            "PREPARE {name}(ag_catalog.agtype) AS \
+             SELECT {} FROM ag_catalog.cypher('{graph}', {tag}{cypher}{tag}, $1) \
+             AS t({}); \
+             EXECUTE {name}('{literal}');",
+            outs.join(", "),
+            cols.join(", ")
+        );
+        (batch, Some(name))
+    } else {
+        (
+            format!(
+                "SELECT {} FROM ag_catalog.cypher('{graph}', {tag}{cypher}{tag}) \
+                 AS t({})",
+                outs.join(", "),
+                cols.join(", ")
+            ),
+            None,
+        )
+    }
+}
+
 /// A dollar-quote tag that provably does not occur in `text`: extend a
 /// base tag with a counter until absent — no escape rules to get wrong.
 fn dollar_tag(text: &str) -> String {
@@ -523,6 +539,67 @@ mod tests {
         let hostile = "RETURN '$skq$ $skq1$'";
         let tag = dollar_tag(hostile);
         assert!(!hostile.contains(&tag), "{tag}");
+    }
+
+    #[test]
+    fn parameterless_sql_is_a_single_select_with_no_prepare() {
+        let (sql, prepared) = build_cypher_sql(
+            "kg",
+            0,
+            "MATCH (n) RETURN n.a, n.b",
+            &serde_json::json!({}),
+            2,
+        );
+        assert!(prepared.is_none(), "no params → nothing to DEALLOCATE");
+        assert!(
+            sql.starts_with("SELECT c0, c1 FROM ag_catalog.cypher('kg', $skq$"),
+            "{sql}"
+        );
+        assert!(
+            sql.ends_with("AS t(c0 ag_catalog.agtype, c1 ag_catalog.agtype)"),
+            "{sql}"
+        );
+        assert!(!sql.contains("PREPARE"), "{sql}");
+    }
+
+    #[test]
+    fn parameterized_sql_prepares_executes_and_names_the_statement() {
+        let (sql, prepared) = build_cypher_sql(
+            "kg",
+            7,
+            "MATCH (n) WHERE n.x = $x RETURN n",
+            &serde_json::json!({"x": 1}),
+            1,
+        );
+        let name = prepared.expect("params → PREPARE name to DEALLOCATE");
+        assert!(name.starts_with("skq_p_"), "{name}");
+        assert!(name.ends_with("_7"), "the seq uniquifies: {name}");
+        assert!(
+            sql.contains(&format!("PREPARE {name}(ag_catalog.agtype)")),
+            "{sql}"
+        );
+        assert!(
+            sql.contains(&format!("EXECUTE {name}('{{\"x\":1}}');")),
+            "{sql}"
+        );
+    }
+
+    #[test]
+    fn hostile_values_stay_inside_their_literals() {
+        // Graph names double their quotes; param values ride serde_json
+        // encoding plus WHOLE-literal quote doubling — the SQL text can
+        // never fall out of its string literal.
+        let (sql, _) = build_cypher_sql(
+            "kg",
+            0,
+            "RETURN $s",
+            &serde_json::json!({"s": "O'Brien '; DROP TABLE x; --"}),
+            1,
+        );
+        assert!(sql.contains("O''Brien ''; DROP TABLE x; --"), "{sql}");
+
+        let (sql, _) = build_cypher_sql("g'name", 0, "RETURN 1", &serde_json::json!({}), 1);
+        assert!(sql.contains("cypher('g''name'"), "{sql}");
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/graph/config.rs
+++ b/crates/skardi/src/sources/providers/graph/config.rs
@@ -8,6 +8,10 @@ use super::error::GraphError;
 
 /// Default per-query timeout (design §Security and operational bounds).
 pub const DEFAULT_QUERY_TIMEOUT_SECONDS: u64 = 30;
+/// Upper bound on the configurable timeout: one day. Keeps the value
+/// well inside Postgres's statement_timeout range (int4 milliseconds)
+/// and makes the client-side `+5s` wrap arithmetic trivially safe.
+pub const MAX_QUERY_TIMEOUT_SECONDS: u64 = 86_400;
 /// Default per-query row cap.
 pub const DEFAULT_MAX_ROWS: usize = 10_000;
 /// Default connection-pool size.
@@ -80,6 +84,34 @@ impl GraphConfig {
                     .to_string(),
             });
         }
+        // Credentials travel as env-var NAMES only (username_env /
+        // password_env) — a password embedded in the URL would sit in
+        // config repos, deploy logs, and diagnostics. Parsed, not
+        // substring-matched, so `:` in a database name cannot
+        // false-positive. The error never echoes the URL (it may carry
+        // the very secret being rejected).
+        if let Ok(parsed) = url::Url::parse(connection_string) {
+            if parsed.password().is_some() {
+                return Err(GraphError::InvalidConfig {
+                    name: name.to_string(),
+                    reason: "connection_string must not embed a password — set \
+                             password_env to the NAME of an environment variable \
+                             instead"
+                        .to_string(),
+                });
+            }
+            if parsed
+                .query_pairs()
+                .any(|(k, _)| k.eq_ignore_ascii_case("password"))
+            {
+                return Err(GraphError::InvalidConfig {
+                    name: name.to_string(),
+                    reason: "connection_string must not carry a password= query \
+                             parameter — set password_env instead"
+                        .to_string(),
+                });
+            }
+        }
         // The graph name is spliced into `cypher('<name>', …)` as a SQL
         // literal — identifier shape keeps it inert belt-and-braces (the
         // literal is also quote-escaped at the call site).
@@ -119,10 +151,16 @@ impl GraphConfig {
                 reason: "max_rows must be positive".to_string(),
             });
         }
-        if self.query_timeout_seconds == 0 {
+        if self.query_timeout_seconds == 0 || self.query_timeout_seconds > MAX_QUERY_TIMEOUT_SECONDS
+        {
             return Err(GraphError::InvalidConfig {
                 name: name.to_string(),
-                reason: "query_timeout_seconds must be positive".to_string(),
+                reason: format!(
+                    "query_timeout_seconds must be in 1..={MAX_QUERY_TIMEOUT_SECONDS} \
+                     (got {}) — the value feeds Postgres's statement_timeout and the \
+                     client-side wrap",
+                    self.query_timeout_seconds
+                ),
             });
         }
         if self.max_connections == 0 {
@@ -191,6 +229,37 @@ password_env: AGE_PG_PASS
         c.username_env = Some("BAD NAME".into());
         let err = c.validate("kg", "postgres://h/db").unwrap_err();
         assert!(err.to_string().contains("environment variable NAME"));
+    }
+
+    #[test]
+    fn url_embedded_passwords_are_rejected_without_echoing_the_url() {
+        let c = base();
+        for url in [
+            "postgres://user:s3cret@localhost:5432/db",
+            "postgresql://h/db?password=s3cret",
+            "postgres://h/db?PASSWORD=s3cret",
+        ] {
+            let err = c.validate("kg", url).unwrap_err();
+            let msg = err.to_string();
+            assert!(msg.contains("password_env"), "{msg}");
+            assert!(!msg.contains("s3cret"), "the secret never echoes: {msg}");
+        }
+        // A bare username is identity, not a secret — allowed.
+        c.validate("kg", "postgres://postgres@localhost:5432/db")
+            .expect("username-only URL is fine");
+    }
+
+    #[test]
+    fn timeout_has_a_hard_ceiling() {
+        let mut c = base();
+        c.query_timeout_seconds = MAX_QUERY_TIMEOUT_SECONDS + 1;
+        let err = c.validate("kg", "postgres://h/db").unwrap_err();
+        assert!(err.to_string().contains("1..=86400"), "{err}");
+        c.query_timeout_seconds = u64::MAX; // would overflow the +5s wrap
+        assert!(c.validate("kg", "postgres://h/db").is_err());
+        c.query_timeout_seconds = MAX_QUERY_TIMEOUT_SECONDS;
+        c.validate("kg", "postgres://h/db")
+            .expect("the ceiling itself is legal");
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/graph/config.rs
+++ b/crates/skardi/src/sources/providers/graph/config.rs
@@ -1,0 +1,187 @@
+//! Typed configuration for a `type: graph` data source (design
+//! §GraphConfig typed YAML). Milestone 1 supports the `age` backend;
+//! views land with milestone 4.
+
+use serde::Deserialize;
+
+use super::error::GraphError;
+
+/// Default per-query timeout (design §Security and operational bounds).
+pub const DEFAULT_QUERY_TIMEOUT_SECONDS: u64 = 30;
+/// Default per-query row cap.
+pub const DEFAULT_MAX_ROWS: usize = 10_000;
+
+/// The `graph:` block of a `type: graph` data source.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GraphConfig {
+    /// Backend engine. Milestone 1: `age` (openCypher inside Postgres).
+    pub backend: String,
+    /// AGE graphs are named per database.
+    pub graph_name: String,
+    /// Environment variable NAMES holding credentials — values never
+    /// appear in YAML (Open Connector's hygiene; the topology differs:
+    /// there is no gateway, so Skardi holds the credential in memory).
+    #[serde(default)]
+    pub username_env: Option<String>,
+    #[serde(default)]
+    pub password_env: Option<String>,
+    /// Passed to the backend as the transaction timeout, so runaway
+    /// traversals die server-side.
+    #[serde(default = "default_timeout")]
+    pub query_timeout_seconds: u64,
+    /// Rows Skardi will consume per query; exceeding it is a typed error,
+    /// never a silent truncation.
+    #[serde(default = "default_max_rows")]
+    pub max_rows: usize,
+}
+
+fn default_timeout() -> u64 {
+    DEFAULT_QUERY_TIMEOUT_SECONDS
+}
+
+fn default_max_rows() -> usize {
+    DEFAULT_MAX_ROWS
+}
+
+impl GraphConfig {
+    /// Pure validation (no network I/O): backend and scheme allowlists,
+    /// identifier shape for the graph name, env-var NAME shape for
+    /// credentials. `connection_string` is operator trust (the same tier
+    /// as a Postgres connection string in the same file) — no SSRF guard,
+    /// only a scheme allowlist (design §Security).
+    pub fn validate(&self, name: &str, connection_string: &str) -> Result<(), GraphError> {
+        if self.backend != "age" {
+            return Err(GraphError::InvalidConfig {
+                name: name.to_string(),
+                reason: format!(
+                    "backend '{}' is not supported (milestone 1 supports: age; \
+                     neo4j and kuzu are later milestones)",
+                    self.backend
+                ),
+            });
+        }
+        let scheme_ok = connection_string.starts_with("postgres://")
+            || connection_string.starts_with("postgresql://");
+        if !scheme_ok {
+            return Err(GraphError::InvalidConfig {
+                name: name.to_string(),
+                reason: "the age backend requires a postgres:// or postgresql:// \
+                         connection_string"
+                    .to_string(),
+            });
+        }
+        // The graph name is spliced into `cypher('<name>', …)` as a SQL
+        // literal — identifier shape keeps it inert belt-and-braces (the
+        // literal is also quote-escaped at the call site).
+        if self.graph_name.is_empty()
+            || !self
+                .graph_name
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_')
+        {
+            return Err(GraphError::InvalidConfig {
+                name: name.to_string(),
+                reason: format!(
+                    "graph_name '{}' must be a bare identifier ([A-Za-z0-9_]+)",
+                    self.graph_name
+                ),
+            });
+        }
+        for (field, value) in [
+            ("username_env", &self.username_env),
+            ("password_env", &self.password_env),
+        ] {
+            if let Some(v) = value
+                && !is_env_var_name(v)
+            {
+                return Err(GraphError::InvalidConfig {
+                    name: name.to_string(),
+                    reason: format!(
+                        "{field} '{v}' must be an environment variable NAME \
+                         ([A-Za-z_][A-Za-z0-9_]*)"
+                    ),
+                });
+            }
+        }
+        if self.max_rows == 0 {
+            return Err(GraphError::InvalidConfig {
+                name: name.to_string(),
+                reason: "max_rows must be positive".to_string(),
+            });
+        }
+        if self.query_timeout_seconds == 0 {
+            return Err(GraphError::InvalidConfig {
+                name: name.to_string(),
+                reason: "query_timeout_seconds must be positive".to_string(),
+            });
+        }
+        Ok(())
+    }
+}
+
+fn is_env_var_name(s: &str) -> bool {
+    let mut chars = s.chars();
+    chars
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base() -> GraphConfig {
+        serde_yaml::from_str(
+            r#"
+backend: age
+graph_name: knowledge
+username_env: AGE_PG_USER
+password_env: AGE_PG_PASS
+"#,
+        )
+        .expect("parses")
+    }
+
+    #[test]
+    fn defaults_and_valid_config_pass() {
+        let c = base();
+        assert_eq!(c.query_timeout_seconds, DEFAULT_QUERY_TIMEOUT_SECONDS);
+        assert_eq!(c.max_rows, DEFAULT_MAX_ROWS);
+        c.validate("kg", "postgres://localhost:5432/graphrag")
+            .expect("valid");
+        c.validate("kg", "postgresql://h/db").expect("valid");
+    }
+
+    #[test]
+    fn non_age_backends_and_wrong_schemes_are_named_errors() {
+        let mut c = base();
+        c.backend = "neo4j".into();
+        let err = c.validate("kg", "postgres://h/db").unwrap_err();
+        assert!(err.to_string().contains("later milestones"), "{err}");
+
+        let c = base();
+        let err = c.validate("kg", "bolt://localhost:7687").unwrap_err();
+        assert!(err.to_string().contains("postgres://"), "{err}");
+    }
+
+    #[test]
+    fn graph_name_and_env_names_are_shape_checked() {
+        let mut c = base();
+        c.graph_name = "bad-name".into();
+        assert!(c.validate("kg", "postgres://h/db").is_err());
+
+        let mut c = base();
+        c.username_env = Some("BAD NAME".into());
+        let err = c.validate("kg", "postgres://h/db").unwrap_err();
+        assert!(err.to_string().contains("environment variable NAME"));
+    }
+
+    #[test]
+    fn unknown_fields_are_rejected_at_parse() {
+        let err = serde_yaml::from_str::<GraphConfig>("backend: age\ngraph_name: g\nviews: []\n")
+            .unwrap_err();
+        assert!(err.to_string().contains("views"), "{err}");
+    }
+}

--- a/crates/skardi/src/sources/providers/graph/config.rs
+++ b/crates/skardi/src/sources/providers/graph/config.rs
@@ -263,6 +263,37 @@ password_env: AGE_PG_PASS
     }
 
     #[test]
+    fn remaining_bounds_are_validated() {
+        let mut c = base();
+        c.max_rows = 0;
+        assert!(
+            c.validate("kg", "postgres://h/db")
+                .unwrap_err()
+                .to_string()
+                .contains("max_rows")
+        );
+        let mut c = base();
+        c.max_connections = 0;
+        assert!(
+            c.validate("kg", "postgres://h/db")
+                .unwrap_err()
+                .to_string()
+                .contains("max_connections")
+        );
+        let mut c = base();
+        c.graph_name = String::new();
+        assert!(
+            c.validate("kg", "postgres://h/db")
+                .unwrap_err()
+                .to_string()
+                .contains("bare identifier")
+        );
+        let mut c = base();
+        c.password_env = Some("2BAD".into());
+        assert!(c.validate("kg", "postgres://h/db").is_err());
+    }
+
+    #[test]
     fn unknown_fields_are_rejected_at_parse() {
         let err = serde_yaml::from_str::<GraphConfig>("backend: age\ngraph_name: g\nviews: []\n")
             .unwrap_err();

--- a/crates/skardi/src/sources/providers/graph/config.rs
+++ b/crates/skardi/src/sources/providers/graph/config.rs
@@ -14,8 +14,21 @@ pub const DEFAULT_QUERY_TIMEOUT_SECONDS: u64 = 30;
 pub const MAX_QUERY_TIMEOUT_SECONDS: u64 = 86_400;
 /// Default per-query row cap.
 pub const DEFAULT_MAX_ROWS: usize = 10_000;
+/// Upper bound on the configurable row cap: one million rows. The knob
+/// maps to MEMORY, not just wire traffic — the milestone-1 client
+/// buffers the whole result (JSON rows, then the collected stream, then
+/// every RecordBatch) before the first batch is emitted, so peak
+/// resident memory is a small multiple of the result set and scales
+/// linearly with this value. Bounded by construction beats bounded by
+/// review: an accidental `max_rows: 50000000` must be a config error,
+/// not an in-process OOM.
+pub const MAX_MAX_ROWS: usize = 1_000_000;
 /// Default connection-pool size.
 pub const DEFAULT_MAX_CONNECTIONS: u32 = 4;
+/// Upper bound on the pool size — same bounded-by-construction
+/// principle; anything past this is far beyond a Postgres default
+/// (`max_connections = 100`) and reads like a typo'd row cap.
+pub const MAX_MAX_CONNECTIONS: u32 = 64;
 
 /// The `graph:` block of a `type: graph` data source.
 #[derive(Debug, Clone, Deserialize)]
@@ -37,12 +50,21 @@ pub struct GraphConfig {
     #[serde(default = "default_timeout")]
     pub query_timeout_seconds: u64,
     /// Rows Skardi will consume per query; exceeding it is a typed error,
-    /// never a silent truncation.
+    /// never a silent truncation. This is a MEMORY knob: the client
+    /// buffers the whole result before emitting (see [`MAX_MAX_ROWS`]).
     #[serde(default = "default_max_rows")]
     pub max_rows: usize,
     /// Connection-pool size against the backend.
     #[serde(default = "default_max_connections")]
     pub max_connections: u32,
+    /// PARSED but not yet supported: YAML catalog views are milestone 4.
+    /// The field exists so an operator copying the design doc's example
+    /// gets "views arrive with milestone 4" from validation — not
+    /// serde's "unknown field `views`", which reads as "skardi doesn't
+    /// support views". Accepted-and-ignored would be worse: a declared
+    /// view that silently does nothing.
+    #[serde(default)]
+    pub views: Option<serde_yaml::Value>,
 }
 
 fn default_timeout() -> u64 {
@@ -145,10 +167,15 @@ impl GraphConfig {
                 });
             }
         }
-        if self.max_rows == 0 {
+        if self.max_rows == 0 || self.max_rows > MAX_MAX_ROWS {
             return Err(GraphError::InvalidConfig {
                 name: name.to_string(),
-                reason: "max_rows must be positive".to_string(),
+                reason: format!(
+                    "max_rows must be in 1..={MAX_MAX_ROWS} (got {}) — the milestone-1 \
+                     client buffers the whole result, so this knob is peak memory, and \
+                     it gets the same hard ceiling the timeout got",
+                    self.max_rows
+                ),
             });
         }
         if self.query_timeout_seconds == 0 || self.query_timeout_seconds > MAX_QUERY_TIMEOUT_SECONDS
@@ -163,10 +190,22 @@ impl GraphConfig {
                 ),
             });
         }
-        if self.max_connections == 0 {
+        if self.max_connections == 0 || self.max_connections > MAX_MAX_CONNECTIONS {
             return Err(GraphError::InvalidConfig {
                 name: name.to_string(),
-                reason: "max_connections must be positive".to_string(),
+                reason: format!(
+                    "max_connections must be in 1..={MAX_MAX_CONNECTIONS} (got {})",
+                    self.max_connections
+                ),
+            });
+        }
+        if self.views.is_some() {
+            return Err(GraphError::InvalidConfig {
+                name: name.to_string(),
+                reason: "`views` arrive with milestone 4 (YAML catalog views); the \
+                         ad-hoc surface today is cypher_query(...) — remove the views \
+                         block until then"
+                    .to_string(),
             });
         }
         Ok(())
@@ -295,8 +334,39 @@ password_env: AGE_PG_PASS
 
     #[test]
     fn unknown_fields_are_rejected_at_parse() {
-        let err = serde_yaml::from_str::<GraphConfig>("backend: age\ngraph_name: g\nviews: []\n")
+        let err = serde_yaml::from_str::<GraphConfig>("backend: age\ngraph_name: g\nviewz: []\n")
             .unwrap_err();
-        assert!(err.to_string().contains("views"), "{err}");
+        assert!(err.to_string().contains("viewz"), "{err}");
+    }
+
+    #[test]
+    fn views_parse_but_are_named_as_milestone_4_work() {
+        // The design doc's own example carries `views:` — an operator
+        // copying it must get "milestone 4", not serde's unknown-field
+        // error (which reads as "skardi doesn't support views").
+        let c: GraphConfig = serde_yaml::from_str(
+            "backend: age\ngraph_name: g\nviews:\n  - name: user_posts\n    cypher: MATCH (n) RETURN n\n",
+        )
+        .expect("the field parses");
+        let err = c.validate("kg", "postgres://h/db").unwrap_err();
+        assert!(err.to_string().contains("milestone 4"), "{err}");
+    }
+
+    #[test]
+    fn max_rows_and_max_connections_have_hard_ceilings() {
+        // The row cap is a MEMORY knob under the fully-buffering client
+        // — an accidental 50M must be a config error, not an OOM.
+        let mut c = base();
+        c.max_rows = MAX_MAX_ROWS + 1;
+        let err = c.validate("kg", "postgres://h/db").unwrap_err();
+        assert!(err.to_string().contains("1..=1000000"), "{err}");
+        c.max_rows = MAX_MAX_ROWS;
+        c.validate("kg", "postgres://h/db")
+            .expect("the ceiling itself is legal");
+
+        let mut c = base();
+        c.max_connections = MAX_MAX_CONNECTIONS + 1;
+        let err = c.validate("kg", "postgres://h/db").unwrap_err();
+        assert!(err.to_string().contains("1..=64"), "{err}");
     }
 }

--- a/crates/skardi/src/sources/providers/graph/config.rs
+++ b/crates/skardi/src/sources/providers/graph/config.rs
@@ -10,6 +10,8 @@ use super::error::GraphError;
 pub const DEFAULT_QUERY_TIMEOUT_SECONDS: u64 = 30;
 /// Default per-query row cap.
 pub const DEFAULT_MAX_ROWS: usize = 10_000;
+/// Default connection-pool size.
+pub const DEFAULT_MAX_CONNECTIONS: u32 = 4;
 
 /// The `graph:` block of a `type: graph` data source.
 #[derive(Debug, Clone, Deserialize)]
@@ -34,6 +36,9 @@ pub struct GraphConfig {
     /// never a silent truncation.
     #[serde(default = "default_max_rows")]
     pub max_rows: usize,
+    /// Connection-pool size against the backend.
+    #[serde(default = "default_max_connections")]
+    pub max_connections: u32,
 }
 
 fn default_timeout() -> u64 {
@@ -42,6 +47,10 @@ fn default_timeout() -> u64 {
 
 fn default_max_rows() -> usize {
     DEFAULT_MAX_ROWS
+}
+
+fn default_max_connections() -> u32 {
+    DEFAULT_MAX_CONNECTIONS
 }
 
 impl GraphConfig {
@@ -114,6 +123,12 @@ impl GraphConfig {
             return Err(GraphError::InvalidConfig {
                 name: name.to_string(),
                 reason: "query_timeout_seconds must be positive".to_string(),
+            });
+        }
+        if self.max_connections == 0 {
+            return Err(GraphError::InvalidConfig {
+                name: name.to_string(),
+                reason: "max_connections must be positive".to_string(),
             });
         }
         Ok(())

--- a/crates/skardi/src/sources/providers/graph/config.rs
+++ b/crates/skardi/src/sources/providers/graph/config.rs
@@ -69,17 +69,30 @@ impl GraphConfig {
     /// as a Postgres connection string in the same file) — no SSRF guard,
     /// only a scheme allowlist (design §Security).
     pub fn validate(&self, name: &str, connection_string: &str) -> Result<(), GraphError> {
-        // Scheme allowlists are per backend (design §Security): the URL
-        // is operator trust, but a bolt:// URL on the age backend (or
-        // vice versa) is a misconfiguration worth naming at load.
-        let scheme_ok = match self.backend.as_str() {
-            "age" => {
-                connection_string.starts_with("postgres://")
-                    || connection_string.starts_with("postgresql://")
-            }
-            "neo4j" => ["bolt://", "bolt+s://", "neo4j://", "neo4j+s://"]
-                .iter()
-                .any(|scheme| connection_string.starts_with(scheme)),
+        // ONE rules row per backend — the scheme list drives both the
+        // check and the error text, and the graph_name rule rides along,
+        // so milestone 3's kuzu is one new row here instead of parallel
+        // matches that can drift.
+        let rules = match self.backend.as_str() {
+            "age" => BackendRules {
+                schemes: &["postgres://", "postgresql://"],
+                // Spliced into `cypher('<name>', …)` as a SQL literal —
+                // identifier shape keeps it inert belt-and-braces (the
+                // literal is also quote-escaped at the call site).
+                name_required: true,
+                name_extra_chars: &[],
+                name_shape: "a bare identifier ([A-Za-z0-9_]+)",
+            },
+            "neo4j" => BackendRules {
+                schemes: &["bolt://", "bolt+s://", "neo4j://", "neo4j+s://"],
+                // Optional (the server default database); travels as
+                // driver-bound Bolt metadata, never query text — the
+                // shape check (Neo4j's own name alphabet) keeps typos
+                // loud, nothing more.
+                name_required: false,
+                name_extra_chars: &['.', '-'],
+                name_shape: "a database name ([A-Za-z0-9_.-]+)",
+            },
             other => {
                 return Err(GraphError::InvalidConfig {
                     name: name.to_string(),
@@ -90,16 +103,17 @@ impl GraphConfig {
                 });
             }
         };
-        if !scheme_ok {
-            let allowed = match self.backend.as_str() {
-                "age" => "postgres:// or postgresql://",
-                _ => "bolt://, bolt+s://, neo4j://, or neo4j+s://",
-            };
+        if !rules
+            .schemes
+            .iter()
+            .any(|scheme| connection_string.starts_with(scheme))
+        {
             return Err(GraphError::InvalidConfig {
                 name: name.to_string(),
                 reason: format!(
-                    "the {} backend requires a {allowed} connection_string",
-                    self.backend
+                    "the {} backend requires a {} connection_string",
+                    self.backend,
+                    rules.schemes.join(" / ")
                 ),
             });
         }
@@ -131,15 +145,8 @@ impl GraphConfig {
                 });
             }
         }
-        // Per backend: on AGE the graph name is REQUIRED and spliced into
-        // `cypher('<name>', …)` as a SQL literal — identifier shape keeps
-        // it inert belt-and-braces (the literal is also quote-escaped at
-        // the call site). On neo4j it is optional (the server default
-        // database) and travels as driver-bound Bolt metadata, never
-        // query text — but the same identifier shape (plus `.` and `-`,
-        // legal in Neo4j database names) keeps typos loud.
-        match (self.backend.as_str(), self.graph_name.as_deref()) {
-            ("age", None) => {
+        match self.graph_name.as_deref() {
+            None if rules.name_required => {
                 return Err(GraphError::InvalidConfig {
                     name: name.to_string(),
                     reason: "the age backend requires graph_name (AGE graphs are named \
@@ -147,30 +154,17 @@ impl GraphConfig {
                         .to_string(),
                 });
             }
-            ("age", Some(graph_name))
+            Some(graph_name)
                 if graph_name.is_empty()
-                    || !graph_name
-                        .chars()
-                        .all(|c| c.is_ascii_alphanumeric() || c == '_') =>
+                    || !graph_name.chars().all(|c| {
+                        c.is_ascii_alphanumeric() || c == '_' || rules.name_extra_chars.contains(&c)
+                    }) =>
             {
                 return Err(GraphError::InvalidConfig {
                     name: name.to_string(),
                     reason: format!(
-                        "graph_name '{graph_name}' must be a bare identifier ([A-Za-z0-9_]+)"
-                    ),
-                });
-            }
-            ("neo4j", Some(db))
-                if db.is_empty()
-                    || !db
-                        .chars()
-                        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.' || c == '-') =>
-            {
-                return Err(GraphError::InvalidConfig {
-                    name: name.to_string(),
-                    reason: format!(
-                        "graph_name '{db}' must be a database name ([A-Za-z0-9_.-]+) \
-                         on the neo4j backend"
+                        "graph_name '{graph_name}' must be {} on the {} backend",
+                        rules.name_shape, self.backend
                     ),
                 });
             }
@@ -218,6 +212,16 @@ impl GraphConfig {
         }
         Ok(())
     }
+}
+
+/// Per-backend validation rules — one row per backend in `validate`, so
+/// the scheme allowlist, its error text, and the graph_name contract
+/// cannot drift apart across parallel matches.
+struct BackendRules {
+    schemes: &'static [&'static str],
+    name_required: bool,
+    name_extra_chars: &'static [char],
+    name_shape: &'static str,
 }
 
 fn is_env_var_name(s: &str) -> bool {

--- a/crates/skardi/src/sources/providers/graph/config.rs
+++ b/crates/skardi/src/sources/providers/graph/config.rs
@@ -110,29 +110,40 @@ impl GraphConfig {
         // password_env) — a password embedded in the URL would sit in
         // config repos, deploy logs, and diagnostics. Parsed, not
         // substring-matched, so `:` in a database name cannot
-        // false-positive. The error never echoes the URL (it may carry
-        // the very secret being rejected).
-        if let Ok(parsed) = url::Url::parse(connection_string) {
-            if parsed.password().is_some() {
-                return Err(GraphError::InvalidConfig {
-                    name: name.to_string(),
-                    reason: "connection_string must not embed a password — set \
-                             password_env to the NAME of an environment variable \
-                             instead"
-                        .to_string(),
-                });
-            }
-            if parsed
-                .query_pairs()
-                .any(|(k, _)| k.eq_ignore_ascii_case("password"))
-            {
-                return Err(GraphError::InvalidConfig {
-                    name: name.to_string(),
-                    reason: "connection_string must not carry a password= query \
-                             parameter — set password_env instead"
-                        .to_string(),
-                });
-            }
+        // false-positive. FAIL-CLOSED: a string this parser cannot read
+        // is a config error, never a skipped check — the url crate and
+        // the driver's own parser are different implementations, and a
+        // value only the driver accepts would otherwise carry a secret
+        // past a validator that reported success. The scheme allowlist
+        // above already guarantees the string is URL-shaped, so nothing
+        // legitimate lands here. The error never echoes the URL (it may
+        // carry the very secret being rejected).
+        let parsed = url::Url::parse(connection_string).map_err(|_| GraphError::InvalidConfig {
+            name: name.to_string(),
+            reason: "connection_string is not a parseable URL (the embedded-credential \
+                     check could not run, so the value is rejected rather than passed \
+                     through unvetted)"
+                .to_string(),
+        })?;
+        if parsed.password().is_some() {
+            return Err(GraphError::InvalidConfig {
+                name: name.to_string(),
+                reason: "connection_string must not embed a password — set \
+                         password_env to the NAME of an environment variable \
+                         instead"
+                    .to_string(),
+            });
+        }
+        if parsed
+            .query_pairs()
+            .any(|(k, _)| k.eq_ignore_ascii_case("password"))
+        {
+            return Err(GraphError::InvalidConfig {
+                name: name.to_string(),
+                reason: "connection_string must not carry a password= query \
+                         parameter — set password_env instead"
+                    .to_string(),
+            });
         }
         // The graph name is spliced into `cypher('<name>', …)` as a SQL
         // literal — identifier shape keeps it inert belt-and-braces (the
@@ -286,6 +297,16 @@ password_env: AGE_PG_PASS
         // A bare username is identity, not a secret — allowed.
         c.validate("kg", "postgres://postgres@localhost:5432/db")
             .expect("username-only URL is fine");
+        // FAIL-CLOSED: a URL the checker cannot parse is rejected, not
+        // waved past the credential checks (the url crate and the
+        // driver parse differently). Scheme-prefixed so it reaches the
+        // parse step, then malformed.
+        let err = c
+            .validate("kg", "postgres://[not-a-host/db?password=s3cret")
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("not a parseable URL"), "{msg}");
+        assert!(!msg.contains("s3cret"), "never echoed: {msg}");
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/graph/config.rs
+++ b/crates/skardi/src/sources/providers/graph/config.rs
@@ -1,6 +1,6 @@
 //! Typed configuration for a `type: graph` data source (design
-//! §GraphConfig typed YAML). Milestone 1 supports the `age` backend;
-//! views land with milestone 4.
+//! §GraphConfig typed YAML). Milestones 1-2 support the `age` and
+//! `neo4j` backends; views land with milestone 4.
 
 use serde::Deserialize;
 
@@ -21,10 +21,15 @@ pub const DEFAULT_MAX_CONNECTIONS: u32 = 4;
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct GraphConfig {
-    /// Backend engine. Milestone 1: `age` (openCypher inside Postgres).
+    /// Backend engine: `age` (openCypher inside Postgres) or `neo4j`
+    /// (Bolt).
     pub backend: String,
-    /// AGE graphs are named per database.
-    pub graph_name: String,
+    /// What it names is per backend: AGE graphs are named per database,
+    /// so `age` REQUIRES it; on `neo4j` it selects the database and may
+    /// be omitted for the server default (the design's neo4j example
+    /// carries no graph_name).
+    #[serde(default)]
+    pub graph_name: Option<String>,
     /// Environment variable NAMES holding credentials — values never
     /// appear in YAML (Open Connector's hygiene; the topology differs:
     /// there is no gateway, so Skardi holds the credential in memory).
@@ -64,24 +69,38 @@ impl GraphConfig {
     /// as a Postgres connection string in the same file) — no SSRF guard,
     /// only a scheme allowlist (design §Security).
     pub fn validate(&self, name: &str, connection_string: &str) -> Result<(), GraphError> {
-        if self.backend != "age" {
+        // Scheme allowlists are per backend (design §Security): the URL
+        // is operator trust, but a bolt:// URL on the age backend (or
+        // vice versa) is a misconfiguration worth naming at load.
+        let scheme_ok = match self.backend.as_str() {
+            "age" => {
+                connection_string.starts_with("postgres://")
+                    || connection_string.starts_with("postgresql://")
+            }
+            "neo4j" => ["bolt://", "bolt+s://", "neo4j://", "neo4j+s://"]
+                .iter()
+                .any(|scheme| connection_string.starts_with(scheme)),
+            other => {
+                return Err(GraphError::InvalidConfig {
+                    name: name.to_string(),
+                    reason: format!(
+                        "backend '{other}' is not supported (milestones 1-2 support: \
+                         age, neo4j; kuzu is a later milestone)"
+                    ),
+                });
+            }
+        };
+        if !scheme_ok {
+            let allowed = match self.backend.as_str() {
+                "age" => "postgres:// or postgresql://",
+                _ => "bolt://, bolt+s://, neo4j://, or neo4j+s://",
+            };
             return Err(GraphError::InvalidConfig {
                 name: name.to_string(),
                 reason: format!(
-                    "backend '{}' is not supported (milestone 1 supports: age; \
-                     neo4j and kuzu are later milestones)",
+                    "the {} backend requires a {allowed} connection_string",
                     self.backend
                 ),
-            });
-        }
-        let scheme_ok = connection_string.starts_with("postgres://")
-            || connection_string.starts_with("postgresql://");
-        if !scheme_ok {
-            return Err(GraphError::InvalidConfig {
-                name: name.to_string(),
-                reason: "the age backend requires a postgres:// or postgresql:// \
-                         connection_string"
-                    .to_string(),
             });
         }
         // Credentials travel as env-var NAMES only (username_env /
@@ -112,22 +131,50 @@ impl GraphConfig {
                 });
             }
         }
-        // The graph name is spliced into `cypher('<name>', …)` as a SQL
-        // literal — identifier shape keeps it inert belt-and-braces (the
-        // literal is also quote-escaped at the call site).
-        if self.graph_name.is_empty()
-            || !self
-                .graph_name
-                .chars()
-                .all(|c| c.is_ascii_alphanumeric() || c == '_')
-        {
-            return Err(GraphError::InvalidConfig {
-                name: name.to_string(),
-                reason: format!(
-                    "graph_name '{}' must be a bare identifier ([A-Za-z0-9_]+)",
-                    self.graph_name
-                ),
-            });
+        // Per backend: on AGE the graph name is REQUIRED and spliced into
+        // `cypher('<name>', …)` as a SQL literal — identifier shape keeps
+        // it inert belt-and-braces (the literal is also quote-escaped at
+        // the call site). On neo4j it is optional (the server default
+        // database) and travels as driver-bound Bolt metadata, never
+        // query text — but the same identifier shape (plus `.` and `-`,
+        // legal in Neo4j database names) keeps typos loud.
+        match (self.backend.as_str(), self.graph_name.as_deref()) {
+            ("age", None) => {
+                return Err(GraphError::InvalidConfig {
+                    name: name.to_string(),
+                    reason: "the age backend requires graph_name (AGE graphs are named \
+                             per database)"
+                        .to_string(),
+                });
+            }
+            ("age", Some(graph_name))
+                if graph_name.is_empty()
+                    || !graph_name
+                        .chars()
+                        .all(|c| c.is_ascii_alphanumeric() || c == '_') =>
+            {
+                return Err(GraphError::InvalidConfig {
+                    name: name.to_string(),
+                    reason: format!(
+                        "graph_name '{graph_name}' must be a bare identifier ([A-Za-z0-9_]+)"
+                    ),
+                });
+            }
+            ("neo4j", Some(db))
+                if db.is_empty()
+                    || !db
+                        .chars()
+                        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.' || c == '-') =>
+            {
+                return Err(GraphError::InvalidConfig {
+                    name: name.to_string(),
+                    reason: format!(
+                        "graph_name '{db}' must be a database name ([A-Za-z0-9_.-]+) \
+                         on the neo4j backend"
+                    ),
+                });
+            }
+            _ => {}
         }
         for (field, value) in [
             ("username_env", &self.username_env),
@@ -157,8 +204,8 @@ impl GraphConfig {
                 name: name.to_string(),
                 reason: format!(
                     "query_timeout_seconds must be in 1..={MAX_QUERY_TIMEOUT_SECONDS} \
-                     (got {}) — the value feeds Postgres's statement_timeout and the \
-                     client-side wrap",
+                     (got {}) — the value feeds the backend's server-side timeout \
+                     (statement_timeout / tx_timeout) and the client-side wrap",
                     self.query_timeout_seconds
                 ),
             });
@@ -208,21 +255,67 @@ password_env: AGE_PG_PASS
     }
 
     #[test]
-    fn non_age_backends_and_wrong_schemes_are_named_errors() {
+    fn unknown_backends_and_wrong_schemes_are_named_errors() {
         let mut c = base();
-        c.backend = "neo4j".into();
+        c.backend = "kuzu".into();
         let err = c.validate("kg", "postgres://h/db").unwrap_err();
-        assert!(err.to_string().contains("later milestones"), "{err}");
+        assert!(err.to_string().contains("later milestone"), "{err}");
 
+        // Cross-backend URLs are misconfigurations, both directions.
         let c = base();
         let err = c.validate("kg", "bolt://localhost:7687").unwrap_err();
         assert!(err.to_string().contains("postgres://"), "{err}");
+        let mut c = base();
+        c.backend = "neo4j".into();
+        let err = c.validate("kg", "postgres://h/db").unwrap_err();
+        assert!(err.to_string().contains("bolt://"), "{err}");
+    }
+
+    #[test]
+    fn neo4j_accepts_bolt_schemes_and_an_optional_database() {
+        let mut c = base();
+        c.backend = "neo4j".into();
+        for url in [
+            "bolt://localhost:7687",
+            "bolt+s://h:7687",
+            "neo4j://h:7687",
+            "neo4j+s://h:7687",
+        ] {
+            c.validate("kg", url).expect(url);
+        }
+        // graph_name is the database selector there — optional, and
+        // Neo4j's own name alphabet (dots, dashes) is legal.
+        c.graph_name = None;
+        c.validate("kg", "bolt://h:7687")
+            .expect("default database needs no graph_name");
+        c.graph_name = Some("my-db.prod".into());
+        c.validate("kg", "bolt://h:7687")
+            .expect("neo4j db alphabet");
+        c.graph_name = Some("bad name".into());
+        let err = c.validate("kg", "bolt://h:7687").unwrap_err();
+        assert!(err.to_string().contains("database name"), "{err}");
+        // The +ssc self-signed variants are deliberately NOT allowlisted.
+        c.graph_name = None;
+        let err = c.validate("kg", "bolt+ssc://h:7687").unwrap_err();
+        assert!(err.to_string().contains("bolt://"), "{err}");
+    }
+
+    #[test]
+    fn age_requires_a_graph_name_and_neo4j_dots_stay_illegal_there() {
+        let mut c = base();
+        c.graph_name = None;
+        let err = c.validate("kg", "postgres://h/db").unwrap_err();
+        assert!(err.to_string().contains("requires graph_name"), "{err}");
+        let mut c = base();
+        c.graph_name = Some("my.graph".into());
+        let err = c.validate("kg", "postgres://h/db").unwrap_err();
+        assert!(err.to_string().contains("bare identifier"), "{err}");
     }
 
     #[test]
     fn graph_name_and_env_names_are_shape_checked() {
         let mut c = base();
-        c.graph_name = "bad-name".into();
+        c.graph_name = Some("bad-name".into());
         assert!(c.validate("kg", "postgres://h/db").is_err());
 
         let mut c = base();
@@ -281,7 +374,7 @@ password_env: AGE_PG_PASS
                 .contains("max_connections")
         );
         let mut c = base();
-        c.graph_name = String::new();
+        c.graph_name = Some(String::new());
         assert!(
             c.validate("kg", "postgres://h/db")
                 .unwrap_err()

--- a/crates/skardi/src/sources/providers/graph/error.rs
+++ b/crates/skardi/src/sources/providers/graph/error.rs
@@ -94,6 +94,19 @@ pub enum GraphError {
         message: String,
     },
 
+    /// A backend row carried a different column count than the declared
+    /// schema — driver drift, surfaced as a typed error instead of an
+    /// index panic.
+    #[error(
+        "graph result row {row} carries {found} columns but {expected} were declared — \
+         the backend and the declared schema disagree"
+    )]
+    RowArityMismatch {
+        row: usize,
+        expected: usize,
+        found: usize,
+    },
+
     /// A response cell was not parseable agtype/JSON. Carries position
     /// only.
     #[error(

--- a/crates/skardi/src/sources/providers/graph/error.rs
+++ b/crates/skardi/src/sources/providers/graph/error.rs
@@ -173,6 +173,23 @@ mod tests {
     }
 
     #[test]
+    fn short_backend_messages_pass_untruncated_and_kinds_cover_json() {
+        let err = GraphError::backend("kg", "42601", "syntax error");
+        assert!(err.to_string().contains("syntax error"), "{err}");
+        assert!(!err.to_string().contains('…'), "no ellipsis when unclipped");
+        for (v, kind) in [
+            (serde_json::json!(null), "null"),
+            (serde_json::json!(true), "a boolean"),
+            (serde_json::json!(1), "a number"),
+            (serde_json::json!("s"), "a string"),
+            (serde_json::json!([1]), "an array"),
+            (serde_json::json!({}), "an object"),
+        ] {
+            assert_eq!(json_kind(&v), kind);
+        }
+    }
+
+    #[test]
     fn mutation_rejected_never_carries_query_text() {
         let err = GraphError::MutationRejected {
             keyword: "CREATE",

--- a/crates/skardi/src/sources/providers/graph/error.rs
+++ b/crates/skardi/src/sources/providers/graph/error.rs
@@ -1,0 +1,172 @@
+//! Error taxonomy for the graph engine bypass (design
+//! `docs/superpowers/specs/2026-08-08-graph-engine-bypass-design.md`
+//! §Error handling).
+//!
+//! Errors carry identity — connection, column, row, keyword — and JSON
+//! *kinds*, never values: row data and query text (whose inline literals
+//! are values) never appear in a rendered message, so nothing sensitive
+//! leaks into logs or agent prompts.
+
+use thiserror::Error;
+
+/// How many bytes of a backend error message survive into ours. Backend
+/// messages can embed query text, so the snippet is length-capped, never
+/// forwarded whole.
+const BACKEND_MESSAGE_CAP: usize = 300;
+
+/// Errors surfaced by graph sources and the `cypher_query` /
+/// `graph_schema` UDTFs.
+#[derive(Debug, Error)]
+pub enum GraphError {
+    /// The `connection` argument named no registered `type: graph` source.
+    #[error(
+        "graph connection '{name}' is not registered (known connections: {known}); \
+         declare a `type: graph` data source with that name"
+    )]
+    ConnectionNotFound { name: String, known: String },
+
+    /// A config field failed validation at load/registration time.
+    #[error("graph source '{name}': {reason}")]
+    InvalidConfig { name: String, reason: String },
+
+    /// The fast-path keyword guard blocked caller-supplied Cypher. Names
+    /// the blocked keyword and its byte offset — NEVER the query text
+    /// (inline Cypher literals are values).
+    #[error(
+        "cypher_query is read-only: the keyword '{keyword}' at byte {offset} is not \
+         allowed (writes and procedure calls are rejected; the backend's READ ONLY \
+         transaction enforces this regardless)"
+    )]
+    MutationRejected {
+        keyword: &'static str,
+        offset: usize,
+    },
+
+    /// The declared `columns` argument failed to parse or used an unknown
+    /// type name.
+    #[error("cypher_query 'columns': {reason}; accepted types: {accepted}")]
+    InvalidColumns {
+        reason: String,
+        accepted: &'static str,
+    },
+
+    /// The `params` argument was not a JSON object.
+    #[error("cypher_query 'params' must be a JSON object, got {found}")]
+    InvalidParams { found: String },
+
+    /// A returned value did not convert to its declared column type.
+    /// Carries the JSON *kind* found, never the value.
+    #[error(
+        "graph column '{column}' at result row {row}: declared '{expected}' but the \
+         backend returned {found}; declare the column as 'json' (verbatim) or \
+         normalize in Cypher (toString()/toInteger())"
+    )]
+    TypeMismatch {
+        column: String,
+        row: usize,
+        expected: &'static str,
+        found: &'static str,
+    },
+
+    /// The scan hit the per-source row cap. Loud and typed — never a
+    /// silent truncation.
+    #[error(
+        "graph scan exceeded max_rows = {max_rows}: the backend returned more rows \
+         than the source allows per query; add a Cypher LIMIT or raise the \
+         source's max_rows"
+    )]
+    RowCapExceeded { max_rows: usize },
+
+    /// The backend did not answer within the per-source timeout.
+    #[error(
+        "graph query timed out after {seconds}s (the source's query_timeout_seconds); \
+         narrow the traversal or raise the timeout"
+    )]
+    Timeout { seconds: u64 },
+
+    /// A driver/backend failure. `code` is the backend's error code
+    /// verbatim; `message` is a bounded snippet (see
+    /// [`GraphError::backend`]).
+    #[error("graph backend error on '{source_name}' [{code}]: {message}")]
+    Backend {
+        source_name: String,
+        code: String,
+        message: String,
+    },
+
+    /// A response cell was not parseable agtype/JSON. Carries position
+    /// only.
+    #[error(
+        "graph response cell at row {row}, column {column} is not parseable agtype \
+         ({reason})"
+    )]
+    MalformedCell {
+        row: usize,
+        column: usize,
+        reason: String,
+    },
+}
+
+impl GraphError {
+    /// Build a [`GraphError::Backend`] with the message snippet bounded at
+    /// a fixed byte cap (on a char boundary) — backend messages can embed
+    /// query text, and query text can embed values.
+    pub fn backend(source_name: &str, code: &str, message: &str) -> Self {
+        let mut end = message.len().min(BACKEND_MESSAGE_CAP);
+        while end < message.len() && !message.is_char_boundary(end) {
+            end += 1;
+        }
+        let mut snippet = message[..end].to_string();
+        if end < message.len() {
+            snippet.push('…');
+        }
+        GraphError::Backend {
+            source_name: source_name.to_string(),
+            code: code.to_string(),
+            message: snippet,
+        }
+    }
+}
+
+/// The JSON kind of a value, for type-mismatch diagnostics — kinds only,
+/// never the value itself.
+pub fn json_kind(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "a boolean",
+        serde_json::Value::Number(_) => "a number",
+        serde_json::Value::String(_) => "a string",
+        serde_json::Value::Array(_) => "an array",
+        serde_json::Value::Object(_) => "an object",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backend_messages_are_bounded_on_char_boundaries() {
+        let long = "颱".repeat(200); // 3 bytes each — 600 bytes
+        let err = GraphError::backend("kg", "XX000", &long);
+        let GraphError::Backend { message, .. } = &err else {
+            panic!("backend variant");
+        };
+        assert!(message.len() <= BACKEND_MESSAGE_CAP + '…'.len_utf8() + 3);
+        assert!(message.ends_with('…'), "truncation is visible");
+        // No panic on the boundary is the real assertion; the display
+        // renders the identity pieces.
+        assert!(err.to_string().contains("[XX000]"));
+    }
+
+    #[test]
+    fn mutation_rejected_never_carries_query_text() {
+        let err = GraphError::MutationRejected {
+            keyword: "CREATE",
+            offset: 42,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("'CREATE'"));
+        assert!(msg.contains("byte 42"));
+    }
+}

--- a/crates/skardi/src/sources/providers/graph/guard.rs
+++ b/crates/skardi/src/sources/providers/graph/guard.rs
@@ -1,0 +1,100 @@
+//! The fast-path keyword guard — UX, not the security boundary.
+//!
+//! Screens CALLER-supplied Cypher only (the text passed to
+//! `cypher_query`); engine-authored introspection (`graph_schema`'s
+//! `ag_catalog` reads) never passes through it. It exists to hand an
+//! agent a fast, actionable error naming the blocked keyword before any
+//! network round-trip; the backend's READ ONLY transaction is what
+//! actually guarantees read-only (design §Security and operational
+//! bounds). Deliberately conservative: keyword-shaped string literals
+//! (`RETURN 'DELETE'`) false-positive — an accepted tax. Word-boundary
+//! matching keeps identifiers like `created_at` out of the blast radius.
+
+use super::error::GraphError;
+
+/// Mutating and escape-hatch keywords, screened on word boundaries.
+/// `CALL` is here because procedures can mutate without any write
+/// keyword; `LOAD` (as in `LOAD CSV`) because it makes the *graph server*
+/// fetch arbitrary URLs.
+const BLOCKED: &[&str] = &[
+    "CREATE", "SET", "DELETE", "DETACH", "REMOVE", "MERGE", "DROP", "CALL", "LOAD",
+];
+
+/// Reject Cypher containing a blocked keyword. The error names the
+/// keyword and its byte offset — never the query text.
+pub fn reject_mutations(cypher: &str) -> Result<(), GraphError> {
+    let upper = cypher.to_ascii_uppercase();
+    let bytes = upper.as_bytes();
+    for keyword in BLOCKED {
+        let mut from = 0;
+        while let Some(pos) = upper[from..].find(keyword) {
+            let start = from + pos;
+            let end = start + keyword.len();
+            let boundary_before = start == 0 || !is_word_byte(bytes[start - 1]);
+            let boundary_after = end == bytes.len() || !is_word_byte(bytes[end]);
+            if boundary_before && boundary_after {
+                return Err(GraphError::MutationRejected {
+                    keyword,
+                    offset: start,
+                });
+            }
+            from = end;
+        }
+    }
+    Ok(())
+}
+
+fn is_word_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_keywords_are_rejected_case_insensitively() {
+        for q in [
+            "CREATE (n)",
+            "match (n) set n.x = 1",
+            "MATCH (n) DETACH DELETE n",
+            "merge (n:X)",
+            "DROP GRAPH g",
+            "CALL db.labels()",
+            "LOAD CSV FROM 'https://x' AS row RETURN row",
+        ] {
+            let err = reject_mutations(q).unwrap_err();
+            assert!(
+                matches!(err, GraphError::MutationRejected { .. }),
+                "{q}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn word_boundaries_spare_identifiers() {
+        for q in [
+            "MATCH (n) WHERE n.created_at > 0 RETURN n", // CREATE inside created_at
+            "MATCH (n) RETURN n.dataset",                // SET inside dataset
+            "MATCH (n) RETURN n.calls",                  // CALL inside calls
+            "MATCH (n) RETURN n.reload",                 // LOAD inside reload
+        ] {
+            assert!(reject_mutations(q).is_ok(), "{q}");
+        }
+    }
+
+    #[test]
+    fn keyword_shaped_literals_false_positive_by_design() {
+        // The accepted tax (design §Security): the guard is conservative
+        // and the backend READ ONLY transaction is the real boundary.
+        assert!(reject_mutations("MATCH (n) WHERE n.op = 'DELETE' RETURN n").is_err());
+    }
+
+    #[test]
+    fn the_error_names_keyword_and_offset_not_the_query() {
+        let err = reject_mutations("MATCH (n) SET n.secret = 'v'").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("'SET'"), "{msg}");
+        assert!(!msg.contains("secret"), "query text never leaks: {msg}");
+    }
+}

--- a/crates/skardi/src/sources/providers/graph/guard.rs
+++ b/crates/skardi/src/sources/providers/graph/guard.rs
@@ -22,7 +22,7 @@ const BLOCKED: &[&str] = &[
 
 /// Reject Cypher containing a blocked keyword. The error names the
 /// keyword and its byte offset — never the query text. The FIRST match
-/// in the query wins, not the first keyword in [`BLOCKED`]: the error
+/// in the query wins, not the first keyword in `BLOCKED`: the error
 /// exists to hand an LLM the place to start rewriting, and
 /// `DETACH DELETE` must point at `DETACH`, not at the later `DELETE`
 /// that happens to sort earlier in the list.

--- a/crates/skardi/src/sources/providers/graph/guard.rs
+++ b/crates/skardi/src/sources/providers/graph/guard.rs
@@ -21,10 +21,15 @@ const BLOCKED: &[&str] = &[
 ];
 
 /// Reject Cypher containing a blocked keyword. The error names the
-/// keyword and its byte offset — never the query text.
+/// keyword and its byte offset — never the query text. The FIRST match
+/// in the query wins, not the first keyword in [`BLOCKED`]: the error
+/// exists to hand an LLM the place to start rewriting, and
+/// `DETACH DELETE` must point at `DETACH`, not at the later `DELETE`
+/// that happens to sort earlier in the list.
 pub fn reject_mutations(cypher: &str) -> Result<(), GraphError> {
     let upper = cypher.to_ascii_uppercase();
     let bytes = upper.as_bytes();
+    let mut earliest: Option<(&'static str, usize)> = None;
     for keyword in BLOCKED {
         let mut from = 0;
         while let Some(pos) = upper[from..].find(keyword) {
@@ -33,15 +38,18 @@ pub fn reject_mutations(cypher: &str) -> Result<(), GraphError> {
             let boundary_before = start == 0 || !is_word_byte(bytes[start - 1]);
             let boundary_after = end == bytes.len() || !is_word_byte(bytes[end]);
             if boundary_before && boundary_after {
-                return Err(GraphError::MutationRejected {
-                    keyword,
-                    offset: start,
-                });
+                if earliest.is_none_or(|(_, best)| start < best) {
+                    earliest = Some((keyword, start));
+                }
+                break; // later occurrences of this keyword can't be earlier
             }
             from = end;
         }
     }
-    Ok(())
+    match earliest {
+        Some((keyword, offset)) => Err(GraphError::MutationRejected { keyword, offset }),
+        None => Ok(()),
+    }
 }
 
 fn is_word_byte(b: u8) -> bool {
@@ -96,5 +104,17 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("'SET'"), "{msg}");
         assert!(!msg.contains("secret"), "query text never leaks: {msg}");
+    }
+
+    #[test]
+    fn the_first_keyword_in_the_query_wins_not_the_first_in_the_list() {
+        // DETACH sits earlier in the text, DELETE earlier in BLOCKED —
+        // the LLM's rewrite anchor is the text position.
+        let err = reject_mutations("MATCH (n) DETACH DELETE n").unwrap_err();
+        let GraphError::MutationRejected { keyword, offset } = err else {
+            panic!("mutation");
+        };
+        assert_eq!(keyword, "DETACH");
+        assert_eq!(offset, 10);
     }
 }

--- a/crates/skardi/src/sources/providers/graph/mod.rs
+++ b/crates/skardi/src/sources/providers/graph/mod.rs
@@ -109,6 +109,10 @@ pub async fn register_graph_source(
         }
     }
     let timeout = Duration::from_secs(config.query_timeout_seconds);
+    // Explicit per-backend arms, no wildcard: when milestone 3 adds
+    // `kuzu` to validate()'s allowlist, forgetting this match must be a
+    // loud unreachable here — never a Kuzu URL silently dialed with the
+    // Bolt client.
     let client: Arc<dyn client::GraphClient> = match config.backend.as_str() {
         "age" => Arc::new(
             AgeClient::connect(
@@ -125,8 +129,7 @@ pub async fn register_graph_source(
             )
             .await?,
         ),
-        // validate() has already rejected everything else.
-        _ => Arc::new(
+        "neo4j" => Arc::new(
             Neo4jClient::connect(
                 name,
                 connection_string,
@@ -138,6 +141,7 @@ pub async fn register_graph_source(
             )
             .await?,
         ),
+        other => unreachable!("validate() rejected backend '{other}' before dispatch"),
     };
     let handle = Arc::new(GraphSourceHandle {
         client,

--- a/crates/skardi/src/sources/providers/graph/mod.rs
+++ b/crates/skardi/src/sources/providers/graph/mod.rs
@@ -51,6 +51,30 @@ pub use udtf::register_graph_udtfs;
 /// # Errors
 /// [`GraphError::InvalidConfig`] for validation failures;
 /// [`GraphError::Backend`] when the backend refuses the connection.
+///
+/// # Example
+/// ```no_run
+/// use std::collections::HashMap;
+/// use std::sync::{Arc, RwLock};
+/// use skardi::sources::providers::graph::config::GraphConfig;
+/// use skardi::sources::providers::graph::udtf::GraphSources;
+/// use skardi::sources::providers::graph::register_graph_source;
+///
+/// # async fn demo() -> Result<(), Box<dyn std::error::Error>> {
+/// let sources: GraphSources = Arc::new(RwLock::new(HashMap::new()));
+/// let config: GraphConfig =
+///     serde_yaml::from_str("backend: age\ngraph_name: knowledge\n")?;
+/// register_graph_source(
+///     &sources,
+///     "kg",
+///     "postgres://localhost:5432/graphrag",
+///     &config,
+/// )
+/// .await?;
+/// // cypher_query('kg', …) and graph_schema('kg') now resolve.
+/// # Ok(())
+/// # }
+/// ```
 pub async fn register_graph_source(
     sources: &GraphSources,
     name: &str,
@@ -64,6 +88,7 @@ pub async fn register_graph_source(
         &config.graph_name,
         config.username_env.as_deref(),
         config.password_env.as_deref(),
+        config.max_connections,
     )
     .await?;
     let handle = Arc::new(GraphSourceHandle {
@@ -73,10 +98,10 @@ pub async fn register_graph_source(
             max_rows: config.max_rows,
         },
     });
-    let mut map = sources.write().map_err(|_| GraphError::InvalidConfig {
-        name: name.to_string(),
-        reason: "graph sources lock poisoned".to_string(),
-    })?;
+    // Poisoning degrades gracefully (AGENTS.md convention) — and it also
+    // keeps InvalidConfig meaning what it says instead of moonlighting as
+    // a lock error.
+    let mut map = sources.write().unwrap_or_else(|p| p.into_inner());
     if map.insert(name.to_string(), handle).is_some() {
         return Err(GraphError::InvalidConfig {
             name: name.to_string(),

--- a/crates/skardi/src/sources/providers/graph/mod.rs
+++ b/crates/skardi/src/sources/providers/graph/mod.rs
@@ -7,30 +7,37 @@
 //! **planning-time-stable schema** (caller-declared columns; no probes,
 //! no network I/O at planning). Milestone 1 ships the Apache AGE backend
 //! (openCypher inside Postgres — the GraphRAG-in-Postgres deployment,
-//! zero new infrastructure) with:
+//! zero new infrastructure); milestone 2 adds Neo4j over Bolt behind the
+//! same [`client::GraphClient`] trait:
 //!
 //! - `cypher_query(connection, cypher, params, columns)` — declared
-//!   columns required on AGE (its `cypher()` call must declare arity);
+//!   columns required on AGE (its `cypher()` call must declare arity;
+//!   binding is positional there) and optional on Neo4j (Bolt carries
+//!   field names: binding is BY NAME, and omission is the JSON-`record`
+//!   fallback);
 //! - `graph_schema(connection)` — the agent-discovery surface, one
-//!   `(label, kind)` row per label off `ag_catalog`, names only (all
-//!   the AGE catalog knows: it is schema-optional and declares no
-//!   properties — property names/types come with the Neo4j/Kuzu
-//!   milestones, whose catalogs carry them);
-//! - read-only enforced by the BACKEND (`READ ONLY` transactions), with
-//!   the keyword guard as fast-path UX;
+//!   `(label, kind, property, property_type)` row per label off the
+//!   backend catalog. Names and types only, per what each catalog knows:
+//!   AGE serves label names and kinds (schema-optional store, property
+//!   columns always null); Neo4j adds property names/types via
+//!   `db.schema.nodeTypeProperties()` / `relTypeProperties()`;
+//! - read-only enforced by the BACKEND (AGE: `READ ONLY` transactions;
+//!   Neo4j: auto-commit READ-access-mode transactions, proven at
+//!   registration — see `neo4j.rs`), with the keyword guard as
+//!   fast-path UX;
 //! - every query bounded (`query_timeout_seconds`, `max_rows`) with
 //!   typed errors, never silent truncation;
 //! - the `datafusion-functions-json` getter family registered alongside,
 //!   so `properties` JSON columns are queryable without leaving SQL.
 //!
-//! Neo4j (Bolt, gated on the access-mode spike) and Kuzu are later
-//! milestones behind the same [`client::GraphClient`] trait; YAML
-//! catalog views and `type: graph` server registration are milestone 4.
+//! Kuzu is a later milestone behind the same trait; YAML catalog views
+//! and `type: graph` server registration are milestone 4.
 
 pub mod client;
 pub mod config;
 pub mod error;
 pub mod guard;
+pub mod neo4j;
 pub mod udtf;
 pub mod value;
 
@@ -40,6 +47,7 @@ use std::time::Duration;
 use client::{AgeClient, QueryBounds};
 use config::GraphConfig;
 use error::GraphError;
+use neo4j::Neo4jClient;
 use udtf::{GraphSourceHandle, GraphSources};
 
 pub use udtf::register_graph_udtfs;
@@ -100,20 +108,41 @@ pub async fn register_graph_source(
             });
         }
     }
-    let client = AgeClient::connect(
-        name,
-        connection_string,
-        &config.graph_name,
-        config.username_env.as_deref(),
-        config.password_env.as_deref(),
-        config.max_connections,
-        Duration::from_secs(config.query_timeout_seconds),
-    )
-    .await?;
+    let timeout = Duration::from_secs(config.query_timeout_seconds);
+    let client: Arc<dyn client::GraphClient> = match config.backend.as_str() {
+        "age" => Arc::new(
+            AgeClient::connect(
+                name,
+                connection_string,
+                config
+                    .graph_name
+                    .as_deref()
+                    .expect("validate() requires graph_name on age"),
+                config.username_env.as_deref(),
+                config.password_env.as_deref(),
+                config.max_connections,
+                timeout,
+            )
+            .await?,
+        ),
+        // validate() has already rejected everything else.
+        _ => Arc::new(
+            Neo4jClient::connect(
+                name,
+                connection_string,
+                config.graph_name.as_deref(),
+                config.username_env.as_deref(),
+                config.password_env.as_deref(),
+                config.max_connections,
+                timeout,
+            )
+            .await?,
+        ),
+    };
     let handle = Arc::new(GraphSourceHandle {
-        client: Arc::new(client),
+        client,
         bounds: QueryBounds {
-            timeout: Duration::from_secs(config.query_timeout_seconds),
+            timeout,
             max_rows: config.max_rows,
         },
     });

--- a/crates/skardi/src/sources/providers/graph/mod.rs
+++ b/crates/skardi/src/sources/providers/graph/mod.rs
@@ -1,0 +1,87 @@
+//! Graph engine bypass — read-only Cypher as SQL tables (design:
+//! `docs/superpowers/specs/2026-08-08-graph-engine-bypass-design.md`).
+//!
+//! Skardi does not parse, plan, or store graphs: the graph engine owns
+//! storage, indexing, and traversal, and this module forwards read-only
+//! Cypher and maps the results into Arrow rows with a
+//! **planning-time-stable schema** (caller-declared columns; no probes,
+//! no network I/O at planning). Milestone 1 ships the Apache AGE backend
+//! (openCypher inside Postgres — the GraphRAG-in-Postgres deployment,
+//! zero new infrastructure) with:
+//!
+//! - `cypher_query(connection, cypher, params, columns)` — declared
+//!   columns required on AGE (its `cypher()` call must declare arity);
+//! - `graph_schema(connection)` — the agent-discovery surface, one
+//!   `(label, kind)` row per label off `ag_catalog`, names only;
+//! - read-only enforced by the BACKEND (`READ ONLY` transactions), with
+//!   the keyword guard as fast-path UX;
+//! - every query bounded (`query_timeout_seconds`, `max_rows`) with
+//!   typed errors, never silent truncation;
+//! - the `datafusion-functions-json` getter family registered alongside,
+//!   so `properties` JSON columns are queryable without leaving SQL.
+//!
+//! Neo4j (Bolt, gated on the access-mode spike) and Kuzu are later
+//! milestones behind the same [`client::GraphClient`] trait; YAML
+//! catalog views and `type: graph` server registration are milestone 4.
+
+pub mod client;
+pub mod config;
+pub mod error;
+pub mod guard;
+pub mod udtf;
+pub mod value;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use client::{AgeClient, QueryBounds};
+use config::GraphConfig;
+use error::GraphError;
+use udtf::{GraphSourceHandle, GraphSources};
+
+pub use udtf::register_graph_udtfs;
+
+/// Connect and register one `type: graph` source under `name`, making it
+/// resolvable from `cypher_query('<name>', …)` / `graph_schema('<name>')`.
+///
+/// Config validation is pure and runs first; the connection pool is then
+/// established eagerly so a wrong URL or credential fails HERE, at
+/// registration, with the source named — not at first query.
+///
+/// # Errors
+/// [`GraphError::InvalidConfig`] for validation failures;
+/// [`GraphError::Backend`] when the backend refuses the connection.
+pub async fn register_graph_source(
+    sources: &GraphSources,
+    name: &str,
+    connection_string: &str,
+    config: &GraphConfig,
+) -> Result<(), GraphError> {
+    config.validate(name, connection_string)?;
+    let client = AgeClient::connect(
+        name,
+        connection_string,
+        &config.graph_name,
+        config.username_env.as_deref(),
+        config.password_env.as_deref(),
+    )
+    .await?;
+    let handle = Arc::new(GraphSourceHandle {
+        client: Arc::new(client),
+        bounds: QueryBounds {
+            timeout: Duration::from_secs(config.query_timeout_seconds),
+            max_rows: config.max_rows,
+        },
+    });
+    let mut map = sources.write().map_err(|_| GraphError::InvalidConfig {
+        name: name.to_string(),
+        reason: "graph sources lock poisoned".to_string(),
+    })?;
+    if map.insert(name.to_string(), handle).is_some() {
+        return Err(GraphError::InvalidConfig {
+            name: name.to_string(),
+            reason: "a graph source with this name is already registered".to_string(),
+        });
+    }
+    Ok(())
+}

--- a/crates/skardi/src/sources/providers/graph/mod.rs
+++ b/crates/skardi/src/sources/providers/graph/mod.rs
@@ -103,13 +103,21 @@ pub async fn register_graph_source(
     });
     // Poisoning degrades gracefully (AGENTS.md convention) — and it also
     // keeps InvalidConfig meaning what it says instead of moonlighting as
-    // a lock error.
+    // a lock error. Entry-based: a duplicate name must leave the ORIGINAL
+    // handle untouched — insert-then-check would replace the live
+    // connection and then report failure, leaving queries silently
+    // routed to the new one.
     let mut map = sources.write().unwrap_or_else(|p| p.into_inner());
-    if map.insert(name.to_string(), handle).is_some() {
-        return Err(GraphError::InvalidConfig {
+    match map.entry(name.to_string()) {
+        std::collections::hash_map::Entry::Occupied(_) => Err(GraphError::InvalidConfig {
             name: name.to_string(),
-            reason: "a graph source with this name is already registered".to_string(),
-        });
+            reason: "a graph source with this name is already registered \
+                     (the existing connection is unchanged)"
+                .to_string(),
+        }),
+        std::collections::hash_map::Entry::Vacant(slot) => {
+            slot.insert(handle);
+            Ok(())
+        }
     }
-    Ok(())
 }

--- a/crates/skardi/src/sources/providers/graph/mod.rs
+++ b/crates/skardi/src/sources/providers/graph/mod.rs
@@ -12,7 +12,10 @@
 //! - `cypher_query(connection, cypher, params, columns)` — declared
 //!   columns required on AGE (its `cypher()` call must declare arity);
 //! - `graph_schema(connection)` — the agent-discovery surface, one
-//!   `(label, kind)` row per label off `ag_catalog`, names only;
+//!   `(label, kind)` row per label off `ag_catalog`, names only (all
+//!   the AGE catalog knows: it is schema-optional and declares no
+//!   properties — property names/types come with the Neo4j/Kuzu
+//!   milestones, whose catalogs carry them);
 //! - read-only enforced by the BACKEND (`READ ONLY` transactions), with
 //!   the keyword guard as fast-path UX;
 //! - every query bounded (`query_timeout_seconds`, `max_rows`) with

--- a/crates/skardi/src/sources/providers/graph/mod.rs
+++ b/crates/skardi/src/sources/providers/graph/mod.rs
@@ -85,6 +85,21 @@ pub async fn register_graph_source(
     config: &GraphConfig,
 ) -> Result<(), GraphError> {
     config.validate(name, connection_string)?;
+    // Check-early AND check-again: this peek spares a doomed registration
+    // the full eager connect (pool + graph probe, possibly a slow
+    // backend); the entry-based check after connect is what actually
+    // closes the race between two concurrent registrations.
+    {
+        let map = sources.read().unwrap_or_else(|p| p.into_inner());
+        if map.contains_key(name) {
+            return Err(GraphError::InvalidConfig {
+                name: name.to_string(),
+                reason: "a graph source with this name is already registered \
+                         (the existing connection is unchanged)"
+                    .to_string(),
+            });
+        }
+    }
     let client = AgeClient::connect(
         name,
         connection_string,
@@ -92,6 +107,7 @@ pub async fn register_graph_source(
         config.username_env.as_deref(),
         config.password_env.as_deref(),
         config.max_connections,
+        Duration::from_secs(config.query_timeout_seconds),
     )
     .await?;
     let handle = Arc::new(GraphSourceHandle {

--- a/crates/skardi/src/sources/providers/graph/neo4j.rs
+++ b/crates/skardi/src/sources/providers/graph/neo4j.rs
@@ -26,10 +26,12 @@
 //! registration's **read-mode proof** probes that exact unit: it sends a
 //! trivial write (`CREATE (n:…) DELETE n` — self-erasing even if it were
 //! to execute, since auto-commit has no rollback to fall back on) through
-//! `execute_read` and requires the SERVER to refuse it. A driver/server
-//! pair that does not enforce read mode fails registration closed
-//! (design §Security: "the milestone does not ship on the keyword guard
-//! alone").
+//! `execute_read` and requires the server's ACCESS-MODE refusal
+//! (`Neo.ClientError.Statement.AccessMode`, pinned live) — nothing else
+//! passes: a write that executes fails registration, and so does any
+//! OTHER error (a transient failure proves nothing about enforcement, so
+//! it fails closed too; design §Security: "the milestone does not ship
+//! on the keyword guard alone").
 //!
 //! ## Result decoding
 //!
@@ -42,7 +44,9 @@
 //! Bolt path's index list. Ids are Bolt's numeric ids stringified (the
 //! default protocol negotiates Bolt 4.4, which predates `elementId()`;
 //! design §Backend abstraction covers exactly this normalization).
-//! Temporal values render as ISO-8601 text, spatial points as small JSON
+//! Temporal values render as ISO-8601 text (durations through the
+//! driver's signed (seconds, nanos) view — its `std::time::Duration`
+//! conversion would wrap negatives), spatial points as small JSON
 //! objects, byte arrays as lowercase hex — all JSON-representable, so a
 //! `datetime()` property cannot fail a whole scan. Non-finite floats
 //! decode to null (the same decision the AGE decoder made for agtype's
@@ -63,10 +67,14 @@ use std::time::Duration;
 use async_trait::async_trait;
 use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime};
 use futures::StreamExt;
-use neo4rs::{BoltType, ConfigBuilder, Graph, Query};
+use neo4rs::{BoltNode, BoltType, ConfigBuilder, Graph, Query};
+use serde::Deserialize;
+use serde::de::IntoDeserializer;
 use serde_json::Value;
 
-use super::client::{GraphClient, GraphRow, GraphRowStream, QueryBounds, SchemaRow};
+use super::client::{
+    GraphClient, GraphRow, GraphRowStream, QueryBounds, SchemaRow, bounded, read_env,
+};
 use super::error::GraphError;
 use super::value::DeclaredColumn;
 
@@ -147,40 +155,51 @@ impl Neo4jClient {
             graph,
             source_name: source_name.to_string(),
         };
-        client
-            .bounded(timeout, async {
-                let mut rows = client
-                    .graph
-                    .execute_read(Query::new("RETURN 1".to_string()))
-                    .await
-                    .map_err(|e| map_driver_error(&client.source_name, &e))?;
-                rows.next()
-                    .await
-                    .map_err(|e| map_driver_error(&client.source_name, &e))?;
-                Ok(())
-            })
-            .await?;
+        bounded(timeout, async {
+            let mut rows = client
+                .graph
+                .execute_read(Query::new("RETURN 1".to_string()))
+                .await
+                .map_err(|e| map_driver_error(&client.source_name, &e))?;
+            rows.next()
+                .await
+                .map_err(|e| map_driver_error(&client.source_name, &e))?;
+            Ok(())
+        })
+        .await?;
         client.read_mode_proof(timeout).await?;
         Ok(client)
     }
 
     /// The registration read-mode proof (design §Milestone 2): send a
     /// trivial, self-erasing write through the SAME auto-commit read
-    /// channel every later query uses, and require the server to refuse
-    /// it. Success means read mode is not enforced by this driver/server
-    /// pair — fail closed, never register.
+    /// channel every later query uses, and require the server's
+    /// ACCESS-MODE refusal. Fail-closed in every other outcome: a write
+    /// that EXECUTES means read mode is not enforced, and any OTHER
+    /// error (transient network failure, auth hiccup, a server that
+    /// rejects the statement for unrelated reasons) proves nothing about
+    /// enforcement — registration surfaces it instead of vacuously
+    /// passing the security gate on it.
     async fn read_mode_proof(&self, timeout: Duration) -> Result<(), GraphError> {
         let probe = format!("CREATE (n:{READ_PROOF_LABEL}) DELETE n");
-        let outcome = self
-            .bounded(timeout, async {
-                Ok(self.graph.execute_read(Query::new(probe)).await)
-            })
-            .await?;
+        let outcome = bounded(timeout, async {
+            Ok(self.graph.execute_read(Query::new(probe)).await)
+        })
+        .await?;
         match outcome {
-            // The server refused a write inside the read-mode
-            // transaction — the boundary the whole milestone rests on
-            // demonstrably holds for this exact pair.
-            Err(_) => Ok(()),
+            // The one passing outcome, pinned live against Neo4j 5:
+            // Neo.ClientError.Statement.AccessMode, "Writing in read
+            // access mode not allowed".
+            Err(neo4rs::Error::Neo4j(err)) if err.code().contains("AccessMode") => Ok(()),
+            Err(other) => Err(GraphError::InvalidConfig {
+                name: self.source_name.to_string(),
+                reason: format!(
+                    "the read-mode proof failed for a reason OTHER than the server's \
+                     access-mode refusal — enforcement is unproven, so the source is \
+                     not registered; underlying error: {}",
+                    map_driver_error(&self.source_name, &other)
+                ),
+            }),
             Ok(_) => Err(GraphError::InvalidConfig {
                 name: self.source_name.to_string(),
                 reason: "the server EXECUTED a write inside a read-access-mode \
@@ -192,36 +211,21 @@ impl Neo4jClient {
         }
     }
 
-    /// Client-side timeout wrap, same shape as the AGE client's: the
-    /// server-side `tx_timeout` is authoritative; this covers a backend
-    /// that stops answering entirely.
-    async fn bounded<T>(
-        &self,
-        timeout: Duration,
-        fut: impl Future<Output = Result<T, GraphError>>,
-    ) -> Result<T, GraphError> {
-        tokio::time::timeout(timeout.saturating_add(Duration::from_secs(5)), fut)
-            .await
-            .map_err(|_| GraphError::Timeout {
-                seconds: timeout.as_secs(),
-            })?
-    }
-
     /// Build the driver query: params driver-bound (never interpolated —
     /// the design's normal road, which AGE alone cannot take), and the
     /// transaction timeout in the RUN extra so runaway traversals die
     /// server-side.
-    fn build_query(cypher: &str, params: &Value, bounds: QueryBounds) -> Query {
+    fn build_query(cypher: &str, params: &Value, bounds: QueryBounds) -> Result<Query, GraphError> {
         let mut query = Query::new(cypher.to_string()).extra(
             "tx_timeout",
             i64::try_from(bounds.timeout.as_millis()).unwrap_or(i64::MAX),
         );
         if let Some(map) = params.as_object() {
             for (key, value) in map {
-                query = query.param(key, json_to_bolt(value));
+                query = query.param(key, json_to_bolt(value)?);
             }
         }
-        query
+        Ok(query)
     }
 
     /// Consume up to `fetch` rows. Shared row-loop semantics with the AGE
@@ -271,6 +275,69 @@ impl Neo4jClient {
         }
         Ok(rows)
     }
+
+    /// One `db.schema.*` catalog query, flattened to [`SchemaRow`]s.
+    async fn schema_rows(
+        &self,
+        query: String,
+        kind: &'static str,
+        bounds: QueryBounds,
+    ) -> Result<Vec<SchemaRow>, GraphError> {
+        let source = &self.source_name;
+        let mut stream = self
+            .graph
+            .execute_read(Self::build_query(&query, &Value::Null, bounds)?)
+            .await
+            .map_err(|e| map_query_error(source, bounds, &e))?;
+        let mut out = Vec::new();
+        while let Some(row) = stream
+            .next()
+            .await
+            .map_err(|e| map_query_error(source, bounds, &e))?
+        {
+            let labels: Vec<String> = match kind {
+                "vertex" => {
+                    let labels = row
+                        .get::<Vec<String>>("nodeLabels")
+                        .map_err(|e| schema_shape_error(source, &e))?;
+                    if labels.is_empty() {
+                        // Label-less nodes are legal on Neo4j and their
+                        // node type still carries properties — one row
+                        // with an empty label keeps them discoverable
+                        // instead of silently vanishing from the roster.
+                        vec![String::new()]
+                    } else {
+                        labels
+                    }
+                }
+                // relType arrives as ":`KNOWS`" — strip to the name.
+                _ => vec![strip_rel_type(
+                    &row.get::<String>("relType")
+                        .map_err(|e| schema_shape_error(source, &e))?,
+                )],
+            };
+            // A label with no properties yields one row with a null
+            // propertyName — keep it: the label's existence IS the
+            // information. Decode ERRORS are not null: a YIELD-shape
+            // drift must surface, exactly like nodeLabels above.
+            let property: Option<String> = row
+                .get("propertyName")
+                .map_err(|e| schema_shape_error(source, &e))?;
+            let property_type: Option<String> = row
+                .get::<Option<Vec<String>>>("propertyTypes")
+                .map_err(|e| schema_shape_error(source, &e))?
+                .map(|types| types.join("|"));
+            for label in labels {
+                out.push(SchemaRow {
+                    label,
+                    kind: kind.to_string(),
+                    property: property.clone(),
+                    property_type: property_type.clone(),
+                });
+            }
+        }
+        Ok(out)
+    }
 }
 
 #[async_trait]
@@ -283,20 +350,19 @@ impl GraphClient for Neo4jClient {
         bounds: QueryBounds,
         limit: Option<usize>,
     ) -> Result<GraphRowStream, GraphError> {
-        let query = Self::build_query(cypher, params, bounds);
-        let rows = self
-            .bounded(
-                bounds.timeout,
-                self.collect_rows(query, columns, bounds, limit),
-            )
-            .await?;
+        let query = Self::build_query(cypher, params, bounds)?;
+        let rows = bounded(
+            bounds.timeout,
+            self.collect_rows(query, columns, bounds, limit),
+        )
+        .await?;
         Ok(futures::stream::iter(rows.into_iter().map(Ok)).boxed())
     }
 
-    fn requires_declared_columns(&self) -> bool {
+    fn declared_columns_requirement(&self) -> Option<&'static str> {
         // Bolt records carry field names and need no declared arity —
         // the JSON-record fallback is native here.
-        false
+        None
     }
 
     async fn schema(
@@ -321,53 +387,26 @@ impl GraphClient for Neo4jClient {
              RETURN relType, propertyName, propertyTypes LIMIT {fetch}"
         );
         let run = async {
-            let mut out: Vec<SchemaRow> = Vec::new();
-            for (query, kind) in [(node_q, "vertex"), (rel_q, "edge")] {
-                let mut stream = self
-                    .graph
-                    .execute_read(Self::build_query(&query, &Value::Null, bounds))
-                    .await
-                    .map_err(|e| map_driver_error(&self.source_name, &e))?;
-                while let Some(row) = stream
-                    .next()
-                    .await
-                    .map_err(|e| map_driver_error(&self.source_name, &e))?
-                {
-                    let labels: Vec<String> = match kind {
-                        "vertex" => row
-                            .get::<Vec<String>>("nodeLabels")
-                            .map_err(|e| schema_shape_error(&self.source_name, &e))?,
-                        // relType arrives as ":`KNOWS`" — strip to the name.
-                        _ => vec![strip_rel_type(
-                            &row.get::<String>("relType")
-                                .map_err(|e| schema_shape_error(&self.source_name, &e))?,
-                        )],
-                    };
-                    // A label with no properties yields one row with a
-                    // null propertyName — keep it: the label's existence
-                    // IS the information.
-                    let property: Option<String> = row.get("propertyName").unwrap_or(None);
-                    let property_type: Option<String> = row
-                        .get::<Option<Vec<String>>>("propertyTypes")
-                        .unwrap_or(None)
-                        .map(|types| types.join("|"));
-                    for label in labels {
-                        if out.len() > bounds.max_rows {
-                            return Err(GraphError::RowCapExceeded {
-                                max_rows: bounds.max_rows,
-                            });
-                        }
-                        out.push(SchemaRow {
-                            label,
-                            kind: kind.to_string(),
-                            property: property.clone(),
-                            property_type: property_type.clone(),
-                        });
-                    }
-                }
+            // The two catalog queries share no state — concurrent, on
+            // two pooled connections.
+            let (nodes, rels) = futures::try_join!(
+                self.schema_rows(node_q, "vertex", bounds),
+                self.schema_rows(rel_q, "edge", bounds),
+            )?;
+            let mut out = nodes;
+            out.extend(rels);
+            // The cap rule is the AGE client's, verbatim: a caller LIMIT
+            // at or under the cap is a clean early stop (never a cap
+            // error), and only an uncapped/over-cap read that actually
+            // exceeds max_rows is the loud overflow.
+            if limit.is_none_or(|l| l > bounds.max_rows) && out.len() > bounds.max_rows {
+                return Err(GraphError::RowCapExceeded {
+                    max_rows: bounds.max_rows,
+                });
             }
             // The procedures publish no order; sort for a deterministic
-            // agent-facing roster (AGE orders by name in SQL).
+            // agent-facing roster (AGE orders by name in SQL — and like
+            // SQL, the sort runs before the LIMIT truncation).
             out.sort_by(|a, b| {
                 (&a.kind, &a.label, &a.property).cmp(&(&b.kind, &b.label, &b.property))
             });
@@ -376,22 +415,13 @@ impl GraphClient for Neo4jClient {
             }
             Ok(out)
         };
-        self.bounded(bounds.timeout, run).await
+        bounded(bounds.timeout, run).await
     }
-}
-
-fn read_env(source: &str, field: &str, env: &str) -> Result<String, GraphError> {
-    std::env::var(env).map_err(|_| GraphError::InvalidConfig {
-        name: source.to_string(),
-        reason: format!("{field} names environment variable '{env}', which is not set"),
-    })
 }
 
 /// Map a driver error to the taxonomy. Neo4j server errors carry their
 /// code verbatim and a bounded message via [`GraphError::backend`]
-/// (never `Display` of the whole error — messages can embed query text);
-/// the server-side transaction timeout becomes the typed
-/// [`GraphError::Timeout`].
+/// (never `Display` of the whole error — messages can embed query text).
 fn map_driver_error(source: &str, e: &neo4rs::Error) -> GraphError {
     match e {
         neo4rs::Error::Neo4j(err) => GraphError::backend(source, err.code(), err.message()),
@@ -455,44 +485,66 @@ fn decode_declared(
 }
 
 /// Decode one Bolt record as the whole-record JSON object (the fallback
-/// mode). Keys are sorted — the driver's row is a hash map, so RETURN
-/// order is not recoverable; sorted beats nondeterministic.
+/// mode) — ONE deserialization pass over the row, then keys sorted (the
+/// driver's row is a hash map, so RETURN order is not recoverable;
+/// sorted beats nondeterministic).
 fn decode_record(row: &neo4rs::Row, row_idx: usize) -> Result<Value, GraphError> {
-    let mut keys: Vec<String> = row.keys().iter().map(|k| k.value.clone()).collect();
-    keys.sort_unstable();
-    let mut record = serde_json::Map::with_capacity(keys.len());
-    for (col_idx, key) in keys.iter().enumerate() {
-        let bolt: BoltType = row.get(key).map_err(|e| GraphError::MalformedCell {
-            row: row_idx,
-            column: col_idx,
-            reason: format!("record field failed to decode: {e}"),
-        })?;
-        record.insert(key.clone(), bolt_to_json(&bolt));
+    let map: neo4rs::BoltMap = row.to_strict().map_err(|e| GraphError::MalformedCell {
+        row: row_idx,
+        column: 0,
+        reason: format!("record failed to decode: {e}"),
+    })?;
+    let mut entries: Vec<(&str, &BoltType)> = map
+        .value
+        .iter()
+        .map(|(k, v)| (k.value.as_str(), v))
+        .collect();
+    entries.sort_unstable_by_key(|(k, _)| *k);
+    let mut record = serde_json::Map::with_capacity(entries.len());
+    for (key, bolt) in entries {
+        record.insert(key.to_string(), bolt_to_json(bolt));
     }
     Ok(Value::Object(record))
 }
 
 /// One JSON parameter value → the driver's Bolt value. Recursion mirrors
-/// JSON's own shape; numbers prefer i64 and fall back to f64 (JSON's own
-/// widening).
-fn json_to_bolt(v: &Value) -> BoltType {
-    match v {
+/// JSON's own shape. Numbers must fit Bolt's 64-bit signed integers or
+/// arrive as floats — a u64 beyond i64::MAX is a typed error, never a
+/// silent narrowing to f64 (an equality filter on a narrowed id would
+/// silently match nothing; AGE passes the exact literal through, and
+/// divergence here must be loud).
+fn json_to_bolt(v: &Value) -> Result<BoltType, GraphError> {
+    Ok(match v {
         Value::Null => BoltType::Null(neo4rs::BoltNull),
         Value::Bool(b) => BoltType::Boolean(neo4rs::BoltBoolean::new(*b)),
-        Value::Number(n) => match n.as_i64() {
-            Some(i) => BoltType::Integer(neo4rs::BoltInteger::new(i)),
-            None => BoltType::Float(neo4rs::BoltFloat::new(n.as_f64().unwrap_or(f64::NAN))),
-        },
+        Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                BoltType::Integer(neo4rs::BoltInteger::new(i))
+            } else if n.is_u64() {
+                return Err(GraphError::InvalidParams {
+                    found: "an integer beyond the neo4j backend's signed 64-bit range \
+                            (pass it as a string instead)"
+                        .to_string(),
+                });
+            } else {
+                BoltType::Float(neo4rs::BoltFloat::new(n.as_f64().unwrap_or(f64::NAN)))
+            }
+        }
         Value::String(s) => BoltType::String(neo4rs::BoltString::new(s)),
-        Value::Array(items) => items.iter().map(json_to_bolt).collect(),
+        Value::Array(items) => items
+            .iter()
+            .map(json_to_bolt)
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .collect(),
         Value::Object(map) => {
             let mut bolt = neo4rs::BoltMap::with_capacity(map.len());
             for (k, val) in map {
-                bolt.put(neo4rs::BoltString::new(k), json_to_bolt(val));
+                bolt.put(neo4rs::BoltString::new(k), json_to_bolt(val)?);
             }
             BoltType::Map(bolt)
         }
-    }
+    })
 }
 
 /// One Bolt value → the canonical JSON shape `value.rs` converts
@@ -510,24 +562,18 @@ fn bolt_to_json(v: &BoltType) -> Value {
             .unwrap_or(Value::Null),
         BoltType::String(s) => Value::from(s.value.clone()),
         BoltType::List(items) => Value::Array(items.iter().map(bolt_to_json).collect()),
-        BoltType::Map(map) => {
-            let mut out = serde_json::Map::with_capacity(map.value.len());
-            for (k, val) in &map.value {
-                out.insert(k.value.clone(), bolt_to_json(val));
-            }
-            Value::Object(out)
-        }
+        BoltType::Map(map) => bolt_map_json(map),
         BoltType::Node(n) => node_json(n),
-        BoltType::Relation(r) => serde_json::json!({
-            "id": r.id.value.to_string(),
-            "start_id": r.start_node_id.value.to_string(),
-            "end_id": r.end_node_id.value.to_string(),
-            "label": r.typ.value,
-            "properties": bolt_map_json(&r.properties),
-        }),
+        BoltType::Relation(r) => rel_json(
+            r.id.value,
+            r.start_node_id.value,
+            r.end_node_id.value,
+            &r.typ.value,
+            &r.properties,
+        ),
         // Outside a path a relationship always arrives bounded; an
         // unbounded one at the top level would be driver drift. Decoded
-        // with empty endpoints rather than failing the scan — the shape
+        // with no endpoints rather than failing the scan — the shape
         // check in value.rs will name it if a declared column meets it.
         BoltType::UnboundedRelation(r) => serde_json::json!({
             "id": r.id.value.to_string(),
@@ -565,12 +611,26 @@ fn bolt_to_json(v: &BoltType) -> Value {
             )),
             Err(_) => Value::Null,
         },
-        BoltType::Duration(d) => {
-            // ISO-8601 duration via the driver's std conversion (which
-            // flattens the months/days components — its documented
-            // approximation; sub-second precision survives).
-            let std: std::time::Duration = d.clone().into();
-            Value::from(format!("PT{}.{:09}S", std.as_secs(), std.subsec_nanos()))
+        BoltType::Duration(_) => {
+            // Through the driver's EXTERNAL serde view — a signed
+            // (seconds, nanos) pair (months/days collapsed, saturating).
+            // Its `From<BoltDuration> for std::time::Duration` is NOT
+            // usable here: it casts `seconds as u64`, so a negative
+            // Cypher duration (legal: duration({seconds: -30})) would
+            // wrap to ~1.8e19 and render as garbage.
+            match <(i64, i64)>::deserialize(v.into_deserializer()) {
+                Ok((secs, nanos)) => {
+                    let total = i128::from(secs) * 1_000_000_000 + i128::from(nanos);
+                    let sign = if total < 0 { "-" } else { "" };
+                    let abs = total.unsigned_abs();
+                    Value::from(format!(
+                        "{sign}PT{}.{:09}S",
+                        abs / 1_000_000_000,
+                        abs % 1_000_000_000
+                    ))
+                }
+                Err(_) => Value::Null,
+            }
         }
         BoltType::Point2D(p) => serde_json::json!({
             "srid": p.sr_id.value, "x": p.x.value, "y": p.y.value,
@@ -589,19 +649,24 @@ fn bolt_to_json(v: &BoltType) -> Value {
 /// A Bolt node → the canonical vertex object. `labels` is an ARRAY (the
 /// multi-label spelling `value.rs` accepts alongside AGE's single
 /// `label`).
-fn node_json(n: &neo4rs::BoltNode) -> Value {
-    let labels: Vec<Value> = n
-        .labels
-        .iter()
-        .map(|l| match l {
-            BoltType::String(s) => Value::from(s.value.clone()),
-            other => bolt_to_json(other),
-        })
-        .collect();
+fn node_json(n: &BoltNode) -> Value {
     serde_json::json!({
         "id": n.id.value.to_string(),
-        "labels": labels,
+        "labels": n.labels.iter().map(bolt_to_json).collect::<Vec<_>>(),
         "properties": bolt_map_json(&n.properties),
+    })
+}
+
+/// The canonical bounded-relationship object — ONE spelling, shared by
+/// the top-level Relation arm and path hops, so the contract `value.rs`
+/// consumes cannot fork.
+fn rel_json(id: i64, start_id: i64, end_id: i64, typ: &str, properties: &neo4rs::BoltMap) -> Value {
+    serde_json::json!({
+        "id": id.to_string(),
+        "start_id": start_id.to_string(),
+        "end_id": end_id.to_string(),
+        "label": typ,
+        "properties": bolt_map_json(properties),
     })
 }
 
@@ -621,14 +686,34 @@ fn bolt_map_json(map: &neo4rs::BoltMap) -> Value {
 /// relationship index (sign = direction) followed by a 0-based node
 /// index. The canonical shape wants bounded relationships (`start_id` /
 /// `end_id`), so each hop resolves its endpoints from the nodes it
-/// connects; a malformed index is decoded as null (which `value.rs`
-/// rejects with the path's identity) rather than panicking on driver
-/// drift.
+/// connects; a malformed element or index is decoded as null (which
+/// `value.rs` rejects with the path's identity) rather than panicking on
+/// driver drift. Everything is borrowed from the BoltPath's own lists —
+/// the driver's accessor methods deep-clone every element and are
+/// deliberately not used.
 fn path_json(p: &neo4rs::BoltPath) -> Value {
-    let nodes = p.nodes();
-    let rels = p.rels();
-    let indices = p.indices();
-    let Some(start) = nodes.first() else {
+    let mut nodes: Vec<&BoltNode> = Vec::with_capacity(p.nodes.len());
+    for element in p.nodes.iter() {
+        let BoltType::Node(n) = element else {
+            return Value::Null; // non-node in the node list: drift
+        };
+        nodes.push(n);
+    }
+    let mut rels: Vec<&neo4rs::BoltUnboundedRelation> = Vec::with_capacity(p.rels.len());
+    for element in p.rels.iter() {
+        let BoltType::UnboundedRelation(r) = element else {
+            return Value::Null;
+        };
+        rels.push(r);
+    }
+    let mut indices: Vec<i64> = Vec::with_capacity(p.indices.len());
+    for element in p.indices.iter() {
+        let BoltType::Integer(i) = element else {
+            return Value::Null;
+        };
+        indices.push(i.value);
+    }
+    let Some(&start) = nodes.first() else {
         return Value::Null; // no start node: not a path
     };
     let mut elements: Vec<Value> = Vec::with_capacity(indices.len() + 1);
@@ -638,30 +723,30 @@ fn path_json(p: &neo4rs::BoltPath) -> Value {
         let [rel_idx, node_idx] = hop else {
             return Value::Null; // odd index list: not a path
         };
-        let rel_pos = rel_idx.value.unsigned_abs() as usize;
+        let rel_pos = rel_idx.unsigned_abs() as usize;
         let (Some(rel), Ok(node_pos)) = (
-            rel_pos.checked_sub(1).and_then(|i| rels.get(i)),
-            usize::try_from(node_idx.value),
+            rel_pos.checked_sub(1).and_then(|i| rels.get(i).copied()),
+            usize::try_from(*node_idx),
         ) else {
             return Value::Null;
         };
-        let Some(next) = nodes.get(node_pos) else {
+        let Some(&next) = nodes.get(node_pos) else {
             return Value::Null;
         };
         // Positive index: traversed with the relationship (current →
         // next); negative: against it.
-        let (start_id, end_id) = if rel_idx.value >= 0 {
+        let (start_id, end_id) = if *rel_idx >= 0 {
             (current.id.value, next.id.value)
         } else {
             (next.id.value, current.id.value)
         };
-        elements.push(serde_json::json!({
-            "id": rel.id.value.to_string(),
-            "start_id": start_id.to_string(),
-            "end_id": end_id.to_string(),
-            "label": rel.typ.value,
-            "properties": bolt_map_json(&rel.properties),
-        }));
+        elements.push(rel_json(
+            rel.id.value,
+            start_id,
+            end_id,
+            &rel.typ.value,
+            &rel.properties,
+        ));
         elements.push(node_json(next));
         current = next;
     }
@@ -671,7 +756,7 @@ fn path_json(p: &neo4rs::BoltPath) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use neo4rs::{BoltBoolean, BoltInteger, BoltList, BoltMap, BoltNode, BoltPath, BoltString};
+    use neo4rs::{BoltBoolean, BoltInteger, BoltList, BoltMap, BoltPath, BoltString};
 
     fn bolt_node(id: i64, labels: &[&str], props: &[(&str, &str)]) -> BoltNode {
         let mut label_list = BoltList::new();
@@ -817,25 +902,66 @@ mod tests {
     }
 
     #[test]
-    fn params_convert_shape_faithfully() {
+    fn negative_durations_render_signed_never_wrapped() {
+        // duration({seconds: -30}) is legal Cypher; the driver's own
+        // std::time::Duration conversion would wrap it to ~1.8e19.
+        let neg = neo4rs::BoltDuration::new(0.into(), 0.into(), (-30i64).into(), 0.into());
+        assert_eq!(
+            bolt_to_json(&BoltType::Duration(neg)),
+            serde_json::json!("-PT30.000000000S")
+        );
+        // Mixed sign resolves through total nanoseconds: -1s + 0.25s.
+        let mixed =
+            neo4rs::BoltDuration::new(0.into(), 0.into(), (-1i64).into(), 250_000_000i64.into());
+        assert_eq!(
+            bolt_to_json(&BoltType::Duration(mixed)),
+            serde_json::json!("-PT0.750000000S")
+        );
+    }
+
+    #[test]
+    fn params_convert_shape_faithfully_and_overflow_is_typed() {
         let params = serde_json::json!({
             "s": "it's", "i": 3, "f": 2.5, "b": true, "nul": null,
             "list": [1, 2], "map": {"k": "v"},
         });
         let map = params.as_object().unwrap();
-        assert!(matches!(json_to_bolt(&map["s"]), BoltType::String(_)));
-        assert!(matches!(json_to_bolt(&map["i"]), BoltType::Integer(_)));
-        assert!(matches!(json_to_bolt(&map["f"]), BoltType::Float(_)));
-        assert!(matches!(json_to_bolt(&map["b"]), BoltType::Boolean(_)));
-        assert!(matches!(json_to_bolt(&map["nul"]), BoltType::Null(_)));
-        let BoltType::List(l) = json_to_bolt(&map["list"]) else {
+        assert!(matches!(
+            json_to_bolt(&map["s"]).unwrap(),
+            BoltType::String(_)
+        ));
+        assert!(matches!(
+            json_to_bolt(&map["i"]).unwrap(),
+            BoltType::Integer(_)
+        ));
+        assert!(matches!(
+            json_to_bolt(&map["f"]).unwrap(),
+            BoltType::Float(_)
+        ));
+        assert!(matches!(
+            json_to_bolt(&map["b"]).unwrap(),
+            BoltType::Boolean(_)
+        ));
+        assert!(matches!(
+            json_to_bolt(&map["nul"]).unwrap(),
+            BoltType::Null(_)
+        ));
+        let BoltType::List(l) = json_to_bolt(&map["list"]).unwrap() else {
             panic!("list");
         };
         assert_eq!(l.len(), 2);
-        let BoltType::Map(m) = json_to_bolt(&map["map"]) else {
+        let BoltType::Map(m) = json_to_bolt(&map["map"]).unwrap() else {
             panic!("map");
         };
         assert_eq!(m.len(), 1);
+        // A u64 beyond i64::MAX must be a typed refusal, never a silent
+        // narrowing to f64 (an equality filter would then silently miss).
+        let big = serde_json::json!(u64::MAX);
+        let err = json_to_bolt(&big).unwrap_err();
+        assert!(err.to_string().contains("64-bit"), "{err}");
+        // Nested overflows are caught too.
+        let nested = serde_json::json!({"ids": [1, u64::MAX]});
+        assert!(json_to_bolt(&nested).is_err());
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/graph/neo4j.rs
+++ b/crates/skardi/src/sources/providers/graph/neo4j.rs
@@ -1,0 +1,846 @@
+//! The milestone-2 backend: [`Neo4jClient`] — Neo4j over Bolt, via
+//! `neo4rs` (design §Milestone 2).
+//!
+//! ## The access-mode spike, recorded (the milestone's hard precondition)
+//!
+//! The design gates this milestone on the driver being able to express
+//! Bolt's READ access mode. Findings against `neo4rs` (verified in its
+//! source at the pinned version):
+//!
+//! - **0.8.0 (latest stable) has no read-mode channel at all** — no
+//!   `execute_read`, no `Operation`, and its `BEGIN` carries no mode.
+//! - **0.9.0-rc.10 sends `mode: "r"` in the RUN message's extra map**
+//!   when a query goes through `Graph::execute_read` — and for an
+//!   AUTO-COMMIT transaction that is exactly where the Bolt protocol
+//!   says the access mode belongs. This is the channel this client
+//!   rides: every query is one auto-commit READ transaction.
+//! - **Explicit transactions do NOT work for this**: the driver's
+//!   `Begin` builder supports `with_mode`, but `Txn::new` never calls it
+//!   (BEGIN always goes out in the default `"w"` mode), and the Bolt
+//!   spec ignores the mode field on RUN *inside* an explicit
+//!   transaction. So `start_txn_as(Operation::Read)` — behind the
+//!   `unstable-bolt-protocol-impl-v2` feature — would add an unstable
+//!   surface without adding enforcement. Not used; feature stays off.
+//!
+//! Because the enforcement unit is the auto-commit read transaction,
+//! registration's **read-mode proof** probes that exact unit: it sends a
+//! trivial write (`CREATE (n:…) DELETE n` — self-erasing even if it were
+//! to execute, since auto-commit has no rollback to fall back on) through
+//! `execute_read` and requires the SERVER to refuse it. A driver/server
+//! pair that does not enforce read mode fails registration closed
+//! (design §Security: "the milestone does not ship on the keyword guard
+//! alone").
+//!
+//! ## Result decoding
+//!
+//! Bolt values decode into the same canonical JSON shapes the AGE client
+//! produces (`value.rs` is the shared converter): nodes as
+//! `{id, labels, properties}` (multi-label is native here — `labels` is
+//! an array), relationships as `{id, start_id, end_id, label,
+//! properties}`, paths as the flat `[node, rel, node, …]` alternation
+//! reconstructed **in traversal order with directions resolved** from the
+//! Bolt path's index list. Ids are Bolt's numeric ids stringified (the
+//! default protocol negotiates Bolt 4.4, which predates `elementId()`;
+//! design §Backend abstraction covers exactly this normalization).
+//! Temporal values render as ISO-8601 text, spatial points as small JSON
+//! objects, byte arrays as lowercase hex — all JSON-representable, so a
+//! `datetime()` property cannot fail a whole scan. Non-finite floats
+//! decode to null (the same decision the AGE decoder made for agtype's
+//! `Infinity`/`NaN` tokens).
+//!
+//! ## Column binding is BY NAME on this backend
+//!
+//! Bolt records carry their field names, so declared columns bind to
+//! RETURN entries by NAME — the positional-order footgun documented for
+//! AGE does not exist here, and a declared name missing from the record
+//! is a typed error naming it. The JSON-`record` fallback (no declared
+//! columns) packs the whole record as one JSON object per row; its keys
+//! are emitted in SORTED order because the driver hands rows over as
+//! hash maps (RETURN order is not recoverable through its public API).
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime};
+use futures::StreamExt;
+use neo4rs::{BoltType, ConfigBuilder, Graph, Query};
+use serde_json::Value;
+
+use super::client::{GraphClient, GraphRow, GraphRowStream, QueryBounds, SchemaRow};
+use super::error::GraphError;
+use super::value::DeclaredColumn;
+
+/// Bolt PULL batch size. The wire-level bound for early stops: abandoning
+/// a result after n rows costs at most one extra PULL batch, never the
+/// whole result (Bolt streams incrementally, unlike the simple-protocol
+/// full drain that pushed the AGE client to a real SQL LIMIT).
+const FETCH_SIZE: usize = 1024;
+
+/// The label used by the registration read-mode proof. Namespaced and
+/// self-erasing: the probe query deletes what it creates in the same
+/// statement, so even a non-enforcing server is left unchanged — and
+/// registration then fails closed anyway.
+const READ_PROOF_LABEL: &str = "__skardi_read_mode_probe__";
+
+/// Neo4j over Bolt. Every query is one auto-commit READ-access-mode
+/// transaction (see the module doc for why auto-commit is the sound
+/// channel on the pinned driver).
+pub struct Neo4jClient {
+    graph: Graph,
+    source_name: String,
+}
+
+impl std::fmt::Debug for Neo4jClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // neo4rs's Graph holds the credential; identity only here.
+        f.debug_struct("Neo4jClient")
+            .field("source_name", &self.source_name)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Neo4jClient {
+    /// Connect, verify reachability, and run the read-mode proof.
+    /// Credentials arrive as env-var NAMES (values never in YAML);
+    /// `database` selects a non-default database (`graph_name` in the
+    /// config — omitted means the server's default).
+    pub async fn connect(
+        source_name: &str,
+        connection_string: &str,
+        database: Option<&str>,
+        username_env: Option<&str>,
+        password_env: Option<&str>,
+        max_connections: u32,
+        timeout: Duration,
+    ) -> Result<Self, GraphError> {
+        let user = match username_env {
+            Some(env) => read_env(source_name, "username_env", env)?,
+            None => String::new(),
+        };
+        let pass = match password_env {
+            Some(env) => read_env(source_name, "password_env", env)?,
+            None => String::new(),
+        };
+        let mut config = ConfigBuilder::default()
+            .uri(connection_string)
+            .user(user)
+            .password(pass)
+            .fetch_size(FETCH_SIZE)
+            .max_connections(max_connections as usize)
+            // Dialing is bounded by the same knob as queries — an
+            // unreachable host must fail registration within the
+            // configured bound, not the driver's own default.
+            .connection_timeout(timeout);
+        if let Some(db) = database {
+            config = config.db(db);
+        }
+        let config = config.build().map_err(|e| GraphError::InvalidConfig {
+            name: source_name.to_string(),
+            reason: format!("neo4j driver config rejected: {e}"),
+        })?;
+        // Graph::connect only builds the pool — connections dial lazily,
+        // so registration probes eagerly: a wrong URL, credential, or
+        // database name fails HERE, source named (mod.rs's eager-fail
+        // contract).
+        let graph = Graph::connect(config).map_err(|e| map_driver_error(source_name, &e))?;
+        let client = Self {
+            graph,
+            source_name: source_name.to_string(),
+        };
+        client
+            .bounded(timeout, async {
+                let mut rows = client
+                    .graph
+                    .execute_read(Query::new("RETURN 1".to_string()))
+                    .await
+                    .map_err(|e| map_driver_error(&client.source_name, &e))?;
+                rows.next()
+                    .await
+                    .map_err(|e| map_driver_error(&client.source_name, &e))?;
+                Ok(())
+            })
+            .await?;
+        client.read_mode_proof(timeout).await?;
+        Ok(client)
+    }
+
+    /// The registration read-mode proof (design §Milestone 2): send a
+    /// trivial, self-erasing write through the SAME auto-commit read
+    /// channel every later query uses, and require the server to refuse
+    /// it. Success means read mode is not enforced by this driver/server
+    /// pair — fail closed, never register.
+    async fn read_mode_proof(&self, timeout: Duration) -> Result<(), GraphError> {
+        let probe = format!("CREATE (n:{READ_PROOF_LABEL}) DELETE n");
+        let outcome = self
+            .bounded(timeout, async {
+                Ok(self.graph.execute_read(Query::new(probe)).await)
+            })
+            .await?;
+        match outcome {
+            // The server refused a write inside the read-mode
+            // transaction — the boundary the whole milestone rests on
+            // demonstrably holds for this exact pair.
+            Err(_) => Ok(()),
+            Ok(_) => Err(GraphError::InvalidConfig {
+                name: self.source_name.to_string(),
+                reason: "the server EXECUTED a write inside a read-access-mode \
+                         transaction — read-only cannot be enforced by this \
+                         driver/server pair, so the source is not registered \
+                         (the probe was self-erasing; the graph is unchanged)"
+                    .to_string(),
+            }),
+        }
+    }
+
+    /// Client-side timeout wrap, same shape as the AGE client's: the
+    /// server-side `tx_timeout` is authoritative; this covers a backend
+    /// that stops answering entirely.
+    async fn bounded<T>(
+        &self,
+        timeout: Duration,
+        fut: impl Future<Output = Result<T, GraphError>>,
+    ) -> Result<T, GraphError> {
+        tokio::time::timeout(timeout.saturating_add(Duration::from_secs(5)), fut)
+            .await
+            .map_err(|_| GraphError::Timeout {
+                seconds: timeout.as_secs(),
+            })?
+    }
+
+    /// Build the driver query: params driver-bound (never interpolated —
+    /// the design's normal road, which AGE alone cannot take), and the
+    /// transaction timeout in the RUN extra so runaway traversals die
+    /// server-side.
+    fn build_query(cypher: &str, params: &Value, bounds: QueryBounds) -> Query {
+        let mut query = Query::new(cypher.to_string()).extra(
+            "tx_timeout",
+            i64::try_from(bounds.timeout.as_millis()).unwrap_or(i64::MAX),
+        );
+        if let Some(map) = params.as_object() {
+            for (key, value) in map {
+                query = query.param(key, json_to_bolt(value));
+            }
+        }
+        query
+    }
+
+    /// Consume up to `fetch` rows. Shared row-loop semantics with the AGE
+    /// client: hitting `limit` is a clean early stop, `max_rows + 1` is
+    /// the loud overflow proof.
+    async fn collect_rows(
+        &self,
+        query: Query,
+        columns: Option<&[DeclaredColumn]>,
+        bounds: QueryBounds,
+        limit: Option<usize>,
+    ) -> Result<Vec<GraphRow>, GraphError> {
+        let source = &self.source_name;
+        // `map_query_error`, not `map_driver_error`: the server-side
+        // tx_timeout surfaces mid-query and must map to the typed
+        // Timeout naming the configured seconds.
+        let mut stream = self
+            .graph
+            .execute_read(query)
+            .await
+            .map_err(|e| map_query_error(source, bounds, &e))?;
+        let mut rows: Vec<GraphRow> = Vec::new();
+        loop {
+            if limit.is_some_and(|l| rows.len() >= l) {
+                // Enough rows is success; tell the server to discard the
+                // rest instead of abandoning the stream mid-result.
+                let _ = stream.finish().await;
+                break;
+            }
+            let Some(row) = stream
+                .next()
+                .await
+                .map_err(|e| map_query_error(source, bounds, &e))?
+            else {
+                break;
+            };
+            if rows.len() >= bounds.max_rows {
+                return Err(GraphError::RowCapExceeded {
+                    max_rows: bounds.max_rows,
+                });
+            }
+            let row_idx = rows.len();
+            rows.push(match columns {
+                Some(declared) => decode_declared(&row, declared, row_idx)?,
+                None => vec![decode_record(&row, row_idx)?],
+            });
+        }
+        Ok(rows)
+    }
+}
+
+#[async_trait]
+impl GraphClient for Neo4jClient {
+    async fn execute(
+        &self,
+        cypher: &str,
+        params: &Value,
+        columns: Option<&[DeclaredColumn]>,
+        bounds: QueryBounds,
+        limit: Option<usize>,
+    ) -> Result<GraphRowStream, GraphError> {
+        let query = Self::build_query(cypher, params, bounds);
+        let rows = self
+            .bounded(
+                bounds.timeout,
+                self.collect_rows(query, columns, bounds, limit),
+            )
+            .await?;
+        Ok(futures::stream::iter(rows.into_iter().map(Ok)).boxed())
+    }
+
+    fn requires_declared_columns(&self) -> bool {
+        // Bolt records carry field names and need no declared arity —
+        // the JSON-record fallback is native here.
+        false
+    }
+
+    async fn schema(
+        &self,
+        bounds: QueryBounds,
+        limit: Option<usize>,
+    ) -> Result<Vec<SchemaRow>, GraphError> {
+        // Engine-authored introspection — these fixed texts never pass
+        // through the keyword guard (design: rejecting CALL must not
+        // self-block discovery). The LIMIT bounds PROCEDURE rows; every
+        // procedure row flattens to >= 1 schema rows, so max_rows + 1
+        // procedure rows are enough to prove any flattened overflow.
+        let fetch = bounds.max_rows.saturating_add(1);
+        let node_q = format!(
+            "CALL db.schema.nodeTypeProperties() \
+             YIELD nodeLabels, propertyName, propertyTypes \
+             RETURN nodeLabels, propertyName, propertyTypes LIMIT {fetch}"
+        );
+        let rel_q = format!(
+            "CALL db.schema.relTypeProperties() \
+             YIELD relType, propertyName, propertyTypes \
+             RETURN relType, propertyName, propertyTypes LIMIT {fetch}"
+        );
+        let run = async {
+            let mut out: Vec<SchemaRow> = Vec::new();
+            for (query, kind) in [(node_q, "vertex"), (rel_q, "edge")] {
+                let mut stream = self
+                    .graph
+                    .execute_read(Self::build_query(&query, &Value::Null, bounds))
+                    .await
+                    .map_err(|e| map_driver_error(&self.source_name, &e))?;
+                while let Some(row) = stream
+                    .next()
+                    .await
+                    .map_err(|e| map_driver_error(&self.source_name, &e))?
+                {
+                    let labels: Vec<String> = match kind {
+                        "vertex" => row
+                            .get::<Vec<String>>("nodeLabels")
+                            .map_err(|e| schema_shape_error(&self.source_name, &e))?,
+                        // relType arrives as ":`KNOWS`" — strip to the name.
+                        _ => vec![strip_rel_type(
+                            &row.get::<String>("relType")
+                                .map_err(|e| schema_shape_error(&self.source_name, &e))?,
+                        )],
+                    };
+                    // A label with no properties yields one row with a
+                    // null propertyName — keep it: the label's existence
+                    // IS the information.
+                    let property: Option<String> = row.get("propertyName").unwrap_or(None);
+                    let property_type: Option<String> = row
+                        .get::<Option<Vec<String>>>("propertyTypes")
+                        .unwrap_or(None)
+                        .map(|types| types.join("|"));
+                    for label in labels {
+                        if out.len() > bounds.max_rows {
+                            return Err(GraphError::RowCapExceeded {
+                                max_rows: bounds.max_rows,
+                            });
+                        }
+                        out.push(SchemaRow {
+                            label,
+                            kind: kind.to_string(),
+                            property: property.clone(),
+                            property_type: property_type.clone(),
+                        });
+                    }
+                }
+            }
+            // The procedures publish no order; sort for a deterministic
+            // agent-facing roster (AGE orders by name in SQL).
+            out.sort_by(|a, b| {
+                (&a.kind, &a.label, &a.property).cmp(&(&b.kind, &b.label, &b.property))
+            });
+            if let Some(l) = limit {
+                out.truncate(l);
+            }
+            Ok(out)
+        };
+        self.bounded(bounds.timeout, run).await
+    }
+}
+
+fn read_env(source: &str, field: &str, env: &str) -> Result<String, GraphError> {
+    std::env::var(env).map_err(|_| GraphError::InvalidConfig {
+        name: source.to_string(),
+        reason: format!("{field} names environment variable '{env}', which is not set"),
+    })
+}
+
+/// Map a driver error to the taxonomy. Neo4j server errors carry their
+/// code verbatim and a bounded message via [`GraphError::backend`]
+/// (never `Display` of the whole error — messages can embed query text);
+/// the server-side transaction timeout becomes the typed
+/// [`GraphError::Timeout`].
+fn map_driver_error(source: &str, e: &neo4rs::Error) -> GraphError {
+    match e {
+        neo4rs::Error::Neo4j(err) => GraphError::backend(source, err.code(), err.message()),
+        // IO/protocol errors carry addresses, never credentials or query
+        // text — but bounded all the same.
+        other => GraphError::backend(source, "driver", &other.to_string()),
+    }
+}
+
+/// Like [`map_driver_error`] but with bounds in scope, so the server's
+/// transaction timeout maps to the typed [`GraphError::Timeout`] naming
+/// the configured seconds.
+fn map_query_error(source: &str, bounds: QueryBounds, e: &neo4rs::Error) -> GraphError {
+    // `contains`, not a suffix match: the live server answers a
+    // client-set tx_timeout with `Transaction.
+    // TransactionTimedOutClientConfiguration` (verified against Neo4j 5;
+    // the server-config variant is plain `TransactionTimedOut`).
+    if let neo4rs::Error::Neo4j(err) = e
+        && err.code().contains("TransactionTimedOut")
+    {
+        return GraphError::Timeout {
+            seconds: bounds.timeout.as_secs(),
+        };
+    }
+    map_driver_error(source, e)
+}
+
+/// `db.schema.relTypeProperties()` spells relationship types as
+/// ``:`KNOWS` `` — strip the decoration, keep the name.
+fn strip_rel_type(raw: &str) -> String {
+    raw.trim_start_matches(':').trim_matches('`').to_string()
+}
+
+/// A schema-procedure row that does not match the documented YIELD shape
+/// — a server-version drift, surfaced with the field identity only.
+fn schema_shape_error(source: &str, e: &neo4rs::DeError) -> GraphError {
+    GraphError::backend(source, "schema-introspection", &e.to_string())
+}
+
+/// Decode one Bolt record against the declared columns, BY NAME.
+fn decode_declared(
+    row: &neo4rs::Row,
+    columns: &[DeclaredColumn],
+    row_idx: usize,
+) -> Result<GraphRow, GraphError> {
+    let mut values = Vec::with_capacity(columns.len());
+    for (col_idx, col) in columns.iter().enumerate() {
+        let bolt: BoltType = row.get(&col.name).map_err(|_| GraphError::MalformedCell {
+            row: row_idx,
+            column: col_idx,
+            reason: format!(
+                "the query returned no field named '{}' — on neo4j, declared \
+                 columns bind to RETURN entries BY NAME; alias the entry \
+                 (… AS {}) or fix the declaration",
+                col.name, col.name
+            ),
+        })?;
+        values.push(bolt_to_json(&bolt));
+    }
+    Ok(values)
+}
+
+/// Decode one Bolt record as the whole-record JSON object (the fallback
+/// mode). Keys are sorted — the driver's row is a hash map, so RETURN
+/// order is not recoverable; sorted beats nondeterministic.
+fn decode_record(row: &neo4rs::Row, row_idx: usize) -> Result<Value, GraphError> {
+    let mut keys: Vec<String> = row.keys().iter().map(|k| k.value.clone()).collect();
+    keys.sort_unstable();
+    let mut record = serde_json::Map::with_capacity(keys.len());
+    for (col_idx, key) in keys.iter().enumerate() {
+        let bolt: BoltType = row.get(key).map_err(|e| GraphError::MalformedCell {
+            row: row_idx,
+            column: col_idx,
+            reason: format!("record field failed to decode: {e}"),
+        })?;
+        record.insert(key.clone(), bolt_to_json(&bolt));
+    }
+    Ok(Value::Object(record))
+}
+
+/// One JSON parameter value → the driver's Bolt value. Recursion mirrors
+/// JSON's own shape; numbers prefer i64 and fall back to f64 (JSON's own
+/// widening).
+fn json_to_bolt(v: &Value) -> BoltType {
+    match v {
+        Value::Null => BoltType::Null(neo4rs::BoltNull),
+        Value::Bool(b) => BoltType::Boolean(neo4rs::BoltBoolean::new(*b)),
+        Value::Number(n) => match n.as_i64() {
+            Some(i) => BoltType::Integer(neo4rs::BoltInteger::new(i)),
+            None => BoltType::Float(neo4rs::BoltFloat::new(n.as_f64().unwrap_or(f64::NAN))),
+        },
+        Value::String(s) => BoltType::String(neo4rs::BoltString::new(s)),
+        Value::Array(items) => items.iter().map(json_to_bolt).collect(),
+        Value::Object(map) => {
+            let mut bolt = neo4rs::BoltMap::with_capacity(map.len());
+            for (k, val) in map {
+                bolt.put(neo4rs::BoltString::new(k), json_to_bolt(val));
+            }
+            BoltType::Map(bolt)
+        }
+    }
+}
+
+/// One Bolt value → the canonical JSON shape `value.rs` converts
+/// (module doc: nodes/relationships/paths in the shared contract;
+/// temporals as ISO-8601 text; non-finite floats as null).
+fn bolt_to_json(v: &BoltType) -> Value {
+    match v {
+        BoltType::Null(_) => Value::Null,
+        BoltType::Boolean(b) => Value::Bool(b.value),
+        BoltType::Integer(i) => Value::from(i.value),
+        // serde_json has no spelling for NaN/Infinity — null, the same
+        // decision the agtype decoder made for AGE's bare tokens.
+        BoltType::Float(f) => serde_json::Number::from_f64(f.value)
+            .map(Value::Number)
+            .unwrap_or(Value::Null),
+        BoltType::String(s) => Value::from(s.value.clone()),
+        BoltType::List(items) => Value::Array(items.iter().map(bolt_to_json).collect()),
+        BoltType::Map(map) => {
+            let mut out = serde_json::Map::with_capacity(map.value.len());
+            for (k, val) in &map.value {
+                out.insert(k.value.clone(), bolt_to_json(val));
+            }
+            Value::Object(out)
+        }
+        BoltType::Node(n) => node_json(n),
+        BoltType::Relation(r) => serde_json::json!({
+            "id": r.id.value.to_string(),
+            "start_id": r.start_node_id.value.to_string(),
+            "end_id": r.end_node_id.value.to_string(),
+            "label": r.typ.value,
+            "properties": bolt_map_json(&r.properties),
+        }),
+        // Outside a path a relationship always arrives bounded; an
+        // unbounded one at the top level would be driver drift. Decoded
+        // with empty endpoints rather than failing the scan — the shape
+        // check in value.rs will name it if a declared column meets it.
+        BoltType::UnboundedRelation(r) => serde_json::json!({
+            "id": r.id.value.to_string(),
+            "label": r.typ.value,
+            "properties": bolt_map_json(&r.properties),
+        }),
+        BoltType::Path(p) => path_json(p),
+        BoltType::Date(d) => match NaiveDate::try_from(d) {
+            Ok(date) => Value::from(date.format("%Y-%m-%d").to_string()),
+            Err(_) => Value::Null,
+        },
+        BoltType::Time(t) => {
+            let (time, offset): (NaiveTime, FixedOffset) = t.into();
+            Value::from(format!("{}{}", time.format("%H:%M:%S%.f"), offset))
+        }
+        BoltType::LocalTime(t) => {
+            let time: NaiveTime = t.into();
+            Value::from(time.format("%H:%M:%S%.f").to_string())
+        }
+        BoltType::DateTime(dt) => match DateTime::<FixedOffset>::try_from(dt) {
+            Ok(dt) => Value::from(dt.to_rfc3339()),
+            Err(_) => Value::Null,
+        },
+        BoltType::LocalDateTime(dt) => match NaiveDateTime::try_from(dt) {
+            Ok(dt) => Value::from(dt.format("%Y-%m-%dT%H:%M:%S%.f").to_string()),
+            Err(_) => Value::Null,
+        },
+        BoltType::DateTimeZoneId(dt) => match NaiveDateTime::try_from(dt) {
+            // The IANA zone id survives as a suffix (the chrono-tz
+            // resolution is deliberately not a dependency here).
+            Ok(naive) => Value::from(format!(
+                "{}[{}]",
+                naive.format("%Y-%m-%dT%H:%M:%S%.f"),
+                dt.tz_id()
+            )),
+            Err(_) => Value::Null,
+        },
+        BoltType::Duration(d) => {
+            // ISO-8601 duration via the driver's std conversion (which
+            // flattens the months/days components — its documented
+            // approximation; sub-second precision survives).
+            let std: std::time::Duration = d.clone().into();
+            Value::from(format!("PT{}.{:09}S", std.as_secs(), std.subsec_nanos()))
+        }
+        BoltType::Point2D(p) => serde_json::json!({
+            "srid": p.sr_id.value, "x": p.x.value, "y": p.y.value,
+        }),
+        BoltType::Point3D(p) => serde_json::json!({
+            "srid": p.sr_id.value, "x": p.x.value, "y": p.y.value, "z": p.z.value,
+        }),
+        BoltType::Bytes(b) => Value::from(b.value.iter().fold(String::new(), |mut acc, byte| {
+            use std::fmt::Write;
+            let _ = write!(acc, "{byte:02x}");
+            acc
+        })),
+    }
+}
+
+/// A Bolt node → the canonical vertex object. `labels` is an ARRAY (the
+/// multi-label spelling `value.rs` accepts alongside AGE's single
+/// `label`).
+fn node_json(n: &neo4rs::BoltNode) -> Value {
+    let labels: Vec<Value> = n
+        .labels
+        .iter()
+        .map(|l| match l {
+            BoltType::String(s) => Value::from(s.value.clone()),
+            other => bolt_to_json(other),
+        })
+        .collect();
+    serde_json::json!({
+        "id": n.id.value.to_string(),
+        "labels": labels,
+        "properties": bolt_map_json(&n.properties),
+    })
+}
+
+fn bolt_map_json(map: &neo4rs::BoltMap) -> Value {
+    let mut out = serde_json::Map::with_capacity(map.value.len());
+    for (k, v) in &map.value {
+        out.insert(k.value.clone(), bolt_to_json(v));
+    }
+    Value::Object(out)
+}
+
+/// A Bolt path → the canonical flat alternation `[node, rel, node, …]`,
+/// in TRAVERSAL order with directions resolved.
+///
+/// Bolt encodes a path as (nodes, unbound rels, indices): the start node
+/// is `nodes[0]`, and each hop is an index pair — a 1-based, SIGNED
+/// relationship index (sign = direction) followed by a 0-based node
+/// index. The canonical shape wants bounded relationships (`start_id` /
+/// `end_id`), so each hop resolves its endpoints from the nodes it
+/// connects; a malformed index is decoded as null (which `value.rs`
+/// rejects with the path's identity) rather than panicking on driver
+/// drift.
+fn path_json(p: &neo4rs::BoltPath) -> Value {
+    let nodes = p.nodes();
+    let rels = p.rels();
+    let indices = p.indices();
+    let Some(start) = nodes.first() else {
+        return Value::Null; // no start node: not a path
+    };
+    let mut elements: Vec<Value> = Vec::with_capacity(indices.len() + 1);
+    elements.push(node_json(start));
+    let mut current = start;
+    for hop in indices.chunks(2) {
+        let [rel_idx, node_idx] = hop else {
+            return Value::Null; // odd index list: not a path
+        };
+        let rel_pos = rel_idx.value.unsigned_abs() as usize;
+        let (Some(rel), Ok(node_pos)) = (
+            rel_pos.checked_sub(1).and_then(|i| rels.get(i)),
+            usize::try_from(node_idx.value),
+        ) else {
+            return Value::Null;
+        };
+        let Some(next) = nodes.get(node_pos) else {
+            return Value::Null;
+        };
+        // Positive index: traversed with the relationship (current →
+        // next); negative: against it.
+        let (start_id, end_id) = if rel_idx.value >= 0 {
+            (current.id.value, next.id.value)
+        } else {
+            (next.id.value, current.id.value)
+        };
+        elements.push(serde_json::json!({
+            "id": rel.id.value.to_string(),
+            "start_id": start_id.to_string(),
+            "end_id": end_id.to_string(),
+            "label": rel.typ.value,
+            "properties": bolt_map_json(&rel.properties),
+        }));
+        elements.push(node_json(next));
+        current = next;
+    }
+    Value::Array(elements)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use neo4rs::{BoltBoolean, BoltInteger, BoltList, BoltMap, BoltNode, BoltPath, BoltString};
+
+    fn bolt_node(id: i64, labels: &[&str], props: &[(&str, &str)]) -> BoltNode {
+        let mut label_list = BoltList::new();
+        for l in labels {
+            label_list.push(BoltType::String(BoltString::new(l)));
+        }
+        let mut properties = BoltMap::new();
+        for (k, v) in props {
+            properties.put(BoltString::new(k), BoltType::String(BoltString::new(v)));
+        }
+        BoltNode::new(BoltInteger::new(id), label_list, properties)
+    }
+
+    fn bolt_rel(id: i64, typ: &str) -> neo4rs::BoltUnboundedRelation {
+        neo4rs::BoltUnboundedRelation::new(
+            BoltInteger::new(id),
+            BoltString::new(typ),
+            BoltMap::new(),
+        )
+    }
+
+    #[test]
+    fn scalars_decode_to_their_json_kinds_and_specials_go_null() {
+        assert_eq!(bolt_to_json(&BoltType::Null(neo4rs::BoltNull)), Value::Null);
+        assert_eq!(
+            bolt_to_json(&BoltType::Boolean(BoltBoolean::new(true))),
+            Value::Bool(true)
+        );
+        assert_eq!(
+            bolt_to_json(&BoltType::Integer(BoltInteger::new(-7))),
+            serde_json::json!(-7)
+        );
+        assert_eq!(
+            bolt_to_json(&BoltType::String(BoltString::new("颱風 café ☔"))),
+            serde_json::json!("颱風 café ☔")
+        );
+        // The agtype decoder's float-specials decision, honored here too.
+        for special in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert_eq!(
+                bolt_to_json(&BoltType::Float(neo4rs::BoltFloat::new(special))),
+                Value::Null
+            );
+        }
+    }
+
+    #[test]
+    fn nodes_carry_all_labels_and_stringified_ids() {
+        let v = bolt_to_json(&BoltType::Node(bolt_node(
+            42,
+            &["Person", "Admin"],
+            &[("name", "ada")],
+        )));
+        assert_eq!(v["id"], "42");
+        assert_eq!(v["labels"], serde_json::json!(["Person", "Admin"]));
+        assert_eq!(v["properties"]["name"], "ada");
+    }
+
+    #[test]
+    fn paths_reconstruct_traversal_order_and_direction() {
+        // (a)-[:KNOWS]->(b)<-[:KNOWS]-(c), traversed a → b → c: hop 2
+        // goes AGAINST its relationship, so its index is negative and
+        // its endpoints must come out (c, b).
+        let a = bolt_node(1, &["P"], &[]);
+        let b = bolt_node(2, &["P"], &[]);
+        let c = bolt_node(3, &["P"], &[]);
+        let mut nodes = BoltList::new();
+        for n in [&a, &b, &c] {
+            nodes.push(BoltType::Node(n.clone()));
+        }
+        let mut rels = BoltList::new();
+        rels.push(BoltType::UnboundedRelation(bolt_rel(10, "KNOWS")));
+        rels.push(BoltType::UnboundedRelation(bolt_rel(11, "KNOWS")));
+        let mut indices = BoltList::new();
+        for i in [1i64, 1, -2, 2] {
+            indices.push(BoltType::Integer(BoltInteger::new(i)));
+        }
+        let path = BoltPath {
+            nodes,
+            rels,
+            indices,
+        };
+        let v = bolt_to_json(&BoltType::Path(path));
+        let elements = v.as_array().expect("alternation array");
+        assert_eq!(elements.len(), 5, "3 nodes + 2 rels");
+        assert_eq!(elements[0]["id"], "1");
+        assert_eq!(elements[1]["start_id"], "1");
+        assert_eq!(elements[1]["end_id"], "2");
+        assert_eq!(elements[2]["id"], "2");
+        // The reversed hop: traversal b → c, relationship c → b.
+        assert_eq!(elements[3]["start_id"], "3");
+        assert_eq!(elements[3]["end_id"], "2");
+        assert_eq!(elements[4]["id"], "3");
+    }
+
+    #[test]
+    fn zero_hop_paths_are_one_node() {
+        let mut nodes = BoltList::new();
+        nodes.push(BoltType::Node(bolt_node(1, &["P"], &[])));
+        let path = BoltPath {
+            nodes,
+            rels: BoltList::new(),
+            indices: BoltList::new(),
+        };
+        let v = bolt_to_json(&BoltType::Path(path));
+        assert_eq!(v.as_array().map(Vec::len), Some(1));
+    }
+
+    #[test]
+    fn malformed_path_indices_decode_null_never_panic() {
+        // rel index 1 with no rels — driver drift, not a panic.
+        let mut nodes = BoltList::new();
+        nodes.push(BoltType::Node(bolt_node(1, &["P"], &[])));
+        nodes.push(BoltType::Node(bolt_node(2, &["P"], &[])));
+        let mut indices = BoltList::new();
+        for i in [1i64, 1] {
+            indices.push(BoltType::Integer(BoltInteger::new(i)));
+        }
+        let path = BoltPath {
+            nodes,
+            rels: BoltList::new(),
+            indices,
+        };
+        assert_eq!(bolt_to_json(&BoltType::Path(path)), Value::Null);
+    }
+
+    #[test]
+    fn temporals_render_iso_text() {
+        let date = NaiveDate::from_ymd_opt(2026, 8, 13).unwrap();
+        assert_eq!(
+            bolt_to_json(&BoltType::Date(date.into())),
+            serde_json::json!("2026-08-13")
+        );
+        let dt = DateTime::parse_from_rfc3339("2026-08-13T09:30:00+08:00").unwrap();
+        assert_eq!(
+            bolt_to_json(&BoltType::DateTime(dt.into())),
+            serde_json::json!("2026-08-13T09:30:00+08:00")
+        );
+        let std_dur = std::time::Duration::new(90, 500_000_000);
+        assert_eq!(
+            bolt_to_json(&BoltType::Duration(std_dur.into())),
+            serde_json::json!("PT90.500000000S")
+        );
+    }
+
+    #[test]
+    fn params_convert_shape_faithfully() {
+        let params = serde_json::json!({
+            "s": "it's", "i": 3, "f": 2.5, "b": true, "nul": null,
+            "list": [1, 2], "map": {"k": "v"},
+        });
+        let map = params.as_object().unwrap();
+        assert!(matches!(json_to_bolt(&map["s"]), BoltType::String(_)));
+        assert!(matches!(json_to_bolt(&map["i"]), BoltType::Integer(_)));
+        assert!(matches!(json_to_bolt(&map["f"]), BoltType::Float(_)));
+        assert!(matches!(json_to_bolt(&map["b"]), BoltType::Boolean(_)));
+        assert!(matches!(json_to_bolt(&map["nul"]), BoltType::Null(_)));
+        let BoltType::List(l) = json_to_bolt(&map["list"]) else {
+            panic!("list");
+        };
+        assert_eq!(l.len(), 2);
+        let BoltType::Map(m) = json_to_bolt(&map["map"]) else {
+            panic!("map");
+        };
+        assert_eq!(m.len(), 1);
+    }
+
+    #[test]
+    fn rel_type_decoration_strips() {
+        assert_eq!(strip_rel_type(":`KNOWS`"), "KNOWS");
+        assert_eq!(strip_rel_type("KNOWS"), "KNOWS");
+    }
+}

--- a/crates/skardi/src/sources/providers/graph/udtf.rs
+++ b/crates/skardi/src/sources/providers/graph/udtf.rs
@@ -505,7 +505,11 @@ fn labels_batch(
     handle: Arc<GraphSourceHandle>,
 ) -> futures::stream::BoxStream<'static, DFResult<RecordBatch>> {
     stream::once(async move {
-        let labels = handle.client.labels().await.map_err(execution_error)?;
+        let labels = handle
+            .client
+            .labels(handle.bounds)
+            .await
+            .map_err(execution_error)?;
         let mut names = arrow::array::StringBuilder::new();
         let mut kinds = arrow::array::StringBuilder::new();
         for (name, kind) in &labels {
@@ -549,7 +553,7 @@ mod tests {
             Ok(stream::iter(self.rows.clone().into_iter().map(Ok)).boxed())
         }
 
-        async fn labels(&self) -> Result<Vec<(String, String)>, GraphError> {
+        async fn labels(&self, _bounds: QueryBounds) -> Result<Vec<(String, String)>, GraphError> {
             Ok(self.labels.clone())
         }
     }

--- a/crates/skardi/src/sources/providers/graph/udtf.rs
+++ b/crates/skardi/src/sources/providers/graph/udtf.rs
@@ -1,0 +1,732 @@
+//! The graph SQL surface: `cypher_query` and `graph_schema` (design
+//! §SQL surface, §cypher_query UDTF signature).
+//!
+//! Both are registered ONCE as global UDTFs and resolve the connection
+//! by name at call time — the `open_connector_query` shape, not one
+//! function per source. Planning performs no network I/O: the schema
+//! comes from the caller-declared `columns` (parsed and validated at
+//! plan time), the keyword guard runs at plan time, and the backend is
+//! first touched when the plan executes.
+//!
+//! Call-shape constraints (stated because agents generate these calls):
+//! arguments are positional, so declaring `columns` requires passing
+//! `params` — `'{}'` is the no-parameters spelling, and NULL is rejected
+//! (schema-shaping arguments are strict string literals). Milestone 1 is
+//! AGE-only, and AGE's `cypher()` call must declare its result arity —
+//! so `columns` is REQUIRED here: omitting it is a targeted error, and
+//! the JSON-`record` fallback ships with the Neo4j milestone, where Bolt
+//! needs no declared arity.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::{Arc, RwLock};
+
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow::record_batch::RecordBatch;
+use async_trait::async_trait;
+use datafusion::catalog::{Session, TableFunctionImpl, TableProvider};
+use datafusion::common::plan_err;
+use datafusion::datasource::TableType;
+use datafusion::error::{DataFusionError, Result as DFResult};
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::logical_expr::Expr;
+use datafusion::physical_expr::EquivalenceProperties;
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
+};
+use datafusion::prelude::SessionContext;
+use futures::StreamExt;
+use futures::stream::{self, TryStreamExt};
+use serde_json::Value;
+
+use super::client::{GraphClient, QueryBounds, validate_params};
+use super::error::{GraphError, json_kind};
+use super::guard::reject_mutations;
+use super::value::{ACCEPTED_TYPES, DeclaredColumn, GraphType, build_batch, declared_schema};
+use crate::sources::providers::udtf_args::strict_string_arg;
+
+/// Conversion batch size (design §Schema handling): the atomic unit —
+/// each batch converts as a whole before it is emitted, so a mid-scan
+/// type mismatch never emits a partially converted batch, and peak
+/// conversion memory is one batch, not one result.
+const CONVERSION_BATCH_ROWS: usize = 1024;
+
+/// One registered `type: graph` source, resolvable by connection name.
+#[derive(Debug)]
+pub struct GraphSourceHandle {
+    pub client: Arc<dyn GraphClient>,
+    pub bounds: QueryBounds,
+}
+
+/// Shared map of connection name → handle, owned by the front-end the
+/// way `OpenConnectorGateways` is.
+pub type GraphSources = Arc<RwLock<HashMap<String, Arc<GraphSourceHandle>>>>;
+
+/// Register `cypher_query`, `graph_schema`, and the JSON getter family
+/// (`datafusion-functions-json`: `json_get`, `json_get_str`, …) on a
+/// session. The getters are what make node/relationship `properties`
+/// columns queryable without leaving SQL.
+pub fn register_graph_udtfs(ctx: &SessionContext, sources: GraphSources) -> DFResult<()> {
+    datafusion_functions_json::register_all(&mut ctx.clone())?;
+    ctx.register_udtf(
+        "cypher_query",
+        Arc::new(CypherQueryFunction {
+            sources: Arc::clone(&sources),
+        }),
+    );
+    ctx.register_udtf("graph_schema", Arc::new(GraphSchemaFunction { sources }));
+    Ok(())
+}
+
+fn lookup(sources: &GraphSources, name: &str) -> DFResult<Arc<GraphSourceHandle>> {
+    let map = sources
+        .read()
+        .map_err(|_| DataFusionError::Internal("graph sources lock poisoned".into()))?;
+    map.get(name).cloned().ok_or_else(|| {
+        let mut known: Vec<&str> = map.keys().map(String::as_str).collect();
+        known.sort_unstable();
+        plan_error(GraphError::ConnectionNotFound {
+            name: name.to_string(),
+            known: if known.is_empty() {
+                "none".to_string()
+            } else {
+                known.join(", ")
+            },
+        })
+    })
+}
+
+fn plan_error(e: GraphError) -> DataFusionError {
+    DataFusionError::Plan(e.to_string())
+}
+
+/// `cypher_query('connection', 'cypher'[, 'params_json'[, 'columns_json']])`.
+#[derive(Debug)]
+pub struct CypherQueryFunction {
+    sources: GraphSources,
+}
+
+impl TableFunctionImpl for CypherQueryFunction {
+    fn call(&self, exprs: &[Expr]) -> DFResult<Arc<dyn TableProvider>> {
+        if exprs.len() < 2 || exprs.len() > 4 {
+            return plan_err!(
+                "cypher_query(connection, cypher, [params_json], [columns_json]) \
+                 expects 2-4 arguments, got {}",
+                exprs.len()
+            );
+        }
+        let connection = strict_string_arg(&exprs[0], "cypher_query", "connection")?;
+        let cypher = strict_string_arg(&exprs[1], "cypher_query", "cypher")?;
+        let params_json = exprs
+            .get(2)
+            .map(|e| strict_string_arg(e, "cypher_query", "params_json"))
+            .transpose()?;
+        let columns_json = exprs
+            .get(3)
+            .map(|e| strict_string_arg(e, "cypher_query", "columns_json"))
+            .transpose()?;
+
+        // The guard runs at PLAN time — an agent's mutating Cypher fails
+        // before any network round-trip, keyword named.
+        reject_mutations(&cypher).map_err(plan_error)?;
+
+        let params: Value = match params_json.as_deref() {
+            None | Some("") => Value::Object(serde_json::Map::new()),
+            Some(text) => {
+                let parsed: Value = serde_json::from_str(text).map_err(|e| {
+                    plan_error(GraphError::InvalidParams {
+                        found: format!("unparseable JSON ({e})"),
+                    })
+                })?;
+                validate_params(&parsed).map_err(plan_error)?;
+                parsed
+            }
+        };
+
+        // Milestone 1 is AGE-only: `columns` is required (AGE's cypher()
+        // must declare its arity; the JSON-record fallback ships with the
+        // Neo4j milestone).
+        let Some(columns_json) = columns_json else {
+            return plan_err!(
+                "cypher_query: 'columns' is required on the age backend — declare the \
+                 output columns as the 4th argument, e.g. \
+                 '{{\"name\": \"string\", \"n\": \"node\"}}' (accepted types: {})",
+                ACCEPTED_TYPES
+            );
+        };
+        let columns = parse_columns(&columns_json).map_err(plan_error)?;
+
+        let handle = lookup(&self.sources, &connection)?;
+        Ok(Arc::new(CypherQueryProvider {
+            handle,
+            cypher,
+            params,
+            columns: Arc::new(columns),
+        }))
+    }
+}
+
+/// Parse the declared-columns JSON object. Declaration order is object
+/// order (this crate's serde_json enables `preserve_order`); every
+/// column is nullable (Cypher can produce null in any position — there
+/// is no way to declare otherwise, by design).
+fn parse_columns(text: &str) -> Result<Vec<DeclaredColumn>, GraphError> {
+    let parsed: Value = serde_json::from_str(text).map_err(|e| GraphError::InvalidColumns {
+        reason: format!("unparseable JSON ({e})"),
+        accepted: ACCEPTED_TYPES,
+    })?;
+    let Value::Object(map) = parsed else {
+        return Err(GraphError::InvalidColumns {
+            reason: format!("expected a JSON object, got {}", json_kind(&parsed)),
+            accepted: ACCEPTED_TYPES,
+        });
+    };
+    if map.is_empty() {
+        return Err(GraphError::InvalidColumns {
+            reason: "at least one column must be declared".to_string(),
+            accepted: ACCEPTED_TYPES,
+        });
+    }
+    map.into_iter()
+        .map(|(name, ty)| {
+            let Value::String(ty_name) = &ty else {
+                return Err(GraphError::InvalidColumns {
+                    reason: format!(
+                        "column '{name}': type must be a string, got {}",
+                        json_kind(&ty)
+                    ),
+                    accepted: ACCEPTED_TYPES,
+                });
+            };
+            let ty = GraphType::parse(ty_name).ok_or_else(|| GraphError::InvalidColumns {
+                reason: format!("column '{name}': unknown type '{ty_name}'"),
+                accepted: ACCEPTED_TYPES,
+            })?;
+            Ok(DeclaredColumn { name, ty })
+        })
+        .collect()
+}
+
+/// The provider behind one `cypher_query` call: planning-time-stable
+/// declared schema, backend touched only at execute.
+#[derive(Debug)]
+struct CypherQueryProvider {
+    handle: Arc<GraphSourceHandle>,
+    cypher: String,
+    params: Value,
+    columns: Arc<Vec<DeclaredColumn>>,
+}
+
+#[async_trait]
+impl TableProvider for CypherQueryProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        declared_schema(&self.columns)
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(GraphScanExec::new(
+            GraphScanKind::Cypher {
+                handle: Arc::clone(&self.handle),
+                cypher: self.cypher.clone(),
+                params: self.params.clone(),
+                columns: Arc::clone(&self.columns),
+            },
+            self.schema(),
+            projection.cloned(),
+        )?))
+    }
+}
+
+/// `graph_schema('connection')` — the agent-discovery surface: one row
+/// per label, `(label, kind)`, straight off the backend catalog. Names
+/// only, never property values.
+#[derive(Debug)]
+pub struct GraphSchemaFunction {
+    sources: GraphSources,
+}
+
+impl TableFunctionImpl for GraphSchemaFunction {
+    fn call(&self, exprs: &[Expr]) -> DFResult<Arc<dyn TableProvider>> {
+        if exprs.len() != 1 {
+            return plan_err!(
+                "graph_schema(connection) expects exactly 1 argument, got {}",
+                exprs.len()
+            );
+        }
+        let connection = strict_string_arg(&exprs[0], "graph_schema", "connection")?;
+        let handle = lookup(&self.sources, &connection)?;
+        Ok(Arc::new(GraphSchemaProvider { handle }))
+    }
+}
+
+fn graph_schema_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("label", DataType::Utf8, false),
+        Field::new("kind", DataType::Utf8, false),
+    ]))
+}
+
+#[derive(Debug)]
+struct GraphSchemaProvider {
+    handle: Arc<GraphSourceHandle>,
+}
+
+#[async_trait]
+impl TableProvider for GraphSchemaProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        graph_schema_schema()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(GraphScanExec::new(
+            GraphScanKind::Labels {
+                handle: Arc::clone(&self.handle),
+            },
+            self.schema(),
+            projection.cloned(),
+        )?))
+    }
+}
+
+/// What one graph scan executes.
+enum GraphScanKind {
+    Cypher {
+        handle: Arc<GraphSourceHandle>,
+        cypher: String,
+        params: Value,
+        columns: Arc<Vec<DeclaredColumn>>,
+    },
+    Labels {
+        handle: Arc<GraphSourceHandle>,
+    },
+}
+
+impl fmt::Debug for GraphScanKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // The Cypher text and params are caller data — identity only.
+        match self {
+            Self::Cypher { columns, .. } => f
+                .debug_struct("Cypher")
+                .field("columns", &columns.len())
+                .finish_non_exhaustive(),
+            Self::Labels { .. } => f.debug_struct("Labels").finish_non_exhaustive(),
+        }
+    }
+}
+
+/// Leaf plan: one partition, executes the graph call on first poll.
+#[derive(Debug)]
+struct GraphScanExec {
+    kind: GraphScanKind,
+    projection: Option<Vec<usize>>,
+    properties: PlanProperties,
+}
+
+impl GraphScanExec {
+    fn new(
+        kind: GraphScanKind,
+        schema: SchemaRef,
+        projection: Option<Vec<usize>>,
+    ) -> DFResult<Self> {
+        let projected = match &projection {
+            Some(indices) => Arc::new(schema.project(indices)?),
+            None => Arc::clone(&schema),
+        };
+        let properties = PlanProperties::new(
+            EquivalenceProperties::new(Arc::clone(&projected)),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        );
+        // `schema` itself is not stored: the projected schema lives in
+        // the plan properties, and the full schema is the provider's.
+        Ok(Self {
+            kind,
+            projection,
+            properties,
+        })
+    }
+
+    fn projected_schema(&self) -> SchemaRef {
+        Arc::clone(self.properties.eq_properties.schema())
+    }
+}
+
+impl DisplayAs for GraphScanExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        match &self.kind {
+            GraphScanKind::Cypher { columns, .. } => {
+                write!(f, "GraphScanExec: cypher_query columns={}", columns.len())
+            }
+            GraphScanKind::Labels { .. } => write!(f, "GraphScanExec: graph_schema"),
+        }
+    }
+}
+
+impl ExecutionPlan for GraphScanExec {
+    fn name(&self) -> &str {
+        "GraphScanExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        if children.is_empty() {
+            Ok(self)
+        } else {
+            Err(DataFusionError::Internal(
+                "GraphScanExec is a leaf plan and takes no children".to_string(),
+            ))
+        }
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> DFResult<SendableRecordBatchStream> {
+        if partition != 0 {
+            return Err(DataFusionError::Internal(format!(
+                "GraphScanExec has 1 partition, got partition {partition}"
+            )));
+        }
+        let projected = self.projected_schema();
+        let projection = self.projection.clone();
+        let batches = match &self.kind {
+            GraphScanKind::Cypher {
+                handle,
+                cypher,
+                params,
+                columns,
+            } => cypher_batches(
+                Arc::clone(handle),
+                cypher.clone(),
+                params.clone(),
+                Arc::clone(columns),
+            ),
+            GraphScanKind::Labels { handle } => labels_batch(Arc::clone(handle)),
+        };
+        let stream = batches
+            .map(move |batch| {
+                let batch = batch?;
+                match &projection {
+                    Some(indices) => batch
+                        .project(indices)
+                        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None)),
+                    None => Ok(batch),
+                }
+            })
+            .boxed();
+        Ok(Box::pin(RecordBatchStreamAdapter::new(projected, stream)))
+    }
+}
+
+/// The cypher scan: run on first poll, then convert in batch-atomic
+/// chunks (design §Schema handling — the conversion batch is the defined
+/// atomic unit; a type mismatch fails the CURRENT batch before emission).
+fn cypher_batches(
+    handle: Arc<GraphSourceHandle>,
+    cypher: String,
+    params: Value,
+    columns: Arc<Vec<DeclaredColumn>>,
+) -> futures::stream::BoxStream<'static, DFResult<RecordBatch>> {
+    stream::once(async move {
+        let rows = handle
+            .client
+            .execute(&cypher, &params, columns.len(), handle.bounds)
+            .await
+            .map_err(execution_error)?
+            .try_collect::<Vec<_>>()
+            .await
+            .map_err(execution_error)?;
+        let mut batches = Vec::with_capacity(rows.len() / CONVERSION_BATCH_ROWS + 1);
+        for (chunk_idx, chunk) in rows.chunks(CONVERSION_BATCH_ROWS).enumerate() {
+            batches.push(
+                build_batch(&columns, chunk, chunk_idx * CONVERSION_BATCH_ROWS)
+                    .map_err(execution_error)?,
+            );
+        }
+        if batches.is_empty() {
+            // An empty result is a complete result with the SAME schema.
+            batches.push(RecordBatch::new_empty(declared_schema(&columns)));
+        }
+        Ok::<_, DataFusionError>(batches)
+    })
+    .map_ok(|batches| stream::iter(batches.into_iter().map(Ok)))
+    .try_flatten()
+    .boxed()
+}
+
+fn labels_batch(
+    handle: Arc<GraphSourceHandle>,
+) -> futures::stream::BoxStream<'static, DFResult<RecordBatch>> {
+    stream::once(async move {
+        let labels = handle.client.labels().await.map_err(execution_error)?;
+        let mut names = arrow::array::StringBuilder::new();
+        let mut kinds = arrow::array::StringBuilder::new();
+        for (name, kind) in &labels {
+            names.append_value(name);
+            kinds.append_value(kind);
+        }
+        RecordBatch::try_new(
+            graph_schema_schema(),
+            vec![Arc::new(names.finish()), Arc::new(kinds.finish())],
+        )
+        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+    })
+    .boxed()
+}
+
+fn execution_error(e: GraphError) -> DataFusionError {
+    DataFusionError::Execution(e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream::BoxStream;
+
+    /// Canned-rows client: the UDTF/exec seam without a backend.
+    #[derive(Debug)]
+    struct MockClient {
+        rows: Vec<Vec<Value>>,
+        labels: Vec<(String, String)>,
+    }
+
+    #[async_trait]
+    impl GraphClient for MockClient {
+        async fn execute(
+            &self,
+            _cypher: &str,
+            _params: &Value,
+            _arity: usize,
+            _bounds: QueryBounds,
+        ) -> Result<BoxStream<'static, Result<Vec<Value>, GraphError>>, GraphError> {
+            Ok(stream::iter(self.rows.clone().into_iter().map(Ok)).boxed())
+        }
+
+        async fn labels(&self) -> Result<Vec<(String, String)>, GraphError> {
+            Ok(self.labels.clone())
+        }
+    }
+
+    fn sources_with(rows: Vec<Vec<Value>>) -> GraphSources {
+        let handle = Arc::new(GraphSourceHandle {
+            client: Arc::new(MockClient {
+                rows,
+                labels: vec![
+                    ("Person".to_string(), "vertex".to_string()),
+                    ("KNOWS".to_string(), "edge".to_string()),
+                ],
+            }),
+            bounds: QueryBounds {
+                timeout: std::time::Duration::from_secs(5),
+                max_rows: 100,
+            },
+        });
+        Arc::new(RwLock::new(HashMap::from([("kg".to_string(), handle)])))
+    }
+
+    async fn ctx_with(rows: Vec<Vec<Value>>) -> SessionContext {
+        let ctx = SessionContext::new();
+        register_graph_udtfs(&ctx, sources_with(rows)).expect("registration");
+        ctx
+    }
+
+    async fn collect(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch> {
+        ctx.sql(sql)
+            .await
+            .expect("plan")
+            .collect()
+            .await
+            .expect("collect")
+    }
+
+    #[tokio::test]
+    async fn declared_columns_scan_end_to_end() {
+        let ctx = ctx_with(vec![
+            vec![serde_json::json!("ada"), serde_json::json!(1)],
+            vec![serde_json::json!("bob"), Value::Null],
+        ])
+        .await;
+        let batches = collect(
+            &ctx,
+            "SELECT name, n FROM cypher_query('kg', \
+             'MATCH (p:Person) RETURN p.name, p.n', '{}', \
+             '{\"name\": \"string\", \"n\": \"int\"}') ORDER BY name",
+        )
+        .await;
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total, 2);
+    }
+
+    #[tokio::test]
+    async fn mutating_cypher_fails_at_plan_time_with_the_keyword() {
+        let ctx = ctx_with(vec![]).await;
+        let err = ctx
+            .sql(
+                "SELECT * FROM cypher_query('kg', 'CREATE (n) RETURN n', '{}', \
+                 '{\"n\": \"node\"}')",
+            )
+            .await
+            .expect_err("plans must fail");
+        let msg = err.to_string();
+        assert!(msg.contains("'CREATE'"), "{msg}");
+        assert!(msg.contains("read-only"), "{msg}");
+    }
+
+    #[tokio::test]
+    async fn omitted_columns_is_a_targeted_age_error() {
+        let ctx = ctx_with(vec![]).await;
+        let err = ctx
+            .sql("SELECT * FROM cypher_query('kg', 'MATCH (n) RETURN n', '{}')")
+            .await
+            .expect_err("columns required on age");
+        let msg = err.to_string();
+        assert!(msg.contains("'columns' is required"), "{msg}");
+        assert!(msg.contains("age backend"), "{msg}");
+    }
+
+    #[tokio::test]
+    async fn unknown_connection_lists_the_known_roster() {
+        let ctx = ctx_with(vec![]).await;
+        let err = ctx
+            .sql(
+                "SELECT * FROM cypher_query('nope', 'MATCH (n) RETURN n', '{}', \
+                 '{\"n\": \"node\"}')",
+            )
+            .await
+            .expect_err("unknown connection");
+        let msg = err.to_string();
+        assert!(msg.contains("'nope'"), "{msg}");
+        assert!(msg.contains("kg"), "the roster names what exists: {msg}");
+    }
+
+    #[tokio::test]
+    async fn unknown_type_names_the_accepted_set() {
+        let ctx = ctx_with(vec![]).await;
+        let err = ctx
+            .sql(
+                "SELECT * FROM cypher_query('kg', 'MATCH (n) RETURN n', '{}', \
+                 '{\"n\": \"Utf8\"}')",
+            )
+            .await
+            .expect_err("PascalCase is not the vocabulary");
+        let msg = err.to_string();
+        assert!(msg.contains("unknown type 'Utf8'"), "{msg}");
+        assert!(msg.contains("node, relationship, path"), "{msg}");
+    }
+
+    #[tokio::test]
+    async fn empty_results_keep_the_declared_schema() {
+        let ctx = ctx_with(vec![]).await;
+        let batches = collect(
+            &ctx,
+            "SELECT name FROM cypher_query('kg', 'MATCH (p) RETURN p.name', '{}', \
+             '{\"name\": \"string\"}')",
+        )
+        .await;
+        assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 0);
+        assert_eq!(batches[0].schema().field(0).name(), "name");
+    }
+
+    #[tokio::test]
+    async fn mid_scan_type_mismatch_is_typed_and_value_free() {
+        let ctx = ctx_with(vec![
+            vec![serde_json::json!(1)],
+            vec![serde_json::json!("secret")],
+        ])
+        .await;
+        let err = ctx
+            .sql(
+                "SELECT n FROM cypher_query('kg', 'MATCH (x) RETURN x.n', '{}', \
+                 '{\"n\": \"int\"}')",
+            )
+            .await
+            .expect("plans")
+            .collect()
+            .await
+            .expect_err("second row is a string");
+        let msg = err.to_string();
+        assert!(msg.contains("declared 'int'"), "{msg}");
+        assert!(!msg.contains("secret"), "values never leak: {msg}");
+    }
+
+    #[tokio::test]
+    async fn graph_schema_lists_labels_and_kinds() {
+        let ctx = ctx_with(vec![]).await;
+        let batches = collect(
+            &ctx,
+            "SELECT label, kind FROM graph_schema('kg') ORDER BY label",
+        )
+        .await;
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total, 2);
+    }
+
+    #[tokio::test]
+    async fn json_getters_are_registered_for_properties_extraction() {
+        // A node's `properties` column is JSON text; the registered
+        // json_get family is what makes it queryable without leaving SQL.
+        let node = serde_json::json!({
+            "id": 1, "label": "Person", "properties": {"name": "ada"}
+        });
+        let ctx = ctx_with(vec![vec![node]]).await;
+        let batches = collect(
+            &ctx,
+            "SELECT json_get_str(v.properties, 'name') AS name FROM \
+             cypher_query('kg', 'MATCH (v) RETURN v', '{}', '{\"v\": \"node\"}')",
+        )
+        .await;
+        let col = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .unwrap();
+        assert_eq!(col.value(0), "ada");
+    }
+}

--- a/crates/skardi/src/sources/providers/graph/udtf.rs
+++ b/crates/skardi/src/sources/providers/graph/udtf.rs
@@ -194,24 +194,18 @@ impl TableFunctionImpl for CypherQueryFunction {
         };
 
         // Whether `columns` may be omitted is the BACKEND's contract
-        // (resolved through the handle, still at plan time): AGE's
-        // cypher() must declare its arity, so omission there is a
-        // targeted error; on backends whose wire carries field names
-        // (Neo4j) the omission is the JSON-`record` fallback.
+        // (resolved through the handle, still at plan time): the
+        // requirement REASON comes from the backend itself, so this
+        // shared code never hardcodes one backend's binding rules.
         let handle = lookup(&self.sources, &connection)?;
         let columns = match columns_json {
             Some(text) => Some(Arc::new(parse_columns(&text).map_err(plan_error)?)),
-            None if handle.client.requires_declared_columns() => {
-                return plan_err!(
-                    "cypher_query: 'columns' is required on the age backend — declare the \
-                     output columns IN THE SAME ORDER AS YOUR RETURN CLAUSE (the binding \
-                     is positional; two same-typed columns declared out of order swap \
-                     silently), e.g. '{{\"name\": \"string\", \"n\": \"node\"}}' \
-                     (accepted types: {})",
-                    ACCEPTED_TYPES
-                );
-            }
-            None => None,
+            None => match handle.client.declared_columns_requirement() {
+                Some(reason) => {
+                    return plan_err!("cypher_query: {reason} (accepted types: {ACCEPTED_TYPES})");
+                }
+                None => None,
+            },
         };
         Ok(Arc::new(CypherQueryProvider {
             handle,
@@ -225,11 +219,17 @@ impl TableFunctionImpl for CypherQueryFunction {
 /// The JSON-`record` fallback's one-column schema: each row is the whole
 /// Cypher record as canonical JSON text (keys sorted — the Bolt driver
 /// hands records over as hash maps, so RETURN order is not recoverable).
-fn record_fallback_columns() -> Vec<DeclaredColumn> {
-    vec![DeclaredColumn {
-        name: "record".to_string(),
-        ty: GraphType::Json,
-    }]
+/// Static: it is consulted on every planning pass and every fallback
+/// scan and never changes.
+fn record_fallback_columns() -> Arc<Vec<DeclaredColumn>> {
+    static COLUMNS: std::sync::LazyLock<Arc<Vec<DeclaredColumn>>> =
+        std::sync::LazyLock::new(|| {
+            Arc::new(vec![DeclaredColumn {
+                name: "record".to_string(),
+                ty: GraphType::Json,
+            }])
+        });
+    Arc::clone(&COLUMNS)
 }
 
 /// Parse the declared-columns JSON object. Declaration order is object
@@ -597,7 +597,7 @@ fn cypher_batches(
             .map_err(execution_error)?;
         // Conversion always runs against concrete columns: the declared
         // ones, or the fallback's single `record: json`.
-        let columns = columns.unwrap_or_else(|| Arc::new(record_fallback_columns()));
+        let columns = columns.unwrap_or_else(record_fallback_columns);
         let mut batches = Vec::with_capacity(rows.len() / CONVERSION_BATCH_ROWS + 1);
         for (chunk_idx, chunk) in rows.chunks(CONVERSION_BATCH_ROWS).enumerate() {
             batches.push(
@@ -691,8 +691,11 @@ mod tests {
             Ok(stream::iter(rows.into_iter().map(Ok)).boxed())
         }
 
-        fn requires_declared_columns(&self) -> bool {
-            self.declared_required
+        fn declared_columns_requirement(&self) -> Option<&'static str> {
+            self.declared_required.then_some(
+                "'columns' is required on the age backend — declare the output \
+                 columns IN THE SAME ORDER AS YOUR RETURN CLAUSE",
+            )
         }
 
         async fn schema(

--- a/crates/skardi/src/sources/providers/graph/udtf.rs
+++ b/crates/skardi/src/sources/providers/graph/udtf.rs
@@ -57,6 +57,16 @@ use super::guard::reject_mutations;
 use super::value::{ACCEPTED_TYPES, DeclaredColumn, GraphType, build_batch, declared_schema};
 use crate::sources::providers::udtf_args::strict_string_arg;
 
+/// Projection prunes AFTER conversion, deliberately: the declared
+/// schema is the CALLER'S CONTRACT, so a violated declaration fails
+/// loudly whether or not this query selected the column — otherwise the
+/// error surfaces only when someone finally selects it, far from the
+/// query that established the bad declaration. A reader making
+/// projection pushdown actually prune work would change observable
+/// behaviour;
+/// `an_unprojected_declared_column_still_fails_its_type_contract` pins
+/// it.
+///
 /// Conversion batch size (design §Schema handling): the atomic unit —
 /// each batch converts as a whole before it is emitted, so a mid-scan
 /// type mismatch never emits a partially converted batch.

--- a/crates/skardi/src/sources/providers/graph/udtf.rs
+++ b/crates/skardi/src/sources/providers/graph/udtf.rs
@@ -69,6 +69,20 @@ pub type GraphSources = Arc<RwLock<HashMap<String, Arc<GraphSourceHandle>>>>;
 /// (`datafusion-functions-json`: `json_get`, `json_get_str`, …) on a
 /// session. The getters are what make node/relationship `properties`
 /// columns queryable without leaving SQL.
+///
+/// # Example
+/// ```
+/// use std::collections::HashMap;
+/// use std::sync::{Arc, RwLock};
+/// use datafusion::prelude::SessionContext;
+/// use skardi::sources::providers::graph::udtf::{GraphSources, register_graph_udtfs};
+///
+/// let sources: GraphSources = Arc::new(RwLock::new(HashMap::new()));
+/// let ctx = SessionContext::new();
+/// register_graph_udtfs(&ctx, sources).unwrap();
+/// // cypher_query('kg', …) now plans; with no source registered it
+/// // fails at planning naming the (empty) roster.
+/// ```
 pub fn register_graph_udtfs(ctx: &SessionContext, sources: GraphSources) -> DFResult<()> {
     datafusion_functions_json::register_all(&mut ctx.clone())?;
     ctx.register_udtf(
@@ -82,9 +96,10 @@ pub fn register_graph_udtfs(ctx: &SessionContext, sources: GraphSources) -> DFRe
 }
 
 fn lookup(sources: &GraphSources, name: &str) -> DFResult<Arc<GraphSourceHandle>> {
-    let map = sources
-        .read()
-        .map_err(|_| DataFusionError::Internal("graph sources lock poisoned".into()))?;
+    // Poisoning degrades gracefully (AGENTS.md: the optimizer-registry /
+    // model-cache pattern) — the map holds only Arc'd handles, so a
+    // panicked writer cannot leave it half-updated in a harmful way.
+    let map = sources.read().unwrap_or_else(|p| p.into_inner());
     map.get(name).cloned().ok_or_else(|| {
         let mut known: Vec<&str> = map.keys().map(String::as_str).collect();
         known.sort_unstable();
@@ -239,7 +254,7 @@ impl TableProvider for CypherQueryProvider {
         _state: &dyn Session,
         projection: Option<&Vec<usize>>,
         _filters: &[Expr],
-        _limit: Option<usize>,
+        limit: Option<usize>,
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(GraphScanExec::new(
             GraphScanKind::Cypher {
@@ -247,6 +262,10 @@ impl TableProvider for CypherQueryProvider {
                 cypher: self.cypher.clone(),
                 params: self.params.clone(),
                 columns: Arc::clone(&self.columns),
+                // LIMIT pushes to the CONSUMPTION side: the client stops
+                // reading the backend stream after this many rows instead
+                // of pulling max_rows and letting DataFusion truncate.
+                limit,
             },
             self.schema(),
             projection.cloned(),
@@ -326,6 +345,7 @@ enum GraphScanKind {
         cypher: String,
         params: Value,
         columns: Arc<Vec<DeclaredColumn>>,
+        limit: Option<usize>,
     },
     Labels {
         handle: Arc<GraphSourceHandle>,
@@ -366,7 +386,12 @@ impl GraphScanExec {
         let properties = PlanProperties::new(
             EquivalenceProperties::new(Arc::clone(&projected)),
             Partitioning::UnknownPartitioning(1),
-            EmissionType::Incremental,
+            // Final, honestly: the milestone-1 client buffers the whole
+            // result before the first batch is emitted (the repo's
+            // buffering scans — postgres/mysql/mongo/sqlite — all declare
+            // Final; Incremental is for genuinely streaming plans, and
+            // the optimizer takes the declaration at its word).
+            EmissionType::Final,
             Boundedness::Bounded,
         );
         // `schema` itself is not stored: the projected schema lives in
@@ -442,11 +467,13 @@ impl ExecutionPlan for GraphScanExec {
                 cypher,
                 params,
                 columns,
+                limit,
             } => cypher_batches(
                 Arc::clone(handle),
                 cypher.clone(),
                 params.clone(),
                 Arc::clone(columns),
+                *limit,
             ),
             GraphScanKind::Labels { handle } => labels_batch(Arc::clone(handle)),
         };
@@ -473,11 +500,12 @@ fn cypher_batches(
     cypher: String,
     params: Value,
     columns: Arc<Vec<DeclaredColumn>>,
+    limit: Option<usize>,
 ) -> futures::stream::BoxStream<'static, DFResult<RecordBatch>> {
     stream::once(async move {
         let rows = handle
             .client
-            .execute(&cypher, &params, columns.len(), handle.bounds)
+            .execute(&cypher, &params, columns.len(), handle.bounds, limit)
             .await
             .map_err(execution_error)?
             .try_collect::<Vec<_>>()
@@ -549,8 +577,13 @@ mod tests {
             _params: &Value,
             _arity: usize,
             _bounds: QueryBounds,
+            limit: Option<usize>,
         ) -> Result<BoxStream<'static, Result<Vec<Value>, GraphError>>, GraphError> {
-            Ok(stream::iter(self.rows.clone().into_iter().map(Ok)).boxed())
+            let mut rows = self.rows.clone();
+            if let Some(l) = limit {
+                rows.truncate(l);
+            }
+            Ok(stream::iter(rows.into_iter().map(Ok)).boxed())
         }
 
         async fn labels(&self, _bounds: QueryBounds) -> Result<Vec<(String, String)>, GraphError> {
@@ -663,6 +696,26 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("unknown type 'Utf8'"), "{msg}");
         assert!(msg.contains("node, relationship, path"), "{msg}");
+    }
+
+    #[tokio::test]
+    async fn sql_limit_pushes_to_the_consumption_side() {
+        // LIMIT reaches the client as a consumption bound (the mock
+        // truncates, standing in for the AGE client's early stop) — the
+        // scan does not pull max_rows and let DataFusion discard.
+        let ctx = ctx_with(vec![
+            vec![serde_json::json!("a")],
+            vec![serde_json::json!("b")],
+            vec![serde_json::json!("c")],
+        ])
+        .await;
+        let batches = collect(
+            &ctx,
+            "SELECT name FROM cypher_query('kg', 'MATCH (p) RETURN p.name', '{}', \
+             '{\"name\": \"string\"}') LIMIT 1",
+        )
+        .await;
+        assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 1);
     }
 
     #[tokio::test]

--- a/crates/skardi/src/sources/providers/graph/udtf.rs
+++ b/crates/skardi/src/sources/providers/graph/udtf.rs
@@ -16,6 +16,15 @@
 //! so `columns` is REQUIRED here: omitting it is a targeted error, and
 //! the JSON-`record` fallback ships with the Neo4j milestone, where Bolt
 //! needs no declared arity.
+//!
+//! **Declared-column ORDER is load-bearing**: the binding to the Cypher
+//! `RETURN` clause is positional (all AGE's `cypher()` gives us), so
+//! `columns` must list them in RETURN order. Two same-typed columns
+//! declared out of order swap SILENTLY — same JSON kind, no
+//! `TypeMismatch`, nothing downstream can tell — which is also the
+//! mis-declaration an LLM is most likely to produce. The error message,
+//! this doc, and the design's §Schema handling all state it because no
+//! structural check is possible.
 
 use std::any::Any;
 use std::collections::HashMap;
@@ -69,6 +78,19 @@ pub type GraphSources = Arc<RwLock<HashMap<String, Arc<GraphSourceHandle>>>>;
 /// (`datafusion-functions-json`: `json_get`, `json_get_str`, …) on a
 /// session. The getters are what make node/relationship `properties`
 /// columns queryable without leaving SQL.
+///
+/// **Scope, stated plainly**: `register_all` registers 12 UDFs *and* a
+/// function rewriter *and* an expr planner that remap the SQL operators
+/// `->`, `->>` and `?` to `json_get`/`json_as_text`/`json_contains` for
+/// EVERY query in the session, not just graph ones — and it overwrites
+/// same-named UDFs (debug-level log only). Additive today (DF 52 parses
+/// `->` but ships no implementation; `json_pack` does not collide).
+/// Before M4 wires this into the server session: re-home the JSON family
+/// next to skardi's other UDF registrations, and check the
+/// datafusion-federation interaction — the rewrite runs at analysis,
+/// ahead of federation planning, so a remote `data->'k'` that used to
+/// push down could become a local `json_get` and a full scan (recorded
+/// in the design's M4 milestone).
 ///
 /// # Example
 /// ```
@@ -167,8 +189,10 @@ impl TableFunctionImpl for CypherQueryFunction {
         let Some(columns_json) = columns_json else {
             return plan_err!(
                 "cypher_query: 'columns' is required on the age backend — declare the \
-                 output columns as the 4th argument, e.g. \
-                 '{{\"name\": \"string\", \"n\": \"node\"}}' (accepted types: {})",
+                 output columns IN THE SAME ORDER AS YOUR RETURN CLAUSE (the binding \
+                 is positional; two same-typed columns declared out of order swap \
+                 silently), e.g. '{{\"name\": \"string\", \"n\": \"node\"}}' \
+                 (accepted types: {})",
                 ACCEPTED_TYPES
             );
         };

--- a/crates/skardi/src/sources/providers/graph/udtf.rs
+++ b/crates/skardi/src/sources/providers/graph/udtf.rs
@@ -276,6 +276,14 @@ impl TableProvider for CypherQueryProvider {
 /// `graph_schema('connection')` — the agent-discovery surface: one row
 /// per label, `(label, kind)`, straight off the backend catalog. Names
 /// only, never property values.
+///
+/// No property columns on AGE, structurally: `ag_catalog` records label
+/// names and kinds ONLY (AGE is schema-optional — properties are
+/// untyped agtype maps with no catalog declaration), and property
+/// discovery would mean scanning data, unbounded on the agent's FIRST
+/// call. Property names/types arrive with the Neo4j
+/// (`db.schema.nodeTypeProperties()`) and Kuzu (typed catalog)
+/// milestones, whose catalogs actually carry them.
 #[derive(Debug)]
 pub struct GraphSchemaFunction {
     sources: GraphSources,

--- a/crates/skardi/src/sources/providers/graph/udtf.rs
+++ b/crates/skardi/src/sources/providers/graph/udtf.rs
@@ -774,6 +774,86 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn wrong_arg_counts_fail_with_the_signature_named() {
+        let ctx = ctx_with(vec![]).await;
+        for sql in [
+            "SELECT * FROM cypher_query('kg')",
+            "SELECT * FROM cypher_query('kg', 'RETURN 1', '{}', '{\"a\":\"int\"}', 'extra')",
+            "SELECT * FROM graph_schema()",
+            "SELECT * FROM graph_schema('kg', 'extra')",
+        ] {
+            let err = ctx.sql(sql).await.expect_err(sql);
+            let msg = err.to_string();
+            assert!(
+                msg.contains("expects") || msg.contains("exactly"),
+                "{sql}: {msg}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn malformed_params_and_columns_fail_at_planning() {
+        let ctx = ctx_with(vec![]).await;
+        // params: unparseable JSON, then a non-object.
+        for (params, needle) in [("{not json", "unparseable JSON"), ("[1]", "an array")] {
+            let err = ctx
+                .sql(&format!(
+                    "SELECT * FROM cypher_query('kg', 'MATCH (n) RETURN n', '{params}', \
+                     '{{\"n\": \"node\"}}')"
+                ))
+                .await
+                .expect_err(params);
+            assert!(err.to_string().contains(needle), "{params}: {err}");
+        }
+        // columns: unparseable, non-object, empty, non-string type.
+        for (columns, needle) in [
+            ("{not json", "unparseable JSON"),
+            ("[1]", "expected a JSON object"),
+            ("{}", "at least one column"),
+            ("{\"n\": 7}", "type must be a string"),
+        ] {
+            let err = ctx
+                .sql(&format!(
+                    "SELECT * FROM cypher_query('kg', 'MATCH (n) RETURN n', '{{}}', '{columns}')"
+                ))
+                .await
+                .expect_err(columns);
+            assert!(err.to_string().contains(needle), "{columns}: {err}");
+        }
+    }
+
+    #[tokio::test]
+    async fn projection_prunes_columns_and_explain_renders_the_plan() {
+        let ctx = ctx_with(vec![vec![serde_json::json!("ada"), serde_json::json!(1)]]).await;
+        // Projection: only the second declared column is scanned out.
+        let batches = collect(
+            &ctx,
+            "SELECT n FROM cypher_query('kg', 'MATCH (p) RETURN p.name, p.n', '{}', \
+             '{\"name\": \"string\", \"n\": \"int\"}')",
+        )
+        .await;
+        assert_eq!(batches[0].num_columns(), 1);
+        assert_eq!(batches[0].schema().field(0).name(), "n");
+        // EXPLAIN drives DisplayAs for both scan kinds.
+        let plan = collect(
+            &ctx,
+            "EXPLAIN SELECT n FROM cypher_query('kg', 'MATCH (p) RETURN p.n', '{}', \
+             '{\"n\": \"int\"}')",
+        )
+        .await;
+        assert!(!plan.is_empty());
+        let plan = collect(&ctx, "EXPLAIN SELECT * FROM graph_schema('kg')").await;
+        assert!(!plan.is_empty());
+    }
+
+    #[tokio::test]
+    async fn graph_schema_respects_a_sql_limit() {
+        let ctx = ctx_with(vec![]).await;
+        let batches = collect(&ctx, "SELECT label FROM graph_schema('kg') LIMIT 1").await;
+        assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 1);
+    }
+
+    #[tokio::test]
     async fn graph_schema_lists_labels_and_kinds() {
         let ctx = ctx_with(vec![]).await;
         let batches = collect(

--- a/crates/skardi/src/sources/providers/graph/udtf.rs
+++ b/crates/skardi/src/sources/providers/graph/udtf.rs
@@ -880,6 +880,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn an_unprojected_declared_column_still_fails_its_type_contract() {
+        // The projection contract (see CONVERSION_BATCH_ROWS' doc): the
+        // declared schema is the contract, projection prunes AFTER
+        // conversion — `b` mis-declared fails even though only `a` was
+        // selected.
+        let ctx = ctx_with(vec![vec![
+            serde_json::json!("ada"),
+            serde_json::json!("not-an-int"),
+        ]])
+        .await;
+        let err = ctx
+            .sql(
+                "SELECT a FROM cypher_query('kg', 'MATCH (x) RETURN x.a, x.b', '{}', \
+                 '{\"a\": \"string\", \"b\": \"int\"}')",
+            )
+            .await
+            .expect("plans")
+            .collect()
+            .await
+            .expect_err("the unprojected column's violated declaration is still loud");
+        let msg = err.to_string();
+        assert!(msg.contains("'b'"), "{msg}");
+        assert!(msg.contains("declared 'int'"), "{msg}");
+    }
+
+    #[tokio::test]
     async fn graph_schema_respects_a_sql_limit() {
         let ctx = ctx_with(vec![]).await;
         let batches = collect(&ctx, "SELECT label FROM graph_schema('kg') LIMIT 1").await;

--- a/crates/skardi/src/sources/providers/graph/udtf.rs
+++ b/crates/skardi/src/sources/providers/graph/udtf.rs
@@ -59,8 +59,17 @@ use crate::sources::providers::udtf_args::strict_string_arg;
 
 /// Conversion batch size (design §Schema handling): the atomic unit —
 /// each batch converts as a whole before it is emitted, so a mid-scan
-/// type mismatch never emits a partially converted batch, and peak
-/// conversion memory is one batch, not one result.
+/// type mismatch never emits a partially converted batch.
+///
+/// Milestone-1 reality, stated so this comment cannot outlive the code
+/// it describes: BOTH layers fully buffer (the client collects every
+/// row, and `cypher_batches` materializes every RecordBatch before the
+/// first is emitted — which `EmissionType::Final` declares honestly).
+/// So today NOTHING is emitted before a mid-scan failure — the design's
+/// explicitly-permitted whole-result variant, strictly stronger than
+/// the batch-atomic contract. The chunking below is where the contract
+/// will start to bind if a later client genuinely streams; it is not
+/// buying partial emission now.
 const CONVERSION_BATCH_ROWS: usize = 1024;
 
 /// One registered `type: graph` source, resolvable by connection name.

--- a/crates/skardi/src/sources/providers/graph/udtf.rs
+++ b/crates/skardi/src/sources/providers/graph/udtf.rs
@@ -334,11 +334,13 @@ impl TableProvider for GraphSchemaProvider {
         _state: &dyn Session,
         projection: Option<&Vec<usize>>,
         _filters: &[Expr],
-        _limit: Option<usize>,
+        limit: Option<usize>,
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(GraphScanExec::new(
             GraphScanKind::Labels {
                 handle: Arc::clone(&self.handle),
+                // The SQL LIMIT rides into the catalog fetch itself.
+                limit,
             },
             self.schema(),
             projection.cloned(),
@@ -357,6 +359,7 @@ enum GraphScanKind {
     },
     Labels {
         handle: Arc<GraphSourceHandle>,
+        limit: Option<usize>,
     },
 }
 
@@ -483,7 +486,7 @@ impl ExecutionPlan for GraphScanExec {
                 Arc::clone(columns),
                 *limit,
             ),
-            GraphScanKind::Labels { handle } => labels_batch(Arc::clone(handle)),
+            GraphScanKind::Labels { handle, limit } => labels_batch(Arc::clone(handle), *limit),
         };
         let stream = batches
             .map(move |batch| {
@@ -539,11 +542,12 @@ fn cypher_batches(
 
 fn labels_batch(
     handle: Arc<GraphSourceHandle>,
+    limit: Option<usize>,
 ) -> futures::stream::BoxStream<'static, DFResult<RecordBatch>> {
     stream::once(async move {
         let labels = handle
             .client
-            .labels(handle.bounds)
+            .labels(handle.bounds, limit)
             .await
             .map_err(execution_error)?;
         let mut names = arrow::array::StringBuilder::new();
@@ -594,8 +598,16 @@ mod tests {
             Ok(stream::iter(rows.into_iter().map(Ok)).boxed())
         }
 
-        async fn labels(&self, _bounds: QueryBounds) -> Result<Vec<(String, String)>, GraphError> {
-            Ok(self.labels.clone())
+        async fn labels(
+            &self,
+            _bounds: QueryBounds,
+            limit: Option<usize>,
+        ) -> Result<Vec<(String, String)>, GraphError> {
+            let mut labels = self.labels.clone();
+            if let Some(l) = limit {
+                labels.truncate(l);
+            }
+            Ok(labels)
         }
     }
 

--- a/crates/skardi/src/sources/providers/graph/udtf.rs
+++ b/crates/skardi/src/sources/providers/graph/udtf.rs
@@ -11,20 +11,30 @@
 //! Call-shape constraints (stated because agents generate these calls):
 //! arguments are positional, so declaring `columns` requires passing
 //! `params` — `'{}'` is the no-parameters spelling, and NULL is rejected
-//! (schema-shaping arguments are strict string literals). Milestone 1 is
-//! AGE-only, and AGE's `cypher()` call must declare its result arity —
-//! so `columns` is REQUIRED here: omitting it is a targeted error, and
-//! the JSON-`record` fallback ships with the Neo4j milestone, where Bolt
-//! needs no declared arity.
+//! (schema-shaping arguments are strict string literals). Whether
+//! `columns` may be OMITTED is per backend: AGE's `cypher()` call must
+//! declare its result arity, so omitting it there is a targeted error;
+//! on Neo4j (Bolt needs no declared arity) the omission is the
+//! JSON-`record` fallback — one `record: Utf8` column carrying each
+//! whole record as canonical JSON text, keys in sorted order.
 //!
-//! **Declared-column ORDER is load-bearing**: the binding to the Cypher
-//! `RETURN` clause is positional (all AGE's `cypher()` gives us), so
-//! `columns` must list them in RETURN order. Two same-typed columns
-//! declared out of order swap SILENTLY — same JSON kind, no
-//! `TypeMismatch`, nothing downstream can tell — which is also the
-//! mis-declaration an LLM is most likely to produce. The error message,
-//! this doc, and the design's §Schema handling all state it because no
-//! structural check is possible.
+//! **How declared columns BIND is per backend, and both contracts are
+//! stated here** (the schema itself is identical either way):
+//!
+//! - **AGE: positional.** The binding to the Cypher `RETURN` clause is
+//!   positional (all AGE's `cypher()` gives us), so `columns` must list
+//!   them in RETURN order. Two same-typed columns declared out of order
+//!   swap SILENTLY — same JSON kind, no `TypeMismatch`, nothing
+//!   downstream can tell — which is also the mis-declaration an LLM is
+//!   most likely to produce. The error message, this doc, and the
+//!   design's §Schema handling all state it because no structural check
+//!   is possible.
+//! - **Neo4j: by NAME.** Bolt records carry field names, so each
+//!   declared column binds to the RETURN entry of the same name —
+//!   declaration order only sets output column order, and a declared
+//!   name the query never returns is a typed error naming it (alias the
+//!   entry with `AS`). The positional footgun above does not exist on
+//!   this backend.
 
 use std::any::Any;
 use std::collections::HashMap;
@@ -183,29 +193,43 @@ impl TableFunctionImpl for CypherQueryFunction {
             }
         };
 
-        // Milestone 1 is AGE-only: `columns` is required (AGE's cypher()
-        // must declare its arity; the JSON-record fallback ships with the
-        // Neo4j milestone).
-        let Some(columns_json) = columns_json else {
-            return plan_err!(
-                "cypher_query: 'columns' is required on the age backend — declare the \
-                 output columns IN THE SAME ORDER AS YOUR RETURN CLAUSE (the binding \
-                 is positional; two same-typed columns declared out of order swap \
-                 silently), e.g. '{{\"name\": \"string\", \"n\": \"node\"}}' \
-                 (accepted types: {})",
-                ACCEPTED_TYPES
-            );
-        };
-        let columns = parse_columns(&columns_json).map_err(plan_error)?;
-
+        // Whether `columns` may be omitted is the BACKEND's contract
+        // (resolved through the handle, still at plan time): AGE's
+        // cypher() must declare its arity, so omission there is a
+        // targeted error; on backends whose wire carries field names
+        // (Neo4j) the omission is the JSON-`record` fallback.
         let handle = lookup(&self.sources, &connection)?;
+        let columns = match columns_json {
+            Some(text) => Some(Arc::new(parse_columns(&text).map_err(plan_error)?)),
+            None if handle.client.requires_declared_columns() => {
+                return plan_err!(
+                    "cypher_query: 'columns' is required on the age backend — declare the \
+                     output columns IN THE SAME ORDER AS YOUR RETURN CLAUSE (the binding \
+                     is positional; two same-typed columns declared out of order swap \
+                     silently), e.g. '{{\"name\": \"string\", \"n\": \"node\"}}' \
+                     (accepted types: {})",
+                    ACCEPTED_TYPES
+                );
+            }
+            None => None,
+        };
         Ok(Arc::new(CypherQueryProvider {
             handle,
             cypher,
             params,
-            columns: Arc::new(columns),
+            columns,
         }))
     }
+}
+
+/// The JSON-`record` fallback's one-column schema: each row is the whole
+/// Cypher record as canonical JSON text (keys sorted — the Bolt driver
+/// hands records over as hash maps, so RETURN order is not recoverable).
+fn record_fallback_columns() -> Vec<DeclaredColumn> {
+    vec![DeclaredColumn {
+        name: "record".to_string(),
+        ty: GraphType::Json,
+    }]
 }
 
 /// Parse the declared-columns JSON object. Declaration order is object
@@ -250,13 +274,16 @@ fn parse_columns(text: &str) -> Result<Vec<DeclaredColumn>, GraphError> {
 }
 
 /// The provider behind one `cypher_query` call: planning-time-stable
-/// declared schema, backend touched only at execute.
+/// schema (declared columns, or the record fallback), backend touched
+/// only at execute.
 #[derive(Debug)]
 struct CypherQueryProvider {
     handle: Arc<GraphSourceHandle>,
     cypher: String,
     params: Value,
-    columns: Arc<Vec<DeclaredColumn>>,
+    /// `None` is the JSON-`record` fallback (never on AGE — the call
+    /// refuses it at plan time there).
+    columns: Option<Arc<Vec<DeclaredColumn>>>,
 }
 
 #[async_trait]
@@ -266,7 +293,10 @@ impl TableProvider for CypherQueryProvider {
     }
 
     fn schema(&self) -> SchemaRef {
-        declared_schema(&self.columns)
+        match &self.columns {
+            Some(columns) => declared_schema(columns),
+            None => declared_schema(&record_fallback_columns()),
+        }
     }
 
     fn table_type(&self) -> TableType {
@@ -285,7 +315,7 @@ impl TableProvider for CypherQueryProvider {
                 handle: Arc::clone(&self.handle),
                 cypher: self.cypher.clone(),
                 params: self.params.clone(),
-                columns: Arc::clone(&self.columns),
+                columns: self.columns.clone(),
                 // LIMIT pushes to the CONSUMPTION side: the client stops
                 // reading the backend stream after this many rows instead
                 // of pulling max_rows and letting DataFusion truncate.
@@ -298,16 +328,18 @@ impl TableProvider for CypherQueryProvider {
 }
 
 /// `graph_schema('connection')` — the agent-discovery surface: one row
-/// per label, `(label, kind)`, straight off the backend catalog. Names
-/// only, never property values.
+/// per label `(label, kind, property, property_type)`, straight off the
+/// backend catalog. Names and types only, never property values.
 ///
-/// No property columns on AGE, structurally: `ag_catalog` records label
-/// names and kinds ONLY (AGE is schema-optional — properties are
+/// The property columns are filled per backend, by what each catalog
+/// actually knows: Neo4j serves property names and types via
+/// `db.schema.nodeTypeProperties()` / `relTypeProperties()` (one row per
+/// label × property; a property-less label keeps one row with nulls);
+/// on AGE they are ALWAYS null, structurally — `ag_catalog` records
+/// label names and kinds only (AGE is schema-optional — properties are
 /// untyped agtype maps with no catalog declaration), and property
 /// discovery would mean scanning data, unbounded on the agent's FIRST
-/// call. Property names/types arrive with the Neo4j
-/// (`db.schema.nodeTypeProperties()`) and Kuzu (typed catalog)
-/// milestones, whose catalogs actually carry them.
+/// call. Kuzu's typed catalog arrives with its milestone.
 #[derive(Debug)]
 pub struct GraphSchemaFunction {
     sources: GraphSources,
@@ -331,6 +363,10 @@ fn graph_schema_schema() -> SchemaRef {
     Arc::new(Schema::new(vec![
         Field::new("label", DataType::Utf8, false),
         Field::new("kind", DataType::Utf8, false),
+        // Nullable BY MEANING: null is "this backend's catalog declares
+        // no properties" (all of AGE) or "this label has none" (Neo4j).
+        Field::new("property", DataType::Utf8, true),
+        Field::new("property_type", DataType::Utf8, true),
     ]))
 }
 
@@ -378,7 +414,8 @@ enum GraphScanKind {
         handle: Arc<GraphSourceHandle>,
         cypher: String,
         params: Value,
-        columns: Arc<Vec<DeclaredColumn>>,
+        /// `None` is the record fallback.
+        columns: Option<Arc<Vec<DeclaredColumn>>>,
         limit: Option<usize>,
     },
     Labels {
@@ -393,7 +430,7 @@ impl fmt::Debug for GraphScanKind {
         match self {
             Self::Cypher { columns, .. } => f
                 .debug_struct("Cypher")
-                .field("columns", &columns.len())
+                .field("columns", &columns.as_ref().map_or(1, |c| c.len()))
                 .finish_non_exhaustive(),
             Self::Labels { .. } => f.debug_struct("Labels").finish_non_exhaustive(),
         }
@@ -446,8 +483,14 @@ impl GraphScanExec {
 impl DisplayAs for GraphScanExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
         match &self.kind {
-            GraphScanKind::Cypher { columns, .. } => {
+            GraphScanKind::Cypher {
+                columns: Some(columns),
+                ..
+            } => {
                 write!(f, "GraphScanExec: cypher_query columns={}", columns.len())
+            }
+            GraphScanKind::Cypher { columns: None, .. } => {
+                write!(f, "GraphScanExec: cypher_query record-fallback")
             }
             GraphScanKind::Labels { .. } => write!(f, "GraphScanExec: graph_schema"),
         }
@@ -507,7 +550,7 @@ impl ExecutionPlan for GraphScanExec {
                 Arc::clone(handle),
                 cypher.clone(),
                 params.clone(),
-                Arc::clone(columns),
+                columns.clone(),
                 *limit,
             ),
             GraphScanKind::Labels { handle, limit } => labels_batch(Arc::clone(handle), *limit),
@@ -534,18 +577,27 @@ fn cypher_batches(
     handle: Arc<GraphSourceHandle>,
     cypher: String,
     params: Value,
-    columns: Arc<Vec<DeclaredColumn>>,
+    columns: Option<Arc<Vec<DeclaredColumn>>>,
     limit: Option<usize>,
 ) -> futures::stream::BoxStream<'static, DFResult<RecordBatch>> {
     stream::once(async move {
         let rows = handle
             .client
-            .execute(&cypher, &params, columns.len(), handle.bounds, limit)
+            .execute(
+                &cypher,
+                &params,
+                columns.as_ref().map(|c| c.as_slice()),
+                handle.bounds,
+                limit,
+            )
             .await
             .map_err(execution_error)?
             .try_collect::<Vec<_>>()
             .await
             .map_err(execution_error)?;
+        // Conversion always runs against concrete columns: the declared
+        // ones, or the fallback's single `record: json`.
+        let columns = columns.unwrap_or_else(|| Arc::new(record_fallback_columns()));
         let mut batches = Vec::with_capacity(rows.len() / CONVERSION_BATCH_ROWS + 1);
         for (chunk_idx, chunk) in rows.chunks(CONVERSION_BATCH_ROWS).enumerate() {
             batches.push(
@@ -569,20 +621,29 @@ fn labels_batch(
     limit: Option<usize>,
 ) -> futures::stream::BoxStream<'static, DFResult<RecordBatch>> {
     stream::once(async move {
-        let labels = handle
+        let rows = handle
             .client
-            .labels(handle.bounds, limit)
+            .schema(handle.bounds, limit)
             .await
             .map_err(execution_error)?;
         let mut names = arrow::array::StringBuilder::new();
         let mut kinds = arrow::array::StringBuilder::new();
-        for (name, kind) in &labels {
-            names.append_value(name);
-            kinds.append_value(kind);
+        let mut properties = arrow::array::StringBuilder::new();
+        let mut property_types = arrow::array::StringBuilder::new();
+        for row in &rows {
+            names.append_value(&row.label);
+            kinds.append_value(&row.kind);
+            properties.append_option(row.property.as_deref());
+            property_types.append_option(row.property_type.as_deref());
         }
         RecordBatch::try_new(
             graph_schema_schema(),
-            vec![Arc::new(names.finish()), Arc::new(kinds.finish())],
+            vec![
+                Arc::new(names.finish()),
+                Arc::new(kinds.finish()),
+                Arc::new(properties.finish()),
+                Arc::new(property_types.finish()),
+            ],
         )
         .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
     })
@@ -596,13 +657,17 @@ fn execution_error(e: GraphError) -> DataFusionError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow::array::Array;
     use futures::stream::BoxStream;
 
     /// Canned-rows client: the UDTF/exec seam without a backend.
+    /// `declared_required` flips it between the two backend contracts
+    /// (true = AGE-shaped, false = Neo4j-shaped with record fallback).
     #[derive(Debug)]
     struct MockClient {
         rows: Vec<Vec<Value>>,
-        labels: Vec<(String, String)>,
+        schema_rows: Vec<super::super::client::SchemaRow>,
+        declared_required: bool,
     }
 
     #[async_trait]
@@ -611,10 +676,14 @@ mod tests {
             &self,
             _cypher: &str,
             _params: &Value,
-            _arity: usize,
+            columns: Option<&[DeclaredColumn]>,
             _bounds: QueryBounds,
             limit: Option<usize>,
         ) -> Result<BoxStream<'static, Result<Vec<Value>, GraphError>>, GraphError> {
+            assert!(
+                columns.is_some() || !self.declared_required,
+                "the UDTF must not reach a declared-required client without columns"
+            );
             let mut rows = self.rows.clone();
             if let Some(l) = limit {
                 rows.truncate(l);
@@ -622,27 +691,46 @@ mod tests {
             Ok(stream::iter(rows.into_iter().map(Ok)).boxed())
         }
 
-        async fn labels(
+        fn requires_declared_columns(&self) -> bool {
+            self.declared_required
+        }
+
+        async fn schema(
             &self,
             _bounds: QueryBounds,
             limit: Option<usize>,
-        ) -> Result<Vec<(String, String)>, GraphError> {
-            let mut labels = self.labels.clone();
+        ) -> Result<Vec<super::super::client::SchemaRow>, GraphError> {
+            let mut rows = self.schema_rows.clone();
             if let Some(l) = limit {
-                labels.truncate(l);
+                rows.truncate(l);
             }
-            Ok(labels)
+            Ok(rows)
         }
     }
 
-    fn sources_with(rows: Vec<Vec<Value>>) -> GraphSources {
+    fn schema_row(
+        label: &str,
+        kind: &str,
+        property: Option<&str>,
+        property_type: Option<&str>,
+    ) -> super::super::client::SchemaRow {
+        super::super::client::SchemaRow {
+            label: label.to_string(),
+            kind: kind.to_string(),
+            property: property.map(str::to_string),
+            property_type: property_type.map(str::to_string),
+        }
+    }
+
+    fn sources_shaped(rows: Vec<Vec<Value>>, declared_required: bool) -> GraphSources {
         let handle = Arc::new(GraphSourceHandle {
             client: Arc::new(MockClient {
                 rows,
-                labels: vec![
-                    ("Person".to_string(), "vertex".to_string()),
-                    ("KNOWS".to_string(), "edge".to_string()),
+                schema_rows: vec![
+                    schema_row("Person", "vertex", Some("name"), Some("String")),
+                    schema_row("KNOWS", "edge", None, None),
                 ],
+                declared_required,
             }),
             bounds: QueryBounds {
                 timeout: std::time::Duration::from_secs(5),
@@ -652,9 +740,20 @@ mod tests {
         Arc::new(RwLock::new(HashMap::from([("kg".to_string(), handle)])))
     }
 
+    fn sources_with(rows: Vec<Vec<Value>>) -> GraphSources {
+        sources_shaped(rows, true)
+    }
+
     async fn ctx_with(rows: Vec<Vec<Value>>) -> SessionContext {
         let ctx = SessionContext::new();
         register_graph_udtfs(&ctx, sources_with(rows)).expect("registration");
+        ctx
+    }
+
+    /// A Neo4j-shaped session: declared columns optional.
+    async fn ctx_record_capable(rows: Vec<Vec<Value>>) -> SessionContext {
+        let ctx = SessionContext::new();
+        register_graph_udtfs(&ctx, sources_shaped(rows, false)).expect("registration");
         ctx
     }
 
@@ -710,6 +809,57 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("'columns' is required"), "{msg}");
         assert!(msg.contains("age backend"), "{msg}");
+    }
+
+    #[tokio::test]
+    async fn omitted_columns_is_the_record_fallback_where_the_backend_allows() {
+        // A record-capable (Neo4j-shaped) client: each row is one whole
+        // record object, and the planned schema is the single `record`
+        // Utf8 column carrying it as JSON text.
+        let ctx = ctx_record_capable(vec![
+            vec![serde_json::json!({"name": "ada", "age": 36})],
+            vec![serde_json::json!({"name": "bob", "age": 41})],
+        ])
+        .await;
+        let batches = collect(
+            &ctx,
+            "SELECT record FROM cypher_query('kg', 'MATCH (p) RETURN p.name, p.age')",
+        )
+        .await;
+        assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 2);
+        assert_eq!(batches[0].schema().field(0).name(), "record");
+        let col = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .unwrap();
+        // Verbatim JSON text — and queryable in place via the registered
+        // json getters.
+        assert!(col.value(0).contains("\"ada\""), "{}", col.value(0));
+        let extracted = collect(
+            &ctx,
+            "SELECT json_get_str(record, 'name') AS name FROM \
+             cypher_query('kg', 'MATCH (p) RETURN p.name, p.age') ORDER BY name",
+        )
+        .await;
+        let names = extracted[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .unwrap();
+        assert_eq!(names.value(0), "ada");
+    }
+
+    #[tokio::test]
+    async fn record_fallback_keeps_its_schema_on_empty_results() {
+        let ctx = ctx_record_capable(vec![]).await;
+        let batches = collect(
+            &ctx,
+            "SELECT * FROM cypher_query('kg', 'MATCH (p) RETURN p')",
+        )
+        .await;
+        assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 0);
+        assert_eq!(batches[0].schema().field(0).name(), "record");
     }
 
     #[tokio::test]
@@ -878,15 +1028,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn graph_schema_lists_labels_and_kinds() {
+    async fn graph_schema_lists_labels_kinds_and_per_backend_properties() {
         let ctx = ctx_with(vec![]).await;
         let batches = collect(
             &ctx,
-            "SELECT label, kind FROM graph_schema('kg') ORDER BY label",
+            "SELECT label, kind, property, property_type FROM graph_schema('kg') \
+             ORDER BY label",
         )
         .await;
         let total: usize = batches.iter().map(|b| b.num_rows()).sum();
         assert_eq!(total, 2);
+        let batch = &batches[0];
+        let property = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .unwrap();
+        // KNOWS sorts first: a property-less label keeps its row, nulls
+        // in the property columns; Person carries (name, String).
+        assert!(property.is_null(0));
+        assert_eq!(property.value(1), "name");
     }
 
     #[tokio::test]

--- a/crates/skardi/src/sources/providers/graph/value.rs
+++ b/crates/skardi/src/sources/providers/graph/value.rs
@@ -14,7 +14,10 @@
 //!   against the declared columns. Every declared column is nullable
 //!   (Cypher can produce null in any position); a non-null value of the
 //!   wrong JSON kind is [`GraphError::TypeMismatch`] carrying kinds, never
-//!   values.
+//!   values. The JSON row is the CONTRACT between every backend client
+//!   and this converter: the Neo4j client decodes Bolt values into the
+//!   same shapes (its nodes spell multi-label as a `labels` array where
+//!   AGE spells its single label as `label` — both accepted below).
 //!
 //! The canonical STRUCT shapes (design §Result flattening):
 //! - node: `STRUCT<id Utf8, labels List<Utf8>, properties Utf8>` —
@@ -396,13 +399,15 @@ fn mismatch(col: &DeclaredColumn, row: usize, expected: &'static str, v: &Value)
     }
 }
 
-/// One vertex, decomposed: (id, label, properties-json). AGE vertex
-/// objects carry `id` (number), `label` (string), `properties` (object).
-/// Ids are stringified: opaque tokens, stable for the entity's life
-/// within one database (design §Backend abstraction).
+/// One vertex, decomposed: (id, labels, properties-json). AGE vertex
+/// objects carry `id` (number), `label` (ONE string — AGE vertices are
+/// single-label), `properties` (object); Neo4j nodes carry `labels` (an
+/// array — multi-label is native there), and [`node_parts`] accepts
+/// both spellings. Ids are stringified: opaque tokens, stable for the
+/// entity's life within one database (design §Backend abstraction).
 struct NodeParts {
     id: String,
-    label: String,
+    labels: Vec<String>,
     properties: String,
 }
 
@@ -423,13 +428,31 @@ fn node_parts(
     match v {
         Value::Null => Ok(None),
         Value::Object(map) => {
-            let (Some(id), Some(label)) = (map.get("id"), map.get("label").and_then(Value::as_str))
-            else {
+            let Some(id) = map.get("id") else {
                 return Err(mismatch(col, row, "node", v));
+            };
+            // Two accepted spellings, per backend reality: AGE emits ONE
+            // `label` string (its vertices are single-label); Neo4j emits
+            // a `labels` array (multi-label is native, and an empty array
+            // is a legal label-less node there). Exactly one must be
+            // present and well-formed.
+            let labels = match (map.get("labels"), map.get("label")) {
+                (Some(Value::Array(items)), None) => {
+                    let mut labels = Vec::with_capacity(items.len());
+                    for item in items {
+                        let Value::String(s) = item else {
+                            return Err(mismatch(col, row, "node", v));
+                        };
+                        labels.push(s.clone());
+                    }
+                    labels
+                }
+                (None, Some(Value::String(label))) => vec![label.clone()],
+                _ => return Err(mismatch(col, row, "node", v)),
             };
             Ok(Some(NodeParts {
                 id: scalar_to_string(id),
-                label: label.to_string(),
+                labels,
                 properties: map
                     .get("properties")
                     .cloned()
@@ -527,7 +550,9 @@ fn node_struct_array(items: &[Option<NodeParts>]) -> StructArray {
         match item {
             Some(n) => {
                 ids.append_value(&n.id);
-                labels.values().append_value(&n.label);
+                for label in &n.labels {
+                    labels.values().append_value(label);
+                }
                 labels.append(true);
                 props.append_value(&n.properties);
                 validity.push(true);
@@ -609,7 +634,7 @@ fn path_struct_array(items: &[Option<PathParts>]) -> StructArray {
                 flat_nodes.extend(nodes.iter().map(|n| {
                     Some(NodeParts {
                         id: n.id.clone(),
-                        label: n.label.clone(),
+                        labels: n.labels.clone(),
                         properties: n.properties.clone(),
                     })
                 }));
@@ -1018,5 +1043,42 @@ mod tests {
             serde_json::json!([{"id":1,"label":"A","properties":{}}]),
         ]];
         build_batch(&columns, &rows, 0).expect("a single-node path is the legal minimum");
+    }
+
+    #[test]
+    fn nodes_accept_both_label_spellings_and_reject_mixtures() {
+        let columns = vec![col("n", GraphType::Node)];
+        // Neo4j's multi-label array — every label lands in the list.
+        let rows = vec![vec![
+            serde_json::json!({"id": "7", "labels": ["Person", "Admin"], "properties": {}}),
+        ]];
+        let batch = build_batch(&columns, &rows, 0).expect("labels array converts");
+        let node = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::StructArray>()
+            .unwrap();
+        let labels = node
+            .column_by_name("labels")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .unwrap();
+        assert_eq!(labels.value(0).len(), 2, "both labels survive");
+        // An EMPTY labels array is a legal Neo4j node (label-less).
+        let rows = vec![vec![
+            serde_json::json!({"id": "8", "labels": [], "properties": {}}),
+        ]];
+        build_batch(&columns, &rows, 0).expect("label-less node is legal on neo4j");
+        // Both spellings at once, a non-string label, and neither
+        // spelling are all shape errors — kinds only, never values.
+        for bad in [
+            serde_json::json!({"id": 1, "label": "A", "labels": ["A"], "properties": {}}),
+            serde_json::json!({"id": 1, "labels": [7], "properties": {}}),
+            serde_json::json!({"id": 1, "properties": {}}),
+        ] {
+            let err = build_batch(&columns, &[vec![bad]], 0).unwrap_err();
+            assert!(err.to_string().contains("declared 'node'"), "{err}");
+        }
     }
 }

--- a/crates/skardi/src/sources/providers/graph/value.rs
+++ b/crates/skardi/src/sources/providers/graph/value.rs
@@ -229,6 +229,33 @@ pub fn parse_agtype(text: &str) -> Result<Value, String> {
                     i += 1;
                 }
             }
+            b if b.is_ascii_alphabetic() => {
+                // agtype's float specials are bare non-JSON tokens —
+                // VERIFIED live: `RETURN 1.0e308 * 10` emits `Infinity`
+                // through agtype_out (and `-Infinity`/`NaN` are its
+                // siblings). JSON has no spelling for them, so they
+                // decode to null — the proportionate outcome for a
+                // declared float (AGE's own sqrt(-1.0) already answers
+                // SQL NULL), instead of a whole-scan MalformedCell for a
+                // legitimate value. Other bare words (true/false/null)
+                // pass through untouched; strings are untouched by
+                // construction (this arm is outside-string only).
+                let start = i;
+                while i < bytes.len() && bytes[i].is_ascii_alphabetic() {
+                    i += 1;
+                }
+                let word = &text[start..i];
+                if word == "NaN" || word == "Infinity" {
+                    // A leading sign belongs to the token (`-Infinity`),
+                    // not to the null replacing it.
+                    if cleaned.last() == Some(&b'-') {
+                        cleaned.pop();
+                    }
+                    cleaned.extend_from_slice(b"null");
+                } else {
+                    cleaned.extend_from_slice(word.as_bytes());
+                }
+            }
             _ => {
                 cleaned.push(b);
                 i += 1;
@@ -670,6 +697,25 @@ mod tests {
         let v = parse_agtype(r#"["中文", 1.5::numeric, "🎈"]"#).expect("parses");
         assert_eq!(v[0], "中文");
         assert_eq!(v[2], "🎈");
+    }
+
+    #[test]
+    fn agtype_float_specials_decode_to_null_outside_strings_only() {
+        // Verified live: AGE emits bare `Infinity` for float overflow
+        // (1.0e308 * 10). JSON has no spelling for the specials, so they
+        // decode to null — proportionate for a declared float — while
+        // string CONTENT is untouched and ordinary words pass through.
+        let v = parse_agtype(r#"[Infinity, -Infinity, NaN, 1.5, true]"#).expect("parses");
+        assert_eq!(v[0], Value::Null);
+        assert_eq!(v[1], Value::Null, "the sign is consumed with the token");
+        assert_eq!(v[2], Value::Null);
+        assert_eq!(v[3], 1.5);
+        assert_eq!(v[4], true);
+
+        let v =
+            parse_agtype(r#"{"note": "to Infinity and beyond", "x": Infinity}"#).expect("parses");
+        assert_eq!(v["note"], "to Infinity and beyond", "strings untouched");
+        assert_eq!(v["x"], Value::Null);
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/graph/value.rs
+++ b/crates/skardi/src/sources/providers/graph/value.rs
@@ -189,7 +189,15 @@ pub fn declared_schema(columns: &[DeclaredColumn]) -> Arc<Schema> {
 /// which always follow a value (`}`, `]`, digit, or scalar keyword) — are
 /// removed.
 pub fn parse_agtype(text: &str) -> Result<Value, String> {
-    let mut cleaned = String::with_capacity(text.len());
+    // BYTES in, BYTES out, one UTF-8 decode at the end. `u8 as char` is
+    // Latin-1 semantics and would shred every multi-byte UTF-8 character
+    // into mojibake that still parses as JSON — a SILENT corruption
+    // (CJK entity names are the common case in knowledge graphs, not an
+    // edge case). Byte-level scanning is sound because everything the
+    // scanner matches ('"', '\\', ':', the annotation identifiers) is
+    // ASCII, and UTF-8 continuation bytes are all >= 0x80 — a multi-byte
+    // character can never alias a structural byte.
+    let mut cleaned: Vec<u8> = Vec::with_capacity(text.len());
     let bytes = text.as_bytes();
     let mut i = 0;
     let mut in_string = false;
@@ -197,7 +205,7 @@ pub fn parse_agtype(text: &str) -> Result<Value, String> {
     while i < bytes.len() {
         let b = bytes[i];
         if in_string {
-            cleaned.push(b as char);
+            cleaned.push(b);
             if escaped {
                 escaped = false;
             } else if b == b'\\' {
@@ -211,7 +219,7 @@ pub fn parse_agtype(text: &str) -> Result<Value, String> {
         match b {
             b'"' => {
                 in_string = true;
-                cleaned.push('"');
+                cleaned.push(b'"');
                 i += 1;
             }
             b':' if i + 1 < bytes.len() && bytes[i + 1] == b':' => {
@@ -222,13 +230,13 @@ pub fn parse_agtype(text: &str) -> Result<Value, String> {
                 }
             }
             _ => {
-                // Non-ASCII bytes only occur inside strings in agtype's
-                // structural layer, but push byte-faithfully regardless.
-                cleaned.push(b as char);
+                cleaned.push(b);
                 i += 1;
             }
         }
     }
+    let cleaned = String::from_utf8(cleaned)
+        .map_err(|e| format!("agtype text is not valid UTF-8 after annotation strip: {e}"))?;
     serde_json::from_str(&cleaned).map_err(|e| e.to_string())
 }
 
@@ -622,6 +630,23 @@ mod tests {
         let v = parse_agtype(r#"[1.5::numeric, "a", {"x": 2}::vertex]"#).expect("parses");
         assert_eq!(v[0], 1.5);
         assert_eq!(v[2]["x"], 2);
+    }
+
+    #[test]
+    fn non_ascii_string_values_survive_byte_faithfully() {
+        // Latin-1 `u8 as char` shredding would turn 颱風 into mojibake
+        // that STILL parses as JSON — this pins the byte-faithful path
+        // (CJK, emoji, and a combining accent, inside and outside
+        // annotated objects).
+        let text = r#"{"id": 1, "label": "城市", "properties": {"name": "颱風", "note": "café ☔"}}::vertex"#;
+        let v = parse_agtype(text).expect("parses");
+        assert_eq!(v["label"], "城市");
+        assert_eq!(v["properties"]["name"], "颱風");
+        assert_eq!(v["properties"]["note"], "café ☔");
+
+        let v = parse_agtype(r#"["中文", 1.5::numeric, "🎈"]"#).expect("parses");
+        assert_eq!(v[0], "中文");
+        assert_eq!(v[2], "🎈");
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/graph/value.rs
+++ b/crates/skardi/src/sources/providers/graph/value.rs
@@ -423,6 +423,21 @@ fn node_parts(
     match v {
         Value::Null => Ok(None),
         Value::Object(map) => {
+            // Endpoint keys are the structural tell of an EDGE: an edge
+            // object ({id, label, start_id, end_id, properties}) would
+            // otherwise satisfy the node shape completely — id and label
+            // present — and a `RETURN r` declared as `node` would decode
+            // silently, dropping start_id/end_id on the floor. The
+            // reverse direction already fails naturally (a vertex lacks
+            // the endpoint keys a relationship column requires); this
+            // check closes the hole from the other side, turning a
+            // silent wrong answer into the typed error the design
+            // promises. Sound because both keys are structural fields,
+            // never property names: properties live under their own
+            // `properties` sub-object.
+            if map.contains_key("start_id") || map.contains_key("end_id") {
+                return Err(mismatch(col, row, "node", v));
+            }
             let (Some(id), Some(label)) = (map.get("id"), map.get("label").and_then(Value::as_str))
             else {
                 return Err(mismatch(col, row, "node", v));
@@ -905,6 +920,16 @@ mod tests {
             (GraphType::Bool, serde_json::json!("yes"), "bool"),
             (GraphType::Float, serde_json::json!("1.5"), "float"),
             (GraphType::Node, serde_json::json!({"id": 1}), "node"), // no label
+            (
+                // An EDGE object satisfies the node keys (id + label) —
+                // the endpoint keys are what must reject it, or a
+                // `RETURN r` declared `node` decodes silently with
+                // start_id/end_id dropped.
+                GraphType::Node,
+                serde_json::json!({"id": 9, "label": "KNOWS", "start_id": 1,
+                                   "end_id": 2, "properties": {}}),
+                "node",
+            ),
             (
                 GraphType::Relationship,
                 serde_json::json!({"id": 1, "label": "K"}), // no endpoints

--- a/crates/skardi/src/sources/providers/graph/value.rs
+++ b/crates/skardi/src/sources/providers/graph/value.rs
@@ -1,0 +1,784 @@
+//! Graph values → Arrow, type-directed by the caller-declared columns.
+//!
+//! Two halves, both backend-shared:
+//!
+//! - **agtype text → JSON.** AGE serializes results as agtype — JSON with
+//!   `::vertex` / `::edge` / `::path` (and `::numeric`) annotations
+//!   appended after the value they classify. [`parse_agtype`] strips the
+//!   annotations *outside string literals* and parses the remainder as
+//!   JSON. The annotations are not needed afterwards: conversion is
+//!   type-directed by the DECLARED column type (design §Schema handling —
+//!   there is no schema inference anywhere), so a `node` column expects
+//!   the vertex object shape and fails with a typed error otherwise.
+//! - **JSON → Arrow.** [`build_batch`] converts one buffered batch of rows
+//!   against the declared columns. Every declared column is nullable
+//!   (Cypher can produce null in any position); a non-null value of the
+//!   wrong JSON kind is [`GraphError::TypeMismatch`] carrying kinds, never
+//!   values.
+//!
+//! The canonical STRUCT shapes (design §Result flattening):
+//! - node: `STRUCT<id Utf8, labels List<Utf8>, properties Utf8>` —
+//!   properties are JSON text so the schema is independent of which keys
+//!   any row happens to carry.
+//! - relationship: `STRUCT<id Utf8, start_id Utf8, end_id Utf8, type Utf8,
+//!   properties Utf8>`.
+//! - path: `STRUCT<nodes List<node>, relationships List<relationship>>` —
+//!   two parallel typed lists (an Arrow list has ONE element type and a
+//!   path alternates two shapes); relationship *i* connects node *i* to
+//!   node *i+1*.
+
+use std::sync::Arc;
+
+use arrow::array::{
+    ArrayRef, BooleanBuilder, Float64Builder, Int64Builder, ListArray, ListBuilder, StringBuilder,
+    StructArray,
+};
+use arrow::buffer::{NullBuffer, OffsetBuffer};
+use arrow::datatypes::{DataType, Field, Fields, Schema};
+use arrow::record_batch::RecordBatch;
+use serde_json::Value;
+
+use super::error::{GraphError, json_kind};
+
+/// The declared-type vocabulary — the repo's friendly lowercase names
+/// (dynamodb/mongo/seekdb precedent), never Arrow PascalCase. One
+/// spelling, shared verbatim by the future YAML views' `type:` fields.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphType {
+    /// `string` (aliases `str`, `utf8`) → Utf8.
+    String,
+    /// `int` (aliases `integer`, `bigint`) → Int64.
+    Int,
+    /// `float` (alias `double`) → Float64.
+    Float,
+    /// `bool` (alias `boolean`) → Boolean.
+    Bool,
+    /// `json` → Utf8 carrying the value as JSON text verbatim.
+    Json,
+    /// `node` → the canonical vertex STRUCT.
+    Node,
+    /// `relationship` → the canonical edge STRUCT.
+    Relationship,
+    /// `path` → parallel node/relationship lists.
+    Path,
+}
+
+/// The accepted set, for error messages — kept in one place so the
+/// diagnostic can never drift from the parser.
+pub const ACCEPTED_TYPES: &str = "string|str|utf8, int|integer|bigint, float|double, bool|boolean, json, \
+     node, relationship, path";
+
+impl GraphType {
+    /// Parse one friendly type name.
+    pub fn parse(name: &str) -> Option<Self> {
+        match name {
+            "string" | "str" | "utf8" => Some(Self::String),
+            "int" | "integer" | "bigint" => Some(Self::Int),
+            "float" | "double" => Some(Self::Float),
+            "bool" | "boolean" => Some(Self::Bool),
+            "json" => Some(Self::Json),
+            "node" => Some(Self::Node),
+            "relationship" => Some(Self::Relationship),
+            "path" => Some(Self::Path),
+            _ => None,
+        }
+    }
+
+    /// The canonical (post-alias) name, for diagnostics.
+    pub fn canonical(&self) -> &'static str {
+        match self {
+            Self::String => "string",
+            Self::Int => "int",
+            Self::Float => "float",
+            Self::Bool => "bool",
+            Self::Json => "json",
+            Self::Node => "node",
+            Self::Relationship => "relationship",
+            Self::Path => "path",
+        }
+    }
+
+    /// The Arrow type this declared type plans as.
+    pub fn arrow_type(&self) -> DataType {
+        match self {
+            Self::String | Self::Json => DataType::Utf8,
+            Self::Int => DataType::Int64,
+            Self::Float => DataType::Float64,
+            Self::Bool => DataType::Boolean,
+            Self::Node => DataType::Struct(node_fields()),
+            Self::Relationship => DataType::Struct(relationship_fields()),
+            Self::Path => DataType::Struct(path_fields()),
+        }
+    }
+}
+
+/// One declared output column.
+#[derive(Debug, Clone)]
+pub struct DeclaredColumn {
+    pub name: String,
+    pub ty: GraphType,
+}
+
+/// The vertex STRUCT's fields — one definition feeds the planned type AND
+/// the builder so they cannot drift.
+pub fn node_fields() -> Fields {
+    Fields::from(vec![
+        Field::new("id", DataType::Utf8, true),
+        Field::new(
+            "labels",
+            DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+            true,
+        ),
+        Field::new("properties", DataType::Utf8, true),
+    ])
+}
+
+/// The edge STRUCT's fields.
+pub fn relationship_fields() -> Fields {
+    Fields::from(vec![
+        Field::new("id", DataType::Utf8, true),
+        Field::new("start_id", DataType::Utf8, true),
+        Field::new("end_id", DataType::Utf8, true),
+        Field::new("type", DataType::Utf8, true),
+        Field::new("properties", DataType::Utf8, true),
+    ])
+}
+
+/// The path STRUCT's fields: parallel typed lists.
+pub fn path_fields() -> Fields {
+    Fields::from(vec![
+        Field::new(
+            "nodes",
+            DataType::List(Arc::new(Field::new(
+                "item",
+                DataType::Struct(node_fields()),
+                true,
+            ))),
+            true,
+        ),
+        Field::new(
+            "relationships",
+            DataType::List(Arc::new(Field::new(
+                "item",
+                DataType::Struct(relationship_fields()),
+                true,
+            ))),
+            true,
+        ),
+    ])
+}
+
+/// The planned schema for a set of declared columns. Every field is
+/// nullable — Cypher can produce null in any position, and there is no
+/// way to declare otherwise on the ad-hoc surface (design §Schema
+/// handling).
+pub fn declared_schema(columns: &[DeclaredColumn]) -> Arc<Schema> {
+    Arc::new(Schema::new(
+        columns
+            .iter()
+            .map(|c| Field::new(&c.name, c.ty.arrow_type(), true))
+            .collect::<Vec<_>>(),
+    ))
+}
+
+/// Strip agtype's `::identifier` annotations outside string literals and
+/// parse the remainder as JSON.
+///
+/// The scanner tracks JSON string state (including escapes), so a literal
+/// like `"a::vertex"` survives untouched; only structural annotations —
+/// which always follow a value (`}`, `]`, digit, or scalar keyword) — are
+/// removed.
+pub fn parse_agtype(text: &str) -> Result<Value, String> {
+    let mut cleaned = String::with_capacity(text.len());
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    let mut in_string = false;
+    let mut escaped = false;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if in_string {
+            cleaned.push(b as char);
+            if escaped {
+                escaped = false;
+            } else if b == b'\\' {
+                escaped = true;
+            } else if b == b'"' {
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+        match b {
+            b'"' => {
+                in_string = true;
+                cleaned.push('"');
+                i += 1;
+            }
+            b':' if i + 1 < bytes.len() && bytes[i + 1] == b':' => {
+                // `::identifier` — skip the annotation.
+                i += 2;
+                while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+                    i += 1;
+                }
+            }
+            _ => {
+                // Non-ASCII bytes only occur inside strings in agtype's
+                // structural layer, but push byte-faithfully regardless.
+                cleaned.push(b as char);
+                i += 1;
+            }
+        }
+    }
+    serde_json::from_str(&cleaned).map_err(|e| e.to_string())
+}
+
+/// Convert one buffered batch of rows (each row = one JSON value per
+/// declared column) into a RecordBatch. Batch-atomic: any type mismatch
+/// fails the WHOLE batch before anything is emitted (design §Schema
+/// handling). `row_base` is the absolute index of the batch's first row,
+/// so errors name the result row, not the batch-relative one.
+pub fn build_batch(
+    columns: &[DeclaredColumn],
+    rows: &[Vec<Value>],
+    row_base: usize,
+) -> Result<RecordBatch, GraphError> {
+    let mut arrays: Vec<ArrayRef> = Vec::with_capacity(columns.len());
+    for (col_idx, col) in columns.iter().enumerate() {
+        let cells = rows.iter().map(|r| &r[col_idx]);
+        let array: ArrayRef = match col.ty {
+            GraphType::String => {
+                let mut b = StringBuilder::new();
+                for (i, v) in cells.enumerate() {
+                    match v {
+                        Value::Null => b.append_null(),
+                        Value::String(s) => b.append_value(s),
+                        other => return Err(mismatch(col, row_base + i, "string", other)),
+                    }
+                }
+                Arc::new(b.finish())
+            }
+            GraphType::Int => {
+                let mut b = Int64Builder::new();
+                for (i, v) in cells.enumerate() {
+                    match v {
+                        Value::Null => b.append_null(),
+                        Value::Number(n) if n.is_i64() => b.append_value(n.as_i64().unwrap()),
+                        other => return Err(mismatch(col, row_base + i, "int", other)),
+                    }
+                }
+                Arc::new(b.finish())
+            }
+            GraphType::Float => {
+                let mut b = Float64Builder::new();
+                for (i, v) in cells.enumerate() {
+                    match v {
+                        Value::Null => b.append_null(),
+                        // Integers widen losslessly enough for a declared
+                        // float; the reverse (float → int) never does.
+                        Value::Number(n) => match n.as_f64() {
+                            Some(f) => b.append_value(f),
+                            None => return Err(mismatch(col, row_base + i, "float", v)),
+                        },
+                        other => return Err(mismatch(col, row_base + i, "float", other)),
+                    }
+                }
+                Arc::new(b.finish())
+            }
+            GraphType::Bool => {
+                let mut b = BooleanBuilder::new();
+                for (i, v) in cells.enumerate() {
+                    match v {
+                        Value::Null => b.append_null(),
+                        Value::Bool(x) => b.append_value(*x),
+                        other => return Err(mismatch(col, row_base + i, "bool", other)),
+                    }
+                }
+                Arc::new(b.finish())
+            }
+            GraphType::Json => {
+                // Verbatim: any JSON kind is legal, null stays SQL NULL.
+                let mut b = StringBuilder::new();
+                for v in cells {
+                    match v {
+                        Value::Null => b.append_null(),
+                        other => b.append_value(other.to_string()),
+                    }
+                }
+                Arc::new(b.finish())
+            }
+            GraphType::Node => {
+                let mut parts = Vec::with_capacity(rows.len());
+                for (i, v) in cells.enumerate() {
+                    parts.push(node_parts(col, row_base + i, v)?);
+                }
+                Arc::new(node_struct_array(&parts))
+            }
+            GraphType::Relationship => {
+                let mut parts = Vec::with_capacity(rows.len());
+                for (i, v) in cells.enumerate() {
+                    parts.push(relationship_parts(col, row_base + i, v)?);
+                }
+                Arc::new(relationship_struct_array(&parts))
+            }
+            GraphType::Path => {
+                let mut parts = Vec::with_capacity(rows.len());
+                for (i, v) in cells.enumerate() {
+                    parts.push(path_parts(col, row_base + i, v)?);
+                }
+                Arc::new(path_struct_array(&parts))
+            }
+        };
+        arrays.push(array);
+    }
+    RecordBatch::try_new(declared_schema(columns), arrays).map_err(|e| {
+        // Unreachable by construction (builders match the schema); kept as
+        // a typed error rather than a panic.
+        GraphError::backend("<conversion>", "arrow", &e.to_string())
+    })
+}
+
+fn mismatch(col: &DeclaredColumn, row: usize, expected: &'static str, v: &Value) -> GraphError {
+    GraphError::TypeMismatch {
+        column: col.name.clone(),
+        row,
+        expected,
+        found: json_kind(v),
+    }
+}
+
+/// One vertex, decomposed: (id, label, properties-json). AGE vertex
+/// objects carry `id` (number), `label` (string), `properties` (object).
+/// Ids are stringified: opaque tokens, stable for the entity's life
+/// within one database (design §Backend abstraction).
+struct NodeParts {
+    id: String,
+    label: String,
+    properties: String,
+}
+
+/// One edge, decomposed.
+struct RelParts {
+    id: String,
+    start_id: String,
+    end_id: String,
+    rel_type: String,
+    properties: String,
+}
+
+fn node_parts(
+    col: &DeclaredColumn,
+    row: usize,
+    v: &Value,
+) -> Result<Option<NodeParts>, GraphError> {
+    match v {
+        Value::Null => Ok(None),
+        Value::Object(map) => {
+            let (Some(id), Some(label)) = (map.get("id"), map.get("label").and_then(Value::as_str))
+            else {
+                return Err(mismatch(col, row, "node", v));
+            };
+            Ok(Some(NodeParts {
+                id: scalar_to_string(id),
+                label: label.to_string(),
+                properties: map
+                    .get("properties")
+                    .cloned()
+                    .unwrap_or(Value::Null)
+                    .to_string(),
+            }))
+        }
+        other => Err(mismatch(col, row, "node", other)),
+    }
+}
+
+fn relationship_parts(
+    col: &DeclaredColumn,
+    row: usize,
+    v: &Value,
+) -> Result<Option<RelParts>, GraphError> {
+    match v {
+        Value::Null => Ok(None),
+        Value::Object(map) => {
+            let (Some(id), Some(start), Some(end), Some(label)) = (
+                map.get("id"),
+                map.get("start_id"),
+                map.get("end_id"),
+                map.get("label").and_then(Value::as_str),
+            ) else {
+                return Err(mismatch(col, row, "relationship", v));
+            };
+            Ok(Some(RelParts {
+                id: scalar_to_string(id),
+                start_id: scalar_to_string(start),
+                end_id: scalar_to_string(end),
+                rel_type: label.to_string(),
+                properties: map
+                    .get("properties")
+                    .cloned()
+                    .unwrap_or(Value::Null)
+                    .to_string(),
+            }))
+        }
+        other => Err(mismatch(col, row, "relationship", other)),
+    }
+}
+
+/// An AGE path is a JSON array alternating vertex/edge objects
+/// (`[v, e, v, …]` — nodes at the even positions, odd total length).
+/// A path, decomposed into its two parallel element sequences.
+type PathParts = (Vec<NodeParts>, Vec<RelParts>);
+
+fn path_parts(
+    col: &DeclaredColumn,
+    row: usize,
+    v: &Value,
+) -> Result<Option<PathParts>, GraphError> {
+    match v {
+        Value::Null => Ok(None),
+        Value::Array(elements) => {
+            if elements.len().is_multiple_of(2) && !elements.is_empty() {
+                return Err(mismatch(col, row, "path", v));
+            }
+            let mut nodes = Vec::with_capacity(elements.len() / 2 + 1);
+            let mut rels = Vec::with_capacity(elements.len() / 2);
+            for (i, el) in elements.iter().enumerate() {
+                if i.is_multiple_of(2) {
+                    match node_parts(col, row, el)? {
+                        Some(n) => nodes.push(n),
+                        None => return Err(mismatch(col, row, "path", v)),
+                    }
+                } else {
+                    match relationship_parts(col, row, el)? {
+                        Some(r) => rels.push(r),
+                        None => return Err(mismatch(col, row, "path", v)),
+                    }
+                }
+            }
+            Ok(Some((nodes, rels)))
+        }
+        other => Err(mismatch(col, row, "path", other)),
+    }
+}
+
+/// Assemble the canonical vertex STRUCT column: explicit child arrays +
+/// a validity buffer (arrow's `StructBuilder` erases List child builders,
+/// so explicit assembly is both clearer and the only reliable spelling).
+fn node_struct_array(items: &[Option<NodeParts>]) -> StructArray {
+    let mut ids = StringBuilder::new();
+    let mut labels = ListBuilder::new(StringBuilder::new());
+    let mut props = StringBuilder::new();
+    let mut validity = Vec::with_capacity(items.len());
+    for item in items {
+        match item {
+            Some(n) => {
+                ids.append_value(&n.id);
+                labels.values().append_value(&n.label);
+                labels.append(true);
+                props.append_value(&n.properties);
+                validity.push(true);
+            }
+            None => {
+                ids.append_null();
+                labels.append_null();
+                props.append_null();
+                validity.push(false);
+            }
+        }
+    }
+    StructArray::new(
+        node_fields(),
+        vec![
+            Arc::new(ids.finish()),
+            Arc::new(labels.finish()),
+            Arc::new(props.finish()),
+        ],
+        Some(NullBuffer::from(validity)),
+    )
+}
+
+/// Assemble the canonical edge STRUCT column.
+fn relationship_struct_array(items: &[Option<RelParts>]) -> StructArray {
+    let mut ids = StringBuilder::new();
+    let mut starts = StringBuilder::new();
+    let mut ends = StringBuilder::new();
+    let mut types = StringBuilder::new();
+    let mut props = StringBuilder::new();
+    let mut validity = Vec::with_capacity(items.len());
+    for item in items {
+        match item {
+            Some(r) => {
+                ids.append_value(&r.id);
+                starts.append_value(&r.start_id);
+                ends.append_value(&r.end_id);
+                types.append_value(&r.rel_type);
+                props.append_value(&r.properties);
+                validity.push(true);
+            }
+            None => {
+                ids.append_null();
+                starts.append_null();
+                ends.append_null();
+                types.append_null();
+                props.append_null();
+                validity.push(false);
+            }
+        }
+    }
+    StructArray::new(
+        relationship_fields(),
+        vec![
+            Arc::new(ids.finish()),
+            Arc::new(starts.finish()),
+            Arc::new(ends.finish()),
+            Arc::new(types.finish()),
+            Arc::new(props.finish()),
+        ],
+        Some(NullBuffer::from(validity)),
+    )
+}
+
+/// Assemble the path STRUCT column: two parallel typed lists over
+/// flattened node/edge values, offsets per row.
+fn path_struct_array(items: &[Option<PathParts>]) -> StructArray {
+    let mut flat_nodes: Vec<Option<NodeParts>> = Vec::new();
+    let mut flat_rels: Vec<Option<RelParts>> = Vec::new();
+    let mut node_lengths = Vec::with_capacity(items.len());
+    let mut rel_lengths = Vec::with_capacity(items.len());
+    let mut validity = Vec::with_capacity(items.len());
+    for item in items {
+        match item {
+            Some((nodes, rels)) => {
+                node_lengths.push(nodes.len());
+                rel_lengths.push(rels.len());
+                validity.push(true);
+                flat_nodes.extend(nodes.iter().map(|n| {
+                    Some(NodeParts {
+                        id: n.id.clone(),
+                        label: n.label.clone(),
+                        properties: n.properties.clone(),
+                    })
+                }));
+                flat_rels.extend(rels.iter().map(|r| {
+                    Some(RelParts {
+                        id: r.id.clone(),
+                        start_id: r.start_id.clone(),
+                        end_id: r.end_id.clone(),
+                        rel_type: r.rel_type.clone(),
+                        properties: r.properties.clone(),
+                    })
+                }));
+            }
+            None => {
+                node_lengths.push(0);
+                rel_lengths.push(0);
+                validity.push(false);
+            }
+        }
+    }
+    let nodes_list = ListArray::new(
+        Arc::new(Field::new("item", DataType::Struct(node_fields()), true)),
+        OffsetBuffer::from_lengths(node_lengths),
+        Arc::new(node_struct_array(&flat_nodes)),
+        Some(NullBuffer::from(validity.clone())),
+    );
+    let rels_list = ListArray::new(
+        Arc::new(Field::new(
+            "item",
+            DataType::Struct(relationship_fields()),
+            true,
+        )),
+        OffsetBuffer::from_lengths(rel_lengths),
+        Arc::new(relationship_struct_array(&flat_rels)),
+        Some(NullBuffer::from(validity)),
+    );
+    StructArray::new(
+        path_fields(),
+        vec![Arc::new(nodes_list), Arc::new(rels_list)],
+        None,
+    )
+}
+
+/// Ids arrive as agtype integers; stringify without float detours.
+fn scalar_to_string(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Array, StringArray, StructArray};
+
+    #[test]
+    fn agtype_annotations_strip_outside_strings_only() {
+        let text = r#"{"id": 1, "label": "A", "properties": {"note": "x::vertex"}}::vertex"#;
+        let v = parse_agtype(text).expect("parses");
+        assert_eq!(v["properties"]["note"], "x::vertex", "string survives");
+        assert_eq!(v["id"], 1);
+
+        // Numeric annotation mid-array.
+        let v = parse_agtype(r#"[1.5::numeric, "a", {"x": 2}::vertex]"#).expect("parses");
+        assert_eq!(v[0], 1.5);
+        assert_eq!(v[2]["x"], 2);
+    }
+
+    #[test]
+    fn declared_types_parse_with_aliases_and_reject_pascal_case() {
+        assert_eq!(GraphType::parse("utf8"), Some(GraphType::String));
+        assert_eq!(GraphType::parse("bigint"), Some(GraphType::Int));
+        assert_eq!(GraphType::parse("double"), Some(GraphType::Float));
+        assert_eq!(GraphType::parse("path"), Some(GraphType::Path));
+        // Arrow PascalCase is NOT the vocabulary (design: the repo's
+        // friendly lowercase names, one spelling everywhere).
+        assert_eq!(GraphType::parse("Utf8"), None);
+        assert_eq!(GraphType::parse("Int64"), None);
+    }
+
+    fn col(name: &str, ty: GraphType) -> DeclaredColumn {
+        DeclaredColumn {
+            name: name.to_string(),
+            ty,
+        }
+    }
+
+    #[test]
+    fn scalars_convert_and_nulls_pass_through() {
+        let columns = vec![
+            col("s", GraphType::String),
+            col("i", GraphType::Int),
+            col("f", GraphType::Float),
+            col("b", GraphType::Bool),
+            col("j", GraphType::Json),
+        ];
+        let rows = vec![
+            vec![
+                serde_json::json!("hi"),
+                serde_json::json!(7),
+                serde_json::json!(1.5),
+                serde_json::json!(true),
+                serde_json::json!({"k": [1, 2]}),
+            ],
+            vec![
+                Value::Null,
+                Value::Null,
+                serde_json::json!(2), // int widens into a declared float
+                Value::Null,
+                Value::Null,
+            ],
+        ];
+        let batch = build_batch(&columns, &rows, 0).expect("converts");
+        assert_eq!(batch.num_rows(), 2);
+        let s = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(s.value(0), "hi");
+        assert!(s.is_null(1));
+        let j = batch
+            .column(4)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(j.value(0), r#"{"k":[1,2]}"#);
+    }
+
+    #[test]
+    fn type_mismatch_names_column_row_and_kinds_never_values() {
+        let columns = vec![col("n", GraphType::Int)];
+        let rows = vec![
+            vec![serde_json::json!(1)],
+            vec![serde_json::json!("secret-value")],
+        ];
+        let err = build_batch(&columns, &rows, 10).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("'n'"), "{msg}");
+        assert!(msg.contains("row 11"), "absolute row index: {msg}");
+        assert!(msg.contains("a string"), "{msg}");
+        assert!(!msg.contains("secret-value"), "values never leak: {msg}");
+    }
+
+    #[test]
+    fn a_float_does_not_pass_as_a_declared_int() {
+        let columns = vec![col("n", GraphType::Int)];
+        let rows = vec![vec![serde_json::json!(1.5)]];
+        let err = build_batch(&columns, &rows, 0).unwrap_err();
+        assert!(err.to_string().contains("declared 'int'"), "{err}");
+    }
+
+    #[test]
+    fn node_converts_to_the_canonical_struct() {
+        let columns = vec![col("v", GraphType::Node)];
+        let vertex = parse_agtype(
+            r#"{"id": 844424930131969, "label": "Person", "properties": {"name": "redacted"}}::vertex"#,
+        )
+        .unwrap();
+        let rows = vec![vec![vertex], vec![Value::Null]];
+        let batch = build_batch(&columns, &rows, 0).expect("converts");
+        let s = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+        let ids = s
+            .column_by_name("id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(ids.value(0), "844424930131969", "id is stringified");
+        assert!(s.is_null(1), "null node row is a null struct");
+        let props = s
+            .column_by_name("properties")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(props.value(0), r#"{"name":"redacted"}"#);
+    }
+
+    #[test]
+    fn path_splits_into_parallel_typed_lists() {
+        let columns = vec![col("p", GraphType::Path)];
+        let path = parse_agtype(
+            r#"[{"id": 1, "label": "A", "properties": {}}::vertex, \
+                {"id": 9, "label": "KNOWS", "start_id": 1, "end_id": 2, "properties": {}}::edge, \
+                {"id": 2, "label": "B", "properties": {}}::vertex]::path"#
+                .replace("\\\n", "")
+                .as_str(),
+        )
+        .unwrap();
+        let rows = vec![vec![path]];
+        let batch = build_batch(&columns, &rows, 0).expect("converts");
+        let s = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+        let nodes = s.column_by_name("nodes").unwrap();
+        let rels = s.column_by_name("relationships").unwrap();
+        let nodes = nodes
+            .as_any()
+            .downcast_ref::<arrow::array::ListArray>()
+            .unwrap();
+        let rels = rels
+            .as_any()
+            .downcast_ref::<arrow::array::ListArray>()
+            .unwrap();
+        assert_eq!(nodes.value(0).len(), 2, "nodes is one longer");
+        assert_eq!(rels.value(0).len(), 1);
+    }
+
+    #[test]
+    fn an_even_length_path_is_a_typed_mismatch() {
+        let columns = vec![col("p", GraphType::Path)];
+        let rows = vec![vec![
+            serde_json::json!([{"id":1,"label":"A","properties":{}},
+                                                {"id":2,"label":"B","properties":{}}]),
+        ]];
+        let err = build_batch(&columns, &rows, 0).unwrap_err();
+        assert!(err.to_string().contains("declared 'path'"), "{err}");
+    }
+}

--- a/crates/skardi/src/sources/providers/graph/value.rs
+++ b/crates/skardi/src/sources/providers/graph/value.rs
@@ -444,7 +444,12 @@ fn path_parts(
     match v {
         Value::Null => Ok(None),
         Value::Array(elements) => {
-            if elements.len().is_multiple_of(2) && !elements.is_empty() {
+            // A path is ODD-length by construction: n nodes alternate
+            // with n-1 edges, and the minimum is one node (the design's
+            // zero-hop path). Even lengths AND the empty array are both
+            // malformed — an empty array must not be silently accepted
+            // as a "0-node path".
+            if elements.len().is_multiple_of(2) {
                 return Err(mismatch(col, row, "path", v));
             }
             let mut nodes = Vec::with_capacity(elements.len() / 2 + 1);
@@ -797,7 +802,7 @@ mod tests {
     }
 
     #[test]
-    fn an_even_length_path_is_a_typed_mismatch() {
+    fn even_length_and_empty_paths_are_typed_mismatches() {
         let columns = vec![col("p", GraphType::Path)];
         let rows = vec![vec![
             serde_json::json!([{"id":1,"label":"A","properties":{}},
@@ -805,5 +810,18 @@ mod tests {
         ]];
         let err = build_batch(&columns, &rows, 0).unwrap_err();
         assert!(err.to_string().contains("declared 'path'"), "{err}");
+
+        // The empty array is malformed too — an AGE path always carries
+        // at least one node, and silently accepting [] as a "0-node
+        // path" would hide upstream corruption.
+        let rows = vec![vec![serde_json::json!([])]];
+        let err = build_batch(&columns, &rows, 0).unwrap_err();
+        assert!(err.to_string().contains("declared 'path'"), "{err}");
+
+        // The zero-hop minimum stays legal: one node, no edges.
+        let rows = vec![vec![
+            serde_json::json!([{"id":1,"label":"A","properties":{}}]),
+        ]];
+        build_batch(&columns, &rows, 0).expect("a single-node path is the legal minimum");
     }
 }

--- a/crates/skardi/src/sources/providers/graph/value.rs
+++ b/crates/skardi/src/sources/providers/graph/value.rs
@@ -250,6 +250,18 @@ pub fn build_batch(
     rows: &[Vec<Value>],
     row_base: usize,
 ) -> Result<RecordBatch, GraphError> {
+    // Arity first: a backend row shorter than the declared schema must
+    // be a typed error, not an index panic (future Neo4j/Kuzu drivers
+    // make this reachable even if the AGE client can't produce it).
+    for (i, row) in rows.iter().enumerate() {
+        if row.len() != columns.len() {
+            return Err(GraphError::RowArityMismatch {
+                row: row_base + i,
+                expected: columns.len(),
+                found: row.len(),
+            });
+        }
+    }
     let mut arrays: Vec<ArrayRef> = Vec::with_capacity(columns.len());
     for (col_idx, col) in columns.iter().enumerate() {
         let cells = rows.iter().map(|r| &r[col_idx]);
@@ -270,7 +282,10 @@ pub fn build_batch(
                 for (i, v) in cells.enumerate() {
                     match v {
                         Value::Null => b.append_null(),
-                        Value::Number(n) if n.is_i64() => b.append_value(n.as_i64().unwrap()),
+                        Value::Number(n) => match n.as_i64() {
+                            Some(i) => b.append_value(i),
+                            None => return Err(mismatch(col, row_base + i, "int", v)),
+                        },
                         other => return Err(mismatch(col, row_base + i, "int", other)),
                     }
                 }
@@ -602,12 +617,15 @@ fn path_struct_array(items: &[Option<PathParts>]) -> StructArray {
         )),
         OffsetBuffer::from_lengths(rel_lengths),
         Arc::new(relationship_struct_array(&flat_rels)),
-        Some(NullBuffer::from(validity)),
+        Some(NullBuffer::from(validity.clone())),
     );
+    // The parent STRUCT carries the SAME validity as its child lists —
+    // with None here, a NULL path row would read as a valid struct whose
+    // lists happen to be null, and `path IS NULL` would answer false.
     StructArray::new(
         path_fields(),
         vec![Arc::new(nodes_list), Arc::new(rels_list)],
-        None,
+        Some(NullBuffer::from(validity)),
     )
 }
 
@@ -799,6 +817,44 @@ mod tests {
             .unwrap();
         assert_eq!(nodes.value(0).len(), 2, "nodes is one longer");
         assert_eq!(rels.value(0).len(), 1);
+    }
+
+    #[test]
+    fn a_null_path_row_is_a_null_struct() {
+        // With a None parent validity the null row would read as a VALID
+        // struct whose child lists are null — and SQL `path IS NULL`
+        // would answer false. The parent must carry the row validity.
+        let columns = vec![col("p", GraphType::Path)];
+        let rows = vec![
+            vec![serde_json::json!([{"id":1,"label":"A","properties":{}}])],
+            vec![Value::Null],
+        ];
+        let batch = build_batch(&columns, &rows, 0).expect("converts");
+        let paths = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+        assert!(!paths.is_null(0));
+        assert!(paths.is_null(1), "NULL path row must be a NULL struct");
+    }
+
+    #[test]
+    fn a_short_row_is_a_typed_arity_error_not_a_panic() {
+        // A backend row narrower than the declared schema (reachable via
+        // future drivers) must surface as a typed error with identity.
+        let columns = vec![col("a", GraphType::Int), col("b", GraphType::Int)];
+        let rows = vec![
+            vec![serde_json::json!(1), serde_json::json!(2)],
+            vec![serde_json::json!(3)], // one column short
+        ];
+        let err = build_batch(&columns, &rows, 5).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("row 6"), "{msg}");
+        assert!(
+            msg.contains("carries 1 columns but 2 were declared"),
+            "{msg}"
+        );
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/graph/value.rs
+++ b/crates/skardi/src/sources/providers/graph/value.rs
@@ -820,6 +820,99 @@ mod tests {
     }
 
     #[test]
+    fn relationships_convert_to_the_canonical_struct_with_null_rows() {
+        let columns = vec![col("r", GraphType::Relationship)];
+        let edge = parse_agtype(
+            r#"{"id": 9, "label": "KNOWS", "start_id": 1, "end_id": 2, "properties": {"since": 2019}}::edge"#,
+        )
+        .unwrap();
+        let rows = vec![vec![edge], vec![Value::Null]];
+        let batch = build_batch(&columns, &rows, 0).expect("converts");
+        let s = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+        assert!(s.is_null(1), "null relationship row is a null struct");
+        let types = s
+            .column_by_name("type")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(types.value(0), "KNOWS");
+        let starts = s
+            .column_by_name("start_id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(starts.value(0), "1", "endpoint ids stringify");
+    }
+
+    #[test]
+    fn every_wrong_kind_is_a_typed_mismatch_per_declared_type() {
+        // One wrong-kind row per scalar declared type, plus the malformed
+        // struct shapes — each must name the declared type, never a value.
+        let cases: Vec<(GraphType, Value, &str)> = vec![
+            (GraphType::String, serde_json::json!(7), "string"),
+            (GraphType::Bool, serde_json::json!("yes"), "bool"),
+            (GraphType::Float, serde_json::json!("1.5"), "float"),
+            (GraphType::Node, serde_json::json!({"id": 1}), "node"), // no label
+            (
+                GraphType::Relationship,
+                serde_json::json!({"id": 1, "label": "K"}), // no endpoints
+                "relationship",
+            ),
+            (GraphType::Path, serde_json::json!("not-a-list"), "path"),
+        ];
+        for (ty, bad, name) in cases {
+            let columns = vec![col("c", ty)];
+            let err = build_batch(&columns, &[vec![bad]], 0).unwrap_err();
+            assert!(
+                err.to_string().contains(&format!("declared '{name}'")),
+                "{name}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_names_and_arrow_types_cover_every_variant() {
+        for (ty, canonical) in [
+            (GraphType::String, "string"),
+            (GraphType::Int, "int"),
+            (GraphType::Float, "float"),
+            (GraphType::Bool, "bool"),
+            (GraphType::Json, "json"),
+            (GraphType::Node, "node"),
+            (GraphType::Relationship, "relationship"),
+            (GraphType::Path, "path"),
+        ] {
+            assert_eq!(ty.canonical(), canonical);
+            // Round-trip: the canonical name parses back to the same type.
+            assert_eq!(GraphType::parse(canonical), Some(ty));
+            // And every variant plans a concrete Arrow type.
+            let _ = ty.arrow_type();
+        }
+    }
+
+    #[test]
+    fn a_path_with_a_malformed_element_is_a_typed_mismatch() {
+        // An edge slot holding a non-edge object fails as 'relationship'
+        // (the element conversion), with the path row named.
+        let columns = vec![col("p", GraphType::Path)];
+        let rows = vec![vec![serde_json::json!([
+            {"id": 1, "label": "A", "properties": {}},
+            {"id": 9}, // not an edge
+            {"id": 2, "label": "B", "properties": {}}
+        ])]];
+        let err = build_batch(&columns, &rows, 3).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("declared 'relationship'"), "{msg}");
+        assert!(msg.contains("row 3"), "{msg}");
+    }
+
+    #[test]
     fn a_null_path_row_is_a_null_struct() {
         // With a None parent validity the null row would read as a VALID
         // struct whose child lists are null — and SQL `path IS NULL`

--- a/crates/skardi/src/sources/providers/mod.rs
+++ b/crates/skardi/src/sources/providers/mod.rs
@@ -2,6 +2,7 @@ pub mod clickhouse;
 #[cfg(feature = "documents")]
 pub mod documents;
 pub mod dynamodb;
+pub mod graph;
 pub mod iceberg;
 pub mod influxdb;
 pub mod knn_utils;

--- a/crates/skardi/tests/graph_age_live.rs
+++ b/crates/skardi/tests/graph_age_live.rs
@@ -1,0 +1,368 @@
+//! Opt-in live integration tests for the graph engine bypass's milestone-1
+//! backend: Apache AGE (openCypher inside Postgres).
+//!
+//! Disabled by default (`#[ignore]`) so the default suite stays offline and
+//! deterministic. These are the only tests that exercise the real
+//! Postgres+AGE path — everything else mocks at [`GraphClient`] level — so
+//! run them whenever the AGE client or the agtype decoding changes.
+//!
+//! Against a disposable AGE container (no setup needed):
+//!   docker run -d --name skardi-age -p 127.0.0.1:15432:5432 \
+//!     -e POSTGRES_PASSWORD=agepass apache/age
+//!   SKARDI_AGE_LIVE_URL='postgres://postgres:agepass@127.0.0.1:15432/postgres' \
+//!     cargo test -p skardi --test graph_age_live -- --ignored
+//!
+//! Each run creates a uniquely named graph and drops it afterwards, so a
+//! shared database is safe and reruns never collide.
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use arrow::array::{Array, Int64Array, ListArray, StringArray, StructArray};
+use arrow::record_batch::RecordBatch;
+use datafusion::prelude::SessionContext;
+use sqlx::Executor;
+use sqlx::postgres::PgPoolOptions;
+
+use skardi::sources::providers::graph::config::GraphConfig;
+use skardi::sources::providers::graph::udtf::GraphSources;
+use skardi::sources::providers::graph::{register_graph_source, register_graph_udtfs};
+
+fn live_url() -> Option<String> {
+    std::env::var("SKARDI_AGE_LIVE_URL")
+        .ok()
+        .filter(|u| !u.trim().is_empty())
+}
+
+/// Seed a fresh, uniquely named graph through AGE's own APIs (writes go
+/// through psql-side cypher — the Skardi surface under test is read-only
+/// by construction and could not create this data).
+async fn seed_graph(url: &str, graph: &str) -> sqlx::PgPool {
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .after_connect(|conn, _| {
+            Box::pin(async move {
+                conn.execute("LOAD 'age'; SET search_path = ag_catalog, \"$user\", public;")
+                    .await?;
+                Ok(())
+            })
+        })
+        .connect(url)
+        .await
+        .expect("live postgres reachable (SKARDI_AGE_LIVE_URL)");
+    sqlx::query("SELECT create_graph($1)")
+        .bind(graph)
+        .execute(&pool)
+        .await
+        .expect("create_graph");
+    let seed = format!(
+        "SELECT * FROM cypher('{graph}', $$
+            CREATE (a:Person {{name: 'ada', age: 36}}),
+                   (b:Person {{name: 'bob', age: 41}}),
+                   (c:Person {{name: 'cyd'}}),
+                   (a)-[:KNOWS {{since: 2019}}]->(b),
+                   (b)-[:KNOWS {{since: 2021}}]->(c)
+        $$) AS (v agtype)"
+    );
+    pool.execute(seed.as_str()).await.expect("seed cypher");
+    pool
+}
+
+async fn drop_graph(pool: &sqlx::PgPool, graph: &str) {
+    let _ = sqlx::query("SELECT drop_graph($1, true)")
+        .bind(graph)
+        .execute(pool)
+        .await;
+}
+
+/// A registered source + session, against the live database.
+async fn live_ctx(url: &str, graph: &str) -> (SessionContext, GraphSources) {
+    let sources: GraphSources = Arc::new(RwLock::new(HashMap::new()));
+    let config: GraphConfig = serde_yaml::from_str(&format!(
+        "backend: age\ngraph_name: {graph}\nquery_timeout_seconds: 10\nmax_rows: 100\n"
+    ))
+    .expect("config parses");
+    register_graph_source(&sources, "kg", url, &config)
+        .await
+        .expect("registration connects eagerly");
+    let ctx = SessionContext::new();
+    register_graph_udtfs(&ctx, Arc::clone(&sources)).expect("udtfs register");
+    (ctx, sources)
+}
+
+async fn collect(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch> {
+    ctx.sql(sql)
+        .await
+        .expect("plans")
+        .collect()
+        .await
+        .expect("executes")
+}
+
+fn unique_graph(tag: &str) -> String {
+    // Process id + monotonic-ish suffix keeps parallel runs and reruns
+    // apart without any shared state.
+    format!(
+        "skardi_it_{tag}_{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .subsec_nanos()
+    )
+}
+
+#[tokio::test]
+#[ignore = "needs a live Postgres+AGE (set SKARDI_AGE_LIVE_URL); see module doc"]
+async fn scalars_params_and_ordering_round_trip() {
+    let Some(url) = live_url() else {
+        panic!("SKARDI_AGE_LIVE_URL must be set for --ignored live tests");
+    };
+    let graph = unique_graph("scalar");
+    let pool = seed_graph(&url, &graph).await;
+    let (ctx, _sources) = live_ctx(&url, &graph).await;
+
+    // Declared scalars, a bound parameter, engine-side ORDER BY.
+    let batches = collect(
+        &ctx,
+        "SELECT name, age FROM cypher_query('kg', '\
+             MATCH (p:Person) WHERE p.age > $min RETURN p.name, p.age', \
+         '{\"min\": 40}', '{\"name\": \"string\", \"age\": \"int\"}')",
+    )
+    .await;
+    let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total, 1, "only bob is over 40");
+    let names = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(names.value(0), "bob");
+    let ages = batches[0]
+        .column(1)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap();
+    assert_eq!(ages.value(0), 41);
+
+    // A NULL property lands as SQL NULL (cyd has no age).
+    let batches = collect(
+        &ctx,
+        "SELECT name, age FROM cypher_query('kg', '\
+             MATCH (p:Person) RETURN p.name, p.age', '{}', \
+         '{\"name\": \"string\", \"age\": \"int\"}') ORDER BY name",
+    )
+    .await;
+    let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total, 3);
+
+    drop_graph(&pool, &graph).await;
+}
+
+#[tokio::test]
+#[ignore = "needs a live Postgres+AGE (set SKARDI_AGE_LIVE_URL); see module doc"]
+async fn nodes_relationships_and_paths_take_the_canonical_shapes() {
+    let Some(url) = live_url() else {
+        panic!("SKARDI_AGE_LIVE_URL must be set for --ignored live tests");
+    };
+    let graph = unique_graph("shape");
+    let pool = seed_graph(&url, &graph).await;
+    let (ctx, _sources) = live_ctx(&url, &graph).await;
+
+    // Node STRUCT + json_get over its properties.
+    let batches = collect(
+        &ctx,
+        "SELECT v.id AS id, json_get_str(v.properties, 'name') AS name \
+         FROM cypher_query('kg', 'MATCH (v:Person) RETURN v', '{}', \
+         '{\"v\": \"node\"}') ORDER BY name",
+    )
+    .await;
+    let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total, 3);
+    let names = batches[0]
+        .column(1)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(names.value(0), "ada");
+
+    // Relationship STRUCT: type and endpoint ids are strings.
+    let batches = collect(
+        &ctx,
+        "SELECT r FROM cypher_query('kg', \
+         'MATCH ()-[r:KNOWS]->() RETURN r', '{}', '{\"r\": \"relationship\"}')",
+    )
+    .await;
+    let rels = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .unwrap();
+    assert_eq!(rels.len(), 2);
+    let types = rels
+        .column_by_name("type")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(types.value(0), "KNOWS");
+
+    // Path STRUCT: parallel typed lists, nodes one longer.
+    let batches = collect(
+        &ctx,
+        "SELECT p FROM cypher_query('kg', '\
+             MATCH p = (:Person {name: \"ada\"})-[:KNOWS*2]->(:Person) RETURN p', \
+         '{}', '{\"p\": \"path\"}')",
+    )
+    .await;
+    let paths = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .unwrap();
+    assert_eq!(paths.len(), 1, "ada -2 hops-> cyd");
+    let nodes = paths
+        .column_by_name("nodes")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .unwrap();
+    let rels = paths
+        .column_by_name("relationships")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .unwrap();
+    assert_eq!(nodes.value(0).len(), 3);
+    assert_eq!(rels.value(0).len(), 2);
+
+    drop_graph(&pool, &graph).await;
+}
+
+#[tokio::test]
+#[ignore = "needs a live Postgres+AGE (set SKARDI_AGE_LIVE_URL); see module doc"]
+async fn the_backend_read_only_transaction_is_the_boundary() {
+    let Some(url) = live_url() else {
+        panic!("SKARDI_AGE_LIVE_URL must be set for --ignored live tests");
+    };
+    let graph = unique_graph("ro");
+    let pool = seed_graph(&url, &graph).await;
+    let (ctx, sources) = live_ctx(&url, &graph).await;
+
+    // The keyword guard rejects at plan time…
+    let err = ctx
+        .sql(
+            "SELECT * FROM cypher_query('kg', 'CREATE (n:X) RETURN n', '{}', \
+             '{\"n\": \"node\"}')",
+        )
+        .await
+        .expect_err("guard rejects");
+    assert!(err.to_string().contains("'CREATE'"), "{err}");
+
+    // …and the SERVER refuses a write even with the guard out of the
+    // way: drive the client directly (the live proof the design's
+    // security section requires — the guard is UX, the READ ONLY
+    // transaction is the boundary).
+    let handle = {
+        let map = sources.read().unwrap();
+        Arc::clone(map.get("kg").unwrap())
+    };
+    let result = handle
+        .client
+        .execute(
+            "CREATE (n:Sneaky) RETURN n",
+            &serde_json::json!({}),
+            1,
+            handle.bounds,
+        )
+        .await;
+    let err = match result {
+        Err(e) => e.to_string(),
+        Ok(stream) => {
+            use futures::TryStreamExt;
+            stream
+                .try_collect::<Vec<_>>()
+                .await
+                .expect_err("server must refuse the write")
+                .to_string()
+        }
+    };
+    assert!(
+        err.contains("read-only") || err.contains("25006"),
+        "the backend names the read-only violation: {err}"
+    );
+
+    // Nothing was written.
+    let batches = collect(
+        &ctx,
+        "SELECT n FROM cypher_query('kg', 'MATCH (n:Sneaky) RETURN n', '{}', \
+         '{\"n\": \"node\"}')",
+    )
+    .await;
+    assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 0);
+
+    drop_graph(&pool, &graph).await;
+}
+
+#[tokio::test]
+#[ignore = "needs a live Postgres+AGE (set SKARDI_AGE_LIVE_URL); see module doc"]
+async fn graph_schema_lists_labels_and_the_row_cap_fires() {
+    let Some(url) = live_url() else {
+        panic!("SKARDI_AGE_LIVE_URL must be set for --ignored live tests");
+    };
+    let graph = unique_graph("schema");
+    let pool = seed_graph(&url, &graph).await;
+
+    // graph_schema: labels straight off ag_catalog, internal labels
+    // filtered.
+    let (ctx, _sources) = live_ctx(&url, &graph).await;
+    let batches = collect(
+        &ctx,
+        "SELECT label, kind FROM graph_schema('kg') ORDER BY label",
+    )
+    .await;
+    let labels: Vec<(String, String)> = batches
+        .iter()
+        .flat_map(|b| {
+            let l = b.column(0).as_any().downcast_ref::<StringArray>().unwrap();
+            let k = b.column(1).as_any().downcast_ref::<StringArray>().unwrap();
+            (0..b.num_rows())
+                .map(|i| (l.value(i).to_string(), k.value(i).to_string()))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    assert_eq!(
+        labels,
+        vec![
+            ("KNOWS".to_string(), "edge".to_string()),
+            ("Person".to_string(), "vertex".to_string()),
+        ]
+    );
+
+    // The row cap: a 2-row source with max_rows 2 passes; max_rows 1
+    // fails LOUDLY (typed, names the cap), never a silent truncation.
+    let sources: GraphSources = Arc::new(RwLock::new(HashMap::new()));
+    let config: GraphConfig =
+        serde_yaml::from_str(&format!("backend: age\ngraph_name: {graph}\nmax_rows: 1\n"))
+            .expect("config parses");
+    register_graph_source(&sources, "capped", &url, &config)
+        .await
+        .expect("registers");
+    let capped = SessionContext::new();
+    register_graph_udtfs(&capped, sources).expect("udtfs");
+    let err = capped
+        .sql(
+            "SELECT name FROM cypher_query('capped', \
+             'MATCH (p:Person) RETURN p.name', '{}', '{\"name\": \"string\"}')",
+        )
+        .await
+        .expect("plans")
+        .collect()
+        .await
+        .expect_err("3 people, cap 1");
+    let msg = err.to_string();
+    assert!(msg.contains("max_rows = 1"), "{msg}");
+    assert!(msg.contains("LIMIT"), "the fix is named: {msg}");
+
+    drop_graph(&pool, &graph).await;
+}

--- a/crates/skardi/tests/graph_age_live.rs
+++ b/crates/skardi/tests/graph_age_live.rs
@@ -200,7 +200,7 @@ async fn scalars_params_and_ordering_round_trip() {
     assert_eq!(ages.value(0), 41);
 
     // A NULL property lands as SQL NULL (cyd has no age), and the CJK
-    // name round-trips byte-faithfully (the P1 mojibake regression:
+    // name round-trips byte-faithfully (the mojibake failure mode:
     // Latin-1 per-byte push would deliver a corrupted-but-parseable
     // string, so this MUST assert the exact value end to end).
     let batches = collect(
@@ -513,7 +513,7 @@ async fn graph_schema_lists_labels_and_the_row_cap_fires() {
     // CONCURRENT, so the pool genuinely opens max_connections sessions —
     // sequential execute() reuses the one idle connection
     // (min_connections defaults to 0) and a "sweep" would only ever see
-    // a single session (round-4 review).
+    // a single session.
     let hammer_params = serde_json::json!({"x": "nobody"});
     let results = futures::future::join_all((0..8).map(|_| {
         client.execute(
@@ -533,7 +533,7 @@ async fn graph_schema_lists_labels_and_the_row_cap_fires() {
     }
     // BACKEND error paths leak differently from client-local ones: a
     // runtime error aborts the transaction, where DEALLOCATE itself is
-    // refused until ROLLBACK — the round-3 P1. Parameterized (so the
+    // refused until ROLLBACK. Parameterized (so the
     // PREPARE exists and the EXECUTE fails at runtime), concurrent for
     // the same session-fan-out reason as above.
     let div_params = serde_json::json!({"x": 1});
@@ -553,7 +553,7 @@ async fn graph_schema_lists_labels_and_the_row_cap_fires() {
     // Sweep EVERY pooled session, not whichever one a lone query lands
     // on: acquire all max_connections connections and hold them while
     // checking each — that is what makes "no session carries a leak"
-    // true rather than assumed (round-4 review).
+    // true rather than assumed.
     let conns = futures::future::join_all((0..4).map(|_| client.pool_for_tests().acquire())).await;
     for conn in conns {
         let mut conn = conn.expect("acquire pooled session");
@@ -643,7 +643,7 @@ async fn a_typoed_graph_name_fails_registration_not_discovery() {
     // Without the existence probe this split: graph_schema returned ZERO
     // ROWS with no error (an agent reads "empty graph") while
     // cypher_query failed per-query — a typo must fail at registration,
-    // named (round-4 review, reproduced live there).
+    // named (reproduced live before the probe existed).
     let graph = unique_graph("typo");
     let pool = seed_graph(&url, &graph).await;
     let (clean_url, _, _) = split_creds(&url);
@@ -766,8 +766,9 @@ async fn agtype_float_specials_are_pinned() {
         return;
     };
     // Pins whether AGE emits non-JSON float spellings (NaN/Infinity)
-    // through agtype_out, and what our decode does with them — the
-    // round-4 review question. Whatever the outcome, it must be a
+    // through agtype_out, and what our decode does with them (the
+    // overflow spelling is real: 1.0e308 * 10 emits a bare Infinity
+    // token). Whatever the outcome, it must be a
     // PROPORTIONATE per-cell/typed result, not an opaque whole-scan
     // failure with no identity.
     let graph = unique_graph("nan");
@@ -801,7 +802,7 @@ async fn agtype_float_specials_are_pinned() {
 
 #[tokio::test]
 #[ignore = "needs a live Postgres+AGE (set SKARDI_AGE_LIVE_URL); see module doc"]
-async fn round4_fixes_hold_end_to_end() {
+async fn error_paths_bounds_and_binding_hardening_holds_end_to_end() {
     let Some(url) = live_url() else {
         eprintln!("skipping live AGE test: set SKARDI_AGE_LIVE_URL to run");
         return;

--- a/crates/skardi/tests/graph_age_live.rs
+++ b/crates/skardi/tests/graph_age_live.rs
@@ -60,8 +60,10 @@ async fn seed_graph(url: &str, graph: &str) -> sqlx::PgPool {
             CREATE (a:Person {{name: 'ada', age: 36}}),
                    (b:Person {{name: 'bob', age: 41}}),
                    (c:Person {{name: 'cyd'}}),
+                   (d:Person {{name: '颱風', note: 'café ☔'}}),
                    (a)-[:KNOWS {{since: 2019}}]->(b),
-                   (b)-[:KNOWS {{since: 2021}}]->(c)
+                   (b)-[:KNOWS {{since: 2021}}]->(c),
+                   (a)-[:KNOWS {{since: 2024}}]->(d)
         $$) AS (v agtype)"
     );
     pool.execute(seed.as_str()).await.expect("seed cypher");
@@ -149,7 +151,10 @@ async fn scalars_params_and_ordering_round_trip() {
         .unwrap();
     assert_eq!(ages.value(0), 41);
 
-    // A NULL property lands as SQL NULL (cyd has no age).
+    // A NULL property lands as SQL NULL (cyd has no age), and the CJK
+    // name round-trips byte-faithfully (the P1 mojibake regression:
+    // Latin-1 per-byte push would deliver a corrupted-but-parseable
+    // string, so this MUST assert the exact value end to end).
     let batches = collect(
         &ctx,
         "SELECT name, age FROM cypher_query('kg', '\
@@ -158,7 +163,20 @@ async fn scalars_params_and_ordering_round_trip() {
     )
     .await;
     let total: usize = batches.iter().map(|b| b.num_rows()).sum();
-    assert_eq!(total, 3);
+    assert_eq!(total, 4);
+    let all_names: Vec<String> = batches
+        .iter()
+        .flat_map(|b| {
+            let col = b.column(0).as_any().downcast_ref::<StringArray>().unwrap();
+            (0..b.num_rows())
+                .map(|i| col.value(i).to_string())
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    assert!(
+        all_names.contains(&"颱風".to_string()),
+        "CJK survives byte-faithfully: {all_names:?}"
+    );
 
     drop_graph(&pool, &graph).await;
 }
@@ -186,13 +204,29 @@ async fn nodes_relationships_and_paths_take_the_canonical_shapes() {
     )
     .await;
     let total: usize = batches.iter().map(|b| b.num_rows()).sum();
-    assert_eq!(total, 3);
+    assert_eq!(total, 4);
     let names = batches[0]
         .column(1)
         .as_any()
         .downcast_ref::<StringArray>()
         .unwrap();
     assert_eq!(names.value(0), "ada");
+
+    // json_get through a node's properties keeps non-ASCII intact —
+    // the whole agtype → JSON-text → json_get chain, live.
+    let batches = collect(
+        &ctx,
+        "SELECT json_get_str(v.properties, 'note') AS note \
+         FROM cypher_query('kg', 'MATCH (v:Person {name: \"颱風\"}) RETURN v', \
+         '{}', '{\"v\": \"node\"}')",
+    )
+    .await;
+    let notes = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(notes.value(0), "café ☔");
 
     // Relationship STRUCT: type and endpoint ids are strings.
     let batches = collect(
@@ -206,7 +240,7 @@ async fn nodes_relationships_and_paths_take_the_canonical_shapes() {
         .as_any()
         .downcast_ref::<StructArray>()
         .unwrap();
-    assert_eq!(rels.len(), 2);
+    assert_eq!(rels.len(), 3);
     let types = rels
         .column_by_name("type")
         .unwrap()
@@ -375,7 +409,7 @@ async fn graph_schema_lists_labels_and_the_row_cap_fires() {
         .expect("plans")
         .collect()
         .await
-        .expect_err("3 people, cap 1");
+        .expect_err("4 people, cap 1");
     let msg = err.to_string();
     assert!(msg.contains("max_rows = 1"), "{msg}");
     assert!(msg.contains("LIMIT"), "the fix is named: {msg}");

--- a/crates/skardi/tests/graph_age_live.rs
+++ b/crates/skardi/tests/graph_age_live.rs
@@ -19,7 +19,6 @@ use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 use arrow::array::{Array, Int64Array, ListArray, StringArray, StructArray};
-use arrow::record_batch::RecordBatch;
 use datafusion::prelude::SessionContext;
 use sqlx::Executor;
 use sqlx::postgres::PgPoolOptions;
@@ -29,6 +28,9 @@ use skardi::sources::providers::graph::config::GraphConfig;
 use skardi::sources::providers::graph::udtf::GraphSources;
 use skardi::sources::providers::graph::value::{DeclaredColumn, GraphType};
 use skardi::sources::providers::graph::{register_graph_source, register_graph_udtfs};
+
+mod graph_live_support;
+use graph_live_support::{collect, split_creds};
 
 /// One declared column for direct `GraphClient::execute` calls — AGE
 /// binds positionally, so only the COUNT matters to these tests.
@@ -40,9 +42,7 @@ fn one_col() -> Vec<DeclaredColumn> {
 }
 
 fn live_url() -> Option<String> {
-    std::env::var("SKARDI_AGE_LIVE_URL")
-        .ok()
-        .filter(|u| !u.trim().is_empty())
+    graph_live_support::live_url("SKARDI_AGE_LIVE_URL")
 }
 
 /// Seed a fresh, uniquely named graph through AGE's own APIs (writes go
@@ -86,22 +86,6 @@ async fn drop_graph(pool: &sqlx::PgPool, graph: &str) {
         .bind(graph)
         .execute(pool)
         .await;
-}
-
-/// Split a maybe-credentialed URL into (cred-free URL, user, pass):
-/// config validation rejects URL-embedded passwords, so the registered
-/// source takes credentials the designed way — env-var NAMES.
-fn split_creds(url: &str) -> (String, Option<String>, Option<String>) {
-    let mut parsed = url::Url::parse(url).expect("live URL parses");
-    let user = (!parsed.username().is_empty()).then(|| parsed.username().to_string());
-    let pass = parsed.password().map(str::to_string);
-    parsed
-        .set_username("")
-        .expect("postgres URLs take userinfo");
-    parsed
-        .set_password(None)
-        .expect("postgres URLs take userinfo");
-    (parsed.to_string(), user, pass)
 }
 
 /// YAML `username_env`/`password_env` lines for a URL's credentials,
@@ -148,15 +132,6 @@ async fn live_ctx(url: &str, graph: &str) -> (SessionContext, GraphSources) {
     let ctx = SessionContext::new();
     register_graph_udtfs(&ctx, Arc::clone(&sources)).expect("udtfs register");
     (ctx, sources)
-}
-
-async fn collect(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch> {
-    ctx.sql(sql)
-        .await
-        .expect("plans")
-        .collect()
-        .await
-        .expect("executes")
 }
 
 fn unique_graph(tag: &str) -> String {

--- a/crates/skardi/tests/graph_age_live.rs
+++ b/crates/skardi/tests/graph_age_live.rs
@@ -116,7 +116,11 @@ fn unique_graph(tag: &str) -> String {
 #[ignore = "needs a live Postgres+AGE (set SKARDI_AGE_LIVE_URL); see module doc"]
 async fn scalars_params_and_ordering_round_trip() {
     let Some(url) = live_url() else {
-        panic!("SKARDI_AGE_LIVE_URL must be set for --ignored live tests");
+        // CI's coverage job runs `-- --ignored` across the board (the
+        // documents_s3_live convention): absent gating env means SKIP,
+        // loudly on stderr — never a panic.
+        eprintln!("skipping live AGE test: set SKARDI_AGE_LIVE_URL to run");
+        return;
     };
     let graph = unique_graph("scalar");
     let pool = seed_graph(&url, &graph).await;
@@ -163,7 +167,11 @@ async fn scalars_params_and_ordering_round_trip() {
 #[ignore = "needs a live Postgres+AGE (set SKARDI_AGE_LIVE_URL); see module doc"]
 async fn nodes_relationships_and_paths_take_the_canonical_shapes() {
     let Some(url) = live_url() else {
-        panic!("SKARDI_AGE_LIVE_URL must be set for --ignored live tests");
+        // CI's coverage job runs `-- --ignored` across the board (the
+        // documents_s3_live convention): absent gating env means SKIP,
+        // loudly on stderr — never a panic.
+        eprintln!("skipping live AGE test: set SKARDI_AGE_LIVE_URL to run");
+        return;
     };
     let graph = unique_graph("shape");
     let pool = seed_graph(&url, &graph).await;
@@ -243,7 +251,11 @@ async fn nodes_relationships_and_paths_take_the_canonical_shapes() {
 #[ignore = "needs a live Postgres+AGE (set SKARDI_AGE_LIVE_URL); see module doc"]
 async fn the_backend_read_only_transaction_is_the_boundary() {
     let Some(url) = live_url() else {
-        panic!("SKARDI_AGE_LIVE_URL must be set for --ignored live tests");
+        // CI's coverage job runs `-- --ignored` across the board (the
+        // documents_s3_live convention): absent gating env means SKIP,
+        // loudly on stderr — never a panic.
+        eprintln!("skipping live AGE test: set SKARDI_AGE_LIVE_URL to run");
+        return;
     };
     let graph = unique_graph("ro");
     let pool = seed_graph(&url, &graph).await;
@@ -308,7 +320,11 @@ async fn the_backend_read_only_transaction_is_the_boundary() {
 #[ignore = "needs a live Postgres+AGE (set SKARDI_AGE_LIVE_URL); see module doc"]
 async fn graph_schema_lists_labels_and_the_row_cap_fires() {
     let Some(url) = live_url() else {
-        panic!("SKARDI_AGE_LIVE_URL must be set for --ignored live tests");
+        // CI's coverage job runs `-- --ignored` across the board (the
+        // documents_s3_live convention): absent gating env means SKIP,
+        // loudly on stderr — never a panic.
+        eprintln!("skipping live AGE test: set SKARDI_AGE_LIVE_URL to run");
+        return;
     };
     let graph = unique_graph("schema");
     let pool = seed_graph(&url, &graph).await;

--- a/crates/skardi/tests/graph_age_live.rs
+++ b/crates/skardi/tests/graph_age_live.rs
@@ -808,7 +808,7 @@ async fn round4_fixes_hold_end_to_end() {
     };
     let graph = unique_graph("r4");
     let pool = seed_graph(&url, &graph).await;
-    let (ctx, sources) = live_ctx(&url, &graph).await;
+    let (ctx, _sources) = live_ctx(&url, &graph).await;
 
     // ── #9: a BACKEND error must not echo the caller's Cypher. The
     // query carries a recognizable marker; the rendered error must name

--- a/crates/skardi/tests/graph_age_live.rs
+++ b/crates/skardi/tests/graph_age_live.rs
@@ -502,6 +502,7 @@ async fn graph_schema_lists_labels_and_the_row_cap_fires() {
         user.as_ref().map(|_| "SKARDI_AGE_LEAK_USER"),
         pass.as_ref().map(|_| "SKARDI_AGE_LEAK_PASS"),
         4,
+        std::time::Duration::from_secs(10),
     )
     .await
     .expect("connects");
@@ -509,16 +510,23 @@ async fn graph_schema_lists_labels_and_the_row_cap_fires() {
         timeout: std::time::Duration::from_secs(10),
         max_rows: 1,
     };
-    for _ in 0..8 {
-        let err = client
-            .execute(
-                "MATCH (p:Person) WHERE p.name <> $x RETURN p.name",
-                &serde_json::json!({"x": "nobody"}),
-                1,
-                tight,
-                None,
-            )
-            .await
+    // CONCURRENT, so the pool genuinely opens max_connections sessions —
+    // sequential execute() reuses the one idle connection
+    // (min_connections defaults to 0) and a "sweep" would only ever see
+    // a single session (round-4 review).
+    let hammer_params = serde_json::json!({"x": "nobody"});
+    let results = futures::future::join_all((0..8).map(|_| {
+        client.execute(
+            "MATCH (p:Person) WHERE p.name <> $x RETURN p.name",
+            &hammer_params,
+            1,
+            tight,
+            None,
+        )
+    }))
+    .await;
+    for result in results {
+        let err = result
             .err()
             .expect("4 people, cap 1: the capped error path");
         assert!(err.to_string().contains("max_rows = 1"), "{err}");
@@ -526,32 +534,38 @@ async fn graph_schema_lists_labels_and_the_row_cap_fires() {
     // BACKEND error paths leak differently from client-local ones: a
     // runtime error aborts the transaction, where DEALLOCATE itself is
     // refused until ROLLBACK — the round-3 P1. Parameterized (so the
-    // PREPARE exists and the EXECUTE fails at runtime), 8× past the pool.
-    for _ in 0..8 {
-        let err = client
-            .execute(
-                "MATCH (p:Person) RETURN $x / 0",
-                &serde_json::json!({"x": 1}),
-                1,
-                tight,
-                None,
-            )
-            .await
-            .err()
-            .map(|e| e.to_string())
-            .unwrap_or_else(|| "stream deferred".to_string());
-        assert!(!err.is_empty());
+    // PREPARE exists and the EXECUTE fails at runtime), concurrent for
+    // the same session-fan-out reason as above.
+    let div_params = serde_json::json!({"x": 1});
+    let results = futures::future::join_all((0..8).map(|_| {
+        client.execute(
+            "MATCH (p:Person) RETURN $x / 0",
+            &div_params,
+            1,
+            tight,
+            None,
+        )
+    }))
+    .await;
+    for result in results {
+        assert!(result.is_err(), "division by zero is a backend error");
     }
-    for _ in 0..8 {
+    // Sweep EVERY pooled session, not whichever one a lone query lands
+    // on: acquire all max_connections connections and hold them while
+    // checking each — that is what makes "no session carries a leak"
+    // true rather than assumed (round-4 review).
+    let conns = futures::future::join_all((0..4).map(|_| client.pool_for_tests().acquire())).await;
+    for conn in conns {
+        let mut conn = conn.expect("acquire pooled session");
         let leaked: i64 = sqlx::query_scalar(
             "SELECT COUNT(*) FROM pg_prepared_statements WHERE name LIKE 'skq_p_%'",
         )
-        .fetch_one(client.pool_for_tests())
+        .fetch_one(&mut *conn)
         .await
         .expect("pg_prepared_statements readable");
         assert_eq!(
             leaked, 0,
-            "no skq_p_* statement survives client-local OR backend error paths"
+            "no skq_p_* statement survives on ANY pooled session"
         );
     }
 
@@ -595,8 +609,11 @@ async fn duplicate_registration_keeps_the_original_connection() {
     // graph) must fail AND leave the original routing untouched.
     let (clean_url, _, _) = split_creds(&url);
     let creds = cred_lines(&url, "SKARDI_AGE_DUP");
+    // Same (existing) graph, duplicate connection NAME — the name is
+    // what's under test; a nonexistent graph would now trip the
+    // registration-time existence probe first.
     let config: GraphConfig =
-        serde_yaml::from_str(&format!("backend: age\ngraph_name: {graph}_other\n{creds}"))
+        serde_yaml::from_str(&format!("backend: age\ngraph_name: {graph}\n{creds}"))
             .expect("config parses");
     let err = register_graph_source(&sources, "kg", &clean_url, &config)
         .await
@@ -612,6 +629,172 @@ async fn duplicate_registration_keeps_the_original_connection() {
     )
     .await;
     assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 4);
+
+    drop_graph(&pool, &graph).await;
+}
+
+#[tokio::test]
+#[ignore = "needs a live Postgres+AGE (set SKARDI_AGE_LIVE_URL); see module doc"]
+async fn a_typoed_graph_name_fails_registration_not_discovery() {
+    let Some(url) = live_url() else {
+        eprintln!("skipping live AGE test: set SKARDI_AGE_LIVE_URL to run");
+        return;
+    };
+    // Without the existence probe this split: graph_schema returned ZERO
+    // ROWS with no error (an agent reads "empty graph") while
+    // cypher_query failed per-query — a typo must fail at registration,
+    // named (round-4 review, reproduced live there).
+    let graph = unique_graph("typo");
+    let pool = seed_graph(&url, &graph).await;
+    let (clean_url, _, _) = split_creds(&url);
+    let creds = cred_lines(&url, "SKARDI_AGE_TYPO");
+    let config: GraphConfig = serde_yaml::from_str(&format!(
+        "backend: age\ngraph_name: {graph}_misspelled\n{creds}"
+    ))
+    .expect("config parses");
+    let sources: GraphSources = Arc::new(RwLock::new(HashMap::new()));
+    let err = register_graph_source(&sources, "kg", &clean_url, &config)
+        .await
+        .expect_err("nonexistent graph refuses at registration");
+    let msg = err.to_string();
+    assert!(msg.contains("does not exist"), "{msg}");
+    assert!(msg.contains("create_graph"), "the fix is named: {msg}");
+
+    drop_graph(&pool, &graph).await;
+}
+
+#[tokio::test]
+#[ignore = "needs a live Postgres+AGE (set SKARDI_AGE_LIVE_URL); see module doc"]
+async fn the_timeout_bound_is_typed_and_credentials_never_reach_errors() {
+    let Some(url) = live_url() else {
+        eprintln!("skipping live AGE test: set SKARDI_AGE_LIVE_URL to run");
+        return;
+    };
+    let graph = unique_graph("bounds");
+    let pool = seed_graph(&url, &graph).await;
+
+    // 1) The timeout — the row cap's equal-billing sibling — end to end:
+    // statement_timeout fires server-side (57014) and surfaces as the
+    // TYPED Timeout naming the seconds, not a generic Backend error.
+    let (clean_url, user, pass) = split_creds(&url);
+    unsafe {
+        if let Some(u) = &user {
+            std::env::set_var("SKARDI_AGE_BOUNDS_USER", u);
+        }
+        if let Some(p) = &pass {
+            std::env::set_var("SKARDI_AGE_BOUNDS_PASS", p);
+        }
+    }
+    let client = AgeClient::connect(
+        "bounds",
+        &clean_url,
+        &graph,
+        user.as_ref().map(|_| "SKARDI_AGE_BOUNDS_USER"),
+        pass.as_ref().map(|_| "SKARDI_AGE_BOUNDS_PASS"),
+        4,
+        std::time::Duration::from_secs(1),
+    )
+    .await
+    .expect("connects");
+    let err = client
+        .execute(
+            // Unbounded cartesian blowup over the seeded graph: 4^14 ≈
+            // 268M pattern combinations cannot be counted in 1s — and
+            // statement_timeout kills it AT 1s, so the test never waits
+            // for the full count either.
+            "MATCH (a),(b),(c),(d),(e),(f),(g),(h),(i),(j),(k),(l),(m),(n) RETURN count(*)",
+            &serde_json::json!({}),
+            1,
+            QueryBounds {
+                timeout: std::time::Duration::from_secs(1),
+                max_rows: 10,
+            },
+            None,
+        )
+        .await
+        .err()
+        .expect("the cartesian traversal cannot finish in 1s");
+    let msg = err.to_string();
+    assert!(msg.contains("timed out after 1s"), "typed, named: {msg}");
+
+    // 2) graph_schema's own row cap (the labels() branch).
+    let err = client
+        .labels(
+            QueryBounds {
+                timeout: std::time::Duration::from_secs(10),
+                max_rows: 1,
+            },
+            None,
+        )
+        .await
+        .expect_err("2 labels, cap 1");
+    assert!(err.to_string().contains("max_rows = 1"), "{err}");
+
+    // 3) Credentials never reach error text: force an auth failure and
+    // assert neither the wrong nor the real password appears.
+    if pass.is_some() {
+        unsafe { std::env::set_var("SKARDI_AGE_BADPASS", "wrong-password-on-purpose") };
+        let err = AgeClient::connect(
+            "badcreds",
+            &clean_url,
+            &graph,
+            user.as_ref().map(|_| "SKARDI_AGE_BOUNDS_USER"),
+            Some("SKARDI_AGE_BADPASS"),
+            4,
+            std::time::Duration::from_secs(5),
+        )
+        .await
+        .expect_err("wrong password refuses");
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("wrong-password-on-purpose"),
+            "the credential value never appears in errors: {msg}"
+        );
+        if let Some(real) = &pass {
+            assert!(!msg.contains(real.as_str()), "nor the real one: {msg}");
+        }
+    }
+
+    drop_graph(&pool, &graph).await;
+}
+
+#[tokio::test]
+#[ignore = "needs a live Postgres+AGE (set SKARDI_AGE_LIVE_URL); see module doc"]
+async fn agtype_float_specials_are_pinned() {
+    let Some(url) = live_url() else {
+        eprintln!("skipping live AGE test: set SKARDI_AGE_LIVE_URL to run");
+        return;
+    };
+    // Pins whether AGE emits non-JSON float spellings (NaN/Infinity)
+    // through agtype_out, and what our decode does with them — the
+    // round-4 review question. Whatever the outcome, it must be a
+    // PROPORTIONATE per-cell/typed result, not an opaque whole-scan
+    // failure with no identity.
+    let graph = unique_graph("nan");
+    let pool = seed_graph(&url, &graph).await;
+    let (ctx, _sources) = live_ctx(&url, &graph).await;
+
+    // Pinned live: sqrt(-1.0) is SQL NULL from AGE itself, while float
+    // OVERFLOW emits the bare token `Infinity` through agtype_out — the
+    // reachable case the review asked about. Both decode to NULL floats
+    // (proportionate; a whole-scan MalformedCell for a legitimate value
+    // would be the wrong severity).
+    for cypher in ["RETURN sqrt(-1.0)", "RETURN 1.0e308 * 10"] {
+        let batches = collect(
+            &ctx,
+            &format!(
+                "SELECT f FROM cypher_query('kg', '{cypher}', '{{}}', \
+                 '{{\"f\": \"float\"}}')"
+            ),
+        )
+        .await;
+        let col = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::Float64Array>()
+            .unwrap();
+        assert!(col.is_null(0), "{cypher}: a float special is a NULL float");
+    }
 
     drop_graph(&pool, &graph).await;
 }

--- a/crates/skardi/tests/graph_age_live.rs
+++ b/crates/skardi/tests/graph_age_live.rs
@@ -24,6 +24,7 @@ use datafusion::prelude::SessionContext;
 use sqlx::Executor;
 use sqlx::postgres::PgPoolOptions;
 
+use skardi::sources::providers::graph::client::{AgeClient, GraphClient, QueryBounds};
 use skardi::sources::providers::graph::config::GraphConfig;
 use skardi::sources::providers::graph::udtf::GraphSources;
 use skardi::sources::providers::graph::{register_graph_source, register_graph_udtfs};
@@ -389,8 +390,10 @@ async fn graph_schema_lists_labels_and_the_row_cap_fires() {
         ]
     );
 
-    // The row cap: a 2-row source with max_rows 2 passes; max_rows 1
-    // fails LOUDLY (typed, names the cap), never a silent truncation.
+    // The row cap: max_rows 1 fails LOUDLY (typed, names the cap),
+    // never a silent truncation — and the ERROR path must not leak its
+    // PREPARE onto the pooled connection (prepared statements are
+    // session-level; rollback does not clear them).
     let sources: GraphSources = Arc::new(RwLock::new(HashMap::new()));
     let config: GraphConfig =
         serde_yaml::from_str(&format!("backend: age\ngraph_name: {graph}\nmax_rows: 1\n"))
@@ -413,6 +416,43 @@ async fn graph_schema_lists_labels_and_the_row_cap_fires() {
     let msg = err.to_string();
     assert!(msg.contains("max_rows = 1"), "{msg}");
     assert!(msg.contains("LIMIT"), "the fix is named: {msg}");
+
+    // Leak regression: hammer the capped (error) path well past the
+    // pool size — parameterized, so each call PREPAREs — then sweep the
+    // SAME pool's sessions for leftover skq_p_* statements
+    // (pg_prepared_statements is session-local, so the sweep must run on
+    // the very sessions execute used; hence the direct AgeClient and its
+    // test-only pool hook). Before the fix each error path left one
+    // behind, monotonically.
+    let client = AgeClient::connect("leakcheck", &url, &graph, None, None)
+        .await
+        .expect("connects");
+    let tight = QueryBounds {
+        timeout: std::time::Duration::from_secs(10),
+        max_rows: 1,
+    };
+    for _ in 0..8 {
+        let err = client
+            .execute(
+                "MATCH (p:Person) WHERE p.name <> $x RETURN p.name",
+                &serde_json::json!({"x": "nobody"}),
+                1,
+                tight,
+            )
+            .await
+            .err()
+            .expect("4 people, cap 1: the capped error path");
+        assert!(err.to_string().contains("max_rows = 1"), "{err}");
+    }
+    for _ in 0..8 {
+        let leaked: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM pg_prepared_statements WHERE name LIKE 'skq_p_%'",
+        )
+        .fetch_one(client.pool_for_tests())
+        .await
+        .expect("pg_prepared_statements readable");
+        assert_eq!(leaked, 0, "no skq_p_* statement survives an error path");
+    }
 
     drop_graph(&pool, &graph).await;
 }

--- a/crates/skardi/tests/graph_age_live.rs
+++ b/crates/skardi/tests/graph_age_live.rs
@@ -835,11 +835,8 @@ async fn round4_fixes_hold_end_to_end() {
     // defaults to 4; hold all four sessions, then a query's acquire
     // must time out as GraphError::Timeout — not a generic Backend
     // error after sqlx's unrelated 30s default.
-    let handle = {
-        let map = sources.read().unwrap_or_else(|p| p.into_inner());
-        Arc::clone(map.get("kg").unwrap())
-    };
-    // Reach the concrete client for its pool (test-only hook).
+    // A dedicated 1-connection client (the registered source's handle
+    // hides the concrete type behind dyn GraphClient).
     let (clean_url, user, pass) = split_creds(&url);
     unsafe {
         if let Some(u) = &user {

--- a/crates/skardi/tests/graph_age_live.rs
+++ b/crates/skardi/tests/graph_age_live.rs
@@ -798,3 +798,132 @@ async fn agtype_float_specials_are_pinned() {
 
     drop_graph(&pool, &graph).await;
 }
+
+#[tokio::test]
+#[ignore = "needs a live Postgres+AGE (set SKARDI_AGE_LIVE_URL); see module doc"]
+async fn round4_fixes_hold_end_to_end() {
+    let Some(url) = live_url() else {
+        eprintln!("skipping live AGE test: set SKARDI_AGE_LIVE_URL to run");
+        return;
+    };
+    let graph = unique_graph("r4");
+    let pool = seed_graph(&url, &graph).await;
+    let (ctx, sources) = live_ctx(&url, &graph).await;
+
+    // ── #9: a BACKEND error must not echo the caller's Cypher. The
+    // query carries a recognizable marker; the rendered error must name
+    // the backend failure without the statement context Postgres
+    // attaches (db.message(), never sqlx Display or `position` lines).
+    let err = ctx
+        .sql(
+            "SELECT x FROM cypher_query('kg', \
+             'MATCH (marker_needle_xyz) RETURN nonexistent_fn(marker_needle_xyz)', \
+             '{}', '{\"x\": \"json\"}')",
+        )
+        .await
+        .expect("plans")
+        .collect()
+        .await
+        .expect_err("unknown function is a backend error");
+    let msg = err.to_string();
+    assert!(
+        !msg.contains("marker_needle_xyz"),
+        "backend errors never echo query text: {msg}"
+    );
+
+    // ── #8: pool saturation is bounded and TYPED. max_connections
+    // defaults to 4; hold all four sessions, then a query's acquire
+    // must time out as GraphError::Timeout — not a generic Backend
+    // error after sqlx's unrelated 30s default.
+    let handle = {
+        let map = sources.read().unwrap_or_else(|p| p.into_inner());
+        Arc::clone(map.get("kg").unwrap())
+    };
+    // Reach the concrete client for its pool (test-only hook).
+    let (clean_url, user, pass) = split_creds(&url);
+    unsafe {
+        if let Some(u) = &user {
+            std::env::set_var("SKARDI_AGE_R4_USER", u);
+        }
+        if let Some(p) = &pass {
+            std::env::set_var("SKARDI_AGE_R4_PASS", p);
+        }
+    }
+    let client = AgeClient::connect(
+        "saturated",
+        &clean_url,
+        &graph,
+        user.as_ref().map(|_| "SKARDI_AGE_R4_USER"),
+        pass.as_ref().map(|_| "SKARDI_AGE_R4_PASS"),
+        1, // one connection: held below, so acquire must queue
+        std::time::Duration::from_secs(1),
+    )
+    .await
+    .expect("connects");
+    let _held = client
+        .pool_for_tests()
+        .acquire()
+        .await
+        .expect("hold the only connection");
+    let err = client
+        .execute(
+            "MATCH (p:Person) RETURN p.name",
+            &serde_json::json!({}),
+            1,
+            QueryBounds {
+                timeout: std::time::Duration::from_secs(1),
+                max_rows: 10,
+            },
+            None,
+        )
+        .await
+        .err()
+        .expect("no connection can be acquired");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("timed out after 1s"),
+        "saturation surfaces as the typed Timeout: {msg}"
+    );
+    drop(_held);
+
+    // ── #2 (demonstration): declared-column order IS the binding — two
+    // same-typed columns declared out of RETURN order swap silently.
+    // This pins that the documented hazard is real, so the docs can
+    // never drift into describing a check that does not exist.
+    let batches = collect(
+        &ctx,
+        "SELECT * FROM cypher_query('kg', \
+         'MATCH (p:Person {name: \"ada\"}) RETURN p.name, p.age', '{}', \
+         '{\"age\": \"json\", \"name\": \"json\"}')",
+    )
+    .await;
+    let mis_age = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(
+        mis_age.value(0),
+        "\"ada\"",
+        "out-of-order declaration binds positionally: the column NAMED age \
+         carries the name value — the silent swap the docs warn about"
+    );
+
+    // ── #4 (rewriter scope): register_all installs the ->/->> operator
+    // rewrite session-wide; pin that it works over a node's properties
+    // JSON, since that is the documented reason it is registered.
+    let batches = collect(
+        &ctx,
+        "SELECT v.properties->>'name' AS n FROM cypher_query('kg', \
+         'MATCH (v:Person {name: \"bob\"}) RETURN v', '{}', '{\"v\": \"node\"}')",
+    )
+    .await;
+    let n = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(n.value(0), "bob", "the ->> rewrite reaches graph queries");
+
+    drop_graph(&pool, &graph).await;
+}

--- a/crates/skardi/tests/graph_age_live.rs
+++ b/crates/skardi/tests/graph_age_live.rs
@@ -321,6 +321,7 @@ async fn the_backend_read_only_transaction_is_the_boundary() {
             &serde_json::json!({}),
             1,
             handle.bounds,
+            None,
         )
         .await;
     let err = match result {
@@ -417,6 +418,17 @@ async fn graph_schema_lists_labels_and_the_row_cap_fires() {
     assert!(msg.contains("max_rows = 1"), "{msg}");
     assert!(msg.contains("LIMIT"), "the fix is named: {msg}");
 
+    // …and taking the error message's own advice works: a SQL LIMIT at
+    // the cap consumes exactly that many rows and stops CLEANLY — the
+    // limit is pushed to the consumption side, it never trips the cap.
+    let batches = collect(
+        &capped,
+        "SELECT name FROM cypher_query('capped', \
+         'MATCH (p:Person) RETURN p.name', '{}', '{\"name\": \"string\"}') LIMIT 1",
+    )
+    .await;
+    assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 1);
+
     // Leak regression: hammer the capped (error) path well past the
     // pool size — parameterized, so each call PREPAREs — then sweep the
     // SAME pool's sessions for leftover skq_p_* statements
@@ -424,7 +436,7 @@ async fn graph_schema_lists_labels_and_the_row_cap_fires() {
     // the very sessions execute used; hence the direct AgeClient and its
     // test-only pool hook). Before the fix each error path left one
     // behind, monotonically.
-    let client = AgeClient::connect("leakcheck", &url, &graph, None, None)
+    let client = AgeClient::connect("leakcheck", &url, &graph, None, None, 4)
         .await
         .expect("connects");
     let tight = QueryBounds {
@@ -438,6 +450,7 @@ async fn graph_schema_lists_labels_and_the_row_cap_fires() {
                 &serde_json::json!({"x": "nobody"}),
                 1,
                 tight,
+                None,
             )
             .await
             .err()

--- a/crates/skardi/tests/graph_age_live.rs
+++ b/crates/skardi/tests/graph_age_live.rs
@@ -30,9 +30,19 @@ use skardi::sources::providers::graph::udtf::GraphSources;
 use skardi::sources::providers::graph::{register_graph_source, register_graph_udtfs};
 
 fn live_url() -> Option<String> {
-    std::env::var("SKARDI_AGE_LIVE_URL")
+    let url = std::env::var("SKARDI_AGE_LIVE_URL")
         .ok()
-        .filter(|u| !u.trim().is_empty())
+        .filter(|u| !u.trim().is_empty());
+    // CI arms this: absent gating env is a SKIP for a developer's
+    // laptop but a hard failure where the suite is the AGE backend's
+    // ONLY coverage — a renamed or dropped URL var must not turn nine
+    // skips into a green step nobody reads.
+    assert!(
+        url.is_some() || std::env::var("SKARDI_AGE_LIVE_REQUIRED").is_err(),
+        "SKARDI_AGE_LIVE_REQUIRED is set but SKARDI_AGE_LIVE_URL is not — \
+         the AGE backend would have gone untested"
+    );
+    url
 }
 
 /// Seed a fresh, uniquely named graph through AGE's own APIs (writes go
@@ -923,5 +933,135 @@ async fn error_paths_bounds_and_binding_hardening_holds_end_to_end() {
         .unwrap();
     assert_eq!(n.value(0), "bob", "the ->> rewrite reaches graph queries");
 
+    drop_graph(&pool, &graph).await;
+}
+
+#[tokio::test]
+#[ignore = "needs a live Postgres+AGE (set SKARDI_AGE_LIVE_URL); see module doc"]
+async fn a_least_privilege_reader_role_registers_and_queries() {
+    // The design's least-privilege recommendation, executed: a plain
+    // reader role (no superuser) must register and query. This is what
+    // pins `LOAD 'age'` as BEST-EFFORT — a required LOAD is superuser-
+    // only for $libdir libraries and would fail this registration on
+    // the stock apache/age image (which preloads AGE instead).
+    let Some(url) = live_url() else {
+        eprintln!("skipping live AGE test: set SKARDI_AGE_LIVE_URL to run");
+        return;
+    };
+    let graph = unique_graph("reader");
+    let pool = seed_graph(&url, &graph).await;
+    let role = format!("skardi_reader_{graph}");
+    for grant in [
+        format!("CREATE ROLE {role} LOGIN PASSWORD 'readerpass'"),
+        format!("GRANT USAGE ON SCHEMA ag_catalog TO {role}"),
+        format!("GRANT SELECT ON ALL TABLES IN SCHEMA ag_catalog TO {role}"),
+        format!("GRANT USAGE ON SCHEMA {graph} TO {role}"),
+        format!("GRANT SELECT ON ALL TABLES IN SCHEMA {graph} TO {role}"),
+    ] {
+        pool.execute(grant.as_str()).await.expect("grant");
+    }
+
+    let sources: GraphSources = Arc::new(RwLock::new(HashMap::new()));
+    let (clean_url, _, _) = split_creds(&url);
+    let user_env = format!("SKARDI_AGE_READER_USER_{}", graph.to_uppercase());
+    let pass_env = format!("SKARDI_AGE_READER_PASS_{}", graph.to_uppercase());
+    unsafe {
+        std::env::set_var(&user_env, &role);
+        std::env::set_var(&pass_env, "readerpass");
+    }
+    let config: GraphConfig = serde_yaml::from_str(&format!(
+        "backend: age\ngraph_name: {graph}\nquery_timeout_seconds: 10\nmax_rows: 100\n\
+         username_env: {user_env}\npassword_env: {pass_env}\n"
+    ))
+    .expect("config parses");
+    register_graph_source(&sources, "kg", &clean_url, &config)
+        .await
+        .expect("a NON-superuser reader registers (LOAD must be best-effort)");
+    let ctx = SessionContext::new();
+    register_graph_udtfs(&ctx, Arc::clone(&sources)).expect("udtfs register");
+    let batches = collect(
+        &ctx,
+        "SELECT name FROM cypher_query('kg', 'MATCH (p:Person) RETURN p.name', '{}', \
+         '{\"name\": \"string\"}') ORDER BY name",
+    )
+    .await;
+    assert_eq!(
+        batches.iter().map(|b| b.num_rows()).sum::<usize>(),
+        4,
+        "the reader role sees the seeded people"
+    );
+
+    drop(sources);
+    let _ = pool
+        .execute(format!("DROP OWNED BY {role}; DROP ROLE {role};").as_str())
+        .await;
+    drop_graph(&pool, &graph).await;
+}
+
+#[tokio::test]
+#[ignore = "needs a live Postgres+AGE (set SKARDI_AGE_LIVE_URL); see module doc"]
+async fn cancelled_scans_leave_no_prepared_statements() {
+    // The OpenTxnGuard is what RESCUES a cancelled scan's connection
+    // back into the pool — so it must also DEALLOCATE the call's
+    // prepared statement, or every cancellation strands one `skq_p_*`
+    // on the session permanently (monotonic; reproduced in review).
+    let Some(url) = live_url() else {
+        eprintln!("skipping live AGE test: set SKARDI_AGE_LIVE_URL to run");
+        return;
+    };
+    let graph = unique_graph("cancel");
+    let pool = seed_graph(&url, &graph).await;
+    let (clean_url, user, pass) = split_creds(&url);
+    unsafe {
+        std::env::set_var("SKARDI_AGE_CANCEL_USER", user.unwrap_or_default());
+        std::env::set_var("SKARDI_AGE_CANCEL_PASS", pass.unwrap_or_default());
+    }
+    // max_connections = 1: every round and the sweep share ONE session.
+    let client = AgeClient::connect(
+        "kg",
+        &clean_url,
+        &graph,
+        Some("SKARDI_AGE_CANCEL_USER"),
+        Some("SKARDI_AGE_CANCEL_PASS"),
+        1,
+        std::time::Duration::from_secs(30),
+    )
+    .await
+    .expect("connects");
+    let bounds = QueryBounds {
+        timeout: std::time::Duration::from_secs(30),
+        max_rows: 1_000_000,
+    };
+    // Slow enough to still be mid-flight at 300ms: a wide cartesian
+    // whose predicate REJECTS NOTHING (an equality on a missing name
+    // would zero out `a` and finish instantly).
+    let slow = "MATCH (a),(b),(c),(d),(e),(f),(g),(h),(i),(j) \
+                WHERE a.name <> $x RETURN a";
+    let params = serde_json::json!({"x": "nobody"});
+    for round in 0..3 {
+        let fut = client.execute(slow, &params, 1, bounds, None);
+        let outcome = tokio::time::timeout(std::time::Duration::from_millis(300), fut).await;
+        assert!(
+            outcome.is_err(),
+            "round {round}: the future must still be mid-flight when dropped"
+        );
+    }
+    // The guard's cleanup is a spawned task; give it a moment.
+    tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
+    let mut conn = client
+        .pool_for_tests()
+        .acquire()
+        .await
+        .expect("the one session");
+    let leaked: Vec<String> =
+        sqlx::query_scalar("SELECT name FROM pg_prepared_statements WHERE name LIKE 'skq_p_%'")
+            .fetch_all(&mut *conn)
+            .await
+            .expect("sweep");
+    assert!(
+        leaked.is_empty(),
+        "cancelled scans must deallocate their prepared statements, found: {leaked:?}"
+    );
+    drop(conn);
     drop_graph(&pool, &graph).await;
 }

--- a/crates/skardi/tests/graph_age_live.rs
+++ b/crates/skardi/tests/graph_age_live.rs
@@ -78,14 +78,61 @@ async fn drop_graph(pool: &sqlx::PgPool, graph: &str) {
         .await;
 }
 
-/// A registered source + session, against the live database.
+/// Split a maybe-credentialed URL into (cred-free URL, user, pass):
+/// config validation rejects URL-embedded passwords, so the registered
+/// source takes credentials the designed way — env-var NAMES.
+fn split_creds(url: &str) -> (String, Option<String>, Option<String>) {
+    let mut parsed = url::Url::parse(url).expect("live URL parses");
+    let user = (!parsed.username().is_empty()).then(|| parsed.username().to_string());
+    let pass = parsed.password().map(str::to_string);
+    parsed
+        .set_username("")
+        .expect("postgres URLs take userinfo");
+    parsed
+        .set_password(None)
+        .expect("postgres URLs take userinfo");
+    (parsed.to_string(), user, pass)
+}
+
+/// YAML `username_env`/`password_env` lines for a URL's credentials,
+/// with the values exported under `prefix`-derived env names.
+fn cred_lines(url: &str, prefix: &str) -> String {
+    let (_, user, pass) = split_creds(url);
+    let mut lines = String::new();
+    if let Some(u) = &user {
+        let env = format!("{prefix}_USER");
+        unsafe { std::env::set_var(&env, u) };
+        lines.push_str(&format!("username_env: {env}\n"));
+    }
+    if let Some(p) = &pass {
+        let env = format!("{prefix}_PASS");
+        unsafe { std::env::set_var(&env, p) };
+        lines.push_str(&format!("password_env: {env}\n"));
+    }
+    lines
+}
+
+/// A registered source + session, against the live database. Credentials
+/// ride env vars (unique per graph name, so parallel tests never race).
 async fn live_ctx(url: &str, graph: &str) -> (SessionContext, GraphSources) {
     let sources: GraphSources = Arc::new(RwLock::new(HashMap::new()));
+    let (clean_url, user, pass) = split_creds(url);
+    let user_env = format!("SKARDI_AGE_LIVE_USER_{}", graph.to_uppercase());
+    let pass_env = format!("SKARDI_AGE_LIVE_PASS_{}", graph.to_uppercase());
+    let mut cred_lines = String::new();
+    if let Some(u) = &user {
+        unsafe { std::env::set_var(&user_env, u) };
+        cred_lines.push_str(&format!("username_env: {user_env}\n"));
+    }
+    if let Some(p) = &pass {
+        unsafe { std::env::set_var(&pass_env, p) };
+        cred_lines.push_str(&format!("password_env: {pass_env}\n"));
+    }
     let config: GraphConfig = serde_yaml::from_str(&format!(
-        "backend: age\ngraph_name: {graph}\nquery_timeout_seconds: 10\nmax_rows: 100\n"
+        "backend: age\ngraph_name: {graph}\nquery_timeout_seconds: 10\nmax_rows: 100\n{cred_lines}"
     ))
     .expect("config parses");
-    register_graph_source(&sources, "kg", url, &config)
+    register_graph_source(&sources, "kg", &clean_url, &config)
         .await
         .expect("registration connects eagerly");
     let ctx = SessionContext::new();
@@ -396,10 +443,13 @@ async fn graph_schema_lists_labels_and_the_row_cap_fires() {
     // PREPARE onto the pooled connection (prepared statements are
     // session-level; rollback does not clear them).
     let sources: GraphSources = Arc::new(RwLock::new(HashMap::new()));
-    let config: GraphConfig =
-        serde_yaml::from_str(&format!("backend: age\ngraph_name: {graph}\nmax_rows: 1\n"))
-            .expect("config parses");
-    register_graph_source(&sources, "capped", &url, &config)
+    let (clean_url, _, _) = split_creds(&url);
+    let creds = cred_lines(&url, "SKARDI_AGE_CAPPED");
+    let config: GraphConfig = serde_yaml::from_str(&format!(
+        "backend: age\ngraph_name: {graph}\nmax_rows: 1\n{creds}"
+    ))
+    .expect("config parses");
+    register_graph_source(&sources, "capped", &clean_url, &config)
         .await
         .expect("registers");
     let capped = SessionContext::new();
@@ -436,9 +486,25 @@ async fn graph_schema_lists_labels_and_the_row_cap_fires() {
     // the very sessions execute used; hence the direct AgeClient and its
     // test-only pool hook). Before the fix each error path left one
     // behind, monotonically.
-    let client = AgeClient::connect("leakcheck", &url, &graph, None, None, 4)
-        .await
-        .expect("connects");
+    let (clean_url, user, pass) = split_creds(&url);
+    unsafe {
+        if let Some(u) = &user {
+            std::env::set_var("SKARDI_AGE_LEAK_USER", u);
+        }
+        if let Some(p) = &pass {
+            std::env::set_var("SKARDI_AGE_LEAK_PASS", p);
+        }
+    }
+    let client = AgeClient::connect(
+        "leakcheck",
+        &clean_url,
+        &graph,
+        user.as_ref().map(|_| "SKARDI_AGE_LEAK_USER"),
+        pass.as_ref().map(|_| "SKARDI_AGE_LEAK_PASS"),
+        4,
+    )
+    .await
+    .expect("connects");
     let tight = QueryBounds {
         timeout: std::time::Duration::from_secs(10),
         max_rows: 1,
@@ -457,6 +523,25 @@ async fn graph_schema_lists_labels_and_the_row_cap_fires() {
             .expect("4 people, cap 1: the capped error path");
         assert!(err.to_string().contains("max_rows = 1"), "{err}");
     }
+    // BACKEND error paths leak differently from client-local ones: a
+    // runtime error aborts the transaction, where DEALLOCATE itself is
+    // refused until ROLLBACK — the round-3 P1. Parameterized (so the
+    // PREPARE exists and the EXECUTE fails at runtime), 8× past the pool.
+    for _ in 0..8 {
+        let err = client
+            .execute(
+                "MATCH (p:Person) RETURN $x / 0",
+                &serde_json::json!({"x": 1}),
+                1,
+                tight,
+                None,
+            )
+            .await
+            .err()
+            .map(|e| e.to_string())
+            .unwrap_or_else(|| "stream deferred".to_string());
+        assert!(!err.is_empty());
+    }
     for _ in 0..8 {
         let leaked: i64 = sqlx::query_scalar(
             "SELECT COUNT(*) FROM pg_prepared_statements WHERE name LIKE 'skq_p_%'",
@@ -464,8 +549,69 @@ async fn graph_schema_lists_labels_and_the_row_cap_fires() {
         .fetch_one(client.pool_for_tests())
         .await
         .expect("pg_prepared_statements readable");
-        assert_eq!(leaked, 0, "no skq_p_* statement survives an error path");
+        assert_eq!(
+            leaked, 0,
+            "no skq_p_* statement survives client-local OR backend error paths"
+        );
     }
+
+    // Hostile-looking parameter VALUES round-trip inertly through the
+    // serde_json + quote-doubling boundary (the design's recorded AGE
+    // exception): apostrophes, backslashes, SQL fragments.
+    let hostile = r#"O'Brien \ '; DROP TABLE documents; --"#;
+    let stream = client
+        .execute(
+            "RETURN $s",
+            &serde_json::json!({"s": hostile}),
+            1,
+            tight,
+            None,
+        )
+        .await
+        .expect("hostile param is inert data");
+    use futures::TryStreamExt;
+    let rows: Vec<_> = stream.try_collect().await.expect("collects");
+    assert_eq!(
+        rows[0][0],
+        serde_json::json!(hostile),
+        "byte-faithful round trip"
+    );
+
+    drop_graph(&pool, &graph).await;
+}
+
+#[tokio::test]
+#[ignore = "needs a live Postgres+AGE (set SKARDI_AGE_LIVE_URL); see module doc"]
+async fn duplicate_registration_keeps_the_original_connection() {
+    let Some(url) = live_url() else {
+        eprintln!("skipping live AGE test: set SKARDI_AGE_LIVE_URL to run");
+        return;
+    };
+    let graph = unique_graph("dup");
+    let pool = seed_graph(&url, &graph).await;
+    let (ctx, sources) = live_ctx(&url, &graph).await;
+
+    // Second registration under the SAME name (pointing at a different
+    // graph) must fail AND leave the original routing untouched.
+    let (clean_url, _, _) = split_creds(&url);
+    let creds = cred_lines(&url, "SKARDI_AGE_DUP");
+    let config: GraphConfig =
+        serde_yaml::from_str(&format!("backend: age\ngraph_name: {graph}_other\n{creds}"))
+            .expect("config parses");
+    let err = register_graph_source(&sources, "kg", &clean_url, &config)
+        .await
+        .expect_err("duplicate name refuses");
+    assert!(err.to_string().contains("already registered"), "{err}");
+
+    // The original connection still serves — 4 people, not an error and
+    // not the empty _other graph.
+    let batches = collect(
+        &ctx,
+        "SELECT name FROM cypher_query('kg', 'MATCH (p:Person) RETURN p.name', '{}', \
+         '{\"name\": \"string\"}')",
+    )
+    .await;
+    assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 4);
 
     drop_graph(&pool, &graph).await;
 }

--- a/crates/skardi/tests/graph_age_live.rs
+++ b/crates/skardi/tests/graph_age_live.rs
@@ -27,7 +27,17 @@ use sqlx::postgres::PgPoolOptions;
 use skardi::sources::providers::graph::client::{AgeClient, GraphClient, QueryBounds};
 use skardi::sources::providers::graph::config::GraphConfig;
 use skardi::sources::providers::graph::udtf::GraphSources;
+use skardi::sources::providers::graph::value::{DeclaredColumn, GraphType};
 use skardi::sources::providers::graph::{register_graph_source, register_graph_udtfs};
+
+/// One declared column for direct `GraphClient::execute` calls — AGE
+/// binds positionally, so only the COUNT matters to these tests.
+fn one_col() -> Vec<DeclaredColumn> {
+    vec![DeclaredColumn {
+        name: "c0".to_string(),
+        ty: GraphType::Json,
+    }]
+}
 
 fn live_url() -> Option<String> {
     std::env::var("SKARDI_AGE_LIVE_URL")
@@ -366,7 +376,7 @@ async fn the_backend_read_only_transaction_is_the_boundary() {
         .execute(
             "CREATE (n:Sneaky) RETURN n",
             &serde_json::json!({}),
-            1,
+            Some(&one_col()),
             handle.bounds,
             None,
         )
@@ -515,11 +525,12 @@ async fn graph_schema_lists_labels_and_the_row_cap_fires() {
     // (min_connections defaults to 0) and a "sweep" would only ever see
     // a single session (round-4 review).
     let hammer_params = serde_json::json!({"x": "nobody"});
+    let hammer_cols = one_col();
     let results = futures::future::join_all((0..8).map(|_| {
         client.execute(
             "MATCH (p:Person) WHERE p.name <> $x RETURN p.name",
             &hammer_params,
-            1,
+            Some(&hammer_cols),
             tight,
             None,
         )
@@ -537,11 +548,12 @@ async fn graph_schema_lists_labels_and_the_row_cap_fires() {
     // PREPARE exists and the EXECUTE fails at runtime), concurrent for
     // the same session-fan-out reason as above.
     let div_params = serde_json::json!({"x": 1});
+    let div_cols = one_col();
     let results = futures::future::join_all((0..8).map(|_| {
         client.execute(
             "MATCH (p:Person) RETURN $x / 0",
             &div_params,
-            1,
+            Some(&div_cols),
             tight,
             None,
         )
@@ -577,7 +589,7 @@ async fn graph_schema_lists_labels_and_the_row_cap_fires() {
         .execute(
             "RETURN $s",
             &serde_json::json!({"s": hostile}),
-            1,
+            Some(&one_col()),
             tight,
             None,
         )
@@ -704,7 +716,7 @@ async fn the_timeout_bound_is_typed_and_credentials_never_reach_errors() {
             // for the full count either.
             "MATCH (a),(b),(c),(d),(e),(f),(g),(h),(i),(j),(k),(l),(m),(n) RETURN count(*)",
             &serde_json::json!({}),
-            1,
+            Some(&one_col()),
             QueryBounds {
                 timeout: std::time::Duration::from_secs(1),
                 max_rows: 10,
@@ -717,9 +729,9 @@ async fn the_timeout_bound_is_typed_and_credentials_never_reach_errors() {
     let msg = err.to_string();
     assert!(msg.contains("timed out after 1s"), "typed, named: {msg}");
 
-    // 2) graph_schema's own row cap (the labels() branch).
+    // 2) graph_schema's own row cap (the catalog branch).
     let err = client
-        .labels(
+        .schema(
             QueryBounds {
                 timeout: std::time::Duration::from_secs(10),
                 max_rows: 1,
@@ -866,7 +878,7 @@ async fn round4_fixes_hold_end_to_end() {
         .execute(
             "MATCH (p:Person) RETURN p.name",
             &serde_json::json!({}),
-            1,
+            Some(&one_col()),
             QueryBounds {
                 timeout: std::time::Duration::from_secs(1),
                 max_rows: 10,

--- a/crates/skardi/tests/graph_live_support/mod.rs
+++ b/crates/skardi/tests/graph_live_support/mod.rs
@@ -1,0 +1,34 @@
+//! Helpers shared by the graph live suites (`graph_age_live`,
+//! `graph_neo4j_live`). One copy on purpose: `split_creds` is the code
+//! that keeps live passwords out of registered configs — a fix to it
+//! must reach every backend's suite at once.
+
+use arrow::record_batch::RecordBatch;
+use datafusion::prelude::SessionContext;
+
+/// The gating env var's value, if set non-empty (each suite names its
+/// own variable).
+pub fn live_url(var: &str) -> Option<String> {
+    std::env::var(var).ok().filter(|u| !u.trim().is_empty())
+}
+
+/// Split a maybe-credentialed URL into (cred-free URL, user, pass):
+/// config validation rejects URL-embedded passwords, so the registered
+/// source takes credentials the designed way — env-var NAMES.
+pub fn split_creds(url: &str) -> (String, Option<String>, Option<String>) {
+    let mut parsed = url::Url::parse(url).expect("live URL parses");
+    let user = (!parsed.username().is_empty()).then(|| parsed.username().to_string());
+    let pass = parsed.password().map(str::to_string);
+    parsed.set_username("").expect("URL takes userinfo");
+    parsed.set_password(None).expect("URL takes userinfo");
+    (parsed.to_string(), user, pass)
+}
+
+pub async fn collect(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch> {
+    ctx.sql(sql)
+        .await
+        .expect("plans")
+        .collect()
+        .await
+        .expect("executes")
+}

--- a/crates/skardi/tests/graph_neo4j_live.rs
+++ b/crates/skardi/tests/graph_neo4j_live.rs
@@ -1,0 +1,699 @@
+//! Opt-in live integration tests for the graph engine bypass's
+//! milestone-2 backend: Neo4j over Bolt.
+//!
+//! Disabled by default (`#[ignore]`) so the default suite stays offline
+//! and deterministic. These are the only tests that exercise the real
+//! Bolt path — everything else mocks at [`GraphClient`] level — so run
+//! them whenever the Neo4j client or the Bolt decoding changes.
+//!
+//! Against a disposable Neo4j container (no setup needed):
+//!   docker run -d --name skardi-neo4j -p 127.0.0.1:17687:7687 \
+//!     -e NEO4J_AUTH=neo4j/skardipass neo4j:5
+//!   SKARDI_NEO4J_LIVE_URL='bolt://neo4j:skardipass@127.0.0.1:17687' \
+//!     cargo test -p skardi --test graph_neo4j_live -- --ignored
+//!
+//! Neo4j Community has ONE user database (multi-db is enterprise), so
+//! isolation rides uniquely suffixed LABELS per run, cleaned up
+//! afterwards — a shared server is safe and reruns never collide.
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use arrow::array::{Array, ListArray, StringArray, StructArray};
+use arrow::record_batch::RecordBatch;
+use datafusion::prelude::SessionContext;
+
+use skardi::sources::providers::graph::client::{GraphClient, QueryBounds};
+use skardi::sources::providers::graph::config::GraphConfig;
+use skardi::sources::providers::graph::neo4j::Neo4jClient;
+use skardi::sources::providers::graph::udtf::GraphSources;
+use skardi::sources::providers::graph::value::{DeclaredColumn, GraphType};
+use skardi::sources::providers::graph::{register_graph_source, register_graph_udtfs};
+
+fn live_url() -> Option<String> {
+    std::env::var("SKARDI_NEO4J_LIVE_URL")
+        .ok()
+        .filter(|u| !u.trim().is_empty())
+}
+
+/// One declared column for direct `GraphClient::execute` calls. On this
+/// backend the NAME binds (unlike AGE's positional count).
+fn cols(names: &[(&str, GraphType)]) -> Vec<DeclaredColumn> {
+    names
+        .iter()
+        .map(|(name, ty)| DeclaredColumn {
+            name: name.to_string(),
+            ty: *ty,
+        })
+        .collect()
+}
+
+/// Split a maybe-credentialed URL into (cred-free URL, user, pass):
+/// config validation rejects URL-embedded passwords, so the registered
+/// source takes credentials the designed way — env-var NAMES.
+fn split_creds(url: &str) -> (String, Option<String>, Option<String>) {
+    let mut parsed = url::Url::parse(url).expect("live URL parses");
+    let user = (!parsed.username().is_empty()).then(|| parsed.username().to_string());
+    let pass = parsed.password().map(str::to_string);
+    parsed.set_username("").expect("bolt URLs take userinfo");
+    parsed.set_password(None).expect("bolt URLs take userinfo");
+    (parsed.to_string(), user, pass)
+}
+
+/// A run-unique label suffix: Community Neo4j has one database, so the
+/// data namespace is the label alphabet.
+fn unique_suffix(tag: &str) -> String {
+    format!(
+        "{tag}_{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .subsec_nanos()
+    )
+}
+
+/// Seed through the DRIVER's write path (the Skardi surface under test
+/// is read-only by construction and could not create this data).
+/// Labels carry the run suffix; returns the seeding Graph for cleanup.
+async fn seed(url: &str, suffix: &str) -> neo4rs::Graph {
+    let (clean_url, user, pass) = split_creds(url);
+    let graph = neo4rs::Graph::new(
+        clean_url,
+        user.unwrap_or_default(),
+        pass.unwrap_or_default(),
+    )
+    .expect("live neo4j reachable (SKARDI_NEO4J_LIVE_URL)");
+    let create = format!(
+        "CREATE (a:Person_{suffix}:Admin_{suffix} {{name: 'ada', age: 36}}), \
+                (b:Person_{suffix} {{name: 'bob', age: 41}}), \
+                (c:Person_{suffix} {{name: 'cyd'}}), \
+                (d:Person_{suffix} {{name: '颱風', note: 'café ☔', \
+                 joined: date('2024-05-17')}}), \
+                (a)-[:KNOWS_{suffix} {{since: 2019}}]->(b), \
+                (b)-[:KNOWS_{suffix} {{since: 2021}}]->(c), \
+                (a)-[:KNOWS_{suffix} {{since: 2024}}]->(d)"
+    );
+    graph.run(neo4rs::Query::new(create)).await.expect("seed");
+    graph
+}
+
+async fn cleanup(graph: &neo4rs::Graph, suffix: &str) {
+    let _ = graph
+        .run(neo4rs::Query::new(format!(
+            "MATCH (n) WHERE any(l IN labels(n) WHERE l ENDS WITH '{suffix}') \
+             DETACH DELETE n"
+        )))
+        .await;
+}
+
+/// A registered `backend: neo4j` source + session against the live
+/// server. Credentials ride env vars (unique per suffix, so parallel
+/// tests never race). Registration itself runs the read-mode proof —
+/// every `live_ctx` success is one more pass of that gate.
+async fn live_ctx(url: &str, suffix: &str) -> (SessionContext, GraphSources) {
+    let sources: GraphSources = Arc::new(RwLock::new(HashMap::new()));
+    let (clean_url, user, pass) = split_creds(url);
+    let mut cred_lines = String::new();
+    if let Some(u) = &user {
+        let env = format!("SKARDI_NEO4J_LIVE_USER_{}", suffix.to_uppercase());
+        unsafe { std::env::set_var(&env, u) };
+        cred_lines.push_str(&format!("username_env: {env}\n"));
+    }
+    if let Some(p) = &pass {
+        let env = format!("SKARDI_NEO4J_LIVE_PASS_{}", suffix.to_uppercase());
+        unsafe { std::env::set_var(&env, p) };
+        cred_lines.push_str(&format!("password_env: {env}\n"));
+    }
+    let config: GraphConfig = serde_yaml::from_str(&format!(
+        "backend: neo4j\nquery_timeout_seconds: 10\nmax_rows: 100\n{cred_lines}"
+    ))
+    .expect("config parses");
+    register_graph_source(&sources, "kg", &clean_url, &config)
+        .await
+        .expect("registration connects eagerly and passes the read-mode proof");
+    let ctx = SessionContext::new();
+    register_graph_udtfs(&ctx, Arc::clone(&sources)).expect("udtfs register");
+    (ctx, sources)
+}
+
+/// A bare client with tailored bounds, for direct-trait tests.
+async fn live_client(url: &str, timeout_secs: u64) -> Neo4jClient {
+    let (clean_url, user, pass) = split_creds(url);
+    unsafe {
+        std::env::set_var("SKARDI_NEO4J_DIRECT_USER", user.unwrap_or_default());
+        std::env::set_var("SKARDI_NEO4J_DIRECT_PASS", pass.unwrap_or_default());
+    }
+    Neo4jClient::connect(
+        "kg",
+        &clean_url,
+        None,
+        Some("SKARDI_NEO4J_DIRECT_USER"),
+        Some("SKARDI_NEO4J_DIRECT_PASS"),
+        4,
+        std::time::Duration::from_secs(timeout_secs),
+    )
+    .await
+    .expect("connects")
+}
+
+async fn collect(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch> {
+    ctx.sql(sql)
+        .await
+        .expect("plans")
+        .collect()
+        .await
+        .expect("executes")
+}
+
+fn skip() -> bool {
+    if live_url().is_none() {
+        // CI's coverage job runs `-- --ignored` across the board (the
+        // documents_s3_live convention): absent gating env means SKIP,
+        // loudly on stderr — never a panic.
+        eprintln!("skipping live Neo4j test: set SKARDI_NEO4J_LIVE_URL to run");
+        return true;
+    }
+    false
+}
+
+#[tokio::test]
+#[ignore = "needs a live Neo4j (set SKARDI_NEO4J_LIVE_URL); see module doc"]
+async fn scalars_params_and_by_name_binding_round_trip() {
+    if skip() {
+        return;
+    }
+    let url = live_url().unwrap();
+    let suffix = unique_suffix("scalar");
+    let graph = seed(&url, &suffix).await;
+    let (ctx, _sources) = live_ctx(&url, &suffix).await;
+
+    // Declared columns in the OPPOSITE order of the RETURN clause: on
+    // this backend the binding is BY NAME, so — unlike AGE, where this
+    // exact shape silently swaps — the values land under their names.
+    let batches = collect(
+        &ctx,
+        &format!(
+            "SELECT name, age FROM cypher_query('kg', '\
+                 MATCH (p:Person_{suffix}) WHERE p.age > $min \
+                 RETURN p.age AS age, p.name AS name', \
+             '{{\"min\": 40}}', '{{\"name\": \"string\", \"age\": \"int\"}}')"
+        ),
+    )
+    .await;
+    let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total, 1, "only bob is over 40");
+    let names = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(names.value(0), "bob", "name carries the NAME, not the age");
+
+    // CJK and emoji survive Bolt round-trips byte-faithfully.
+    let batches = collect(
+        &ctx,
+        &format!(
+            "SELECT note FROM cypher_query('kg', '\
+                 MATCH (p:Person_{suffix}) WHERE p.name = $who RETURN p.note AS note', \
+             '{{\"who\": \"颱風\"}}', '{{\"note\": \"string\"}}')"
+        ),
+    )
+    .await;
+    let notes = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(notes.value(0), "café ☔");
+
+    // A declared name the query never returns is a typed error naming it.
+    let err = ctx
+        .sql(&format!(
+            "SELECT nope FROM cypher_query('kg', '\
+                 MATCH (p:Person_{suffix}) RETURN p.name AS name', \
+             '{{}}', '{{\"nope\": \"string\"}}')"
+        ))
+        .await
+        .expect("plans")
+        .collect()
+        .await
+        .expect_err("no field named nope");
+    let msg = err.to_string();
+    assert!(msg.contains("'nope'"), "{msg}");
+    assert!(msg.contains("BY NAME"), "{msg}");
+
+    cleanup(&graph, &suffix).await;
+}
+
+#[tokio::test]
+#[ignore = "needs a live Neo4j (set SKARDI_NEO4J_LIVE_URL); see module doc"]
+async fn nodes_relationships_and_paths_take_the_canonical_shapes() {
+    if skip() {
+        return;
+    }
+    let url = live_url().unwrap();
+    let suffix = unique_suffix("shape");
+    let graph = seed(&url, &suffix).await;
+    let (ctx, _sources) = live_ctx(&url, &suffix).await;
+
+    // A MULTI-label node (ada is Person+Admin): both labels land in the
+    // canonical list — the shape AGE structurally cannot produce.
+    let batches = collect(
+        &ctx,
+        &format!(
+            "SELECT v, json_get_str(v.properties, 'name') AS name \
+             FROM cypher_query('kg', '\
+                 MATCH (v:Admin_{suffix}) RETURN v', \
+             '{{}}', '{{\"v\": \"node\"}}')"
+        ),
+    )
+    .await;
+    assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 1);
+    let node = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .unwrap();
+    let labels = node
+        .column_by_name("labels")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .unwrap();
+    assert_eq!(labels.value(0).len(), 2, "Person + Admin, both present");
+    let names = batches[0]
+        .column(1)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(names.value(0), "ada");
+
+    // Relationship: endpoints and type; properties queryable in place.
+    let batches = collect(
+        &ctx,
+        &format!(
+            "SELECT r, json_get_int(r.properties, 'since') AS since \
+             FROM cypher_query('kg', '\
+                 MATCH (:Person_{suffix} {{name: \"ada\"}})-[r:KNOWS_{suffix}]->\
+                       (:Person_{suffix} {{name: \"bob\"}}) RETURN r', \
+             '{{}}', '{{\"r\": \"relationship\"}}')"
+        ),
+    )
+    .await;
+    assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 1);
+    let rel = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .unwrap();
+    let rel_type = rel
+        .column_by_name("type")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(rel_type.value(0), format!("KNOWS_{suffix}"));
+    let start_id = rel
+        .column_by_name("start_id")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert!(!start_id.value(0).is_empty(), "endpoints resolve");
+
+    // Path: ada → bob → cyd in traversal order, parallel lists, hop i
+    // joins node i to node i+1.
+    let batches = collect(
+        &ctx,
+        &format!(
+            "SELECT p FROM cypher_query('kg', '\
+                 MATCH p = (:Person_{suffix} {{name: \"ada\"}})\
+                           -[:KNOWS_{suffix}*2]->\
+                           (:Person_{suffix} {{name: \"cyd\"}}) RETURN p', \
+             '{{}}', '{{\"p\": \"path\"}}')"
+        ),
+    )
+    .await;
+    assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 1);
+    let path = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .unwrap();
+    let nodes = path
+        .column_by_name("nodes")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .unwrap();
+    let rels = path
+        .column_by_name("relationships")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .unwrap();
+    assert_eq!(nodes.value(0).len(), 3, "ada, bob, cyd");
+    assert_eq!(rels.value(0).len(), 2, "two hops");
+
+    // Temporal property: date() renders as ISO text inside properties
+    // JSON — a datetime property must never fail a scan.
+    let batches = collect(
+        &ctx,
+        &format!(
+            "SELECT json_get_str(v.properties, 'joined') AS joined \
+             FROM cypher_query('kg', '\
+                 MATCH (v:Person_{suffix}) WHERE v.name = \"颱風\" RETURN v', \
+             '{{}}', '{{\"v\": \"node\"}}')"
+        ),
+    )
+    .await;
+    let joined = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(joined.value(0), "2024-05-17");
+
+    cleanup(&graph, &suffix).await;
+}
+
+#[tokio::test]
+#[ignore = "needs a live Neo4j (set SKARDI_NEO4J_LIVE_URL); see module doc"]
+async fn record_fallback_returns_json_records_with_sorted_keys() {
+    if skip() {
+        return;
+    }
+    let url = live_url().unwrap();
+    let suffix = unique_suffix("record");
+    let graph = seed(&url, &suffix).await;
+    let (ctx, _sources) = live_ctx(&url, &suffix).await;
+
+    // No declared columns: one `record` column, whole record as JSON.
+    let batches = collect(
+        &ctx,
+        &format!(
+            "SELECT record FROM cypher_query('kg', '\
+                 MATCH (p:Person_{suffix}) WHERE p.age IS NOT NULL \
+                 RETURN p.name AS name, p.age AS age')"
+        ),
+    )
+    .await;
+    assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 2);
+    let records = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(records.value(0)).expect("valid JSON");
+    assert!(parsed.get("name").is_some() && parsed.get("age").is_some());
+    // Sorted keys — the documented determinism contract.
+    assert!(
+        records.value(0).find("\"age\"") < records.value(0).find("\"name\""),
+        "{}",
+        records.value(0)
+    );
+
+    // The record is queryable in place through the json getters.
+    let batches = collect(
+        &ctx,
+        &format!(
+            "SELECT json_get_str(record, 'name') AS name FROM cypher_query('kg', '\
+                 MATCH (p:Person_{suffix}) WHERE p.age IS NOT NULL \
+                 RETURN p.name AS name, p.age AS age') \
+             ORDER BY name"
+        ),
+    )
+    .await;
+    let names = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(names.value(0), "ada");
+
+    // Empty results keep the record schema.
+    let batches = collect(
+        &ctx,
+        "SELECT * FROM cypher_query('kg', 'MATCH (p:NoSuchLabelAnywhere) RETURN p')",
+    )
+    .await;
+    assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 0);
+    assert_eq!(batches[0].schema().field(0).name(), "record");
+
+    cleanup(&graph, &suffix).await;
+}
+
+#[tokio::test]
+#[ignore = "needs a live Neo4j (set SKARDI_NEO4J_LIVE_URL); see module doc"]
+async fn read_only_is_server_enforced_past_the_guard() {
+    if skip() {
+        return;
+    }
+    let url = live_url().unwrap();
+    let suffix = unique_suffix("readonly");
+    let graph = seed(&url, &suffix).await;
+    let (ctx, sources) = live_ctx(&url, &suffix).await;
+
+    // Layer 1: the keyword guard rejects at PLAN time, keyword named.
+    let err = ctx
+        .sql("SELECT * FROM cypher_query('kg', 'CREATE (n:Sneaky) RETURN n', '{}', '{\"n\": \"node\"}')")
+        .await
+        .expect_err("guard rejects");
+    assert!(err.to_string().contains("'CREATE'"), "{err}");
+
+    // Layer 2: bypass the guard entirely (direct client call — the
+    // deliberately-disabled-guard proof the design's testing strategy
+    // names) and require the SERVER to refuse the write inside the
+    // read-mode transaction.
+    let handle = {
+        let map = sources.read().unwrap();
+        Arc::clone(map.get("kg").unwrap())
+    };
+    let columns = cols(&[("n", GraphType::Node)]);
+    let result = handle
+        .client
+        .execute(
+            "CREATE (n:Sneaky) RETURN n",
+            &serde_json::json!({}),
+            Some(&columns),
+            handle.bounds,
+            None,
+        )
+        .await;
+    let err = match result {
+        Err(e) => e.to_string(),
+        Ok(stream) => {
+            use futures::TryStreamExt;
+            stream
+                .try_collect::<Vec<_>>()
+                .await
+                .expect_err("the backend must refuse")
+                .to_string()
+        }
+    };
+    assert!(
+        err.contains("graph backend error"),
+        "server-side refusal surfaces as a typed backend error: {err}"
+    );
+    // The refusal is the ACCESS-MODE one
+    // (Neo.ClientError.Statement.AccessMode, pinned live), not an
+    // incidental failure — the boundary the registration proof relies on.
+    assert!(err.contains("read access mode"), "{err}");
+    // And the write demonstrably did not happen.
+    let batches = collect(
+        &ctx,
+        "SELECT record FROM cypher_query('kg', 'MATCH (n:Sneaky) RETURN n')",
+    )
+    .await;
+    assert_eq!(
+        batches.iter().map(|b| b.num_rows()).sum::<usize>(),
+        0,
+        "nothing was created"
+    );
+
+    cleanup(&graph, &suffix).await;
+}
+
+#[tokio::test]
+#[ignore = "needs a live Neo4j (set SKARDI_NEO4J_LIVE_URL); see module doc"]
+async fn graph_schema_serves_property_names_and_types() {
+    if skip() {
+        return;
+    }
+    let url = live_url().unwrap();
+    let suffix = unique_suffix("schema");
+    let graph = seed(&url, &suffix).await;
+    let (ctx, _sources) = live_ctx(&url, &suffix).await;
+
+    // The milestone-2 discovery upgrade: property names AND types, per
+    // label, straight off db.schema.* — the columns AGE serves as null.
+    let batches = collect(
+        &ctx,
+        &format!(
+            "SELECT label, kind, property, property_type FROM graph_schema('kg') \
+             WHERE label LIKE '%{suffix}' ORDER BY kind, label, property"
+        ),
+    )
+    .await;
+    let mut rows: Vec<(String, String, Option<String>, Option<String>)> = Vec::new();
+    for batch in &batches {
+        let label = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let kind = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let property = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let property_type = batch
+            .column(3)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        for i in 0..batch.num_rows() {
+            rows.push((
+                label.value(i).to_string(),
+                kind.value(i).to_string(),
+                (!property.is_null(i)).then(|| property.value(i).to_string()),
+                (!property_type.is_null(i)).then(|| property_type.value(i).to_string()),
+            ));
+        }
+    }
+    // The KNOWS edge carries (since, Long).
+    assert!(
+        rows.iter().any(|(label, kind, property, ty)| {
+            label == &format!("KNOWS_{suffix}")
+                && kind == "edge"
+                && property.as_deref() == Some("since")
+                && ty.as_deref().is_some_and(|t| t.contains("Long"))
+        }),
+        "KNOWS since:Long expected in {rows:?}"
+    );
+    // Person carries (name, String).
+    assert!(
+        rows.iter().any(|(label, kind, property, ty)| {
+            label == &format!("Person_{suffix}")
+                && kind == "vertex"
+                && property.as_deref() == Some("name")
+                && ty.as_deref().is_some_and(|t| t.contains("String"))
+        }),
+        "Person name:String expected in {rows:?}"
+    );
+
+    cleanup(&graph, &suffix).await;
+}
+
+#[tokio::test]
+#[ignore = "needs a live Neo4j (set SKARDI_NEO4J_LIVE_URL); see module doc"]
+async fn bounds_hold_row_cap_limit_and_typed_timeout() {
+    if skip() {
+        return;
+    }
+    let url = live_url().unwrap();
+    let suffix = unique_suffix("bounds");
+    let graph = seed(&url, &suffix).await;
+
+    let client = live_client(&url, 10).await;
+    let tight = QueryBounds {
+        timeout: std::time::Duration::from_secs(10),
+        max_rows: 1,
+    };
+    let columns = cols(&[("name", GraphType::String)]);
+
+    // Row cap: 4 people, cap 1 — loud typed overflow.
+    let err = client
+        .execute(
+            &format!("MATCH (p:Person_{suffix}) RETURN p.name AS name"),
+            &serde_json::json!({}),
+            Some(&columns),
+            tight,
+            None,
+        )
+        .await
+        .err()
+        .expect("cap must fire");
+    assert!(err.to_string().contains("max_rows = 1"), "{err}");
+
+    // LIMIT under the cap: clean early stop, exactly 1 row.
+    use futures::TryStreamExt;
+    let rows: Vec<_> = client
+        .execute(
+            &format!("MATCH (p:Person_{suffix}) RETURN p.name AS name"),
+            &serde_json::json!({}),
+            Some(&columns),
+            tight,
+            Some(1),
+        )
+        .await
+        .expect("limit is a clean stop")
+        .try_collect()
+        .await
+        .expect("collects");
+    assert_eq!(rows.len(), 1);
+
+    // Server-side tx_timeout: a summation the server cannot finish in 1s
+    // dies THERE and surfaces as the typed Timeout naming the bound —
+    // this is the live proof the RUN-extra tx_timeout actually lands.
+    let err = client
+        .execute(
+            "UNWIND range(1, 100000000) AS i \
+             UNWIND range(1, 100) AS j \
+             RETURN sum(i * j) AS s",
+            &serde_json::json!({}),
+            Some(&cols(&[("s", GraphType::Int)])),
+            QueryBounds {
+                timeout: std::time::Duration::from_secs(1),
+                max_rows: 10,
+            },
+            None,
+        )
+        .await
+        .err()
+        .expect("cannot finish in 1s");
+    let msg = err.to_string();
+    assert!(msg.contains("timed out after 1s"), "typed, named: {msg}");
+
+    cleanup(&graph, &suffix).await;
+}
+
+#[tokio::test]
+#[ignore = "needs a live Neo4j (set SKARDI_NEO4J_LIVE_URL); see module doc"]
+async fn credentials_never_reach_error_text() {
+    if skip() {
+        return;
+    }
+    let url = live_url().unwrap();
+    let (clean_url, user, pass) = split_creds(&url);
+    let Some(real_pass) = pass else {
+        eprintln!("skipping credential-leak probe: live URL carries no password");
+        return;
+    };
+    // Force an auth failure with a WRONG password and assert neither the
+    // wrong nor the real password appears in the error.
+    unsafe {
+        std::env::set_var("SKARDI_NEO4J_WRONGPASS_USER", user.unwrap_or_default());
+        std::env::set_var("SKARDI_NEO4J_WRONGPASS_PASS", "definitely_wrong_pw_9");
+    }
+    let err = Neo4jClient::connect(
+        "kg",
+        &clean_url,
+        None,
+        Some("SKARDI_NEO4J_WRONGPASS_USER"),
+        Some("SKARDI_NEO4J_WRONGPASS_PASS"),
+        2,
+        std::time::Duration::from_secs(10),
+    )
+    .await
+    .expect_err("wrong password fails registration");
+    let msg = err.to_string();
+    assert!(!msg.contains("definitely_wrong_pw_9"), "{msg}");
+    assert!(!msg.contains(&real_pass), "real password never leaks");
+}

--- a/crates/skardi/tests/graph_neo4j_live.rs
+++ b/crates/skardi/tests/graph_neo4j_live.rs
@@ -20,7 +20,6 @@ use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 use arrow::array::{Array, ListArray, StringArray, StructArray};
-use arrow::record_batch::RecordBatch;
 use datafusion::prelude::SessionContext;
 
 use skardi::sources::providers::graph::client::{GraphClient, QueryBounds};
@@ -30,10 +29,11 @@ use skardi::sources::providers::graph::udtf::GraphSources;
 use skardi::sources::providers::graph::value::{DeclaredColumn, GraphType};
 use skardi::sources::providers::graph::{register_graph_source, register_graph_udtfs};
 
+mod graph_live_support;
+use graph_live_support::{collect, split_creds};
+
 fn live_url() -> Option<String> {
-    std::env::var("SKARDI_NEO4J_LIVE_URL")
-        .ok()
-        .filter(|u| !u.trim().is_empty())
+    graph_live_support::live_url("SKARDI_NEO4J_LIVE_URL")
 }
 
 /// One declared column for direct `GraphClient::execute` calls. On this
@@ -46,18 +46,6 @@ fn cols(names: &[(&str, GraphType)]) -> Vec<DeclaredColumn> {
             ty: *ty,
         })
         .collect()
-}
-
-/// Split a maybe-credentialed URL into (cred-free URL, user, pass):
-/// config validation rejects URL-embedded passwords, so the registered
-/// source takes credentials the designed way — env-var NAMES.
-fn split_creds(url: &str) -> (String, Option<String>, Option<String>) {
-    let mut parsed = url::Url::parse(url).expect("live URL parses");
-    let user = (!parsed.username().is_empty()).then(|| parsed.username().to_string());
-    let pass = parsed.password().map(str::to_string);
-    parsed.set_username("").expect("bolt URLs take userinfo");
-    parsed.set_password(None).expect("bolt URLs take userinfo");
-    (parsed.to_string(), user, pass)
 }
 
 /// A run-unique label suffix: Community Neo4j has one database, so the
@@ -155,15 +143,6 @@ async fn live_client(url: &str, timeout_secs: u64) -> Neo4jClient {
     )
     .await
     .expect("connects")
-}
-
-async fn collect(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch> {
-    ctx.sql(sql)
-        .await
-        .expect("plans")
-        .collect()
-        .await
-        .expect("executes")
 }
 
 fn skip() -> bool {
@@ -638,6 +617,24 @@ async fn bounds_hold_row_cap_limit_and_typed_timeout() {
         .await
         .expect("collects");
     assert_eq!(rows.len(), 1);
+
+    // graph_schema shares the bounds discipline, AGE-parity: a LIMIT at
+    // or under the cap is a CLEAN stop even when the flattened catalog
+    // exceeds the cap, and only an uncapped read overflows loudly.
+    let schema_bounds = QueryBounds {
+        timeout: std::time::Duration::from_secs(10),
+        max_rows: 1,
+    };
+    let rows = client
+        .schema(schema_bounds, Some(1))
+        .await
+        .expect("limit at the cap is a clean stop, never a cap error");
+    assert_eq!(rows.len(), 1);
+    let err = client
+        .schema(schema_bounds, None)
+        .await
+        .expect_err("the seeded catalog flattens past a cap of 1");
+    assert!(err.to_string().contains("max_rows = 1"), "{err}");
 
     // Server-side tx_timeout: a summation the server cannot finish in 1s
     // dies THERE and surfaces as the typed Timeout naming the bound —

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -1,0 +1,99 @@
+# Graph sources (Cypher over AGE) — milestone status
+
+Read-only Cypher against a property graph, surfaced as SQL tables
+(design: `docs/superpowers/specs/2026-08-08-graph-engine-bypass-design.md`).
+Skardi does not parse or store graphs — the graph engine owns storage
+and traversal; Skardi forwards read-only Cypher and maps results into
+Arrow rows with a planning-time-stable schema.
+
+**Milestone status: M1 (Apache AGE) is engine-level API.** The
+`cypher_query` / `graph_schema` UDTFs are registered per session via
+`register_graph_source` + `register_graph_udtfs`; `type: graph` YAML
+data sources, catalog views, and server wiring land with milestone 4.
+Nothing here is reachable through a stock `skardi-server` yet.
+
+## Call shapes
+
+```sql
+-- Declared columns (REQUIRED on AGE; listed IN RETURN ORDER — the
+-- binding is positional, and two same-typed columns declared out of
+-- order swap silently):
+SELECT name, n
+FROM cypher_query(
+  'kg',
+  'MATCH (n:Person) WHERE n.age > $min RETURN n.name, n',
+  '{"min": 30}',
+  '{"name": "string", "n": "node"}'
+);
+
+-- Discovery: one (label, kind) row per label off ag_catalog.
+SELECT * FROM graph_schema('kg');
+
+-- Node/relationship `properties` are JSON text; the json_get family is
+-- registered alongside:
+SELECT json_get_str(n.properties, 'name')
+FROM cypher_query('kg', 'MATCH (n) RETURN n', '{}', '{"n": "node"}');
+```
+
+Accepted column types: `string|str|utf8`, `int|integer|bigint`,
+`float|double`, `bool|boolean`, `json`, `node`, `relationship`, `path`.
+Every column is nullable. Writes are rejected twice: a keyword guard at
+plan time (UX), and the backend's `READ ONLY` transaction (the actual
+boundary).
+
+## Session-wide side effect, stated plainly
+
+`register_graph_udtfs` also runs `datafusion-functions-json`'s
+`register_all`, which installs 12 UDFs **plus `->` / `->>` / `?`
+operator rewrites for every query in the session** — not just graph
+ones. Additive today; before milestone 4 wires this into the server
+session it will be re-homed next to skardi's other UDF registrations
+and checked against datafusion-federation (the rewrite runs before
+federation planning). Know this before calling it on a shared session.
+
+## Least-privilege deployment recipe
+
+The read-only guarantee is backend-enforced, so run it with the least
+privilege that works — **never a superuser**:
+
+```sql
+-- As the administrator, once:
+CREATE ROLE kg_reader LOGIN PASSWORD '…';
+GRANT USAGE ON SCHEMA ag_catalog TO kg_reader;
+GRANT SELECT ON ALL TABLES IN SCHEMA ag_catalog TO kg_reader;
+-- Per graph (AGE stores each graph in a schema of the same name):
+GRANT USAGE ON SCHEMA your_graph TO kg_reader;
+GRANT SELECT ON ALL TABLES IN SCHEMA your_graph TO kg_reader;
+```
+
+The client's `LOAD 'age'` is best-effort, deliberately: `LOAD` is
+superuser-only for libraries outside `$libdir/plugins`, and the
+official `apache/age` image already ships
+`shared_preload_libraries = age`, so a reader role works as-is. On a
+self-managed Postgres, set `shared_preload_libraries = 'age'` (or
+`session_preload_libraries`) in postgresql.conf — do NOT solve a
+failing registration by upgrading the credential to superuser. If AGE
+is genuinely absent, registration fails with a named
+`ag_catalog.ag_graph` probe error.
+
+Config carries credentials as environment-variable NAMES only:
+
+```yaml
+# The shape milestone 4 will register; today these values feed
+# register_graph_source directly.
+backend: age
+graph_name: knowledge
+username_env: KG_READER_USER
+password_env: KG_READER_PASS
+query_timeout_seconds: 30   # server-side statement_timeout + client wrap
+max_rows: 10000             # typed overflow error, never silent truncation
+```
+
+## Bounds
+
+Every query is bounded: `query_timeout_seconds` (1..=86400) becomes the
+server-side `statement_timeout` plus a client-side wrap;
+`max_rows` (1..=1000000) caps consumed rows with a typed
+`RowCapExceeded`, and the fetch is a real SQL LIMIT of
+`min(limit, max_rows + 1)` so the wire is bounded too. `max_connections`
+(1..=64) sizes the pool; pool queueing is bounded by the same timeout.

--- a/docs/superpowers/specs/2026-08-08-graph-engine-bypass-design.md
+++ b/docs/superpowers/specs/2026-08-08-graph-engine-bypass-design.md
@@ -459,7 +459,7 @@ An agent cannot write Cypher blindly. It needs machine-readable answers to:
 
 - *What graph backends are configured?* → the existing data-source metadata endpoint (`GET /data_source`) already lists registered sources; `type: graph` sources should appear with their declared views.
 - *What labels, relationship types, and properties exist?* → a lightweight **graph introspection surface** is required. Two options:
-  - a UDTF `graph_schema(connection)` that returns one row per label/relationship type with its property **names and types** (AGE: `ag_catalog`; Neo4j: `db.schema.nodeTypeProperties()` / `db.schema.relTypeProperties()`; Kuzu: its typed catalog, which is exact because Kuzu is schema-full). Deliberately **names and types only, never property values** — sampled values would flow straight into agent prompts, the exact leak the error-handling rules exist to prevent;
+  - a UDTF `graph_schema(connection)` that returns one row per label/relationship type. What it can carry is **per-backend, set by what each backend's catalog actually knows** (an earlier revision over-promised here): AGE's `ag_catalog` records label names and kinds ONLY — AGE is schema-optional, properties live as untyped agtype maps with no catalog declaration, so property discovery on AGE would mean scanning data (unbounded on the agent's FIRST call; deliberately not done in milestone 1 — an explicitly-sampled property-names option is a possible follow-up). Neo4j serves property **names and types** via `db.schema.nodeTypeProperties()` / `db.schema.relTypeProperties()` (its milestone delivers them); Kuzu's typed catalog is exact because Kuzu is schema-full. Everywhere: **names and types only, never property values** — sampled values would flow straight into agent prompts, the exact leak the error-handling rules exist to prevent;
   - a YAML view author who declares `nodes` / `edges` metadata tables alongside the Cypher views.
   The design chooses the first option as an engine-provided helper in milestone 1, because requiring every YAML view to also declare metadata duplicates effort.
 - *What shape does a `cypher_query` result have?* → the schema is fixed at planning time and stated in the function's documentation: either the caller-declared columns, or one `record: Utf8` JSON column. Agents can rely on stable `STRUCT` shapes for nodes and relationships inside those columns.
@@ -512,7 +512,11 @@ read-only guarantee is a Postgres `READ ONLY` transaction, native to
   is NOT in this milestone: AGE's `cypher()` call must declare its
   result arity, so on AGE an omitted `columns` is a targeted error
   (settled — previously an open question).
-- `graph_schema` from `ag_catalog` (names and types only, never values).
+- `graph_schema` from `ag_catalog`: one `(label, kind)` row per label —
+  labels and kinds are ALL the AGE catalog knows (schema-optional store;
+  see the introspection note in §Agent and LLM interaction). Property
+  names/types arrive with the Neo4j and Kuzu milestones, whose catalogs
+  carry them.
 - Keyword guard, query timeout, row cap, error taxonomy.
 - JSON getter: adopt `datafusion-functions-json`'s `json_get` family
   (verify against the pinned DataFusion; a minimal same-named in-tree

--- a/docs/superpowers/specs/2026-08-08-graph-engine-bypass-design.md
+++ b/docs/superpowers/specs/2026-08-08-graph-engine-bypass-design.md
@@ -199,6 +199,14 @@ There is no schema probe anywhere in the design: planning performs no network I/
 
 - **YAML views:** the user declares the output schema explicitly. Skardi validates at registration that the Cypher query returns columns compatible with the declared schema (one live validation call at registration — registration is allowed to do network I/O; query planning is not). Availability and contract violations part ways here, deliberately diverging from Open Connector's hard-fail health check: OC probes a gateway Skardi deploys, while this backend is a shared external database whose transient blip must not hold every unrelated Postgres/CSV/Lance source hostage at server startup. An **unreachable backend registers the source DEGRADED** — views register with their declared (planning-sufficient) schemas, the source is marked unhealthy in `GET /data_source`, and the first scan retries the validation and fails loudly if the backend is still gone or the view no longer matches. A **reachable backend whose view fails validation refuses registration** — that is a contract violation, not an outage.
 - **Declared-type vocabulary — the repo's friendly lowercase names, not Arrow PascalCase** (every existing config-parsed type in the tree spells types this way — dynamodb, mongo, seekdb, llm_extract — and this surface will not introduce a second spelling). The accepted set, exactly: `string` (aliases `str`, `utf8`) → `Utf8`; `int` (aliases `integer`, `bigint`) → `Int64`; `float` (alias `double`) → `Float64`; `bool` (alias `boolean`) → `Boolean`; `json` → `Utf8` carrying JSON text verbatim; `node`, `relationship`, `path` → the canonical `STRUCT` shapes from Result flattening. Anything else fails planning with the accepted set listed. The same vocabulary is used by YAML views' `type:` fields — one spelling everywhere.
+- **Declared-column ORDER is the binding.** The mapping from declared
+  columns to the Cypher `RETURN` clause is positional — all AGE's
+  `cypher()` arity gives us — so the JSON object must list columns in
+  RETURN order. Two same-typed columns declared out of order swap
+  silently (same JSON kind, no TypeMismatch); no structural check is
+  possible, which is exactly why the contract is stated loudly in the
+  UDTF's error message and module doc, and why serde_json's
+  `preserve_order` feature is load-bearing here.
 - **Ad-hoc declared columns are always nullable.** Cypher can produce `null` in any position (`OPTIONAL MATCH`, missing properties), so the ad-hoc JSON object is name→type only and every field is `nullable: true` — there is no way to declare otherwise. YAML views default to `nullable: true` too and may declare `nullable: false` as an author'ed assertion about the view's Cypher; the two declaration paths cannot silently disagree because the stricter bit exists only where an author explicitly wrote it.
 - **Ad-hoc UDTF with declared columns:** an optional fourth argument declares the output columns and their Arrow types as a JSON object (`'{"user_name": "string", "post_title": "string"}'`). The declared object is the planning-time schema; each returned `GraphValue` is converted against its declared type, and a mismatch fails with a typed error carrying column name, row index, expected type, and found JSON kind. Conversion is **batch-atomic, and the batch is the unit this design defines** (a Cypher stream has no upstream "page" the way Open Connector does): the driver stream is consumed in conversion batches of a fixed implementation constant (order 1024 rows, never more than `max_rows`), each batch converts as a unit before it is emitted, and a type mismatch fails the CURRENT batch before emission — batches already emitted may have been consumed downstream, the same trade-off Open Connector's page-atomic conversion accepts. Peak conversion memory is one batch, not one result. Milestone 1 may implement the stream as a single batch of up to `max_rows`, in which case nothing at all is emitted before a mid-scan failure.
 - **Ad-hoc UDTF without declared columns:** every row is returned as one `record: Utf8` column containing the whole Cypher record as canonical JSON text (column names from `RETURN` become keys of the JSON object). Empty results are empty batches with the same one-column schema. **Backend note:** AGE's `cypher()` call must declare its result arity, which the fallback by definition does not know — on AGE, omitting `columns` is an error telling the caller to declare them; the fallback ships with the Neo4j milestone, where Bolt needs no declared arity.
@@ -289,8 +297,9 @@ There is no schema probe anywhere in the design: planning performs no network I/
   `query_timeout_seconds` (default 30) is passed to the backend as the
   transaction timeout so runaway traversals die server-side, and
   `max_rows` (default 10 000) caps the rows Skardi will consume —
-  exceeding it fails with a typed error naming the cap and the row count
-  reached, never a silent truncation. Agents generate pathological Cypher
+  exceeding it fails with a typed error naming the cap, never a silent
+  truncation (the bounded fetch reads at most `max_rows + 1` rows, so
+  the true row count is deliberately never learned). Agents generate pathological Cypher
   (unbounded variable-length paths, whole-graph `RETURN`); bounded by
   construction beats bounded by review.
 
@@ -565,6 +574,16 @@ keyword guard alone.
 
 ### Milestone 4 — YAML catalog views
 
+Two carried-in obligations from milestone 1's review, settled here
+because they only bind once the server session is involved: (a) decide
+the pipeline-parameter substitution story for `params` (see Risks item
+0); (b) re-home the `datafusion-functions-json` registration next to
+skardi's other UDF registrations and CHECK the datafusion-federation
+interaction — its `->`/`->>`/`?` rewriter runs at analysis, ahead of
+federation planning, so a remote `data->'k'` that pushes down today
+could silently become a local `json_get` over a full scan.
+
+
 - `type: graph` data source registration (degraded-on-unreachable,
   refuse-on-mismatch — see Schema handling).
 - Declared-schema views.
@@ -578,6 +597,19 @@ keyword guard alone.
 
 ## Risks and Open Questions
 
+0. **Pipeline parameters cannot reach Cypher parameters yet (decide in
+   milestone 4).** skardi substitutes request parameters into SQL
+   TEXTUALLY, and its two passes disagree about nested-literal
+   positions: inference replaces `{p}` with the bare token `NULL`
+   (fine inside a JSON string), while execution substitutes a QUOTED
+   `'value'` — which terminates the enclosing SQL string literal when
+   `{p}` sits inside the `params` JSON. There is no spelling of
+   `'{"uid": …{user_id}…}'` that satisfies both passes. Nothing breaks
+   today (the server does not register these UDTFs until milestone 4),
+   but §Agent and LLM interaction describes exactly this workflow, so
+   milestone 4 must pick one: a raw/unquoted substitution mode for
+   nested-literal positions, or a params spelling that is not a nested
+   JSON-in-SQL literal.
 1. **Declared-type drift on dynamically-typed properties.** Neo4j property types vary per node: a view declaring `n.value AS Int64` meets a `string` value mid-scan and fails with a typed error (column, row, expected, found-kind). Conversion is page-atomic, but batches already emitted stay emitted — the same mid-scan failure trade-off the Open Connector adapters accept. Views over heterogeneous properties should declare `Utf8` (JSON text) instead of a scalar type, or normalize with Cypher `toInteger()`/`toString()` before `RETURN`.
 2. **Cypher injection.** Parameter binding prevents interpolation attacks. The keyword guard is string-based and bypassable by construction — which is why it is *not* the security boundary: the backend's `READ ONLY` transaction (AGE), read-access-mode transaction (Neo4j), or read-only database open (Kuzu) is what guarantees no write executes. Milestone 1 (AGE) carries no driver risk here — Postgres `READ ONLY` is native to `tokio-postgres`. The `neo4rs` access-mode question is scoped to the Neo4j milestone as a hard precondition (see Milestones), with the registration-time read-mode proof failing closed if the deployed pair cannot enforce it.
 3. **Path representation.** The parallel-lists struct (`nodes` + `relationships`) is lossless and type-homogeneous but positional — consumers must know relationship *i* joins node *i* to node *i+1*. Row-per-hop consumers flatten with Cypher `UNWIND` in the query or view instead of asking Skardi to restructure paths.

--- a/docs/superpowers/specs/2026-08-08-graph-engine-bypass-design.md
+++ b/docs/superpowers/specs/2026-08-08-graph-engine-bypass-design.md
@@ -262,8 +262,20 @@ There is no schema probe anywhere in the design: planning performs no network I/
   fixed, engine-authored introspection queries (`db.schema.*`,
   `ag_catalog` reads) that never pass through it, so rejecting `CALL`
   does not self-block discovery.
-- **Parameterized queries only:** parameters are bound by the driver,
-  never interpolated into the string.
+- **Parameterized queries, with the AGE exception recorded.** On Neo4j
+  and Kuzu, parameters are bound by the driver and never interpolated.
+  AGE cannot take that road: its `cypher()` function needs its arguments
+  resolvable at parse analysis, so the milestone-1 client renders the
+  params object as ONE serde_json-encoded SQL string literal cast to
+  `agtype` inside a `PREPARE ...; EXECUTE ...;` batch. The invariant
+  that replaces driver binding: values are encoded by serde_json (so
+  quotes, backslashes, and control characters cannot break out of the
+  JSON string), and the resulting literal is single-quote-doubled as a
+  whole — the same injection boundary the etl generator's `json_pack`
+  leans on. The caller's Cypher itself rides a dollar-quoted string
+  whose tag is chosen to not occur in the text. Hostile-looking
+  parameter values (apostrophes, backslashes, SQL fragments) are pinned
+  by live tests.
 - **Connection URLs are operator trust, not query trust.** The URL comes
   from context YAML — the same trust tier as a Postgres connection string
   in the same file — and the UDTF only ever accepts a registered

--- a/docs/superpowers/specs/2026-08-08-graph-engine-bypass-design.md
+++ b/docs/superpowers/specs/2026-08-08-graph-engine-bypass-design.md
@@ -181,9 +181,15 @@ and 3 behind the same trait.
   simplicity — the trait shape is what must not change.
 - A `GraphRow` is a vector of `GraphValue` (scalar, node, relationship, path, list, map).
 - Conversion from `GraphValue` to Arrow arrays is centralized and backend-agnostic.
-- Node identity: the `id` field carries Neo4j 5's `elementId()` (a
-  string); Neo4j 4 numeric ids, AGE graphids, and Kuzu internal ids are
-  stringified into the same field. The stability contract, stated
+- Node identity: the `id` field carries the backend's node identity as
+  an opaque STRING — AGE graphids, Neo4j numeric ids, and Kuzu internal
+  ids are stringified into the same field. (Milestone-2 correction: an
+  earlier revision promised Neo4j 5's `elementId()` here, but the
+  pinned driver's stable protocol implementation negotiates Bolt 4.4,
+  which predates it — the numeric id is what the wire carries, and it
+  satisfies the same stability contract below. `elementId()` remains
+  available explicitly via `RETURN elementId(n)` when a caller wants
+  it.) The stability contract, stated
   precisely because federated `JOIN`s are a headline use case: an id is
   **stable for the life of the entity within one database instance**,
   which makes it join-safe across the scans of a single federated query
@@ -553,16 +559,53 @@ driver cannot express Bolt's access mode, wiring or upstreaming it is
 part of this milestone's cost, and the milestone does not ship on the
 keyword guard alone.
 
-- `Neo4jClient` (Bolt): every query in a READ-access-mode transaction;
-  registration performs the read-mode proof (attempt a trivial `CREATE`
-  inside a read transaction, require the SERVER to refuse it, roll back
-  regardless) so a misconfigured driver/server pair fails closed at
-  registration.
-- JSON-`record` fallback mode (Bolt needs no declared arity).
+**Spike outcome (recorded; details in `neo4j.rs`'s module doc):** the
+latest stable `neo4rs` (0.8.0) has no read-mode channel at all; the
+pinned **0.9.0-rc.10** sends Bolt's `mode: "r"` in the RUN extra via
+`Graph::execute_read` — the spelling the Bolt spec honors for
+**auto-commit transactions**, so every milestone-2 query runs as one
+auto-commit READ transaction. The driver's EXPLICIT transactions do not
+carry the mode (its `Begin` builder supports it; `Txn::new` never calls
+it — an upstream gap), so they are not used and the
+`unstable-bolt-protocol-impl-v2` feature stays off. Consequences,
+verified live against Neo4j 5:
+
+- the registration **read-mode proof** probes the exact enforcement
+  unit every query uses: a trivial `CREATE (n:…) DELETE n` through the
+  read channel, required to be REFUSED by the server (it answers
+  `Neo.ClientError.Statement.AccessMode`, "Writing in read access mode
+  not allowed"; the probe is self-erasing rather than rolled back —
+  auto-commit has no rollback — so even a non-enforcing server is left
+  unchanged, and registration then fails closed);
+- the transaction timeout rides the RUN extra (`tx_timeout`), and the
+  server kills at the bound with
+  `Transaction.TransactionTimedOutClientConfiguration` → the typed
+  `GraphError::Timeout`;
+- declared columns bind BY NAME (Bolt records carry field names —
+  AGE's positional-order footgun does not exist here), and a declared
+  name the query never returns is a typed error naming it.
+
+Shipped surface:
+
+- `Neo4jClient` (Bolt) behind the same `GraphClient` trait; every query
+  one auto-commit READ-access-mode transaction; registration runs the
+  reachability probe and the read-mode proof.
+- JSON-`record` fallback mode (Bolt needs no declared arity): one
+  `record: Utf8` column, the whole record as canonical JSON text, keys
+  sorted (the driver surfaces records as hash maps; RETURN order is not
+  recoverable through its public API).
 - `graph_schema` via `db.schema.nodeTypeProperties()` /
-  `db.schema.relTypeProperties()`.
-- Reuses milestone 1's conversion, guards, bounds, and error taxonomy.
-- Integration tests against testcontainer Neo4j (`#[ignore]`-gated).
+  `db.schema.relTypeProperties()`: the shared output grows nullable
+  `property` / `property_type` columns (one row per label × property;
+  AGE serves them as null, structurally).
+- Reuses milestone 1's conversion, guards, bounds, and error taxonomy;
+  the canonical node shape learns the `labels` ARRAY spelling
+  (multi-label is native on Neo4j; AGE's single `label` stays legal),
+  Bolt temporals render as ISO-8601 text, spatial points as small JSON
+  objects, byte arrays as hex, non-finite floats as null (the agtype
+  decoder's decision, honored across backends).
+- Integration tests against a dockerized Neo4j (`#[ignore]`-gated,
+  wired into the CI coverage job like AGE's).
 
 ### Milestone 3 — Kuzu backend
 


### PR DESCRIPTION
Implements **Milestone 2** of the [graph engine bypass design](../blob/feature/graph-neo4j-m2/docs/superpowers/specs/2026-08-08-graph-engine-bypass-design.md): the Neo4j backend over Bolt, behind the same `GraphClient` trait as M1's AGE client.

> **Stacked on #203** (`feature/graph-age-m1`) — draft until the base merges. The diff shown here is M2 only.

## The access-mode spike (the milestone's hard precondition)

The design gates M2 on the pinned driver being able to express Bolt's READ access mode. Findings, verified in `neo4rs`'s source at the pinned version and recorded in `neo4j.rs`'s module doc:

- **0.8.0 (latest stable) has no read-mode channel at all** — no `execute_read`, no `Operation`, and its `BEGIN` carries no mode. M2 pins **0.9.0-rc.10** (default features).
- **The RC sends `mode: "r"` in the RUN extra** via `Graph::execute_read` — the spelling the Bolt spec honors for **auto-commit** transactions. Every M2 query is therefore one auto-commit READ transaction.
- **Explicit transactions are a dead end on this driver**: its `Begin` builder supports `with_mode`, but `Txn::new` never calls it (BEGIN always goes out `"w"`), and Bolt ignores RUN-extra mode inside an explicit transaction — so the `unstable-bolt-protocol-impl-v2` feature would add unstable surface without adding enforcement. It stays off.

## What shipped

- **`Neo4jClient`** (`graph/neo4j.rs`): auto-commit READ transactions; registration runs a reachability probe plus the **read-mode proof** — a self-erasing `CREATE (n:…) DELETE n` through the exact read channel every later query uses, passing ONLY on the server's access-mode refusal (live-pinned: `Neo.ClientError.Statement.AccessMode`). An executed write fails registration; so does any *other* error (a transient failure proves nothing about enforcement — fail closed).
- **By-NAME column binding**: Bolt records carry field names, so declared columns bind to RETURN aliases by name — AGE's positional-order footgun does not exist here, and a declared name the query never returns is a typed error naming it. Demonstrated live with out-of-order declarations (the exact shape that silently swaps on AGE).
- **JSON-`record` fallback**: omitting `columns` yields one `record: Utf8` column carrying each whole record as canonical JSON (keys sorted — the driver's rows are hash maps). On AGE the omission stays a targeted error, now worded by the backend itself (`declared_columns_requirement()` on the trait).
- **`graph_schema` grows property discovery**: output is now `(label, kind, property, property_type)` — Neo4j fills the property columns from `db.schema.nodeTypeProperties()` / `relTypeProperties()` (one row per label × property; property-less labels and label-less node types keep their rows), AGE serves them as null, structurally. The two catalog queries run concurrently; bounds semantics match the AGE client's verbatim (limit-under-cap is a clean stop; overflow is loud) and are pinned live.
- **Bolt decoding into the shared canonical shapes** (`value.rs` unchanged as the converter): multi-label nodes (`labels` array accepted alongside AGE's single `label`), paths reconstructed in traversal order with directions resolved from the Bolt index list (reversed hops pinned by unit test), temporals as ISO-8601 text (negative durations decoded through the driver's signed serde view — its `std::time::Duration` conversion wraps negatives to ~1.8e19), points as JSON objects, bytes as hex, non-finite floats as null (the agtype decoder's decision, honored across backends).
- **Bounds**: `tx_timeout` rides the RUN extra and the server kills at the bound — live verification surfaced the actual code (`Transaction.TransactionTimedOutClientConfiguration`; a suffix match would have missed it) → typed `Timeout`. Row cap and LIMIT semantics identical to AGE. Params are driver-bound (never interpolated — the design's normal road, which AGE alone cannot take); an integer beyond i64::MAX is a typed refusal, never a silent f64 narrowing.
- **Config**: `backend: neo4j` with the design's scheme allowlist (`bolt`/`bolt+s`/`neo4j`/`neo4j+s`; `+ssc` deliberately excluded); `graph_name` becomes per-backend (required on age, optional database selector on neo4j); URL-embedded-password rejection covers bolt URLs unchanged. Validation rules are one `BackendRules` row per backend so milestone 3 is one new row, and the registration dispatch has no wildcard arm (`unreachable!` instead of silently dialing the wrong driver).

## Self-review round (second commit)

An 8-angle review ran over the M2 diff before submission; every finding was verified before acting. Highlights fixed: the read-mode proof was fail-open (any error passed it); `graph_schema` had an off-by-one cap and tripped `RowCapExceeded` on small LIMITs where AGE returns cleanly; its tx_timeout mapped to a generic backend error; negative durations wrapped; u64 params narrowed silently; plus a dedup pass (shared `read_env`/`bounded`, one `rel_json` spelling, shared live-test helpers). Consciously rebutted, with reasons in the commit message: full-result buffering (explicitly allowed by the design text, same as AGE), by-value `bolt_to_json`, and a config `Backend` enum reshape (M3 work if kuzu diverges structurally).

## Verification

- **63 graph unit tests** (`sources::providers::graph`) — new coverage: Bolt decode incl. reversed-hop and zero-hop paths, malformed-index null-not-panic, negative/mixed-sign durations, params conversion + overflow refusal, multi-label and label-less node shapes, record fallback at the UDTF seam, per-backend `graph_schema` shape, config allowlists both directions.
- **Neo4j live suite (new, 7 tests) — 7/7 green** against dockerized `neo4j:5`: by-name binding on out-of-order declarations; canonical shapes incl. a real multi-label node and a temporal property; record fallback with sorted keys queried in place via `json_get_str`; **read-only enforced by the server past a bypassed keyword guard, with the write proven absent afterwards**; `graph_schema` property discovery (`KNOWS since:Long`, `Person name:String`); row cap + LIMIT + typed timeout (the live proof that RUN-extra `tx_timeout` lands) + schema cap semantics; credentials never in error text.
- **AGE live suite re-run green (9/9)** after the shared-trait changes; full lib suite **940 passed**; doctests green; fmt clean; the touched files are clippy-clean (the branch carries pre-existing findings elsewhere that main has since addressed).
- **CI**: the coverage job gains a `neo4j:5` container step mirroring the AGE one (`-E 'binary(graph_neo4j_live)' --no-tests=fail -- --ignored`).

## Design doc updates

The M2 section records the spike outcome and both live-verified error codes; the §Backend abstraction node-identity passage is corrected — the pinned driver's stable protocol implementation negotiates Bolt 4.4, which predates `elementId()`, so ids are the stringified numeric ids (same stability contract; `elementId()` stays available explicitly via `RETURN elementId(n)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)