### PR TITLE
feat(server): audit pipeline executions — one ledger for ad-hoc and pipeline calls

### DIFF
--- a/crates/cli/src/client.rs
+++ b/crates/cli/src/client.rs
@@ -145,8 +145,23 @@ impl ApiClient {
     /// start with `/`) and return the parsed JSON body, or an `ApiError` on
     /// failure.
     pub async fn post(&self, path: &str, body: &Value) -> Result<Value, ApiError> {
+        self.post_with_headers(path, body, &[]).await
+    }
+
+    /// Like [`Self::post`], but attaches each `(name, value)` pair in
+    /// `headers` to the request before auth — e.g. the `x-skardi-session-id`
+    /// header for `skardi run --session-id`.
+    pub async fn post_with_headers(
+        &self,
+        path: &str,
+        body: &Value,
+        headers: &[(&str, &str)],
+    ) -> Result<Value, ApiError> {
         let url = format!("{}{}", self.base_url, path);
         let mut request = self.http.post(&url).json(body);
+        for (name, value) in headers {
+            request = request.header(*name, *value);
+        }
         request = self.with_auth(request);
 
         self.send(request, url).await

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -26,6 +26,25 @@ pub async fn run(
     table: bool,
     session_id: Option<String>,
 ) -> Result<()> {
+    // Validate before building the request: reqwest defers an invalid header
+    // value to `send()`, whose errors are all mapped to `ApiError::Connect` —
+    // so without this check a bad `--session-id` prints a connection error
+    // naming a server that was never contacted, and exits with the
+    // "server unreachable" code. The rules mirror the server's
+    // (`query_handlers::MAX_SESSION_ID_CHARS` = 200 and header-value ASCII);
+    // keep the two in sync.
+    let invalid_session_id = session_id.as_deref().is_some_and(|sid| {
+        sid.is_empty()
+            || sid.chars().count() > 200
+            || !sid.chars().all(|c| c.is_ascii_graphic() || c == ' ')
+    });
+    if invalid_session_id {
+        return Err(anyhow!(
+            "--session-id must be non-empty, at most 200 characters, \
+             and contain only visible ASCII"
+        ));
+    }
+
     let body = build_body(data, param_flags)?;
     let path = format!("/{}/execute", encode_component(name));
 
@@ -53,7 +72,7 @@ pub async fn run(
 #[cfg(test)]
 mod tests {
     use super::run;
-    use crate::client::ApiClient;
+    use crate::client::{ApiClient, ApiError};
     use crate::config::ClientConfig;
     use serde_json::json;
     use wiremock::matchers::{body_json, header, method, path};
@@ -199,6 +218,36 @@ mod tests {
         .await;
 
         assert!(result.is_ok(), "expected Ok, got {result:?}");
+    }
+
+    // -- 5b. invalid --session-id fails fast, before any request ----------
+
+    #[tokio::test]
+    async fn run_with_invalid_session_id_errors_without_contacting_server() {
+        let server = MockServer::start().await;
+        // expect(0): the whole point is that no request is ever sent — a
+        // deferred header error would surface as ApiError::Connect and be
+        // misread as "server unreachable".
+        Mock::given(method("POST"))
+            .and(path("/my-pipe/execute"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(success_envelope()))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(&test_config(&server.uri())).unwrap();
+        for bad in ["", &"x".repeat(201), "sesión-1", "line\nbreak"] {
+            let result = run(&client, "my-pipe", None, &[], false, Some(bad.to_string())).await;
+            let err = result.expect_err("expected validation error");
+            assert!(
+                err.to_string().contains("--session-id"),
+                "expected a --session-id validation message, got: {err}"
+            );
+            assert!(
+                err.downcast_ref::<ApiError>().is_none(),
+                "must not be an ApiError (would map to a connection exit code)"
+            );
+        }
     }
 
     // -- 6. no --session-id sends no header -------------------------------

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -7,6 +7,13 @@ use crate::params::build_body;
 use anyhow::{Result, anyhow};
 use serde_json::Value;
 
+/// Maximum session-id length, in characters. Restates the server's
+/// `query_audit::MAX_SESSION_ID_CHARS` under the same name — `skardi-cli`
+/// does not depend on the server crate, so this cannot be a shared item, but
+/// an identical name keeps `grep MAX_SESSION_ID_CHARS` finding every site
+/// that must move together.
+const MAX_SESSION_ID_CHARS: usize = 200;
+
 /// Run `skardi run <name>`: build the request body from `-d`/`-p`, `POST` it
 /// to `/{name}/execute`, and hand the response envelope to [`print_result`].
 ///
@@ -30,18 +37,21 @@ pub async fn run(
     // value to `send()`, whose errors are all mapped to `ApiError::Connect` —
     // so without this check a bad `--session-id` prints a connection error
     // naming a server that was never contacted, and exits with the
-    // "server unreachable" code. The rules mirror the server's
-    // (`query_handlers::MAX_SESSION_ID_CHARS` = 200 and header-value ASCII);
-    // keep the two in sync.
+    // "server unreachable" code. The rules are an exact mirror of the
+    // server's `session_id_from_headers`: visible ASCII plus space, no tab,
+    // no comma (proxies may merge repeated header lines comma-separated),
+    // and the length cap below.
     let invalid_session_id = session_id.as_deref().is_some_and(|sid| {
         sid.is_empty()
-            || sid.chars().count() > 200
-            || !sid.chars().all(|c| c.is_ascii_graphic() || c == ' ')
+            || sid.chars().count() > MAX_SESSION_ID_CHARS
+            || !sid
+                .chars()
+                .all(|c| (c.is_ascii_graphic() && c != ',') || c == ' ')
     });
     if invalid_session_id {
         return Err(anyhow!(
-            "--session-id must be non-empty, at most 200 characters, \
-             and contain only visible ASCII"
+            "--session-id must be non-empty, at most {MAX_SESSION_ID_CHARS} \
+             characters, and contain only visible ASCII with no commas"
         ));
     }
 
@@ -236,7 +246,14 @@ mod tests {
             .await;
 
         let client = ApiClient::new(&test_config(&server.uri())).unwrap();
-        for bad in ["", &"x".repeat(201), "sesión-1", "line\nbreak"] {
+        for bad in [
+            "",
+            &"x".repeat(201),
+            "sesión-1",
+            "line\nbreak",
+            "tab\there",
+            "sess-1, sess-2", // proxy-merged duplicate shape
+        ] {
             let result = run(&client, "my-pipe", None, &[], false, Some(bad.to_string())).await;
             let err = result.expect_err("expected validation error");
             assert!(

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -37,21 +37,28 @@ pub async fn run(
     // value to `send()`, whose errors are all mapped to `ApiError::Connect` —
     // so without this check a bad `--session-id` prints a connection error
     // naming a server that was never contacted, and exits with the
-    // "server unreachable" code. The rules are an exact mirror of the
-    // server's `session_id_from_headers`: visible ASCII plus space, no tab,
-    // no comma (proxies may merge repeated header lines comma-separated),
-    // and the length cap below.
+    // "server unreachable" code. The rules are now an EXACT mirror of the
+    // server's `session_id_from_headers` — visible ASCII graphic characters,
+    // no comma, no space — with no trimming semantics to reason about on
+    // either side: previously this check let space through, but the server
+    // sees whatever `httparse` hands it after stripping leading/trailing
+    // whitespace per RFC 9110 §5.5 (interior whitespace untouched). That gap
+    // meant `--session-id "  sess-1  "` passed here and got silently
+    // recorded server-side under the different key `sess-1` (breaking the
+    // session stitching this field exists for), while `--session-id "   "`
+    // passed here and then 400ed server-side — the exact fail-late round
+    // trip this client-side check exists to prevent. A grouping key has no
+    // legitimate use for spaces, so both sides now reject them outright
+    // instead of defining trimming semantics.
     let invalid_session_id = session_id.as_deref().is_some_and(|sid| {
         sid.is_empty()
             || sid.chars().count() > MAX_SESSION_ID_CHARS
-            || !sid
-                .chars()
-                .all(|c| (c.is_ascii_graphic() && c != ',') || c == ' ')
+            || !sid.chars().all(|c| c.is_ascii_graphic() && c != ',')
     });
     if invalid_session_id {
         return Err(anyhow!(
             "--session-id must be non-empty, at most {MAX_SESSION_ID_CHARS} \
-             characters, and contain only visible ASCII with no commas"
+             characters, and contain only visible ASCII with no spaces and no commas"
         ));
     }
 
@@ -253,6 +260,8 @@ mod tests {
             "line\nbreak",
             "tab\there",
             "sess-1, sess-2", // proxy-merged duplicate shape
+            "   ",            // spaces-only
+            "sess 1",         // interior space
         ] {
             let result = run(&client, "my-pipe", None, &[], false, Some(bad.to_string())).await;
             let err = result.expect_err("expected validation error");

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -10,6 +10,10 @@ use serde_json::Value;
 /// Run `skardi run <name>`: build the request body from `-d`/`-p`, `POST` it
 /// to `/{name}/execute`, and hand the response envelope to [`print_result`].
 ///
+/// When `session_id` is set, it's sent as the `x-skardi-session-id` header
+/// so the server records this execution against that session in its audit
+/// ledger; when `None`, no such header is sent.
+///
 /// A 404 response is remapped to a friendly "pipeline not found" error
 /// naming `name`; every other `ApiError` passes through unchanged (so, e.g.,
 /// `main`'s `downcast_ref::<ApiError>` exit-code mapping for connect
@@ -20,11 +24,21 @@ pub async fn run(
     data: Option<&str>,
     param_flags: &[String],
     table: bool,
+    session_id: Option<String>,
 ) -> Result<()> {
     let body = build_body(data, param_flags)?;
     let path = format!("/{}/execute", encode_component(name));
 
-    match client.post(&path, &Value::Object(body)).await {
+    let response = match &session_id {
+        Some(sid) => {
+            client
+                .post_with_headers(&path, &Value::Object(body), &[("x-skardi-session-id", sid)])
+                .await
+        }
+        None => client.post(&path, &Value::Object(body)).await,
+    };
+
+    match response {
         Ok(response) => {
             print_result(&response, table);
             Ok(())
@@ -42,7 +56,7 @@ mod tests {
     use crate::client::ApiClient;
     use crate::config::ClientConfig;
     use serde_json::json;
-    use wiremock::matchers::{body_json, method, path};
+    use wiremock::matchers::{body_json, header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn test_config(server: &str) -> ClientConfig {
@@ -81,6 +95,7 @@ mod tests {
             Some(r#"{"user_id":1,"category":"basic"}"#),
             &["category=premium".to_string()],
             false,
+            None,
         )
         .await;
 
@@ -101,7 +116,7 @@ mod tests {
             .await;
 
         let client = ApiClient::new(&test_config(&server.uri())).unwrap();
-        let result = run(&client, "daily_report", None, &[], false).await;
+        let result = run(&client, "daily_report", None, &[], false, None).await;
 
         assert!(result.is_ok(), "expected Ok, got {result:?}");
     }
@@ -124,7 +139,9 @@ mod tests {
             .await;
 
         let client = ApiClient::new(&test_config(&server.uri())).unwrap();
-        let err = run(&client, "ghost", None, &[], false).await.unwrap_err();
+        let err = run(&client, "ghost", None, &[], false, None)
+            .await
+            .unwrap_err();
 
         let message = err.to_string();
         assert!(
@@ -154,6 +171,55 @@ mod tests {
             .await;
 
         let client = ApiClient::new(&test_config(&server.uri())).unwrap();
-        run(&client, "a/b c", None, &[], false).await.unwrap();
+        run(&client, "a/b c", None, &[], false, None).await.unwrap();
+    }
+
+    // -- 5. --session-id sends X-Skardi-Session-Id header ----------------
+
+    #[tokio::test]
+    async fn run_with_session_id_sets_header() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/my-pipe/execute"))
+            .and(header("x-skardi-session-id", "sess-9"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(success_envelope()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(&test_config(&server.uri())).unwrap();
+        let result = run(
+            &client,
+            "my-pipe",
+            None,
+            &[],
+            false,
+            Some("sess-9".to_string()),
+        )
+        .await;
+
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+    }
+
+    // -- 6. no --session-id sends no header -------------------------------
+
+    #[tokio::test]
+    async fn run_without_session_id_sends_no_header() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/my-pipe/execute"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(success_envelope()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(&test_config(&server.uri())).unwrap();
+        let result = run(&client, "my-pipe", None, &[], false, None).await;
+
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+        assert!(!requests[0].headers.contains_key("x-skardi-session-id"));
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -76,6 +76,11 @@ enum Commands {
         /// render results as a table instead of JSON
         #[arg(long)]
         table: bool,
+
+        /// Session id recorded with this execution in the server's audit
+        /// ledger (sent as the X-Skardi-Session-Id header).
+        #[arg(long)]
+        session_id: Option<String>,
     },
 
     /// List pipelines, or show one pipeline's definition.
@@ -155,7 +160,8 @@ async fn dispatch(command: Commands, config: &ClientConfig) -> anyhow::Result<()
             data,
             params,
             table,
-        } => commands::run::run(&client, &name, data.as_deref(), &params, table).await,
+            session_id,
+        } => commands::run::run(&client, &name, data.as_deref(), &params, table, session_id).await,
 
         Commands::Pipeline { cmd } => commands::pipeline::run(&client, cmd).await,
 

--- a/crates/server/src/pipeline_handlers.rs
+++ b/crates/server/src/pipeline_handlers.rs
@@ -37,6 +37,11 @@ use crate::server::AppState;
 /// Optional caller-supplied session header. A header (not a body field)
 /// because the execute body IS the flattened parameter map — a reserved key
 /// could collide with a legitimate SQL parameter of the same name.
+///
+/// Not an auth credential: unrelated to [`require_session`] on the line
+/// above its extraction. The value is caller-asserted, so ledger session
+/// attribution is self-reported rather than derived from an authenticated
+/// principal — the same property as `/query`'s `ai_context.session_id`.
 const SESSION_ID_HEADER: &str = "x-skardi-session-id";
 
 /// Extract and validate the session header. `Ok(None)` when absent; `Err`
@@ -757,16 +762,27 @@ pub async fn execute_pipeline_by_name(
 ) -> Result<Json<Value>, (StatusCode, Json<ErrorResponse>)> {
     require_session(&app_state, &headers).await?;
 
+    let start_time = Instant::now();
+
     let session_id = session_id_from_headers(&headers).map_err(|msg| {
+        // Recorded like every other early reject in this handler — a client
+        // looping on a malformed session id must be visible in metrics.
+        let elapsed_ms = start_time.elapsed().as_millis() as f64;
+        app_state
+            .metrics
+            .record_error(&pipeline_name, elapsed_ms, "parameter_validation_error");
         (
             StatusCode::BAD_REQUEST,
             create_error_response(&msg, "parameter_validation_error", None),
         )
     })?;
 
-    let start_time = Instant::now();
-
+    // `session_id` rides in the INFO marker so operators who stitch sessions
+    // from traces (rather than the opt-in ledger) get attribution too. It is
+    // an opaque, caller-asserted grouping key — value-free by the same
+    // standard as `/query`'s `ai_context` marker field.
     tracing::info!(
+        session_id = session_id.as_deref().unwrap_or_default(),
         "Received execution request for pipeline '{}' with {} parameters",
         pipeline_name,
         request.parameters.len()

--- a/crates/server/src/pipeline_handlers.rs
+++ b/crates/server/src/pipeline_handlers.rs
@@ -26,8 +26,7 @@ use std::time::Instant;
 
 use crate::auth::routes::require_session;
 use crate::config::{DataSourceType, HierarchyLevel};
-use crate::query_audit::QueryAuditStatus;
-use crate::query_handlers::{MAX_SESSION_ID_CHARS, finish_audit};
+use crate::query_audit::{MAX_SESSION_ID_CHARS, QueryAuditStatus, finish_audit};
 use crate::response::{
     ErrorResponse, create_error_response, create_success_response, record_batch_to_json,
 };
@@ -60,6 +59,18 @@ fn session_id_from_headers(headers: &HeaderMap) -> Result<Option<String>, String
     let s = value
         .to_str()
         .map_err(|_| format!("{SESSION_ID_HEADER} must contain only visible ASCII characters"))?;
+    // `to_str` admits horizontal tab; reject it so "visible ASCII" is the
+    // whole truth. Commas are rejected because RFC 9110 §5.3 lets any
+    // intermediary merge repeated header lines into one comma-joined value —
+    // without this, a duplicate sent through such a proxy would slip past
+    // the duplicate check above as a single merged "id1, id2".
+    if s.contains([',', '\t']) {
+        return Err(format!(
+            "{SESSION_ID_HEADER} must not contain commas or tabs \
+             (proxies may merge repeated header lines into one \
+             comma-separated value)"
+        ));
+    }
     if s.is_empty() {
         return Err(format!("{SESSION_ID_HEADER} must not be empty"));
     }
@@ -764,33 +775,9 @@ pub async fn execute_pipeline_by_name(
 
     let start_time = Instant::now();
 
-    let session_id = session_id_from_headers(&headers).map_err(|msg| {
-        // Recorded like every other early reject in this handler — a client
-        // looping on a malformed session id must be visible in metrics.
-        let elapsed_ms = start_time.elapsed().as_millis() as f64;
-        app_state
-            .metrics
-            .record_error(&pipeline_name, elapsed_ms, "parameter_validation_error");
-        (
-            StatusCode::BAD_REQUEST,
-            create_error_response(&msg, "parameter_validation_error", None),
-        )
-    })?;
-
-    // `session_id` rides in the INFO marker so operators who stitch sessions
-    // from traces (rather than the opt-in ledger) get attribution too. It is
-    // an opaque, caller-asserted grouping key — value-free by the same
-    // standard as `/query`'s `ai_context` marker field.
-    tracing::info!(
-        session_id = session_id.as_deref().unwrap_or_default(),
-        "Received execution request for pipeline '{}' with {} parameters",
-        pipeline_name,
-        request.parameters.len()
-    );
-
     // Acquire read lock and get the specified pipeline
     // Extract what we need and drop the lock immediately
-    let (sql_template, expected_params) = {
+    let (sql_template, pipeline_version, expected_params) = {
         let config = app_state.config.read().map_err(|_| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -823,8 +810,43 @@ pub async fn execute_pipeline_by_name(
         // Sort longest-first so a shorter name (e.g. `{user}`) cannot corrupt a longer one
         // (`{user_id}`) during str::replace when both appear in the same SQL template.
         expected_params.sort_by_key(|b| std::cmp::Reverse(b.len()));
-        (query_def.sql.clone(), expected_params)
+        (
+            query_def.sql.clone(),
+            pipeline.version().to_string(),
+            expected_params,
+        )
     };
+
+    // Validated only after the pipeline lookup, deliberately: the reject
+    // below records a metric labeled by `pipeline_name`, and before the
+    // lookup that label is an arbitrary caller-supplied URL segment — an
+    // unauthenticated caller could mint unbounded metric cardinality until
+    // real pipelines overflow the OTel stream cap. Post-lookup the label is
+    // bounded to configured names (and an unknown pipeline correctly 404s
+    // regardless of header shape).
+    let session_id = session_id_from_headers(&headers).map_err(|msg| {
+        // Recorded like every other early reject in this handler — a client
+        // looping on a malformed session id must be visible in metrics.
+        let elapsed_ms = start_time.elapsed().as_millis() as f64;
+        app_state
+            .metrics
+            .record_error(&pipeline_name, elapsed_ms, "parameter_validation_error");
+        (
+            StatusCode::BAD_REQUEST,
+            create_error_response(&msg, "parameter_validation_error", None),
+        )
+    })?;
+
+    // `session_id` rides in the INFO marker so operators who stitch sessions
+    // from traces (rather than the opt-in ledger) get attribution too. It is
+    // an opaque, caller-asserted grouping key — value-free by the same
+    // standard as `/query`'s `ai_context` marker field.
+    tracing::info!(
+        session_id = session_id.as_deref().unwrap_or_default(),
+        "Received execution request for pipeline '{}' with {} parameters",
+        pipeline_name,
+        request.parameters.len()
+    );
 
     let mut sql = sql_template;
 
@@ -877,7 +899,7 @@ pub async fn execute_pipeline_by_name(
     // anything it cannot account for.
     let audit_id = match &app_state.query_audit {
         Some(store) => match store
-            .record_pipeline_started(&pipeline_name, session_id.as_deref())
+            .record_pipeline_started(&pipeline_name, &pipeline_version, session_id.as_deref())
             .await
         {
             Ok(id) => Some(id),
@@ -915,7 +937,7 @@ pub async fn execute_pipeline_by_name(
             // error would smuggle a caller-supplied parameter value into the
             // ledger, which parameter values must never enter.
             finish_audit(
-                &app_state,
+                app_state.query_audit.as_deref(),
                 audit_id.as_deref(),
                 QueryAuditStatus::Failed,
                 None,
@@ -959,7 +981,7 @@ pub async fn execute_pipeline_by_name(
             // echo through error text derived from the query/result, and
             // parameter values must never reach the ledger.
             finish_audit(
-                &app_state,
+                app_state.query_audit.as_deref(),
                 audit_id.as_deref(),
                 QueryAuditStatus::Failed,
                 Some(record_batch.num_rows()),
@@ -987,17 +1009,22 @@ pub async fn execute_pipeline_by_name(
         }
     };
 
-    let execution_time = start_time.elapsed().as_millis() as u64;
     let row_count = record_batch.num_rows();
 
     finish_audit(
-        &app_state,
+        app_state.query_audit.as_deref(),
         audit_id.as_deref(),
         QueryAuditStatus::Succeeded,
         Some(row_count),
         None,
     )
     .await;
+
+    // Measured *after* the outcome write, so the reported latency includes
+    // the second fsync on the critical path — otherwise the exact cost the
+    // audit ledger adds (the thing docs/server.md tells operators to size
+    // for) is invisible in `pipeline_latency_ms` until requests time out.
+    let execution_time = start_time.elapsed().as_millis() as u64;
 
     app_state
         .metrics

--- a/crates/server/src/pipeline_handlers.rs
+++ b/crates/server/src/pipeline_handlers.rs
@@ -14,7 +14,7 @@ use anyhow::Result;
 use axum::{
     Json,
     extract::{Path, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
 };
 use datafusion::prelude::SessionContext;
 use serde::{Deserialize, Serialize};
@@ -26,11 +26,39 @@ use std::time::Instant;
 
 use crate::auth::routes::require_session;
 use crate::config::{DataSourceType, HierarchyLevel};
+use crate::query_audit::QueryAuditStatus;
+use crate::query_handlers::{MAX_SESSION_ID_CHARS, finish_audit};
 use crate::response::{
     ErrorResponse, create_error_response, create_success_response, record_batch_to_json,
 };
 use crate::semantics::SemanticsRegistry;
 use crate::server::AppState;
+
+/// Optional caller-supplied session header. A header (not a body field)
+/// because the execute body IS the flattened parameter map — a reserved key
+/// could collide with a legitimate SQL parameter of the same name.
+const SESSION_ID_HEADER: &str = "x-skardi-session-id";
+
+/// Extract and validate the session header. `Ok(None)` when absent; `Err`
+/// when present but malformed — silently dropping a malformed value would
+/// corrupt session stitching, the one job this field has.
+fn session_id_from_headers(headers: &HeaderMap) -> Result<Option<String>, String> {
+    let Some(value) = headers.get(SESSION_ID_HEADER) else {
+        return Ok(None);
+    };
+    let s = value
+        .to_str()
+        .map_err(|_| format!("{SESSION_ID_HEADER} must be valid UTF-8"))?;
+    if s.is_empty() {
+        return Err(format!("{SESSION_ID_HEADER} must not be empty"));
+    }
+    if s.chars().count() > MAX_SESSION_ID_CHARS {
+        return Err(format!(
+            "{SESSION_ID_HEADER} must be at most {MAX_SESSION_ID_CHARS} characters"
+        ));
+    }
+    Ok(Some(s.to_string()))
+}
 
 /// Request structure for pipeline execution
 #[derive(Debug, Deserialize)]
@@ -723,6 +751,13 @@ pub async fn execute_pipeline_by_name(
 ) -> Result<Json<Value>, (StatusCode, Json<ErrorResponse>)> {
     require_session(&app_state, &headers).await?;
 
+    let session_id = session_id_from_headers(&headers).map_err(|msg| {
+        (
+            StatusCode::BAD_REQUEST,
+            create_error_response(&msg, "parameter_validation_error", None),
+        )
+    })?;
+
     let start_time = Instant::now();
 
     tracing::info!(
@@ -813,12 +848,52 @@ pub async fn execute_pipeline_by_name(
         ));
     }
 
+    // Raw parameter values are never written to the ledger — only the
+    // pipeline name, which doubles as the join key back to the on-disk
+    // template. Committed *before* execution, so a write failure means the
+    // pipeline does not run at all: an audited server must not execute
+    // anything it cannot account for.
+    let audit_id = match &app_state.query_audit {
+        Some(store) => match store
+            .record_pipeline_started(&pipeline_name, session_id.as_deref())
+            .await
+        {
+            Ok(id) => Some(id),
+            Err(e) => {
+                tracing::error!("Pipeline audit write failed; refusing to execute: {e}");
+                let elapsed_ms = start_time.elapsed().as_millis() as f64;
+                app_state
+                    .metrics
+                    .record_error(&pipeline_name, elapsed_ms, "query_audit_error");
+                return Err((
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    create_error_response(
+                        "Query auditing is enabled but the audit record could not be \
+                         written; the pipeline was not executed",
+                        "query_audit_error",
+                        None,
+                    ),
+                ));
+            }
+        },
+        None => None,
+    };
+
     // Execute the query using the DataFusion engine
     let record_batch = match app_state.engine.execute(&sql).await {
         Ok(batch) => batch,
         Err(e) => {
             tracing::error!("Query execution failed: {}", e);
             tracing::debug!("Failed SQL query: {}", sql); // Log SQL for debugging but don't expose in response
+
+            finish_audit(
+                &app_state,
+                audit_id.as_deref(),
+                QueryAuditStatus::Failed,
+                None,
+                Some(&e.to_string()),
+            )
+            .await;
 
             let elapsed_ms = start_time.elapsed().as_millis() as f64;
             app_state
@@ -840,11 +915,25 @@ pub async fn execute_pipeline_by_name(
         }
     };
 
-    // Convert RecordBatch to JSON
-    let data = match record_batch_to_json(&record_batch) {
+    // Convert RecordBatch to JSON.
+    //
+    // `record_batch_to_json` yields a `Box<dyn Error>`, which is not `Send`.
+    // Flatten it to a message up front: holding the box across the audit
+    // await below would make the whole handler future non-`Send` (see the
+    // identical note in `query_handlers::execute_query`).
+    let data = match record_batch_to_json(&record_batch).map_err(|e| e.to_string()) {
         Ok(json_data) => json_data,
         Err(e) => {
             tracing::error!("Failed to convert results to JSON: {}", e);
+
+            finish_audit(
+                &app_state,
+                audit_id.as_deref(),
+                QueryAuditStatus::Failed,
+                Some(record_batch.num_rows()),
+                Some(&e),
+            )
+            .await;
 
             let elapsed_ms = start_time.elapsed().as_millis() as f64;
             app_state
@@ -852,7 +941,7 @@ pub async fn execute_pipeline_by_name(
                 .record_error(&pipeline_name, elapsed_ms, "result_conversion_error");
 
             let error_details = serde_json::json!({
-                "conversion_error": e.to_string(),
+                "conversion_error": e,
                 "record_batch_schema": format!("{:?}", record_batch.schema()),
                 "record_batch_rows": record_batch.num_rows()
             });
@@ -868,6 +957,15 @@ pub async fn execute_pipeline_by_name(
 
     let execution_time = start_time.elapsed().as_millis() as u64;
     let row_count = record_batch.num_rows();
+
+    finish_audit(
+        &app_state,
+        audit_id.as_deref(),
+        QueryAuditStatus::Succeeded,
+        Some(row_count),
+        None,
+    )
+    .await;
 
     app_state
         .metrics

--- a/crates/server/src/pipeline_handlers.rs
+++ b/crates/server/src/pipeline_handlers.rs
@@ -43,12 +43,18 @@ const SESSION_ID_HEADER: &str = "x-skardi-session-id";
 /// when present but malformed — silently dropping a malformed value would
 /// corrupt session stitching, the one job this field has.
 fn session_id_from_headers(headers: &HeaderMap) -> Result<Option<String>, String> {
-    let Some(value) = headers.get(SESSION_ID_HEADER) else {
+    let mut values = headers.get_all(SESSION_ID_HEADER).iter();
+    let Some(value) = values.next() else {
         return Ok(None);
     };
+    if values.next().is_some() {
+        return Err(format!(
+            "{SESSION_ID_HEADER} must not be sent more than once"
+        ));
+    }
     let s = value
         .to_str()
-        .map_err(|_| format!("{SESSION_ID_HEADER} must be valid UTF-8"))?;
+        .map_err(|_| format!("{SESSION_ID_HEADER} must contain only visible ASCII characters"))?;
     if s.is_empty() {
         return Err(format!("{SESSION_ID_HEADER} must not be empty"));
     }

--- a/crates/server/src/pipeline_handlers.rs
+++ b/crates/server/src/pipeline_handlers.rs
@@ -886,12 +886,18 @@ pub async fn execute_pipeline_by_name(
             tracing::error!("Query execution failed: {}", e);
             tracing::debug!("Failed SQL query: {}", sql); // Log SQL for debugging but don't expose in response
 
+            // A fixed, value-free error kind — not `e.to_string()`. Parameter
+            // values are substituted directly into `sql` as literals, and a
+            // type-mismatch engine error can quote the offending literal back
+            // (e.g. `price <= 'not-a-number'`). Persisting the raw engine
+            // error would smuggle a caller-supplied parameter value into the
+            // ledger, which parameter values must never enter.
             finish_audit(
                 &app_state,
                 audit_id.as_deref(),
                 QueryAuditStatus::Failed,
                 None,
-                Some(&e.to_string()),
+                Some("query_execution_error"),
             )
             .await;
 
@@ -926,12 +932,16 @@ pub async fn execute_pipeline_by_name(
         Err(e) => {
             tracing::error!("Failed to convert results to JSON: {}", e);
 
+            // A fixed, value-free error kind, for the same reason as the
+            // engine-execution branch above: substituted parameter values can
+            // echo through error text derived from the query/result, and
+            // parameter values must never reach the ledger.
             finish_audit(
                 &app_state,
                 audit_id.as_deref(),
                 QueryAuditStatus::Failed,
                 Some(record_batch.num_rows()),
-                Some(&e),
+                Some("result_conversion_error"),
             )
             .await;
 

--- a/crates/server/src/pipeline_handlers.rs
+++ b/crates/server/src/pipeline_handlers.rs
@@ -878,8 +878,7 @@ pub async fn execute_pipeline_by_name(
             // unauthenticated route left no trace at all.
             tracing::warn!(
                 requested_pipeline = %pipeline_name,
-                "Rejected execute request for unknown pipeline '{}'",
-                pipeline_name
+                "Rejected execute request for unknown pipeline"
             );
             (
                 StatusCode::NOT_FOUND,
@@ -1764,7 +1763,7 @@ spec:
     }
 
     // -------------------------------------------------------------------------
-    // Finding 5: a JSON object nested inside an array parameter must never be
+    // SQL-injection guard: a JSON object nested inside an array parameter must never be
     // spliced into SQL as raw, unquoted text. Two reachable paths, both
     // exercised below with the injection-shaped payload from the review.
     // -------------------------------------------------------------------------

--- a/crates/server/src/pipeline_handlers.rs
+++ b/crates/server/src/pipeline_handlers.rs
@@ -46,6 +46,18 @@ const SESSION_ID_HEADER: &str = "x-skardi-session-id";
 /// Extract and validate the session header. `Ok(None)` when absent; `Err`
 /// when present but malformed — silently dropping a malformed value would
 /// corrupt session stitching, the one job this field has.
+///
+/// Allowed characters are visible ASCII graphic characters, excluding comma —
+/// no space, no tab, no other whitespace or control character. Space is
+/// rejected (not just trimmed) because `httparse` strips leading/trailing
+/// whitespace per RFC 9110 §5.5 before this code ever sees the value: if
+/// interior/exterior spaces were merely tolerated, `"  sess-1  "` would be
+/// recorded under the different key `sess-1` (silently breaking the session
+/// stitching this field exists for) while `"   "` would 400 here — the exact
+/// fail-late round trip a client-side check exists to prevent. A grouping
+/// key has no legitimate use for spaces, so this rejects them outright
+/// instead of defining trimming semantics. This predicate is mirrored
+/// exactly by the CLI's own check in `crates/cli/src/commands/run.rs`.
 fn session_id_from_headers(headers: &HeaderMap) -> Result<Option<String>, String> {
     let mut values = headers.get_all(SESSION_ID_HEADER).iter();
     let Some(value) = values.next() else {
@@ -59,16 +71,17 @@ fn session_id_from_headers(headers: &HeaderMap) -> Result<Option<String>, String
     let s = value
         .to_str()
         .map_err(|_| format!("{SESSION_ID_HEADER} must contain only visible ASCII characters"))?;
-    // `to_str` admits horizontal tab; reject it so "visible ASCII" is the
-    // whole truth. Commas are rejected because RFC 9110 §5.3 lets any
-    // intermediary merge repeated header lines into one comma-joined value —
-    // without this, a duplicate sent through such a proxy would slip past
-    // the duplicate check above as a single merged "id1, id2".
-    if s.contains([',', '\t']) {
+    // Commas are rejected because RFC 9110 §5.3 lets any intermediary merge
+    // repeated header lines into one comma-joined value — without this, a
+    // duplicate sent through such a proxy would slip past the duplicate
+    // check above as a single merged "id1, id2". Spaces (and every other
+    // non-graphic character, including tab) are rejected for the trimming
+    // reason above.
+    if !s.chars().all(|c| c.is_ascii_graphic() && c != ',') {
         return Err(format!(
-            "{SESSION_ID_HEADER} must not contain commas or tabs \
-             (proxies may merge repeated header lines into one \
-             comma-separated value)"
+            "{SESSION_ID_HEADER} must contain only visible ASCII characters, \
+             with no spaces and no commas (proxies may merge repeated header \
+             lines into one comma-separated value)"
         ));
     }
     if s.is_empty() {
@@ -607,31 +620,49 @@ pub async fn get_data_sources(
     })))
 }
 
+/// Name of a JSON value's type, for value-free diagnostics. Logs must never
+/// carry the value itself — only `unsupported_params` (which feeds the HTTP
+/// 400 body the caller already knows the value of) may do that.
+fn json_type_name(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
 /// Render a single scalar JSON value as the SQL literal form used inside an
 /// array placeholder or a row tuple cell.
 ///
 /// Number/Bool/Null render verbatim; String is single-quoted and escaped.
-/// Anything else falls back to `Value::to_string()`, matching the previous
-/// behaviour for unexpected nested shapes.
-fn scalar_to_sql(v: &Value) -> String {
+/// `Array` and `Object` return `None` — neither has a safe scalar SQL
+/// literal form, and the previous fallback (`Value::to_string()`, emitting
+/// raw unquoted JSON text) let a nested object splice unescaped, attacker-
+/// controlled text straight into the SQL string.
+fn scalar_to_sql(v: &Value) -> Option<String> {
     match v {
-        Value::Number(n) => n.to_string(),
-        Value::String(s) => format!("'{}'", s.replace("'", "''")),
-        Value::Bool(b) => b.to_string(),
-        Value::Null => "NULL".to_string(),
-        other => other.to_string(),
+        Value::Number(n) => Some(n.to_string()),
+        Value::String(s) => Some(format!("'{}'", s.replace("'", "''"))),
+        Value::Bool(b) => Some(b.to_string()),
+        Value::Null => Some("NULL".to_string()),
+        Value::Array(_) | Value::Object(_) => None,
     }
 }
 
 /// Render one cell of a row tuple. Scalars use `scalar_to_sql`; a nested
 /// array is rendered as the bracketed scalar form `[a, b, c]` so VECTOR /
 /// pgvector columns accept the literal as a row-cell value (the same shape
-/// `Value::Array` of scalars produces at the top level).
-fn row_cell_to_sql(v: &Value) -> String {
+/// `Value::Array` of scalars produces at the top level). `None` propagates
+/// from either level — a nested array containing a non-scalar is just as
+/// unrenderable as a bare non-scalar cell.
+fn row_cell_to_sql(v: &Value) -> Option<String> {
     match v {
         Value::Array(inner) => {
-            let elements: Vec<String> = inner.iter().map(scalar_to_sql).collect();
-            format!("[{}]", elements.join(", "))
+            let elements: Option<Vec<String>> = inner.iter().map(scalar_to_sql).collect();
+            elements.map(|els| format!("[{}]", els.join(", ")))
         }
         _ => scalar_to_sql(v),
     }
@@ -719,15 +750,35 @@ fn substitute_sql_params(
                             unsupported_params.push(format!("{}: {:?}", param_name, param_value));
                             continue;
                         }
-                        let rows: Vec<String> = row_arrays
+                        let rendered_rows: Option<Vec<String>> = row_arrays
                             .iter()
                             .map(|cells| {
-                                let rendered: Vec<String> =
+                                let rendered_cells: Option<Vec<String>> =
                                     cells.iter().map(row_cell_to_sql).collect();
-                                format!("({})", rendered.join(", "))
+                                rendered_cells.map(|cells| format!("({})", cells.join(", ")))
                             })
                             .collect();
-                        rows.join(", ")
+                        match rendered_rows {
+                            Some(rows) => rows.join(", "),
+                            None => {
+                                // A cell is a nested object (or an array
+                                // containing one) — no safe SQL literal form
+                                // exists, and the previous fallback spliced
+                                // its raw JSON text, unquoted, into the SQL
+                                // string. Reject the whole parameter, same
+                                // shape as every other unsupported-shape
+                                // reject in this function; value-free per
+                                // the ERROR-log policy above.
+                                tracing::error!(
+                                    "Unsupported cell type inside VALUES tuple list for {}: \
+                                     every cell must be a scalar or an array of scalars.",
+                                    param_name
+                                );
+                                unsupported_params
+                                    .push(format!("{}: {:?}", param_name, param_value));
+                                continue;
+                            }
+                        }
                     } else if arr.iter().any(|v| v.is_array()) {
                         tracing::error!(
                             "Mixed-shape array for {} (some elements are arrays, \
@@ -740,15 +791,43 @@ fn substitute_sql_params(
                         continue;
                     } else {
                         // Flat scalar array — the original vector-literal form.
-                        let elements: Vec<String> = arr.iter().map(scalar_to_sql).collect();
-                        format!("[{}]", elements.join(", "))
+                        // Every element must actually be a scalar: a nested
+                        // object here (`{"p": [{"a": 1}]}`) is neither an
+                        // array (so it never reaches the tuple-list/mixed-
+                        // shape branches above) nor a scalar `scalar_to_sql`
+                        // can render — reject rather than let the previous
+                        // `Value::to_string()` fallback splice raw JSON text
+                        // into the vector literal.
+                        match arr
+                            .iter()
+                            .map(scalar_to_sql)
+                            .collect::<Option<Vec<String>>>()
+                        {
+                            Some(elements) => format!("[{}]", elements.join(", ")),
+                            None => {
+                                tracing::error!(
+                                    "Unsupported element type inside array parameter {}: \
+                                     every element must be a scalar.",
+                                    param_name
+                                );
+                                unsupported_params
+                                    .push(format!("{}: {:?}", param_name, param_value));
+                                continue;
+                            }
+                        }
                     }
                 }
                 _ => {
+                    // Value-free by design: this log is ERROR-level (on by
+                    // default) and fans out to any configured OTLP
+                    // collector, unlike `unsupported_params` below, which
+                    // only ever reaches the caller who already supplied the
+                    // value in their own request body. Only the parameter
+                    // name and the JSON type name are logged.
                     tracing::error!(
-                        "Unsupported parameter type for {}: {:?}",
+                        "Unsupported parameter type for {}: {}",
                         param_name,
-                        param_value
+                        json_type_name(param_value)
                     );
                     unsupported_params.push(format!("{}: {:?}", param_name, param_value));
                     continue;
@@ -790,6 +869,18 @@ pub async fn execute_pipeline_by_name(
         })?;
 
         let pipeline = config.pipelines.get(&pipeline_name).ok_or_else(|| {
+            // Deliberately a log, not a metric: a metric here would let an
+            // unauthenticated caller mint unbounded label cardinality from
+            // arbitrary URL segments (see the comment on `session_id`
+            // validation below for why that reject is deferred past this
+            // point). A log field has no such cardinality constraint, and
+            // without it endpoint-enumeration probes against this
+            // unauthenticated route left no trace at all.
+            tracing::warn!(
+                requested_pipeline = %pipeline_name,
+                "Rejected execute request for unknown pipeline '{}'",
+                pipeline_name
+            );
             (
                 StatusCode::NOT_FOUND,
                 create_error_response(
@@ -833,7 +924,11 @@ pub async fn execute_pipeline_by_name(
             .record_error(&pipeline_name, elapsed_ms, "parameter_validation_error");
         (
             StatusCode::BAD_REQUEST,
-            create_error_response(&msg, "parameter_validation_error", None),
+            create_error_response(
+                &msg,
+                "parameter_validation_error",
+                Some(serde_json::json!({"header": SESSION_ID_HEADER})),
+            ),
         )
     })?;
 
@@ -841,12 +936,23 @@ pub async fn execute_pipeline_by_name(
     // from traces (rather than the opt-in ledger) get attribution too. It is
     // an opaque, caller-asserted grouping key — value-free by the same
     // standard as `/query`'s `ai_context` marker field.
-    tracing::info!(
-        session_id = session_id.as_deref().unwrap_or_default(),
-        "Received execution request for pipeline '{}' with {} parameters",
-        pipeline_name,
-        request.parameters.len()
-    );
+    //
+    // Two arms rather than `unwrap_or_default()`: an unattributed request has
+    // no session id at all, and logging `session_id=""` on every such request
+    // would misrepresent absence as an empty-string value.
+    match session_id.as_deref() {
+        Some(session_id) => tracing::info!(
+            session_id,
+            "Received execution request for pipeline '{}' with {} parameters",
+            pipeline_name,
+            request.parameters.len()
+        ),
+        None => tracing::info!(
+            "Received execution request for pipeline '{}' with {} parameters",
+            pipeline_name,
+            request.parameters.len()
+        ),
+    }
 
     let mut sql = sql_template;
 
@@ -1636,36 +1742,77 @@ spec:
     }
 
     #[test]
-    fn test_substitute_tuple_list_covers_bool_null_and_fallback_cells() {
-        // Locks down the three less-common scalar_to_sql arms that the other
-        // tuple-list tests don't reach: Bool, Null, and the fallback for an
-        // unexpected JSON shape (Object). All three flow through
+    fn test_substitute_tuple_list_covers_bool_and_null_cells() {
+        // Locks down the two less-common scalar_to_sql arms that the other
+        // tuple-list tests don't reach: Bool and Null. Both flow through
         // row_cell_to_sql's `_ => scalar_to_sql(v)` branch.
-        let mut sql = "INSERT INTO t (active, last_login, raw) VALUES {rows}".to_string();
-        let mut obj = serde_json::Map::new();
-        obj.insert("k".to_string(), Value::String("v".to_string()));
+        let mut sql = "INSERT INTO t (active, last_login) VALUES {rows}".to_string();
         let params_map = params(&[(
             "rows",
-            Value::Array(vec![Value::Array(vec![
-                Value::Bool(true),
-                Value::Null,
-                Value::Object(obj),
-            ])]),
+            Value::Array(vec![Value::Array(vec![Value::Bool(true), Value::Null])]),
         )]);
         let (missing, unsupported) =
             substitute_sql_params(&mut sql, &sorted_keys(&params_map), &params_map);
 
         assert!(missing.is_empty());
         assert!(unsupported.is_empty());
-        // Bool → `true`, Null → `NULL`, Object falls through to
-        // `Value::to_string()` which emits the JSON form `{"k":"v"}`.
-        // The Object case isn't useful SQL on most engines, but it's the
-        // pre-existing behaviour for "any other JSON shape" — locking it
-        // here means a future change has to be deliberate.
+        // Bool → `true`, Null → `NULL`.
         assert_eq!(
             sql,
-            "INSERT INTO t (active, last_login, raw) VALUES (true, NULL, {\"k\":\"v\"})"
+            "INSERT INTO t (active, last_login) VALUES (true, NULL)"
         );
+    }
+
+    // -------------------------------------------------------------------------
+    // Finding 5: a JSON object nested inside an array parameter must never be
+    // spliced into SQL as raw, unquoted text. Two reachable paths, both
+    // exercised below with the injection-shaped payload from the review.
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_substitute_tuple_list_rejects_nested_object_cell() {
+        // Path (a): an object nested inside a row-tuple-list cell used to
+        // fall through `scalar_to_sql`'s `other => other.to_string()` catch-
+        // all and render as raw, unquoted JSON text — e.g. `{"a": "x'; -- "}`
+        // spliced straight into `VALUES (...)`, closing the string literal
+        // and injecting a comment that swallows the rest of the statement.
+        // It must be rejected instead, leaving the SQL unsubstituted.
+        let mut sql = "INSERT INTO t (a) VALUES {rows}".to_string();
+        let mut obj = serde_json::Map::new();
+        obj.insert("a".to_string(), Value::String("x'; -- ".to_string()));
+        let params_map = params(&[(
+            "rows",
+            Value::Array(vec![Value::Array(vec![Value::Object(obj)])]),
+        )]);
+        let (missing, unsupported) =
+            substitute_sql_params(&mut sql, &sorted_keys(&params_map), &params_map);
+
+        assert!(missing.is_empty());
+        assert_eq!(unsupported.len(), 1);
+        assert!(unsupported[0].starts_with("rows: "));
+        // Placeholder left untouched on rejection — no injected text reaches
+        // the SQL string at all.
+        assert_eq!(sql, "INSERT INTO t (a) VALUES {rows}");
+    }
+
+    #[test]
+    fn test_substitute_flat_scalar_array_rejects_nested_object_element() {
+        // Path (b): a flat array whose elements are all non-arrays (so
+        // neither the tuple-list branch nor the mixed-shape branch fires)
+        // but one element is an object rather than a scalar. This used to
+        // fall through to `scalar_to_sql`'s catch-all and render as raw JSON
+        // text inside the `[...]` vector literal. Must be rejected instead.
+        let mut sql = "SELECT vector_to_text({p})".to_string();
+        let mut obj = serde_json::Map::new();
+        obj.insert("a".to_string(), Value::Number(1.into()));
+        let params_map = params(&[("p", Value::Array(vec![Value::Object(obj)]))]);
+        let (missing, unsupported) =
+            substitute_sql_params(&mut sql, &sorted_keys(&params_map), &params_map);
+
+        assert!(missing.is_empty());
+        assert_eq!(unsupported.len(), 1);
+        assert!(unsupported[0].starts_with("p: "));
+        assert_eq!(sql, "SELECT vector_to_text({p})");
     }
 
     #[test]

--- a/crates/server/src/query_audit.rs
+++ b/crates/server/src/query_audit.rs
@@ -8,8 +8,10 @@
 //! whose behalf, and did it succeed" rather than merely "what was attempted".
 //!
 //! The `sql` column is overloaded by row kind: raw SQL for ad-hoc rows,
-//! the pipeline *name* for `statement_kind = 'pipeline'` rows (the template
-//! lives on disk; parameter values are never recorded). Ad-hoc rows carry
+//! `name@version` for `statement_kind = 'pipeline'` rows (the versioned
+//! template lives on disk; parameter values are never recorded — the version
+//! is what keeps "what ran" answerable after the promotion loop edits a
+//! template, since rows are kept forever by default). Ad-hoc rows carry
 //! `statement_kind` values from `StatementKind`'s `Debug` form — `Query` /
 //! `Other` — not SQL verbs like `select`.
 //!
@@ -32,10 +34,65 @@
 //! pruned at startup and hourly thereafter. Without that flag rows are kept
 //! forever, and pruning/rotation is the operator's call.
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use serde_json::Value;
+use std::future::Future;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 use tokio_rusqlite::{Connection, params, rusqlite};
+
+/// Upper bound on any single ledger write. Fail-closed only means "503, and
+/// the statement does not run" if a write that *hangs* (a stalled fsync on
+/// EBS/NFS, a full dm-thin pool) is also treated as failed — otherwise the
+/// request hangs with it, and because the store is one serialized writer
+/// thread, every subsequent audited request queues behind it. A timed-out
+/// write may still land later on the writer thread; that leaves an orphaned
+/// `started` row, which the next startup reconciles to `unknown` exactly
+/// like a crash mid-query.
+pub(crate) const AUDIT_WRITE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Maximum length of a session id, in characters — shared by `/query`'s
+/// `ai_context.session_id` and the pipeline execute endpoint's
+/// `x-skardi-session-id` header (see `query_handlers::validate_ai_context`
+/// and `pipeline_handlers::session_id_from_headers`), so the two paths can't
+/// drift apart. It is an opaque grouping key, not a payload.
+///
+/// `skardi-cli` restates this cap under the same name (`run.rs`) because the
+/// CLI crate does not depend on this one; keep them in sync.
+pub(crate) const MAX_SESSION_ID_CHARS: usize = 200;
+
+/// Await a ledger write, bounding it with [`AUDIT_WRITE_TIMEOUT`]. Elapsed
+/// is an error like any other write failure — see the timeout const for why.
+async fn bounded<T>(
+    write: impl Future<Output = tokio_rusqlite::Result<T>>,
+    what: &'static str,
+) -> Result<T> {
+    match tokio::time::timeout(AUDIT_WRITE_TIMEOUT, write).await {
+        Ok(result) => result.context(what),
+        Err(_) => bail!("{what}: timed out after {AUDIT_WRITE_TIMEOUT:?}"),
+    }
+}
+
+/// Stamp the terminal outcome onto an audit record.
+///
+/// Unlike the pre-execution write, a failure (or timeout) here cannot un-run
+/// the statement, so it is logged rather than surfaced: the row simply stays
+/// `started` and the next startup reconciles it to `unknown`. No-op when
+/// auditing is off. Callers pass `app_state.query_audit.as_deref()`.
+pub(crate) async fn finish_audit(
+    store: Option<&QueryAuditStore>,
+    audit_id: Option<&str>,
+    status: QueryAuditStatus,
+    row_count: Option<usize>,
+    error: Option<&str>,
+) {
+    let (Some(store), Some(id)) = (store, audit_id) else {
+        return;
+    };
+    if let Err(e) = store.record_outcome(id, status, row_count, error).await {
+        tracing::error!("Failed to record query-audit outcome for {id}: {e}");
+    }
+}
 
 /// Shorthand for the closure return type `tokio_rusqlite::Connection::call`
 /// expects; the crate cannot infer it from a bare `Ok(())`.
@@ -204,8 +261,8 @@ impl QueryAuditStore {
         let statement_kind = statement_kind.to_string();
         let row_id = id.clone();
 
-        self.conn
-            .call(move |conn| -> SqlResult<()> {
+        bounded(
+            self.conn.call(move |conn| -> SqlResult<()> {
                 conn.execute(
                     "INSERT INTO query_audit
                         (id, created_at, sql, ai_context, session_id, max_rows,
@@ -223,34 +280,38 @@ impl QueryAuditStore {
                     ],
                 )?;
                 Ok(())
-            })
-            .await
-            .context("Failed to write pre-execution query-audit record")?;
+            }),
+            "Failed to write pre-execution query-audit record",
+        )
+        .await?;
 
         Ok(id)
     }
 
     /// Insert a `started` row for a pipeline execution.
     ///
-    /// Stores the pipeline *name* in the `sql` column: the template lives on
-    /// disk with no secrets, and the name is the join key to it and to the
-    /// pipeline's `description` (which carries the purpose). Parameter values
-    /// are deliberately never recorded — they are where PII lives. `ai_context`
-    /// is left NULL rather than synthesized so the column always means
-    /// "caller-sent object".
+    /// Stores `name@version` in the `sql` column: the template lives on disk
+    /// with no secrets, and pipelines are precisely the artifacts the
+    /// promotion loop edits — rows outlive template revisions (retention is
+    /// off by default), so the name alone stops answering *what SQL ran*.
+    /// `version` comes from the pipeline's `metadata.version`. Parameter
+    /// values are deliberately never recorded — they are where PII lives.
+    /// `ai_context` is left NULL rather than synthesized so the column always
+    /// means "caller-sent object".
     pub async fn record_pipeline_started(
         &self,
         pipeline_name: &str,
+        version: &str,
         session_id: Option<&str>,
     ) -> Result<String> {
         let id = new_id();
         let created_at = chrono::Utc::now().to_rfc3339();
-        let name = pipeline_name.to_string();
+        let name_at_version = format!("{pipeline_name}@{version}");
         let session_id = session_id.map(str::to_string);
         let row_id = id.clone();
 
-        self.conn
-            .call(move |conn| -> SqlResult<()> {
+        bounded(
+            self.conn.call(move |conn| -> SqlResult<()> {
                 conn.execute(
                     "INSERT INTO query_audit
                         (id, created_at, sql, ai_context, session_id, max_rows,
@@ -259,7 +320,7 @@ impl QueryAuditStore {
                     params![
                         row_id,
                         created_at,
-                        name,
+                        name_at_version,
                         session_id,
                         PIPELINE_MAX_ROWS_SENTINEL,
                         PIPELINE_STATEMENT_KIND,
@@ -267,9 +328,10 @@ impl QueryAuditStore {
                     ],
                 )?;
                 Ok(())
-            })
-            .await
-            .context("Failed to write pre-execution pipeline-audit record")?;
+            }),
+            "Failed to write pre-execution pipeline-audit record",
+        )
+        .await?;
 
         Ok(id)
     }
@@ -288,8 +350,8 @@ impl QueryAuditStore {
         let row_count = row_count.map(|n| n as i64);
         let error = error.map(str::to_string);
 
-        self.conn
-            .call(move |conn| -> SqlResult<()> {
+        bounded(
+            self.conn.call(move |conn| -> SqlResult<()> {
                 conn.execute(
                     "UPDATE query_audit
                         SET status = ?2, finished_at = ?3, row_count = ?4, error = ?5
@@ -297,9 +359,10 @@ impl QueryAuditStore {
                     params![id, status, finished_at, row_count, error],
                 )?;
                 Ok(())
-            })
-            .await
-            .context("Failed to update query-audit record")?;
+            }),
+            "Failed to update query-audit record",
+        )
+        .await?;
         Ok(())
     }
 
@@ -390,7 +453,12 @@ impl QueryAuditStore {
             .conn
             .call(move |conn| -> SqlResult<Vec<String>> {
                 let mut stmt = conn.prepare(
-                    "SELECT id FROM query_audit WHERE session_id = ?1 ORDER BY created_at ASC",
+                    // `id` breaks created_at ties: `to_rfc3339` emits
+                    // variable-precision subseconds, so two same-instant rows
+                    // compare equal as strings, and `new_id()` is monotonic
+                    // within a process — making the order total.
+                    "SELECT id FROM query_audit WHERE session_id = ?1 \
+                     ORDER BY created_at ASC, id ASC",
                 )?;
                 let ids = stmt
                     .query_map(params![session_id], |row| row.get::<_, String>(0))?
@@ -471,6 +539,13 @@ const PIPELINE_STATEMENT_KIND: &str = "pipeline";
 
 /// `max_rows` does not apply to pipeline executions, but the column is NOT
 /// NULL; pipeline rows store this sentinel.
+///
+/// The sentinel is unambiguous only because `/query` rejects
+/// `max_rows: Some(0)` up front (the `Some(0)` arm in
+/// `query_handlers::execute_query`), so `0` can never appear on an ad-hoc
+/// row. That invariant lives in a
+/// different module — if `/query` ever starts allowing `max_rows: 0`, this
+/// sentinel needs a new value (or a dedicated column) first.
 const PIPELINE_MAX_ROWS_SENTINEL: i64 = 0;
 
 /// Random-ish unique row id. Avoids a `uuid` dependency: the timestamp keeps
@@ -671,7 +746,7 @@ mod tests {
     async fn pipeline_row_round_trips() {
         let store = QueryAuditStore::open_in_memory().await.unwrap();
         let id = store
-            .record_pipeline_started("weekly-churn", Some("sess-1"))
+            .record_pipeline_started("weekly-churn", "1.0.0", Some("sess-1"))
             .await
             .unwrap();
         store
@@ -679,7 +754,7 @@ mod tests {
             .await
             .unwrap();
         let row = store.get(&id).await.unwrap().unwrap();
-        assert_eq!(row["sql"], json!("weekly-churn"));
+        assert_eq!(row["sql"], json!("weekly-churn@1.0.0"));
         assert_eq!(row["statement_kind"], json!("pipeline"));
         assert_eq!(row["session_id"], json!("sess-1"));
         assert_eq!(row["max_rows"], json!(0));
@@ -691,7 +766,7 @@ mod tests {
     async fn pipeline_row_without_session_has_null_session_id() {
         let store = QueryAuditStore::open_in_memory().await.unwrap();
         let id = store
-            .record_pipeline_started("weekly-churn", None)
+            .record_pipeline_started("weekly-churn", "1.0.0", None)
             .await
             .unwrap();
         let row = store.get(&id).await.unwrap().unwrap();
@@ -707,18 +782,25 @@ mod tests {
             .await
             .unwrap();
         store
-            .record_pipeline_started("weekly-churn", Some("sess-mix"))
+            .record_pipeline_started("weekly-churn", "1.0.0", Some("sess-mix"))
             .await
             .unwrap();
         let rows = store.list_by_session("sess-mix").await.unwrap();
         assert_eq!(rows.len(), 2);
+        // The promised property is the *ordering* (insertion order via
+        // created_at with id as tie-break), plus the sql-column overload —
+        // a bare count passes with ORDER BY dropped or reversed.
+        assert_eq!(rows[0]["statement_kind"], json!("Query"));
+        assert_eq!(rows[0]["sql"], json!("SELECT 1"));
+        assert_eq!(rows[1]["statement_kind"], json!("pipeline"));
+        assert_eq!(rows[1]["sql"], json!("weekly-churn@1.0.0"));
     }
 
     #[tokio::test]
     async fn orphaned_pipeline_rows_reconcile_to_unknown() {
         let store = QueryAuditStore::open_in_memory().await.unwrap();
         let id = store
-            .record_pipeline_started("weekly-churn", None)
+            .record_pipeline_started("weekly-churn", "1.0.0", None)
             .await
             .unwrap();
         let n = store.reconcile_orphaned("test restart").await.unwrap();

--- a/crates/server/src/query_audit.rs
+++ b/crates/server/src/query_audit.rs
@@ -34,7 +34,7 @@
 //! pruned at startup and hourly thereafter. Without that flag rows are kept
 //! forever, and pruning/rotation is the operator's call.
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, anyhow};
 use serde_json::Value;
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -46,9 +46,18 @@ use tokio_rusqlite::{Connection, params, rusqlite};
 /// EBS/NFS, a full dm-thin pool) is also treated as failed — otherwise the
 /// request hangs with it, and because the store is one serialized writer
 /// thread, every subsequent audited request queues behind it. A timed-out
-/// write may still land later on the writer thread; that leaves an orphaned
-/// `started` row, which the next startup reconciles to `unknown` exactly
-/// like a crash mid-query.
+/// write may still land later on the writer thread; for `record_outcome`
+/// (and the retention prune) that leaves an orphaned `started` row, which
+/// the next startup reconciles to `unknown` exactly like a crash mid-query.
+/// The two pre-execution writers (`record_started`,
+/// `record_pipeline_started`) know more than that — a timeout there means
+/// the caller has already told the requester "503, did not run" — so they
+/// follow up with a corrective UPDATE instead of leaving that ambiguity for
+/// startup to paper over; see `QueryAuditStore::spawn_timeout_correction`.
+///
+/// Individual stores may override this via `write_timeout` (tests only, to
+/// exercise the timeout branch without waiting out the real bound); the
+/// const remains the production default.
 pub(crate) const AUDIT_WRITE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Maximum length of a session id, in characters — shared by `/query`'s
@@ -61,15 +70,56 @@ pub(crate) const AUDIT_WRITE_TIMEOUT: Duration = Duration::from_secs(5);
 /// CLI crate does not depend on this one; keep them in sync.
 pub(crate) const MAX_SESSION_ID_CHARS: usize = 200;
 
-/// Await a ledger write, bounding it with [`AUDIT_WRITE_TIMEOUT`]. Elapsed
-/// is an error like any other write failure — see the timeout const for why.
+/// Error from [`bounded`] that keeps "the write timed out" distinguishable
+/// from "the write ran and failed" (e.g. `ConnectionClosed`). Only the
+/// pre-execution writers act on that distinction — see
+/// [`QueryAuditStore::spawn_timeout_correction`] — everywhere else this
+/// converts straight to `anyhow::Error` via `?`, same as before.
+#[derive(Debug)]
+enum BoundedError {
+    /// Elapsed `timeout` without the write completing. It may still land
+    /// later on the writer thread.
+    TimedOut(anyhow::Error),
+    /// The write itself returned an error.
+    Other(anyhow::Error),
+}
+
+impl BoundedError {
+    fn is_timeout(&self) -> bool {
+        matches!(self, BoundedError::TimedOut(_))
+    }
+}
+
+impl std::fmt::Display for BoundedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BoundedError::TimedOut(e) | BoundedError::Other(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for BoundedError {}
+
+// `anyhow`'s blanket `impl<E: StdError + Send + Sync + 'static> From<E> for
+// anyhow::Error` covers the `BoundedError -> anyhow::Error` conversion `?`
+// needs at every call site below — an explicit `impl From<BoundedError> for
+// anyhow::Error` here would conflict with it.
+
+/// Await a ledger write, bounding it with `timeout` (production callers pass
+/// [`AUDIT_WRITE_TIMEOUT`]; tests may pass a shorter bound via
+/// `QueryAuditStore::write_timeout`). Elapsed is an error like any other
+/// write failure — see the timeout const for why — but callers that need to
+/// react specifically to a timeout can check [`BoundedError::is_timeout`].
 async fn bounded<T>(
     write: impl Future<Output = tokio_rusqlite::Result<T>>,
     what: &'static str,
-) -> Result<T> {
-    match tokio::time::timeout(AUDIT_WRITE_TIMEOUT, write).await {
-        Ok(result) => result.context(what),
-        Err(_) => bail!("{what}: timed out after {AUDIT_WRITE_TIMEOUT:?}"),
+    timeout: Duration,
+) -> std::result::Result<T, BoundedError> {
+    match tokio::time::timeout(timeout, write).await {
+        Ok(result) => result.context(what).map_err(BoundedError::Other),
+        Err(_) => Err(BoundedError::TimedOut(anyhow!(
+            "{what}: timed out after {timeout:?}"
+        ))),
     }
 }
 
@@ -117,7 +167,9 @@ CREATE INDEX IF NOT EXISTS idx_query_audit_session_created
 CREATE INDEX IF NOT EXISTS idx_query_audit_created
     ON query_audit (created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_query_audit_status
-    ON query_audit (status);";
+    ON query_audit (status);
+CREATE INDEX IF NOT EXISTS idx_query_audit_statement_kind
+    ON query_audit (statement_kind);";
 
 /// Outcome of an audited statement.
 ///
@@ -147,6 +199,10 @@ impl QueryAuditStatus {
 pub struct QueryAuditStore {
     conn: Connection,
     path: PathBuf,
+    /// Bound passed to [`bounded`] for every write. [`AUDIT_WRITE_TIMEOUT`]
+    /// in production; overridable in tests via [`Self::with_write_timeout`]
+    /// so the timeout branch can be exercised without waiting 5s.
+    write_timeout: Duration,
 }
 
 impl std::fmt::Debug for QueryAuditStore {
@@ -206,7 +262,11 @@ impl QueryAuditStore {
             }
         }
 
-        Ok(Self { conn, path })
+        Ok(Self {
+            conn,
+            path,
+            write_timeout: AUDIT_WRITE_TIMEOUT,
+        })
     }
 
     /// Open an in-memory ledger. Tests only — nothing is durable.
@@ -223,11 +283,22 @@ impl QueryAuditStore {
         Ok(Self {
             conn,
             path: PathBuf::from(":memory:"),
+            write_timeout: AUDIT_WRITE_TIMEOUT,
         })
     }
 
     pub fn path(&self) -> &Path {
         &self.path
+    }
+
+    /// Override the write bound. Tests only — lets a test exercise the
+    /// timeout branch (finding: "the timeout branch that fail-closed rests
+    /// on is untested") in milliseconds instead of waiting out the real
+    /// [`AUDIT_WRITE_TIMEOUT`].
+    #[cfg(test)]
+    pub(crate) fn with_write_timeout(mut self, timeout: Duration) -> Self {
+        self.write_timeout = timeout;
+        self
     }
 
     /// Close the backing connection, leaving the store permanently unwritable.
@@ -261,7 +332,7 @@ impl QueryAuditStore {
         let statement_kind = statement_kind.to_string();
         let row_id = id.clone();
 
-        bounded(
+        match bounded(
             self.conn.call(move |conn| -> SqlResult<()> {
                 conn.execute(
                     "INSERT INTO query_audit
@@ -282,10 +353,18 @@ impl QueryAuditStore {
                 Ok(())
             }),
             "Failed to write pre-execution query-audit record",
+            self.write_timeout,
         )
-        .await?;
-
-        Ok(id)
+        .await
+        {
+            Ok(()) => Ok(id),
+            Err(e) => {
+                if e.is_timeout() {
+                    self.spawn_timeout_correction(id);
+                }
+                Err(e.into())
+            }
+        }
     }
 
     /// Insert a `started` row for a pipeline execution.
@@ -310,7 +389,7 @@ impl QueryAuditStore {
         let session_id = session_id.map(str::to_string);
         let row_id = id.clone();
 
-        bounded(
+        match bounded(
             self.conn.call(move |conn| -> SqlResult<()> {
                 conn.execute(
                     "INSERT INTO query_audit
@@ -330,10 +409,18 @@ impl QueryAuditStore {
                 Ok(())
             }),
             "Failed to write pre-execution pipeline-audit record",
+            self.write_timeout,
         )
-        .await?;
-
-        Ok(id)
+        .await
+        {
+            Ok(()) => Ok(id),
+            Err(e) => {
+                if e.is_timeout() {
+                    self.spawn_timeout_correction(id);
+                }
+                Err(e.into())
+            }
+        }
     }
 
     /// Update a record with its terminal outcome.
@@ -361,9 +448,64 @@ impl QueryAuditStore {
                 Ok(())
             }),
             "Failed to update query-audit record",
+            self.write_timeout,
         )
         .await?;
         Ok(())
+    }
+
+    /// Best-effort correction for a pre-execution write that timed out from
+    /// the caller's point of view, submitted as a follow-up UPDATE on a
+    /// cloned connection.
+    ///
+    /// Why this is safe: `tokio_rusqlite::Connection` funnels every `call`
+    /// onto one dedicated writer thread via a FIFO channel. The abandoned
+    /// INSERT's `call` was already sent into that channel before `bounded`
+    /// gave up on it (the timeout races the *await*, not the *send* — the
+    /// future is polled at least once, which is when the message goes onto
+    /// the channel). This UPDATE's `call` is only sent afterwards, from the
+    /// spawned task below, so it is queued strictly after the INSERT and is
+    /// guaranteed to be applied to the real row if the INSERT ever lands —
+    /// turning a fact we already know ("the request was told 503, did not
+    /// run") into the ledger's `failed`/`audit_write_timeout`, instead of
+    /// letting startup reconciliation later guess `unknown` ("may have run
+    /// after a crash") for a row we know did not run. If the INSERT itself
+    /// never lands (e.g. the connection died rather than merely stalled),
+    /// this UPDATE matches no row and is a harmless no-op.
+    ///
+    /// Fire-and-forget by design: the request has already returned 503 by
+    /// the time this could resolve, so the caller does not await it. Any
+    /// failure here can only be observed via logging.
+    fn spawn_timeout_correction(&self, id: String) {
+        let conn = self.conn.clone();
+        tokio::spawn(async move {
+            let finished_at = chrono::Utc::now().to_rfc3339();
+            let outcome = conn
+                .call(move |conn| -> SqlResult<usize> {
+                    conn.execute(
+                        "UPDATE query_audit
+                            SET status = ?2, finished_at = ?3, error = ?4
+                          WHERE id = ?1 AND status = ?5",
+                        params![
+                            id,
+                            QueryAuditStatus::Failed.as_str(),
+                            finished_at,
+                            "audit_write_timeout",
+                            QueryAuditStatus::Started.as_str(),
+                        ],
+                    )
+                })
+                .await;
+            match outcome {
+                // 0 rows means either the INSERT never landed, or it landed
+                // and something else already moved it off `started` —
+                // either way there is nothing to correct.
+                Ok(_) => {}
+                Err(e) => tracing::warn!(
+                    "Failed to apply audit-write-timeout correction to query-audit record: {e}"
+                ),
+            }
+        });
     }
 
     /// Rewrite rows still marked `started` to `unknown`. Called at startup so a
@@ -392,21 +534,48 @@ impl QueryAuditStore {
         Ok(updated)
     }
 
-    /// Delete records created before `cutoff` (RFC 3339). Returns the row count.
+    /// Delete records created before `cutoff` (RFC 3339). Returns the total
+    /// row count deleted.
+    ///
+    /// Runs as repeated bounded, `PRUNE_BATCH_SIZE`-row deletes rather than
+    /// one unbounded `DELETE`. This store's connection is a single
+    /// serialized writer thread shared with every audited request's
+    /// pre-execution INSERT (see the module docs); an unbounded delete over
+    /// a multi-million-row backlog under `synchronous = FULL` can exceed
+    /// [`AUDIT_WRITE_TIMEOUT`] on its own — which, on that shared thread,
+    /// would make every *other* concurrent `/query` and pipeline-execute
+    /// request time out and 503 even though nothing is wrong with them, and
+    /// the prune itself still would not have finished. Chunking keeps each
+    /// individual write comfortably inside the bound (wrapped in `bounded`
+    /// like every other write) and yields between chunks so writes queued
+    /// behind the prune get a chance to interleave rather than all landing
+    /// after it.
     pub async fn prune_before(&self, cutoff: chrono::DateTime<chrono::Utc>) -> Result<usize> {
         let cutoff = cutoff.to_rfc3339();
-        let deleted = self
-            .conn
-            .call(move |conn| -> SqlResult<usize> {
-                let n = conn.execute(
-                    "DELETE FROM query_audit WHERE created_at < ?1",
-                    params![cutoff],
-                )?;
-                Ok(n)
-            })
-            .await
-            .context("Failed to prune query-audit records")?;
-        Ok(deleted)
+        let mut total = 0usize;
+        loop {
+            let batch_cutoff = cutoff.clone();
+            let deleted = bounded(
+                self.conn.call(move |conn| -> SqlResult<usize> {
+                    let n = conn.execute(
+                        "DELETE FROM query_audit WHERE id IN (
+                            SELECT id FROM query_audit WHERE created_at < ?1 LIMIT ?2
+                         )",
+                        params![batch_cutoff, PRUNE_BATCH_SIZE as i64],
+                    )?;
+                    Ok(n)
+                }),
+                "Failed to prune query-audit records",
+                self.write_timeout,
+            )
+            .await?;
+            if deleted == 0 {
+                break;
+            }
+            total += deleted;
+            tokio::task::yield_now().await;
+        }
+        Ok(total)
     }
 
     /// Fetch one record as a JSON object. Test/diagnostic helper.
@@ -548,8 +717,17 @@ const PIPELINE_STATEMENT_KIND: &str = "pipeline";
 /// sentinel needs a new value (or a dedicated column) first.
 const PIPELINE_MAX_ROWS_SENTINEL: i64 = 0;
 
+/// Rows deleted per [`QueryAuditStore::prune_before`] batch. Small enough
+/// that a batch delete is comfortably inside [`AUDIT_WRITE_TIMEOUT`] even on
+/// a slow disk; see that method's doc comment for why batching exists at
+/// all.
+const PRUNE_BATCH_SIZE: usize = 1000;
+
 /// Random-ish unique row id. Avoids a `uuid` dependency: the timestamp keeps
-/// ids ordered and the counter disambiguates within the same nanosecond.
+/// ids ordered and the zero-padded hex counter disambiguates within the same
+/// nanosecond without breaking lexicographic order — `list_by_session`'s
+/// `id ASC` tie-break (and any other string sort) depends on same-width
+/// hex; an unpadded counter would sort `…-f` after `…-10`.
 fn new_id() -> String {
     use std::sync::atomic::{AtomicU64, Ordering};
     static COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -558,7 +736,7 @@ fn new_id() -> String {
         .map(|d| d.as_nanos())
         .unwrap_or_default();
     let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
-    format!("{nanos:x}-{seq:x}")
+    format!("{nanos:x}-{seq:016x}")
 }
 
 #[cfg(test)]
@@ -693,6 +871,120 @@ mod tests {
 
         assert_eq!(store.prune_before(chrono::Utc::now()).await.unwrap(), 1);
         assert_eq!(store.count().await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn prune_deletes_across_multiple_batches() {
+        // PRUNE_BATCH_SIZE is 1000; insert more than two batches' worth so a
+        // single-DELETE implementation and a chunked one would both "work"
+        // in the sense of deleting everything, but only the chunked one
+        // does it as more than one bounded write.
+        let store = QueryAuditStore::open_in_memory().await.unwrap();
+        let total_rows = (PRUNE_BATCH_SIZE * 2) + 500;
+        for _ in 0..total_rows {
+            store
+                .record_started("SELECT 1", None, 1, "Query")
+                .await
+                .unwrap();
+        }
+        assert_eq!(store.count().await.unwrap(), total_rows);
+
+        let deleted = store.prune_before(chrono::Utc::now()).await.unwrap();
+        assert_eq!(deleted, total_rows);
+        assert_eq!(store.count().await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn record_pipeline_started_times_out_when_writer_thread_is_blocked() {
+        // Finding: the timeout branch that fail-closed rests on had no test
+        // exercising it directly — `close_for_test` only covers the
+        // immediate-error path (`ConnectionClosed`). This makes the bound
+        // injectable so a test can pin it far below AUDIT_WRITE_TIMEOUT.
+        let store = QueryAuditStore::open_in_memory()
+            .await
+            .unwrap()
+            .with_write_timeout(Duration::from_millis(100));
+
+        // Occupy the dedicated writer thread well past the bound so the
+        // next write has to wait behind it instead of running immediately.
+        let blocker = store.conn.clone();
+        let blocker_task = tokio::spawn(async move {
+            let _ = blocker
+                .call(|_conn| -> SqlResult<()> {
+                    std::thread::sleep(Duration::from_millis(400));
+                    Ok(())
+                })
+                .await;
+        });
+        // Give the blocking call a moment to actually start running on the
+        // writer thread before racing it.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        let started = std::time::Instant::now();
+        let result = store
+            .record_pipeline_started("weekly-churn", "1.0.0", None)
+            .await;
+        let elapsed = started.elapsed();
+
+        assert!(result.is_err(), "expected a timeout error, got {result:?}");
+        assert!(
+            elapsed < Duration::from_millis(400),
+            "should have returned near the 100ms bound rather than waiting \
+             out the full 400ms blocking call: {elapsed:?}"
+        );
+
+        blocker_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn timed_out_pipeline_start_is_corrected_to_failed_once_it_lands() {
+        // Covers the finding-2 fix: a pre-execution write that times out
+        // from the caller's perspective, but whose INSERT still lands later
+        // on the writer thread, must not sit there as an ambiguous
+        // `started` -> `unknown` row. It should end up `failed` with
+        // `audit_write_timeout` instead. The FIFO ordering the fix relies
+        // on (INSERT queued before the corrective UPDATE) is guaranteed by
+        // the crate, not by timing, so this is asserted with a bounded poll
+        // rather than a fixed sleep — not because the outcome is racy, only
+        // because *when* the writer thread gets to it is not.
+        let store = QueryAuditStore::open_in_memory()
+            .await
+            .unwrap()
+            .with_write_timeout(Duration::from_millis(100));
+
+        let blocker = store.conn.clone();
+        let blocker_task = tokio::spawn(async move {
+            let _ = blocker
+                .call(|_conn| -> SqlResult<()> {
+                    std::thread::sleep(Duration::from_millis(300));
+                    Ok(())
+                })
+                .await;
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        let result = store
+            .record_pipeline_started("weekly-churn", "1.0.0", Some("sess-timeout"))
+            .await;
+        assert!(result.is_err(), "expected a timeout error, got {result:?}");
+
+        blocker_task.await.unwrap();
+
+        let mut rows = Vec::new();
+        for _ in 0..50 {
+            rows = store.list_by_session("sess-timeout").await.unwrap();
+            if rows
+                .first()
+                .is_some_and(|r| r["status"] != json!("started"))
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert_eq!(rows.len(), 1, "{rows:?}");
+        assert_eq!(rows[0]["status"], json!("failed"));
+        assert_eq!(rows[0]["error"], json!("audit_write_timeout"));
+        assert!(!rows[0]["finished_at"].is_null());
     }
 
     #[tokio::test]

--- a/crates/server/src/query_audit.rs
+++ b/crates/server/src/query_audit.rs
@@ -1,10 +1,17 @@
-//! Durable audit store for ad-hoc `/query` statements.
+//! Durable audit store for ad-hoc `/query` statements and pipeline
+//! executions.
 //!
 //! Off unless the operator sets `--query-audit-db <path>`. When enabled, every
-//! statement the `/query` endpoint accepts is written to a SQLite database
-//! *before* execution and updated with its outcome afterwards, so the store
-//! answers "what ran, on whose behalf, and did it succeed" rather than merely
-//! "what was attempted".
+//! statement the `/query` endpoint accepts — and every `POST /:name/execute`
+//! pipeline run — is written to a SQLite database *before* execution and
+//! updated with its outcome afterwards, so the store answers "what ran, on
+//! whose behalf, and did it succeed" rather than merely "what was attempted".
+//!
+//! The `sql` column is overloaded by row kind: raw SQL for ad-hoc rows,
+//! the pipeline *name* for `statement_kind = 'pipeline'` rows (the template
+//! lives on disk; parameter values are never recorded). Ad-hoc rows carry
+//! `statement_kind` values from `StatementKind`'s `Debug` form — `Query` /
+//! `Other` — not SQL verbs like `select`.
 //!
 //! Design notes:
 //!

--- a/crates/server/src/query_audit.rs
+++ b/crates/server/src/query_audit.rs
@@ -460,7 +460,7 @@ fn restrict_permissions(path: &Path) -> Result<()> {
 }
 
 /// Statement-kind marker distinguishing pipeline rows from ad-hoc SQL rows.
-pub const PIPELINE_STATEMENT_KIND: &str = "pipeline";
+const PIPELINE_STATEMENT_KIND: &str = "pipeline";
 
 /// `max_rows` does not apply to pipeline executions, but the column is NOT
 /// NULL; pipeline rows store this sentinel.

--- a/crates/server/src/query_audit.rs
+++ b/crates/server/src/query_audit.rs
@@ -223,6 +223,50 @@ impl QueryAuditStore {
         Ok(id)
     }
 
+    /// Insert a `started` row for a pipeline execution.
+    ///
+    /// Stores the pipeline *name* in the `sql` column: the template lives on
+    /// disk with no secrets, and the name is the join key to it and to the
+    /// pipeline's `description` (which carries the purpose). Parameter values
+    /// are deliberately never recorded — they are where PII lives. `ai_context`
+    /// is left NULL rather than synthesized so the column always means
+    /// "caller-sent object".
+    pub async fn record_pipeline_started(
+        &self,
+        pipeline_name: &str,
+        session_id: Option<&str>,
+    ) -> Result<String> {
+        let id = new_id();
+        let created_at = chrono::Utc::now().to_rfc3339();
+        let name = pipeline_name.to_string();
+        let session_id = session_id.map(str::to_string);
+        let row_id = id.clone();
+
+        self.conn
+            .call(move |conn| -> SqlResult<()> {
+                conn.execute(
+                    "INSERT INTO query_audit
+                        (id, created_at, sql, ai_context, session_id, max_rows,
+                         statement_kind, status)
+                     VALUES (?1, ?2, ?3, NULL, ?4, ?5, ?6, ?7)",
+                    params![
+                        row_id,
+                        created_at,
+                        name,
+                        session_id,
+                        PIPELINE_MAX_ROWS_SENTINEL,
+                        PIPELINE_STATEMENT_KIND,
+                        QueryAuditStatus::Started.as_str(),
+                    ],
+                )?;
+                Ok(())
+            })
+            .await
+            .context("Failed to write pre-execution pipeline-audit record")?;
+
+        Ok(id)
+    }
+
     /// Update a record with its terminal outcome.
     pub async fn record_outcome(
         &self,
@@ -414,6 +458,13 @@ fn restrict_permissions(path: &Path) -> Result<()> {
     let _ = path;
     Ok(())
 }
+
+/// Statement-kind marker distinguishing pipeline rows from ad-hoc SQL rows.
+pub const PIPELINE_STATEMENT_KIND: &str = "pipeline";
+
+/// `max_rows` does not apply to pipeline executions, but the column is NOT
+/// NULL; pipeline rows store this sentinel.
+const PIPELINE_MAX_ROWS_SENTINEL: i64 = 0;
 
 /// Random-ish unique row id. Avoids a `uuid` dependency: the timestamp keeps
 /// ids ordered and the counter disambiguates within the same nanosecond.
@@ -607,5 +658,65 @@ mod tests {
         let reopened = QueryAuditStore::open(&path).await.unwrap();
         let record = reopened.get(&id).await.unwrap().unwrap();
         assert_eq!(record["sql"], json!("SELECT 'durable'"));
+    }
+
+    #[tokio::test]
+    async fn pipeline_row_round_trips() {
+        let store = QueryAuditStore::open_in_memory().await.unwrap();
+        let id = store
+            .record_pipeline_started("weekly-churn", Some("sess-1"))
+            .await
+            .unwrap();
+        store
+            .record_outcome(&id, QueryAuditStatus::Succeeded, Some(42), None)
+            .await
+            .unwrap();
+        let row = store.get(&id).await.unwrap().unwrap();
+        assert_eq!(row["sql"], json!("weekly-churn"));
+        assert_eq!(row["statement_kind"], json!("pipeline"));
+        assert_eq!(row["session_id"], json!("sess-1"));
+        assert_eq!(row["max_rows"], json!(0));
+        assert_eq!(row["row_count"], json!(42));
+        assert!(row["ai_context"].is_null());
+    }
+
+    #[tokio::test]
+    async fn pipeline_row_without_session_has_null_session_id() {
+        let store = QueryAuditStore::open_in_memory().await.unwrap();
+        let id = store
+            .record_pipeline_started("weekly-churn", None)
+            .await
+            .unwrap();
+        let row = store.get(&id).await.unwrap().unwrap();
+        assert!(row["session_id"].is_null());
+    }
+
+    #[tokio::test]
+    async fn list_by_session_interleaves_queries_and_pipelines() {
+        let store = QueryAuditStore::open_in_memory().await.unwrap();
+        let ctx = serde_json::json!({"purpose": "p", "session_id": "sess-mix"});
+        store
+            .record_started("SELECT 1", Some(&ctx), 10, "Query")
+            .await
+            .unwrap();
+        store
+            .record_pipeline_started("weekly-churn", Some("sess-mix"))
+            .await
+            .unwrap();
+        let rows = store.list_by_session("sess-mix").await.unwrap();
+        assert_eq!(rows.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn orphaned_pipeline_rows_reconcile_to_unknown() {
+        let store = QueryAuditStore::open_in_memory().await.unwrap();
+        let id = store
+            .record_pipeline_started("weekly-churn", None)
+            .await
+            .unwrap();
+        let n = store.reconcile_orphaned("test restart").await.unwrap();
+        assert_eq!(n, 1);
+        let row = store.get(&id).await.unwrap().unwrap();
+        assert_eq!(row["status"], json!("unknown"));
     }
 }

--- a/crates/server/src/query_audit.rs
+++ b/crates/server/src/query_audit.rs
@@ -478,31 +478,41 @@ impl QueryAuditStore {
     /// failure here can only be observed via logging.
     fn spawn_timeout_correction(&self, id: String) {
         let conn = self.conn.clone();
+        // The correction is triggered by a stalled writer, which is exactly
+        // the condition under which awaiting it could never resolve — so the
+        // task gives up on the *await*, not on the work. The UPDATE closure
+        // is already in the channel by then and runs whenever the writer
+        // drains, whether or not anyone is still listening; bounding the
+        // await only stops one parked task per timed-out write from
+        // accumulating for the duration of the stall.
+        let correction_bound = self.write_timeout;
         tokio::spawn(async move {
             let finished_at = chrono::Utc::now().to_rfc3339();
-            let outcome = conn
-                .call(move |conn| -> SqlResult<usize> {
-                    conn.execute(
-                        "UPDATE query_audit
+            let update = conn.call(move |conn| -> SqlResult<usize> {
+                conn.execute(
+                    "UPDATE query_audit
                             SET status = ?2, finished_at = ?3, error = ?4
                           WHERE id = ?1 AND status = ?5",
-                        params![
-                            id,
-                            QueryAuditStatus::Failed.as_str(),
-                            finished_at,
-                            "audit_write_timeout",
-                            QueryAuditStatus::Started.as_str(),
-                        ],
-                    )
-                })
-                .await;
-            match outcome {
+                    params![
+                        id,
+                        QueryAuditStatus::Failed.as_str(),
+                        finished_at,
+                        "audit_write_timeout",
+                        QueryAuditStatus::Started.as_str(),
+                    ],
+                )
+            });
+            match tokio::time::timeout(correction_bound, update).await {
                 // 0 rows means either the INSERT never landed, or it landed
                 // and something else already moved it off `started` —
                 // either way there is nothing to correct.
-                Ok(_) => {}
-                Err(e) => tracing::warn!(
+                Ok(Ok(_)) => {}
+                Ok(Err(e)) => tracing::warn!(
                     "Failed to apply audit-write-timeout correction to query-audit record: {e}"
+                ),
+                Err(_) => tracing::warn!(
+                    "Audit-write-timeout correction still queued after {correction_bound:?}; \
+                     it will apply when the writer drains"
                 ),
             }
         });

--- a/crates/server/src/query_handlers.rs
+++ b/crates/server/src/query_handlers.rs
@@ -16,7 +16,7 @@ use skardi::sources::sql_validator::{SqlValidationError, StatementKind, validate
 use std::time::Instant;
 
 use crate::auth::routes::require_session;
-use crate::query_audit::QueryAuditStatus;
+use crate::query_audit::{MAX_SESSION_ID_CHARS, QueryAuditStatus, finish_audit};
 use crate::response::{
     ErrorResponse, create_error_response, create_success_response, record_batch_to_json,
 };
@@ -32,13 +32,9 @@ const QUERY_METRICS_LABEL: &str = "query";
 /// intent, not payloads; the cap keeps a runaway string out of the logs.
 const MAX_PURPOSE_CHARS: usize = 2000;
 
-/// Upper bound on the `session_id` field length (characters). It is an opaque
-/// grouping key, not a payload.
-///
-/// `pub(crate)`: also the cap for the pipeline execute endpoint's
-/// `x-skardi-session-id` header (see `pipeline_handlers::session_id_from_headers`)
-/// — one constant, so the two paths can't drift apart.
-pub(crate) const MAX_SESSION_ID_CHARS: usize = 200;
+// The session-id length cap (`MAX_SESSION_ID_CHARS`) lives in `query_audit`,
+// shared with the pipeline endpoint's header check so audited paths can't
+// drift apart.
 
 /// Upper bound on the serialized size of the whole `ai_context` object (bytes).
 /// The object is free-form beyond its two required fields; the cap keeps a
@@ -125,28 +121,9 @@ fn validate_context_string(
     }
 }
 
-/// Stamp the terminal outcome onto an audit record.
-///
-/// Unlike the pre-execution write, a failure here cannot un-run the query, so
-/// it is logged rather than surfaced: the row simply stays `started` and the
-/// next startup reconciles it to `unknown`. No-op when auditing is off.
-///
-/// `pub(crate)`: also called from `pipeline_handlers::execute_pipeline_by_name`
-/// to stamp pipeline-execution outcomes onto the same ledger.
-pub(crate) async fn finish_audit(
-    app_state: &AppState,
-    audit_id: Option<&str>,
-    status: QueryAuditStatus,
-    row_count: Option<usize>,
-    error: Option<&str>,
-) {
-    let (Some(store), Some(id)) = (&app_state.query_audit, audit_id) else {
-        return;
-    };
-    if let Err(e) = store.record_outcome(id, status, row_count, error).await {
-        tracing::error!("Failed to record query-audit outcome for {id}: {e}");
-    }
-}
+// `finish_audit` lives in `query_audit`: its contract (no-op when auditing is
+// off; a failed outcome write leaves the row `started` for startup reconcile)
+// is the ledger's, not `/query`'s, and it is shared with `pipeline_handlers`.
 
 /// Execute ad-hoc SQL endpoint - POST /query
 pub async fn execute_query(
@@ -317,7 +294,7 @@ pub async fn execute_query(
             // logged here — it lives only in the opt-in audit ledger.
             tracing::error!("Ad-hoc query execution failed: {}", e);
             finish_audit(
-                &app_state,
+                app_state.query_audit.as_deref(),
                 audit_id.as_deref(),
                 QueryAuditStatus::Failed,
                 None,
@@ -366,7 +343,7 @@ pub async fn execute_query(
                 record_batch.num_rows()
             );
             finish_audit(
-                &app_state,
+                app_state.query_audit.as_deref(),
                 audit_id.as_deref(),
                 QueryAuditStatus::Failed,
                 Some(record_batch.num_rows()),
@@ -396,7 +373,7 @@ pub async fn execute_query(
     let row_count = record_batch.num_rows();
 
     finish_audit(
-        &app_state,
+        app_state.query_audit.as_deref(),
         audit_id.as_deref(),
         QueryAuditStatus::Succeeded,
         Some(row_count),

--- a/crates/server/src/query_handlers.rs
+++ b/crates/server/src/query_handlers.rs
@@ -34,7 +34,11 @@ const MAX_PURPOSE_CHARS: usize = 2000;
 
 /// Upper bound on the `session_id` field length (characters). It is an opaque
 /// grouping key, not a payload.
-const MAX_SESSION_ID_CHARS: usize = 200;
+///
+/// `pub(crate)`: also the cap for the pipeline execute endpoint's
+/// `x-skardi-session-id` header (see `pipeline_handlers::session_id_from_headers`)
+/// — one constant, so the two paths can't drift apart.
+pub(crate) const MAX_SESSION_ID_CHARS: usize = 200;
 
 /// Upper bound on the serialized size of the whole `ai_context` object (bytes).
 /// The object is free-form beyond its two required fields; the cap keeps a
@@ -126,7 +130,10 @@ fn validate_context_string(
 /// Unlike the pre-execution write, a failure here cannot un-run the query, so
 /// it is logged rather than surfaced: the row simply stays `started` and the
 /// next startup reconciles it to `unknown`. No-op when auditing is off.
-async fn finish_audit(
+///
+/// `pub(crate)`: also called from `pipeline_handlers::execute_pipeline_by_name`
+/// to stamp pipeline-execution outcomes onto the same ledger.
+pub(crate) async fn finish_audit(
     app_state: &AppState,
     audit_id: Option<&str>,
     status: QueryAuditStatus,

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -253,7 +253,10 @@ pub async fn setup_app_state(config: ServerConfig) -> Result<AppState> {
     // record would be worse than none at all.
     let query_audit = match config.args.query_audit_db.as_ref() {
         Some(path) => {
-            tracing::info!("Opening /query audit ledger at {}", path.display());
+            tracing::info!(
+                "Opening query-audit ledger (ad-hoc + pipeline executions) at {}",
+                path.display()
+            );
             let store = Arc::new(QueryAuditStore::open(path).await.with_context(|| {
                 format!("Failed to open --query-audit-db at {}", path.display())
             })?);
@@ -262,7 +265,7 @@ pub async fn setup_app_state(config: ServerConfig) -> Result<AppState> {
                 .await?;
             if orphaned > 0 {
                 tracing::warn!(
-                    "Reconciled {} /query audit record(s) left in flight by a previous run",
+                    "Reconciled {} query-audit record(s) left in flight by a previous run",
                     orphaned
                 );
             }

--- a/crates/server/tests/pipeline_audit_http.rs
+++ b/crates/server/tests/pipeline_audit_http.rs
@@ -303,6 +303,25 @@ async fn malformed_session_header_is_400_and_records_nothing() {
 }
 
 #[tokio::test]
+async fn duplicate_session_header_is_400_and_records_nothing() {
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    let resp = execute_with_headers(
+        &state,
+        &[
+            ("x-skardi-session-id", "sess-1"),
+            ("x-skardi-session-id", "sess-2"),
+        ],
+        json!({"limit": 5}),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = body_to_json(resp).await;
+    assert_eq!(body["error_type"], json!("parameter_validation_error"));
+    assert_eq!(store.count().await.unwrap(), 0);
+}
+
+#[tokio::test]
 async fn audit_write_failure_is_503_and_pipeline_does_not_run() {
     let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
     let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;

--- a/crates/server/tests/pipeline_audit_http.rs
+++ b/crates/server/tests/pipeline_audit_http.rs
@@ -1,0 +1,187 @@
+//! HTTP integration tests for pipeline-execution auditing
+//! (`POST /:name/execute`) — mirrors the `/query` audit coverage in
+//! `query_http.rs`, but exercises the pipeline path: record-before-execute,
+//! the `x-skardi-session-id` header, and value-free recording (only the
+//! pipeline name is ever written, never parameter values).
+
+use arrow::array::{Float64Array, Int64Array, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use datafusion::prelude::SessionContext;
+use serde_json::{Value, json};
+use skardi::pipeline::pipeline::{Pipeline, StandardPipeline};
+use std::collections::HashMap;
+use std::io::Write;
+use std::sync::Arc;
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+use skardi_server::auth::layer::AuthLayer;
+use skardi_server::config::{CliArgs, ServerConfig};
+use skardi_server::query_audit::QueryAuditStore;
+use skardi_server::semantics::SemanticsRegistry;
+use skardi_server::server::{AppState, configure_routes};
+
+/// Name of the pipeline registered by `make_app_state`. Bound as a `const`
+/// so assertions and the YAML fixture below stay in sync.
+const TEST_PIPELINE_NAME: &str = "product-search";
+
+fn write_yaml(path: &std::path::Path, content: &str) {
+    let mut f = std::fs::File::create(path).unwrap();
+    f.write_all(content.as_bytes()).unwrap();
+}
+
+/// Five-row `products` MemTable: id, brand, price, category. Used as the
+/// fact table for the pipeline's SELECT.
+fn products_batch() -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("brand", DataType::Utf8, false),
+        Field::new("price", DataType::Float64, false),
+        Field::new("category", DataType::Utf8, false),
+    ]));
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(vec![1i64, 2, 3, 4, 5])),
+            Arc::new(StringArray::from(vec![
+                "Apple", "Sony", "Apple", "Samsung", "Apple",
+            ])),
+            Arc::new(Float64Array::from(vec![
+                1299.0, 199.0, 999.0, 599.0, 2499.0,
+            ])),
+            Arc::new(StringArray::from(vec![
+                "Electronics",
+                "Audio",
+                "Electronics",
+                "Electronics",
+                "Electronics",
+            ])),
+        ],
+    )
+    .unwrap()
+}
+
+/// Build an `AppState` with a `products` MemTable, the `product-search`
+/// pipeline loaded from disk in envelope format, and — when requested — an
+/// operator audit ledger wired in.
+async fn make_app_state(query_audit: Option<Arc<QueryAuditStore>>) -> (AppState, TempDir) {
+    let tmp = TempDir::new().unwrap();
+    let ctx = Arc::new(SessionContext::new());
+    ctx.register_batch("products", products_batch()).unwrap();
+
+    let mut pipelines: HashMap<String, StandardPipeline> = HashMap::new();
+    let yaml_path = tmp.path().join("product-search.yaml");
+    write_yaml(
+        &yaml_path,
+        r#"
+kind: pipeline
+metadata:
+  name: "product-search"
+  version: "1.0.0"
+  description: "Filter products by brand + max price"
+spec:
+  query: |
+    SELECT id, brand, price, category
+    FROM products
+    WHERE brand = {brand} AND price <= {max_price}
+    ORDER BY price DESC
+"#,
+    );
+    let pipeline = StandardPipeline::load_from_file(&yaml_path, Arc::clone(&ctx))
+        .await
+        .unwrap();
+    pipelines.insert(pipeline.name().to_string(), pipeline);
+
+    let engine = Arc::new(skardi::engine::datafusion::DataFusionEngine::new_with_arc(
+        Arc::clone(&ctx),
+    ));
+    let config = ServerConfig {
+        pipelines,
+        jobs: HashMap::new(),
+        data_sources: vec![],
+        semantics: SemanticsRegistry::default(),
+        args: CliArgs {
+            pipeline_path: None,
+            jobs_path: None,
+            jobs_db_path: None,
+            ctx_file: None,
+            semantics_path: None,
+            port: 0,
+            query_audit_db: None,
+            query_audit_retention_days: None,
+        },
+    };
+    let state = AppState::new(
+        config,
+        engine,
+        Arc::clone(&ctx),
+        AuthLayer::None,
+        None,
+        query_audit,
+    );
+    (state, tmp)
+}
+
+/// POST `{"brand": "Apple", "max_price": ...}`-shaped params to
+/// `/product-search/execute`, attaching the given extra headers.
+async fn execute_with_headers(
+    state: &AppState,
+    headers: &[(&str, &str)],
+    params: Value,
+) -> axum::response::Response {
+    let app = configure_routes(state.clone());
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri(format!("/{TEST_PIPELINE_NAME}/execute"))
+        .header("content-type", "application/json");
+    for (name, value) in headers {
+        builder = builder.header(*name, *value);
+    }
+    app.oneshot(builder.body(Body::from(params.to_string())).unwrap())
+        .await
+        .unwrap()
+}
+
+/// Full parameter set the fixture pipeline needs to execute successfully.
+fn valid_params() -> Value {
+    json!({"brand": "Apple", "max_price": 1500.0})
+}
+
+#[tokio::test]
+async fn successful_execution_is_audited_with_session() {
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    let resp =
+        execute_with_headers(&state, &[("x-skardi-session-id", "sess-9")], valid_params()).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let rows = store.list_by_session("sess-9").await.unwrap();
+    assert_eq!(rows.len(), 1);
+    let row = &rows[0];
+    assert_eq!(row["statement_kind"], "pipeline");
+    assert_eq!(row["sql"], TEST_PIPELINE_NAME);
+    assert_eq!(row["status"], "succeeded");
+    assert!(row["row_count"].as_u64().is_some());
+    assert!(row["ai_context"].is_null());
+}
+
+#[tokio::test]
+async fn execution_without_header_audits_null_session() {
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    let resp = execute_with_headers(&state, &[], valid_params()).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(store.count().await.unwrap(), 1);
+    // Not reachable via list_by_session: session_id is NULL.
+    assert!(store.list_by_session("").await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn no_store_configured_executes_without_recording() {
+    let (state, _tmp) = make_app_state(None).await;
+    let resp = execute_with_headers(&state, &[], valid_params()).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+}

--- a/crates/server/tests/pipeline_audit_http.rs
+++ b/crates/server/tests/pipeline_audit_http.rs
@@ -4,8 +4,9 @@
 //! the `x-skardi-session-id` header, and value-free recording (only the
 //! pipeline name is ever written, never parameter values).
 
-use arrow::array::{Float64Array, Int64Array, StringArray};
-use arrow::datatypes::{DataType, Field, Schema};
+use arrow::array::{Float64Array, Int64Array, StringArray, UnionArray};
+use arrow::buffer::ScalarBuffer;
+use arrow::datatypes::{DataType, Field, Schema, UnionFields, UnionMode};
 use arrow::record_batch::RecordBatch;
 use axum::body::Body;
 use axum::http::{HeaderValue, Request, StatusCode};
@@ -35,6 +36,15 @@ const TEST_PIPELINE_NAME: &str = "product-search";
 /// execution fails inside the engine (not at parameter validation),
 /// exercising the `query_execution_error` audit path.
 const BROKEN_PIPELINE_NAME: &str = "broken-pipeline";
+
+/// Version set in every fixture pipeline's `metadata.version`; ledger rows
+/// store `sql = "<name>@<version>"`.
+const TEST_PIPELINE_VERSION: &str = "1.0.0";
+
+/// Name of the third fixture pipeline, whose SQL executes fine but yields a
+/// column arrow-json cannot serialize (a sparse `Union`), forcing the
+/// `result_conversion_error` audit path: `Failed` *with* a row_count.
+const CONVERSION_POISON_PIPELINE_NAME: &str = "conversion-poison";
 
 fn write_yaml(path: &std::path::Path, content: &str) {
     let mut f = std::fs::File::create(path).unwrap();
@@ -128,6 +138,46 @@ spec:
         .unwrap();
     pipelines.insert(broken_pipeline.name().to_string(), broken_pipeline);
     ctx.deregister_table("vanishing_table").unwrap();
+
+    // A third pipeline whose SQL executes successfully but yields a Union
+    // column — the one Arrow type arrow-json's encoder rejects that a scan
+    // can actually produce (temporals, decimals, binary, nested types are
+    // all encodable) — the fixture for the `result_conversion_error` path.
+    let union_fields: UnionFields = [(0i8, Arc::new(Field::new("a", DataType::Int64, false)))]
+        .into_iter()
+        .collect();
+    let union_array = UnionArray::try_new(
+        union_fields.clone(),
+        ScalarBuffer::from(vec![0i8]),
+        None,
+        vec![Arc::new(Int64Array::from(vec![7i64]))],
+    )
+    .unwrap();
+    let union_schema = Arc::new(Schema::new(vec![Field::new(
+        "u",
+        DataType::Union(union_fields, UnionMode::Sparse),
+        false,
+    )]));
+    let union_batch = RecordBatch::try_new(union_schema, vec![Arc::new(union_array)]).unwrap();
+    ctx.register_batch("union_poison", union_batch).unwrap();
+    let poison_yaml_path = tmp.path().join("conversion-poison.yaml");
+    write_yaml(
+        &poison_yaml_path,
+        r#"
+kind: pipeline
+metadata:
+  name: "conversion-poison"
+  version: "1.0.0"
+  description: "Executes fine; result cannot be converted to JSON"
+spec:
+  query: |
+    SELECT u FROM union_poison
+"#,
+    );
+    let poison_pipeline = StandardPipeline::load_from_file(&poison_yaml_path, Arc::clone(&ctx))
+        .await
+        .unwrap();
+    pipelines.insert(poison_pipeline.name().to_string(), poison_pipeline);
 
     let engine = Arc::new(skardi::engine::datafusion::DataFusionEngine::new_with_arc(
         Arc::clone(&ctx),
@@ -225,7 +275,10 @@ async fn successful_execution_is_audited_with_session() {
     assert_eq!(rows.len(), 1);
     let row = &rows[0];
     assert_eq!(row["statement_kind"], "pipeline");
-    assert_eq!(row["sql"], TEST_PIPELINE_NAME);
+    assert_eq!(
+        row["sql"],
+        format!("{TEST_PIPELINE_NAME}@{TEST_PIPELINE_VERSION}")
+    );
     assert_eq!(row["status"], "succeeded");
     // Deterministic fixture: Apple rows at 1299.0 and 999.0 pass the 1500.0
     // cap; the 2499.0 one doesn't. An exact count catches a handler that
@@ -322,7 +375,11 @@ async fn execution_without_header_audits_null_session() {
 }
 
 #[tokio::test]
-async fn no_store_configured_executes_without_recording() {
+async fn no_store_configured_still_executes() {
+    // "Without recording" is unverifiable here — there is no store to
+    // inspect — so this pins only what it can: execution succeeds. The
+    // no-recording half is covered structurally by the handler's
+    // `Option<QueryAuditStore>` (`None => None`).
     let (state, _tmp) = make_app_state(None).await;
     let resp = execute_with_headers(&state, &[], valid_params()).await;
     assert_eq!(resp.status(), StatusCode::OK);
@@ -367,7 +424,14 @@ async fn param_validation_failure_records_nothing() {
 async fn malformed_session_header_is_400_and_records_nothing() {
     let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
     let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
-    for bad in [String::new(), "x".repeat(201)] {
+    for bad in [
+        String::new(),
+        "x".repeat(201),
+        "tab\there".to_string(),
+        // The shape a proxy produces by merging two header lines (RFC 9110
+        // §5.3) — must be rejected like a direct duplicate.
+        "sess-1, sess-2".to_string(),
+    ] {
         // The body must be one that would otherwise succeed, so the header is
         // the only possible reject cause — an invalid body 400s with the same
         // error_type at parameter validation, which would make this test pass
@@ -425,13 +489,66 @@ async fn audit_write_failure_is_503_and_pipeline_does_not_run() {
     let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
     let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
     store.close_for_test().await;
-    // Must be a fully valid parameter set: parameter validation runs before
-    // the audit-started write, so an invalid body (like the brief's
-    // `{"limit": 5}`, which this fixture's pipeline doesn't accept) would
-    // 400 out at validation and never reach the audit write this test
-    // targets.
-    let resp = execute_with_headers(&state, &[], valid_params()).await;
+    // Targeting the BROKEN pipeline makes "does not run" observable: its
+    // engine execution can only fail, so if the handler ran the query first
+    // and audited after, this would be a 500 query_execution_error. Getting
+    // 503 query_audit_error proves the engine was never reached — i.e. the
+    // record-before-execute ordering, which is what fail-closed exists for.
+    // (The body must still be valid: the broken pipeline takes no params,
+    // and an invalid body would 400 out before the audit write.)
+    let resp = execute_broken_pipeline(&state, &[]).await;
     assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
     let body = body_to_json(resp).await;
     assert_eq!(body["error_type"], json!("query_audit_error"));
+}
+
+/// The conversion-failure audit path: SQL executes, arrow-json cannot
+/// serialize the result. Distinct row shape — `failed` *with* a row_count —
+/// and the fixed error kind is the security-relevant half of the branch.
+#[tokio::test]
+async fn conversion_failure_is_audited_as_failed_with_row_count() {
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    let app = configure_routes(state.clone());
+    let request = Request::builder()
+        .method("POST")
+        .uri(format!("/{CONVERSION_POISON_PIPELINE_NAME}/execute"))
+        .header("content-type", "application/json")
+        .header("x-skardi-session-id", "sess-conv")
+        .body(Body::from(json!({}).to_string()))
+        .unwrap();
+    let resp = app.oneshot(request).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let body = body_to_json(resp).await;
+    assert_eq!(body["error_type"], json!("result_conversion_error"));
+
+    let rows = store.list_by_session("sess-conv").await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["status"], json!("failed"));
+    assert_eq!(rows[0]["error"], json!("result_conversion_error"));
+    assert_eq!(rows[0]["row_count"], json!(1));
+}
+
+/// An unknown pipeline 404s regardless of header shape: the session header
+/// is validated only after the pipeline lookup, so the reject metric's
+/// `pipeline` label is bounded to configured names — before this ordering,
+/// an unauthenticated caller could mint unbounded metric cardinality from
+/// arbitrary URL segments.
+#[tokio::test]
+async fn unknown_pipeline_with_malformed_header_is_404() {
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    let app = configure_routes(state.clone());
+    let request = Request::builder()
+        .method("POST")
+        .uri("/no-such-pipeline/execute")
+        .header("content-type", "application/json")
+        .header("x-skardi-session-id", "")
+        .body(Body::from(json!({}).to_string()))
+        .unwrap();
+    let resp = app.oneshot(request).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let body = body_to_json(resp).await;
+    assert_eq!(body["error_type"], json!("pipeline_not_found"));
+    assert_eq!(store.count().await.unwrap(), 0);
 }

--- a/crates/server/tests/pipeline_audit_http.rs
+++ b/crates/server/tests/pipeline_audit_http.rs
@@ -15,13 +15,15 @@ use http_body_util::BodyExt;
 use serde_json::{Value, json};
 use skardi::pipeline::pipeline::{Pipeline, StandardPipeline};
 use std::collections::HashMap;
-use std::io::Write;
-use std::sync::Arc;
+use std::io::{self, Write as _};
+use std::sync::{Arc, Mutex};
 use tempfile::TempDir;
 use tower::ServiceExt;
+use tracing_subscriber::layer::SubscriberExt;
 
 use skardi_server::auth::layer::AuthLayer;
 use skardi_server::config::{CliArgs, ServerConfig};
+use skardi_server::logging::build_env_filter;
 use skardi_server::query_audit::QueryAuditStore;
 use skardi_server::semantics::SemanticsRegistry;
 use skardi_server::server::{AppState, configure_routes};
@@ -431,6 +433,15 @@ async fn malformed_session_header_is_400_and_records_nothing() {
         // The shape a proxy produces by merging two header lines (RFC 9110
         // §5.3) — must be rejected like a direct duplicate.
         "sess-1, sess-2".to_string(),
+        // Spaces-only and an interior space: a grouping key has no
+        // legitimate use for spaces, and tolerating them either invites the
+        // fail-late round trip described on `session_id_from_headers` (a
+        // value that's all whitespace would 400 here but pass a
+        // pre-transport client-side check that merely tolerated space) or
+        // silent misattribution (interior spaces surviving wire transport
+        // unstripped, unlike the leading/trailing case httparse handles).
+        "   ".to_string(),
+        "sess 1".to_string(),
     ] {
         // The body must be one that would otherwise succeed, so the header is
         // the only possible reject cause — an invalid body 400s with the same
@@ -451,6 +462,15 @@ async fn malformed_session_header_is_400_and_records_nothing() {
                 .unwrap()
                 .contains("x-skardi-session-id"),
             "expected the session-header reject, got {body}"
+        );
+        // The header reject must carry a details payload naming the offending
+        // header — previously it passed `None`, so an agent branching on
+        // `error_type` alone (the contract `docs/pipelines.md` sells) could
+        // not tell a bad header apart from a bad SQL parameter, which also
+        // returns `parameter_validation_error`.
+        assert_eq!(
+            body["details"]["header"], "x-skardi-session-id",
+            "expected the header reject to name the offending header, got {body}"
         );
     }
     assert_eq!(store.count().await.unwrap(), 0);
@@ -551,4 +571,103 @@ async fn unknown_pipeline_with_malformed_header_is_404() {
     let body = body_to_json(resp).await;
     assert_eq!(body["error_type"], json!("pipeline_not_found"));
     assert_eq!(store.count().await.unwrap(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Finding 1: an unknown-pipeline request must be observable somewhere even
+// though the ordering fix in `execute_pipeline_by_name` deliberately defers
+// the metric-emitting reject past the pipeline lookup (see the comment on
+// `unknown_pipeline_with_malformed_header_is_404` above). The 404 branch logs
+// a `tracing::warn!` naming the requested pipeline; this test captures the
+// tracing subscriber's own formatted output — not just the HTTP response —
+// so a future change that silently drops the log would fail here even though
+// the response body is untouched.
+// ---------------------------------------------------------------------------
+
+/// Shared buffer behind a `MakeWriter`, so the test can read back everything
+/// the fmt layer formatted. Mirrors the identical harness in
+/// `query_plan_logging.rs`.
+#[derive(Clone, Default)]
+struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+impl CaptureWriter {
+    fn contents(&self) -> String {
+        String::from_utf8_lossy(&self.0.lock().unwrap_or_else(|p| p.into_inner())).into_owned()
+    }
+}
+
+impl io::Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+    type Writer = CaptureWriter;
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+/// Runs `unknown_pipeline_with_malformed_header_is_404`'s request under a
+/// captured subscriber and returns everything it formatted.
+///
+/// Deliberately a plain `#[test]` driving its own current-thread runtime
+/// (the same pattern `query_plan_logging.rs` uses), rather than
+/// `#[tokio::test]`: `tracing::subscriber::with_default` installs a
+/// thread-local dispatcher, which only stays valid across `.await` points if
+/// the whole future is guaranteed to stay on one OS thread — true for a
+/// runtime built with `new_current_thread`, not guaranteed for the
+/// multi-threaded default some other test binaries opt into.
+fn capture_unknown_pipeline_request_logs() -> String {
+    let capture = CaptureWriter::default();
+    let subscriber = tracing_subscriber::registry()
+        .with(build_env_filter(Some("warn"), false))
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_writer(capture.clone())
+                .with_ansi(false),
+        );
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    tracing::subscriber::with_default(subscriber, || {
+        runtime.block_on(async {
+            let (state, _tmp) = make_app_state(None).await;
+            let app = configure_routes(state);
+            let request = Request::builder()
+                .method("POST")
+                .uri("/no-such-pipeline/execute")
+                .header("content-type", "application/json")
+                .body(Body::from(json!({}).to_string()))
+                .unwrap();
+            let resp = app.oneshot(request).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        });
+    });
+
+    capture.contents()
+}
+
+#[test]
+fn unknown_pipeline_request_is_logged() {
+    let logs = capture_unknown_pipeline_request_logs();
+    assert!(
+        logs.contains("no-such-pipeline"),
+        "expected the unknown pipeline name in the captured log output, got:\n{logs}"
+    );
+    assert!(
+        logs.to_uppercase().contains("WARN"),
+        "expected a WARN-level record, got:\n{logs}"
+    );
 }

--- a/crates/server/tests/pipeline_audit_http.rs
+++ b/crates/server/tests/pipeline_audit_http.rs
@@ -574,7 +574,8 @@ async fn unknown_pipeline_with_malformed_header_is_404() {
 }
 
 // ---------------------------------------------------------------------------
-// Finding 1: an unknown-pipeline request must be observable somewhere even
+// Observability regression guard: an unknown-pipeline request must be
+// observable somewhere even
 // though the ordering fix in `execute_pipeline_by_name` deliberately defers
 // the metric-emitting reject past the pipeline lookup (see the comment on
 // `unknown_pipeline_with_malformed_header_is_404` above). The 404 branch logs

--- a/crates/server/tests/pipeline_audit_http.rs
+++ b/crates/server/tests/pipeline_audit_http.rs
@@ -10,6 +10,7 @@ use arrow::record_batch::RecordBatch;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use datafusion::prelude::SessionContext;
+use http_body_util::BodyExt;
 use serde_json::{Value, json};
 use skardi::pipeline::pipeline::{Pipeline, StandardPipeline};
 use std::collections::HashMap;
@@ -27,6 +28,13 @@ use skardi_server::server::{AppState, configure_routes};
 /// Name of the pipeline registered by `make_app_state`. Bound as a `const`
 /// so assertions and the YAML fixture below stay in sync.
 const TEST_PIPELINE_NAME: &str = "product-search";
+
+/// Name of the second, intentionally-broken pipeline registered by
+/// `make_app_state` — its SQL references a table that existed only long
+/// enough for load-time schema inference and was then deregistered, so
+/// execution fails inside the engine (not at parameter validation),
+/// exercising the `query_execution_error` audit path.
+const BROKEN_PIPELINE_NAME: &str = "broken-pipeline";
 
 fn write_yaml(path: &std::path::Path, content: &str) {
     let mut f = std::fs::File::create(path).unwrap();
@@ -95,6 +103,32 @@ spec:
         .unwrap();
     pipelines.insert(pipeline.name().to_string(), pipeline);
 
+    // A second pipeline whose SQL targets a table that is present at load
+    // time (schema inference needs it to exist) but removed immediately
+    // after, so `engine.execute` fails at runtime rather than at parameter
+    // validation — the fixture for `engine_failure_is_audited_as_failed`.
+    ctx.register_batch("vanishing_table", products_batch())
+        .unwrap();
+    let broken_yaml_path = tmp.path().join("broken-pipeline.yaml");
+    write_yaml(
+        &broken_yaml_path,
+        r#"
+kind: pipeline
+metadata:
+  name: "broken-pipeline"
+  version: "1.0.0"
+  description: "References a table removed after load, to force an engine-execution failure"
+spec:
+  query: |
+    SELECT id FROM vanishing_table
+"#,
+    );
+    let broken_pipeline = StandardPipeline::load_from_file(&broken_yaml_path, Arc::clone(&ctx))
+        .await
+        .unwrap();
+    pipelines.insert(broken_pipeline.name().to_string(), broken_pipeline);
+    ctx.deregister_table("vanishing_table").unwrap();
+
     let engine = Arc::new(skardi::engine::datafusion::DataFusionEngine::new_with_arc(
         Arc::clone(&ctx),
     ));
@@ -150,6 +184,35 @@ fn valid_params() -> Value {
     json!({"brand": "Apple", "max_price": 1500.0})
 }
 
+/// POST an (empty) body to `/{BROKEN_PIPELINE_NAME}/execute`, attaching the
+/// given extra headers. The broken pipeline takes no parameters, so an
+/// empty JSON object is a complete, valid request body — any failure comes
+/// from the engine, not parameter validation.
+async fn execute_broken_pipeline(
+    state: &AppState,
+    headers: &[(&str, &str)],
+) -> axum::response::Response {
+    let app = configure_routes(state.clone());
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri(format!("/{BROKEN_PIPELINE_NAME}/execute"))
+        .header("content-type", "application/json");
+    for (name, value) in headers {
+        builder = builder.header(*name, *value);
+    }
+    app.oneshot(builder.body(Body::from(json!({}).to_string())).unwrap())
+        .await
+        .unwrap()
+}
+
+/// Parse a response body as JSON. Only the failure-path tests need to
+/// inspect `error_type`; the happy-path tests above read the audit ledger
+/// instead.
+async fn body_to_json(resp: axum::response::Response) -> Value {
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
 #[tokio::test]
 async fn successful_execution_is_audited_with_session() {
     let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
@@ -184,4 +247,73 @@ async fn no_store_configured_executes_without_recording() {
     let (state, _tmp) = make_app_state(None).await;
     let resp = execute_with_headers(&state, &[], valid_params()).await;
     assert_eq!(resp.status(), StatusCode::OK);
+}
+
+// ---------------------------------------------------------------------------
+// Failure paths: an engine failure must still be audited as `failed`, a
+// validation failure must record nothing, a malformed session header must
+// be rejected before any pipeline work happens, and an unwritable audit
+// store must fail closed (no execution) rather than silently skip auditing.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn engine_failure_is_audited_as_failed() {
+    // The broken pipeline's SQL references a table that was deregistered
+    // from the DataFusion context right after load, so the engine call
+    // itself fails (past parameter validation, past the audit-started
+    // write).
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    let resp = execute_broken_pipeline(&state, &[("x-skardi-session-id", "sess-f")]).await;
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let rows = store.list_by_session("sess-f").await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["status"], "failed");
+    // The ledger stores a fixed, value-free error kind — never the raw
+    // engine error text, which could echo a caller-supplied parameter value
+    // substituted directly into the SQL as a literal.
+    assert_eq!(rows[0]["error"], "query_execution_error");
+}
+
+#[tokio::test]
+async fn param_validation_failure_records_nothing() {
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    let resp = execute_with_headers(&state, &[], json!({})).await; // missing required param
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(store.count().await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn malformed_session_header_is_400_and_records_nothing() {
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    for bad in [String::new(), "x".repeat(201)] {
+        let resp = execute_with_headers(
+            &state,
+            &[("x-skardi-session-id", bad.as_str())],
+            json!({"limit": 5}),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = body_to_json(resp).await;
+        assert_eq!(body["error_type"], json!("parameter_validation_error"));
+    }
+    assert_eq!(store.count().await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn audit_write_failure_is_503_and_pipeline_does_not_run() {
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    store.close_for_test().await;
+    // Must be a fully valid parameter set: parameter validation runs before
+    // the audit-started write, so an invalid body (like the brief's
+    // `{"limit": 5}`, which this fixture's pipeline doesn't accept) would
+    // 400 out at validation and never reach the audit write this test
+    // targets.
+    let resp = execute_with_headers(&state, &[], valid_params()).await;
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let body = body_to_json(resp).await;
+    assert_eq!(body["error_type"], json!("query_audit_error"));
 }

--- a/crates/server/tests/pipeline_audit_http.rs
+++ b/crates/server/tests/pipeline_audit_http.rs
@@ -8,7 +8,7 @@ use arrow::array::{Float64Array, Int64Array, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use axum::body::Body;
-use axum::http::{Request, StatusCode};
+use axum::http::{HeaderValue, Request, StatusCode};
 use datafusion::prelude::SessionContext;
 use http_body_util::BodyExt;
 use serde_json::{Value, json};
@@ -227,8 +227,87 @@ async fn successful_execution_is_audited_with_session() {
     assert_eq!(row["statement_kind"], "pipeline");
     assert_eq!(row["sql"], TEST_PIPELINE_NAME);
     assert_eq!(row["status"], "succeeded");
-    assert!(row["row_count"].as_u64().is_some());
+    // Deterministic fixture: Apple rows at 1299.0 and 999.0 pass the 1500.0
+    // cap; the 2499.0 one doesn't. An exact count catches a handler that
+    // records the wrong number, which "is a number" would wave past.
+    assert_eq!(row["row_count"], json!(2));
     assert!(row["ai_context"].is_null());
+}
+
+/// The branch's central invariant, pinned end-to-end: no parameter value may
+/// reach any column of the ledger row — not `sql`, not `error`, not a future
+/// `ai_context` change. Greps the whole serialized row for a canary value so
+/// the test survives refactors of which column would leak.
+#[tokio::test]
+async fn parameter_values_never_reach_the_ledger() {
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    let resp = execute_with_headers(
+        &state,
+        &[("x-skardi-session-id", "sess-pii")],
+        json!({"brand": "PII-CANARY-42", "max_price": 1.0}),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let rows = store.list_by_session("sess-pii").await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert!(
+        !rows[0].to_string().contains("PII-CANARY-42"),
+        "a parameter value reached the ledger: {}",
+        rows[0]
+    );
+}
+
+/// The `to_str` reject (a header value outside visible ASCII) can't be built
+/// through `execute_with_headers` — `Request::builder().header()` refuses the
+/// bytes client-side — so this constructs the `HeaderValue` directly.
+#[tokio::test]
+async fn non_visible_ascii_session_header_is_400_and_records_nothing() {
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    let app = configure_routes(state.clone());
+    let request = Request::builder()
+        .method("POST")
+        .uri(format!("/{TEST_PIPELINE_NAME}/execute"))
+        .header("content-type", "application/json")
+        .header(
+            "x-skardi-session-id",
+            HeaderValue::from_bytes(&[0xff]).unwrap(),
+        )
+        .body(Body::from(valid_params().to_string()))
+        .unwrap();
+    let resp = app.oneshot(request).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = body_to_json(resp).await;
+    assert_eq!(body["error_type"], json!("parameter_validation_error"));
+    assert!(
+        body["error"].as_str().unwrap().contains("visible ASCII"),
+        "expected the ASCII reject, got {body}"
+    );
+    assert_eq!(store.count().await.unwrap(), 0);
+}
+
+/// The docs promise the header is validated whether or not auditing is
+/// enabled; this pins the audit-off half of that promise.
+#[tokio::test]
+async fn session_header_is_validated_even_with_auditing_off() {
+    let (state, _tmp) = make_app_state(None).await;
+    let resp = execute_with_headers(
+        &state,
+        &[("x-skardi-session-id", "x".repeat(201).as_str())],
+        valid_params(),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = body_to_json(resp).await;
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap()
+            .contains("x-skardi-session-id"),
+        "expected the session-header reject, got {body}"
+    );
 }
 
 #[tokio::test]
@@ -289,15 +368,26 @@ async fn malformed_session_header_is_400_and_records_nothing() {
     let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
     let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
     for bad in [String::new(), "x".repeat(201)] {
+        // The body must be one that would otherwise succeed, so the header is
+        // the only possible reject cause — an invalid body 400s with the same
+        // error_type at parameter validation, which would make this test pass
+        // even with the header check deleted.
         let resp = execute_with_headers(
             &state,
             &[("x-skardi-session-id", bad.as_str())],
-            json!({"limit": 5}),
+            valid_params(),
         )
         .await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         let body = body_to_json(resp).await;
         assert_eq!(body["error_type"], json!("parameter_validation_error"));
+        assert!(
+            body["error"]
+                .as_str()
+                .unwrap()
+                .contains("x-skardi-session-id"),
+            "expected the session-header reject, got {body}"
+        );
     }
     assert_eq!(store.count().await.unwrap(), 0);
 }
@@ -306,18 +396,27 @@ async fn malformed_session_header_is_400_and_records_nothing() {
 async fn duplicate_session_header_is_400_and_records_nothing() {
     let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
     let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    // Valid body for the same reason as the malformed-header test above: the
+    // header must be the only possible reject cause.
     let resp = execute_with_headers(
         &state,
         &[
             ("x-skardi-session-id", "sess-1"),
             ("x-skardi-session-id", "sess-2"),
         ],
-        json!({"limit": 5}),
+        valid_params(),
     )
     .await;
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     let body = body_to_json(resp).await;
     assert_eq!(body["error_type"], json!("parameter_validation_error"));
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap()
+            .contains("must not be sent more than once"),
+        "expected the duplicate-header reject, got {body}"
+    );
     assert_eq!(store.count().await.unwrap(), 0);
 }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -146,6 +146,9 @@ sends an array. A value only falls back to a plain string when it isn't
 valid JSON on its own (e.g. `-p name=hello`). This matters because the
 server substitutes typed literals into the pipeline's SQL.
 
+`--session-id <ID>` — sent as `X-Skardi-Session-Id`; groups this
+execution with an agent session in the server's query audit ledger.
+
 Calling a pipeline that doesn't exist on the server returns a friendly
 error instead of a raw 404:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -147,7 +147,13 @@ valid JSON on its own (e.g. `-p name=hello`). This matters because the
 server substitutes typed literals into the pipeline's SQL.
 
 `--session-id <ID>` — sent as `X-Skardi-Session-Id`; groups this
-execution with an agent session in the server's query audit ledger.
+execution with an agent session in the server's query audit ledger. The
+value is validated client-side before any request is sent (non-empty,
+≤ 200 characters, visible ASCII, no commas — the same rules the server
+enforces), so a bad value fails fast instead of surfacing as a connection
+error. When the server has auditing enabled, a `503` with `error_type
+"query_audit_error"` means the pipeline **did not run** and the call is
+safe to retry.
 
 Calling a pipeline that doesn't exist on the server returns a friendly
 error instead of a raw 404:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -149,9 +149,10 @@ server substitutes typed literals into the pipeline's SQL.
 `--session-id <ID>` — sent as `X-Skardi-Session-Id`; groups this
 execution with an agent session in the server's query audit ledger. The
 value is validated client-side before any request is sent (non-empty,
-≤ 200 characters, visible ASCII, no commas — the same rules the server
-enforces), so a bad value fails fast instead of surfacing as a connection
-error. When the server has auditing enabled, a `503` with `error_type
+≤ 200 characters, visible ASCII, no spaces, tabs or commas — byte-for-byte
+the rules the server enforces, so nothing can pass here and be rejected or
+silently rewritten there), so a bad value fails fast instead of surfacing as
+a connection error. When the server has auditing enabled, a `503` with `error_type
 "query_audit_error"` means the pipeline **did not run** and the call is
 safe to retry.
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -231,10 +231,13 @@ branch on without parsing human-readable text.
 
 Send `X-Skardi-Session-Id: <id>` (non-empty, ≤ 200 chars) with an execute
 request to group this run with the rest of an agent session in the query
-audit ledger (`--query-audit-db`). The header is optional and ignored when
-auditing is off. It is a header rather than a body field because the
-request body is the parameter map itself — a reserved key could collide
-with a SQL parameter of the same name.
+audit ledger (`--query-audit-db`). The header is optional. It is always
+validated — a malformed value (empty, over 200 characters, or invalid UTF-8)
+is rejected with `400 parameter_validation_error` whether or not auditing is
+enabled; a well-formed value is simply unused when `--query-audit-db` is not
+configured. It is a header rather than a body field because the request body
+is the parameter map itself — a reserved key could collide with a SQL
+parameter of the same name.
 
 ---
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -227,6 +227,15 @@ verb. Define a [user alias](cli.md) and
 `data_source_error`, `query_execution_error`, …) suitable for agents to
 branch on without parsing human-readable text.
 
+### Session attribution
+
+Send `X-Skardi-Session-Id: <id>` (non-empty, ≤ 200 chars) with an execute
+request to group this run with the rest of an agent session in the query
+audit ledger (`--query-audit-db`). The header is optional and ignored when
+auditing is off. It is a header rather than a body field because the
+request body is the parameter map itself — a reserved key could collide
+with a SQL parameter of the same name.
+
 ---
 
 ## Pipelines vs. jobs — picking the right shape

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -241,15 +241,22 @@ Send `X-Skardi-Session-Id: <id>` (non-empty, ≤ 200 chars) with an execute
 request to group this run with the rest of an agent session in the query
 audit ledger (`--query-audit-db`). The header is optional. It is always
 validated — a malformed value (empty, over 200 characters, outside visible
-ASCII, containing a comma or tab, or sent more than once) is rejected with
-`400 parameter_validation_error` whether or not auditing is enabled; a
-comma is rejected because proxies may merge repeated header lines into one
-comma-separated value (RFC 9110 §5.3), which would otherwise smuggle a
-duplicate past the duplicate check. A
-well-formed value is simply unused when `--query-audit-db` is not
-configured. It is a header rather than a body field because the request body
-is the parameter map itself — a reserved key could collide with a SQL
+ASCII, containing a space, tab or comma, or sent more than once) is rejected
+with `400 parameter_validation_error` whether or not auditing is enabled. The
+reject carries `details.header` so an agent can branch on it without parsing
+the message. Two of those rules earn their keep: a **comma** is rejected
+because proxies may merge repeated header lines into one comma-separated
+value (RFC 9110 §5.3), which would otherwise smuggle a duplicate past the
+duplicate check; a **space** is rejected because HTTP parsers trim leading and
+trailing whitespace (RFC 9110 §5.5), so ` sess-1 ` would be silently recorded
+under the different key `sess-1` — breaking the session stitching the field
+exists for. A well-formed value is simply unused when `--query-audit-db` is
+not configured. It is a header rather than a body field because the request
+body is the parameter map itself — a reserved key could collide with a SQL
 parameter of the same name.
+
+`session_id` is caller-asserted, not authenticated: it groups executions, it
+does not attest to their origin.
 
 ---
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -232,9 +232,10 @@ branch on without parsing human-readable text.
 Send `X-Skardi-Session-Id: <id>` (non-empty, ≤ 200 chars) with an execute
 request to group this run with the rest of an agent session in the query
 audit ledger (`--query-audit-db`). The header is optional. It is always
-validated — a malformed value (empty, over 200 characters, or invalid UTF-8)
-is rejected with `400 parameter_validation_error` whether or not auditing is
-enabled; a well-formed value is simply unused when `--query-audit-db` is not
+validated — a malformed value (empty, over 200 characters, containing
+non-ASCII characters, or sent more than once) is rejected with
+`400 parameter_validation_error` whether or not auditing is enabled; a
+well-formed value is simply unused when `--query-audit-db` is not
 configured. It is a header rather than a body field because the request body
 is the parameter map itself — a reserved key could collide with a SQL
 parameter of the same name.

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -227,14 +227,25 @@ verb. Define a [user alias](cli.md) and
 `data_source_error`, `query_execution_error`, …) suitable for agents to
 branch on without parsing human-readable text.
 
+One tag deserves special handling: **`query_audit_error` (HTTP 503)**. It
+appears only when the operator enabled the audit ledger
+(`--query-audit-db`) and the pre-execution audit write failed or timed out.
+It means **the pipeline did not run** — unlike a `500`, retrying later is
+exactly right, and unlike a `400` there is nothing to fix in the request.
+An agent that treats it as a generic failure either abandons work that
+never executed or hammers a stalled ledger; back off and retry instead.
+
 ### Session attribution
 
 Send `X-Skardi-Session-Id: <id>` (non-empty, ≤ 200 chars) with an execute
 request to group this run with the rest of an agent session in the query
 audit ledger (`--query-audit-db`). The header is optional. It is always
-validated — a malformed value (empty, over 200 characters, containing
-non-ASCII characters, or sent more than once) is rejected with
+validated — a malformed value (empty, over 200 characters, outside visible
+ASCII, containing a comma or tab, or sent more than once) is rejected with
 `400 parameter_validation_error` whether or not auditing is enabled; a
+comma is rejected because proxies may merge repeated header lines into one
+comma-separated value (RFC 9110 §5.3), which would otherwise smuggle a
+duplicate past the duplicate check. A
 well-formed value is simply unused when `--query-audit-db` is not
 configured. It is a header rather than a body field because the request body
 is the parameter map itself — a reserved key could collide with a SQL

--- a/docs/server.md
+++ b/docs/server.md
@@ -211,9 +211,12 @@ with the same record-before-execute and fail-closed semantics as `/query`
 (a failed pre-execution write returns 503 and the pipeline does not run).
 A pipeline row differs from an ad-hoc row in four ways:
 
-- `statement_kind` is `pipeline`, and the `sql` column holds the pipeline
-  *name*, not SQL — the template lives on disk, and the pipeline's
-  `description` carries its purpose.
+- `statement_kind` is `pipeline`, and the `sql` column holds
+  `name@version` (from `metadata.version`), not SQL — the versioned
+  template lives on disk, and the pipeline's `description` carries its
+  purpose. The version matters because pipelines are exactly the artifacts
+  the promotion loop edits, and rows are kept forever by default: without
+  it, "what SQL ran" stops being answerable once a template is revised.
 - Parameter values are never recorded: params are where PII lives.
   `ai_context` is always NULL on pipeline rows.
 - `max_rows` is stored as `0` (not applicable to pipelines).
@@ -223,16 +226,26 @@ A pipeline row differs from an ad-hoc row in four ways:
   ledger. The full error still goes to the HTTP caller.
 
 Scope of the guarantee: "parameter values never reach the ledger" covers the
-ledger only. The pipeline endpoint's HTTP *error responses* currently echo
-engine error text (which can quote parameter values back to the caller who
-sent them) — that surface is explicitly outside this guarantee and is
-tracked as a follow-up.
+ledger only. Four other surfaces on the pipeline path can still carry
+parameter values, all tracked in
+[#217](https://github.com/SkardiLabs/skardi/issues/217): HTTP `400` bodies
+(`error_details.unsupported_parameters` echoes offending values), HTTP `500`
+bodies (engine error text can quote values back to the caller who sent
+them), a `DEBUG`-level log of the substituted SQL, and — the widest one — an
+`ERROR`-level unsupported-parameter log that is on by default and fans out
+to any configured OTLP collector. Do not read the ledger's redaction as
+meaning the logs are covered: today it is the *logs* that reach external
+systems, not the ledger, which is a local `0600` file.
 
 Sizing note: with auditing on, every pipeline execution adds two
 `synchronous = FULL` ledger writes on the request's critical path — and the
-write is fail-closed, so a stalled or slow audit disk stalls pipeline
-execution rather than dropping records. Pipelines are typically the
-higher-QPS path (they are the promoted recurring queries), so put the
+write is fail-closed, so a failing audit disk turns into `503
+query_audit_error` rather than dropped records (each write is bounded by a
+5-second timeout, so a *hung* fsync is treated as a failed one instead of
+hanging the request). All ledger writes — `/query`'s included — funnel
+through one serialized writer thread, so this is a ceiling on total audited
+throughput, not just a per-request latency adder. Pipelines are typically
+the higher-QPS path (they are the promoted recurring queries), so put the
 ledger on storage you'd trust under your serving load.
 
 `session_id` comes from the optional `X-Skardi-Session-Id` request header
@@ -240,6 +253,13 @@ ledger on storage you'd trust under your serving load.
 parameter_validation_error` rather than silently dropped. With the header
 present, one agent session's ad-hoc queries and pipeline calls interleave
 under a single `session_id` in the ledger, ordered by `created_at`.
+
+Reachability caveat: producing that interleaving from the shipped CLI
+requires both halves, and today only `skardi run --session-id` exists —
+`skardi query` cannot send `ai_context` yet
+([#218](https://github.com/SkardiLabs/skardi/issues/218)), so the ad-hoc
+half of a CLI session lands unattributed until then. Direct HTTP callers
+get the full interleaving today.
 
 ---
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -178,7 +178,8 @@ execution and updated with its outcome afterwards:
 | `sql` | raw statement text |
 | `ai_context` | the caller's object, verbatim JSON |
 | `session_id` | denormalised from `ai_context` for indexed session lookup |
-| `max_rows`, `statement_kind` | request shape |
+| `max_rows` | requested row cap (`0` on pipeline rows — not applicable) |
+| `statement_kind` | `Query` or `Other` for ad-hoc rows (the `Debug` form of the server's statement classifier — not SQL verbs like `select`/`dml`), `pipeline` for pipeline rows. Consumers filtering the ledger must match these exact strings. |
 | `status` | `started` → `succeeded` / `failed`, or `unknown` after a crash |
 | `row_count`, `error` | outcome detail |
 
@@ -220,6 +221,19 @@ A pipeline row differs from an ad-hoc row in four ways:
   `result_conversion_error`), never engine error text — engine errors can
   echo substituted parameter values back, and those must not reach the
   ledger. The full error still goes to the HTTP caller.
+
+Scope of the guarantee: "parameter values never reach the ledger" covers the
+ledger only. The pipeline endpoint's HTTP *error responses* currently echo
+engine error text (which can quote parameter values back to the caller who
+sent them) — that surface is explicitly outside this guarantee and is
+tracked as a follow-up.
+
+Sizing note: with auditing on, every pipeline execution adds two
+`synchronous = FULL` ledger writes on the request's critical path — and the
+write is fail-closed, so a stalled or slow audit disk stalls pipeline
+execution rather than dropping records. Pipelines are typically the
+higher-QPS path (they are the promoted recurring queries), so put the
+ledger on storage you'd trust under your serving load.
 
 `session_id` comes from the optional `X-Skardi-Session-Id` request header
 (non-empty, ≤ 200 characters). A malformed header is rejected with `400

--- a/docs/server.md
+++ b/docs/server.md
@@ -183,8 +183,15 @@ execution and updated with its outcome afterwards:
 | `status` | `started` → `succeeded` / `failed`, or `unknown` after a crash |
 | `row_count`, `error` | outcome detail |
 
-Indexed on `(session_id, created_at)`, `created_at` and `status`, so an agent
-session can be reconstructed with plain SQL.
+Indexed on `(session_id, created_at)`, `created_at`, `status` and
+`statement_kind`, so an agent session can be reconstructed — and a single row
+kind selected — with plain SQL.
+
+What is **not** here: job runs. `POST /jobs/:name/run` executes its own SQL
+through the same engine but is recorded in the separate jobs run ledger (see
+[jobs.md](jobs.md)), not in `query_audit`. An operator reasoning about
+coverage during an incident should read this ledger as "ad-hoc queries and
+pipeline executions", not "everything the server ran".
 
 Failure semantics are explicit:
 
@@ -192,13 +199,23 @@ Failure semantics are explicit:
   to audit never runs silently unaudited.
 - **Before execution.** If the pre-execution write fails, the request is
   rejected with `503 query_audit_error` and the statement is **not executed**.
+  Each write is bounded (5s), so a *hung* fsync fails the request rather than
+  hanging it. Because an abandoned write may still land on the writer thread
+  afterwards, a timed-out pre-execution write is followed by a corrective
+  update marking that row `failed` with `error = audit_write_timeout` — the
+  server knows the statement did not run, and the ledger says so rather than
+  degrading to the ambiguous `unknown`.
 - **After execution.** A failed outcome update is logged only; the query
   already ran. The row stays `started` and the next startup reconciles it to
   `unknown`, as it does for statements killed mid-flight.
 
 Retention is opt-in: `--query-audit-retention-days <n>` deletes records older
 than `n` days at startup and hourly thereafter. Without it, records are kept
-forever and pruning is the operator's call.
+forever and pruning is the operator's call. The prune deletes in batches,
+yielding between them: it shares the ledger's single writer thread with the
+fail-closed write path, so an unchunked delete over a large backlog would
+starve concurrent requests into `503 query_audit_error`. Enabling retention
+for the first time on a big ledger is therefore slow, not disruptive.
 
 The ledger holds raw SQL, so it is created owner-only (`0600` on Unix,
 including the WAL sidecars). It is a local database, never the OTLP/tracing
@@ -217,6 +234,18 @@ A pipeline row differs from an ad-hoc row in four ways:
   purpose. The version matters because pipelines are exactly the artifacts
   the promotion loop edits, and rows are kept forever by default: without
   it, "what SQL ran" stops being answerable once a template is revised.
+
+  **Parse rule:** split on the *last* `@` (`rsplit_once('@')`). Pipeline
+  names are not charset-restricted, so a name may itself contain `@`
+  (`billing@eu@1.0.0` is the pipeline `billing@eu` at version `1.0.0`). A
+  trailing `@` with nothing after it means the pipeline declared an empty
+  `metadata.version` — a config smell in the pipeline, not a truncated row.
+
+  The version pins the **template**, not the exact statement: parameter
+  substitution is textual, so two executions of `weekly-churn@1.0.0` run
+  the same SQL skeleton with different literals. Values are deliberately
+  not recorded (see the confidentiality note above), so the ledger
+  identifies the artifact and its revision, not the byte-exact statement.
 - Parameter values are never recorded: params are where PII lives.
   `ai_context` is always NULL on pipeline rows.
 - `max_rows` is stored as `0` (not applicable to pipelines).
@@ -226,16 +255,17 @@ A pipeline row differs from an ad-hoc row in four ways:
   ledger. The full error still goes to the HTTP caller.
 
 Scope of the guarantee: "parameter values never reach the ledger" covers the
-ledger only. Four other surfaces on the pipeline path can still carry
-parameter values, all tracked in
+ledger only. The widest leak — an `ERROR`-level unsupported-parameter log
+that was on by default and fanned out to any configured OTLP collector — is
+closed: that line now logs the parameter's name and JSON type, never its
+contents. Three surfaces still carry parameter values and are tracked in
 [#217](https://github.com/SkardiLabs/skardi/issues/217): HTTP `400` bodies
 (`error_details.unsupported_parameters` echoes offending values), HTTP `500`
 bodies (engine error text can quote values back to the caller who sent
-them), a `DEBUG`-level log of the substituted SQL, and — the widest one — an
-`ERROR`-level unsupported-parameter log that is on by default and fans out
-to any configured OTLP collector. Do not read the ledger's redaction as
-meaning the logs are covered: today it is the *logs* that reach external
-systems, not the ledger, which is a local `0600` file.
+them), and a `DEBUG`-level log of the substituted SQL. The first two reach
+only the caller who supplied the values; the third requires an operator to
+raise `RUST_LOG`. Do not read the ledger's redaction as implying the logs
+are fully covered.
 
 Sizing note: with auditing on, every pipeline execution adds two
 `synchronous = FULL` ledger writes on the request's critical path — and the
@@ -249,10 +279,19 @@ the higher-QPS path (they are the promoted recurring queries), so put the
 ledger on storage you'd trust under your serving load.
 
 `session_id` comes from the optional `X-Skardi-Session-Id` request header
-(non-empty, ≤ 200 characters). A malformed header is rejected with `400
-parameter_validation_error` rather than silently dropped. With the header
-present, one agent session's ad-hoc queries and pipeline calls interleave
-under a single `session_id` in the ledger, ordered by `created_at`.
+(non-empty, ≤ 200 characters, visible ASCII with no spaces, tabs or commas).
+A malformed header is rejected with `400 parameter_validation_error` — carrying
+`details.header` so an agent can tell a header reject from a parameter reject
+— rather than silently dropped. With the header present, one agent session's
+ad-hoc queries and pipeline calls interleave under a single `session_id` in
+the ledger, ordered by `created_at`.
+
+**`session_id` is caller-asserted, not authenticated.** It groups executions;
+it does not attest to their origin. Any caller may stamp its executions with
+another agent's session id, or omit the header and land unattributed. Treat it
+as a correlation key when reading the ledger, never as evidence of who ran
+what. (Spaces are rejected precisely because HTTP intermediaries may trim
+surrounding whitespace, which would silently re-key an execution.)
 
 Reachability caveat: producing that interleaving from the shipped CLI
 requires both halves, and today only `skardi run --session-id` exists —

--- a/docs/server.md
+++ b/docs/server.md
@@ -203,6 +203,30 @@ The ledger holds raw SQL, so it is created owner-only (`0600` on Unix,
 including the WAL sidecars). It is a local database, never the OTLP/tracing
 pipeline, so enabling it does not push query text to external collectors.
 
+#### Pipeline executions in the ledger
+
+When `--query-audit-db` is configured, `POST /:pipeline/execute` is audited
+with the same record-before-execute and fail-closed semantics as `/query`
+(a failed pre-execution write returns 503 and the pipeline does not run).
+A pipeline row differs from an ad-hoc row in four ways:
+
+- `statement_kind` is `pipeline`, and the `sql` column holds the pipeline
+  *name*, not SQL — the template lives on disk, and the pipeline's
+  `description` carries its purpose.
+- Parameter values are never recorded: params are where PII lives.
+  `ai_context` is always NULL on pipeline rows.
+- `max_rows` is stored as `0` (not applicable to pipelines).
+- On failure, `error` holds a fixed kind (`query_execution_error` or
+  `result_conversion_error`), never engine error text — engine errors can
+  echo substituted parameter values back, and those must not reach the
+  ledger. The full error still goes to the HTTP caller.
+
+`session_id` comes from the optional `X-Skardi-Session-Id` request header
+(non-empty, ≤ 200 characters). A malformed header is rejected with `400
+parameter_validation_error` rather than silently dropped. With the header
+present, one agent session's ad-hoc queries and pipeline calls interleave
+under a single `session_id` in the ledger, ordered by `created_at`.
+
 ---
 
 ## Context files

--- a/docs/server.md
+++ b/docs/server.md
@@ -215,7 +215,11 @@ forever and pruning is the operator's call. The prune deletes in batches,
 yielding between them: it shares the ledger's single writer thread with the
 fail-closed write path, so an unchunked delete over a large backlog would
 starve concurrent requests into `503 query_audit_error`. Enabling retention
-for the first time on a big ledger is therefore slow, not disruptive.
+for the first time on a big ledger is therefore slow, not disruptive. Each
+batch is bounded like any other write, so on pathologically slow storage the
+*startup* prune can fail and abort startup — the same fail-closed stance
+that makes a broken ledger fatal rather than silently skipped. Later hourly
+prunes only warn.
 
 The ledger holds raw SQL, so it is created owner-only (`0600` on Unix,
 including the WAL sidecars). It is a local database, never the OTLP/tracing

--- a/docs/superpowers/plans/2026-08-14-pipeline-audit.md
+++ b/docs/superpowers/plans/2026-08-14-pipeline-audit.md
@@ -1,0 +1,602 @@
+# Pipeline-Execution Auditing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Record every pipeline execution in the existing `query_audit` ledger so the self-improving loop keeps seeing promoted tools.
+
+**Architecture:** `POST /:pipeline/execute` writes a `started` row (statement_kind=`pipeline`, pipeline name in the `sql` column, optional session from the `X-Skardi-Session-Id` header) before running, mirrors `/query`'s fail-closed 503 on write failure, and stamps the outcome after. The store gains one insert method; everything downstream (reconcile, retention, `list_by_session`) works unchanged. The CLI gains `skardi run --session-id`.
+
+**Tech Stack:** Rust, Axum, tokio-rusqlite (existing audit store), wiremock (CLI tests).
+
+**Spec:** `docs/superpowers/specs/2026-08-14-pipeline-audit-design.md`
+
+## Global Constraints
+
+- Imports via `use` at the top of the file; never full crate paths inline in function bodies (CLAUDE.md).
+- No raw `.unwrap()` outside `crates/cli/` and test code; lock poisoning recovers via `.unwrap_or_else(|p| p.into_inner())`; true invariants use `.expect("why")` (CLAUDE.md).
+- Parameter values are NEVER written to the ledger, logs, or traces — only the pipeline name.
+- Session header cap reuses `MAX_SESSION_ID_CHARS` (= 200) from `query_handlers.rs` — do not hardcode 200 anywhere else.
+- Every task ends with `cargo fmt` and a passing targeted test run before commit.
+
+---
+
+### Task 1: Store method `record_pipeline_started`
+
+**Files:**
+- Modify: `crates/server/src/query_audit.rs` (insert method next to `record_started` at line ~180; tests in the existing `#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Consumes: existing `new_id()`, `QueryAuditStatus`, `self.conn`.
+- Produces: `pub async fn record_pipeline_started(&self, pipeline_name: &str, session_id: Option<&str>) -> Result<String>` and `pub const PIPELINE_STATEMENT_KIND: &str = "pipeline";` — Task 2 calls both.
+
+- [ ] **Step 1: Write the failing tests** (in `query_audit.rs`'s tests module, matching its existing test style)
+
+```rust
+#[tokio::test]
+async fn pipeline_row_round_trips() {
+    let store = QueryAuditStore::open_in_memory().await.unwrap();
+    let id = store
+        .record_pipeline_started("weekly-churn", Some("sess-1"))
+        .await
+        .unwrap();
+    store
+        .record_outcome(&id, QueryAuditStatus::Succeeded, Some(42), None)
+        .await
+        .unwrap();
+    let row = store.get(&id).await.unwrap().unwrap();
+    assert_eq!(row["sql"], "weekly-churn");
+    assert_eq!(row["statement_kind"], "pipeline");
+    assert_eq!(row["session_id"], "sess-1");
+    assert_eq!(row["max_rows"], 0);
+    assert_eq!(row["row_count"], 42);
+    assert!(row["ai_context"].is_null());
+}
+
+#[tokio::test]
+async fn pipeline_row_without_session_has_null_session_id() {
+    let store = QueryAuditStore::open_in_memory().await.unwrap();
+    let id = store
+        .record_pipeline_started("weekly-churn", None)
+        .await
+        .unwrap();
+    let row = store.get(&id).await.unwrap().unwrap();
+    assert!(row["session_id"].is_null());
+}
+
+#[tokio::test]
+async fn list_by_session_interleaves_queries_and_pipelines() {
+    let store = QueryAuditStore::open_in_memory().await.unwrap();
+    let ctx = serde_json::json!({"purpose": "p", "session_id": "sess-mix"});
+    store
+        .record_started("SELECT 1", Some(&ctx), 10, "Query")
+        .await
+        .unwrap();
+    store
+        .record_pipeline_started("weekly-churn", Some("sess-mix"))
+        .await
+        .unwrap();
+    let rows = store.list_by_session("sess-mix").await.unwrap();
+    assert_eq!(rows.len(), 2);
+}
+
+#[tokio::test]
+async fn orphaned_pipeline_rows_reconcile_to_unknown() {
+    let store = QueryAuditStore::open_in_memory().await.unwrap();
+    let id = store
+        .record_pipeline_started("weekly-churn", None)
+        .await
+        .unwrap();
+    let n = store.reconcile_orphaned("test restart").await.unwrap();
+    assert_eq!(n, 1);
+    let row = store.get(&id).await.unwrap().unwrap();
+    assert_eq!(row["status"], "unknown");
+}
+```
+
+Adjust field-access assertions to `get`'s actual JSON shape if it differs (read the existing round-trip test first); the *behaviors* asserted are fixed.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test -p skardi-server --lib query_audit 2>&1 | tail -5`
+Expected: compile error — `record_pipeline_started` not found.
+
+- [ ] **Step 3: Implement** (next to `record_started`; same style)
+
+```rust
+/// Statement-kind marker distinguishing pipeline rows from ad-hoc SQL rows.
+pub const PIPELINE_STATEMENT_KIND: &str = "pipeline";
+
+/// `max_rows` does not apply to pipeline executions, but the column is NOT
+/// NULL; pipeline rows store this sentinel.
+const PIPELINE_MAX_ROWS_SENTINEL: i64 = 0;
+
+/// Insert a `started` row for a pipeline execution.
+///
+/// Stores the pipeline *name* in the `sql` column: the template lives on
+/// disk with no secrets, and the name is the join key to it and to the
+/// pipeline's `description` (which carries the purpose). Parameter values
+/// are deliberately never recorded — they are where PII lives. `ai_context`
+/// is left NULL rather than synthesized so the column always means
+/// "caller-sent object".
+pub async fn record_pipeline_started(
+    &self,
+    pipeline_name: &str,
+    session_id: Option<&str>,
+) -> Result<String> {
+    let id = new_id();
+    let created_at = chrono::Utc::now().to_rfc3339();
+    let name = pipeline_name.to_string();
+    let session_id = session_id.map(str::to_string);
+    let row_id = id.clone();
+
+    self.conn
+        .call(move |conn| -> SqlResult<()> {
+            conn.execute(
+                "INSERT INTO query_audit
+                    (id, created_at, sql, ai_context, session_id, max_rows,
+                     statement_kind, status)
+                 VALUES (?1, ?2, ?3, NULL, ?4, ?5, ?6, ?7)",
+                params![
+                    row_id,
+                    created_at,
+                    name,
+                    session_id,
+                    PIPELINE_MAX_ROWS_SENTINEL,
+                    PIPELINE_STATEMENT_KIND,
+                    QueryAuditStatus::Started.as_str(),
+                ],
+            )?;
+            Ok(())
+        })
+        .await
+        .context("Failed to write pre-execution pipeline-audit record")?;
+
+    Ok(id)
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test -p skardi-server --lib query_audit 2>&1 | tail -5`
+Expected: all query_audit tests pass, including the 4 new ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/server/src/query_audit.rs
+git commit -m "feat(server): record_pipeline_started — pipeline rows in the query-audit ledger"
+```
+
+---
+
+### Task 2: Handler — audit the execute path (success + session header)
+
+**Files:**
+- Modify: `crates/server/src/pipeline_handlers.rs` (`execute_pipeline_by_name`, line ~718)
+- Modify: `crates/server/src/query_handlers.rs` (make `MAX_SESSION_ID_CHARS` and `finish_audit` `pub(crate)`)
+- Create: `crates/server/tests/pipeline_audit_http.rs`
+
+**Interfaces:**
+- Consumes: `record_pipeline_started(&str, Option<&str>) -> Result<String>` and `QueryAuditStatus` from Task 1; `finish_audit(&AppState, Option<&str>, QueryAuditStatus, Option<usize>, Option<&str>)` from `query_handlers.rs`.
+- Produces: header contract `x-skardi-session-id` (validated: non-empty, ≤ `MAX_SESSION_ID_CHARS` chars, UTF-8) — Tasks 3 and 4 rely on it; test harness `make_app_state(query_audit: Option<Arc<QueryAuditStore>>) -> (AppState, TempDir)` in `pipeline_audit_http.rs` — Task 3 adds tests to it.
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Create `crates/server/tests/pipeline_audit_http.rs`. Copy the harness from `crates/server/tests/pipelines_http.rs` (the `write_yaml` / `products_batch` / `make_app_state` / `body_to_json` block, lines ~27–133) with one change: `make_app_state` takes `query_audit: Option<Arc<QueryAuditStore>>` and passes it as `AppState::new`'s last argument (see `make_state_with_audit` in `tests/query_http.rs:73` for the exact call shape). Always register the test pipeline. Then:
+
+```rust
+#[tokio::test]
+async fn successful_execution_is_audited_with_session() {
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    let resp = execute_with_headers(
+        &state,
+        &[("x-skardi-session-id", "sess-9")],
+        json!({"limit": 5}),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let rows = store.list_by_session("sess-9").await.unwrap();
+    assert_eq!(rows.len(), 1);
+    let row = &rows[0];
+    assert_eq!(row["statement_kind"], "pipeline");
+    assert_eq!(row["sql"], TEST_PIPELINE_NAME);
+    assert_eq!(row["status"], "succeeded");
+    assert!(row["row_count"].as_u64().is_some());
+    assert!(row["ai_context"].is_null());
+}
+
+#[tokio::test]
+async fn execution_without_header_audits_null_session() {
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    let resp = execute_with_headers(&state, &[], json!({"limit": 5})).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(store.count().await.unwrap(), 1);
+    // Not reachable via list_by_session: session_id is NULL.
+    assert!(store.list_by_session("").await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn no_store_configured_executes_without_recording() {
+    let (state, _tmp) = make_app_state(None).await;
+    let resp = execute_with_headers(&state, &[], json!({"limit": 5})).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+```
+
+Helper for the file (adapt the request-building style already used in `pipelines_http.rs` — router vs direct handler call — whichever that file does):
+
+```rust
+async fn execute_with_headers(
+    state: &AppState,
+    headers: &[(&str, &str)],
+    params: Value,
+) -> axum::response::Response {
+    // Build the request exactly the way pipelines_http.rs does, adding the
+    // given headers before dispatch.
+}
+```
+
+`TEST_PIPELINE_NAME` is whatever name the copied harness registers — bind it as a `const` so assertions and YAML stay in sync.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test -p skardi-server --test pipeline_audit_http 2>&1 | tail -10`
+Expected: `successful_execution_is_audited_with_session` and `execution_without_header_audits_null_session` FAIL (0 rows recorded — handler doesn't audit yet). `no_store_configured_executes_without_recording` may already pass.
+
+- [ ] **Step 3: Implement in `execute_pipeline_by_name`**
+
+In `query_handlers.rs`: change `const MAX_SESSION_ID_CHARS` and `async fn finish_audit` to `pub(crate)`.
+
+In `pipeline_handlers.rs` (imports at top: `crate::query_audit::QueryAuditStatus`, `crate::query_handlers::{finish_audit, MAX_SESSION_ID_CHARS}`):
+
+```rust
+/// Optional caller-supplied session header. A header (not a body field)
+/// because the execute body IS the flattened parameter map — a reserved key
+/// could collide with a legitimate SQL parameter of the same name.
+const SESSION_ID_HEADER: &str = "x-skardi-session-id";
+
+/// Extract and validate the session header. `Ok(None)` when absent; `Err`
+/// when present but malformed — silently dropping a malformed value would
+/// corrupt session stitching, the one job this field has.
+fn session_id_from_headers(headers: &HeaderMap) -> Result<Option<String>, String> {
+    let Some(value) = headers.get(SESSION_ID_HEADER) else {
+        return Ok(None);
+    };
+    let s = value
+        .to_str()
+        .map_err(|_| format!("{SESSION_ID_HEADER} must be valid UTF-8"))?;
+    if s.is_empty() {
+        return Err(format!("{SESSION_ID_HEADER} must not be empty"));
+    }
+    if s.chars().count() > MAX_SESSION_ID_CHARS {
+        return Err(format!(
+            "{SESSION_ID_HEADER} must be at most {MAX_SESSION_ID_CHARS} characters"
+        ));
+    }
+    Ok(Some(s.to_string()))
+}
+```
+
+Wire into `execute_pipeline_by_name`:
+
+1. Right after `require_session(...)`: validate the header —
+
+```rust
+let session_id = session_id_from_headers(&headers).map_err(|msg| {
+    (
+        StatusCode::BAD_REQUEST,
+        create_error_response(&msg, "parameter_validation_error", None),
+    )
+})?;
+```
+
+2. After param substitution succeeds, immediately before `app_state.engine.execute(&sql)`: the record-before-execute / fail-closed block, mirroring `query_handlers.rs:247-280` —
+
+```rust
+let audit_id = match &app_state.query_audit {
+    Some(store) => match store
+        .record_pipeline_started(&pipeline_name, session_id.as_deref())
+        .await
+    {
+        Ok(id) => Some(id),
+        Err(e) => {
+            tracing::error!("Pipeline audit write failed; refusing to execute: {e}");
+            let elapsed_ms = start_time.elapsed().as_millis() as f64;
+            app_state
+                .metrics
+                .record_error(&pipeline_name, elapsed_ms, "query_audit_error");
+            return Err((
+                StatusCode::SERVICE_UNAVAILABLE,
+                create_error_response(
+                    "Query auditing is enabled but the audit record could not be \
+                     written; the pipeline was not executed",
+                    "query_audit_error",
+                    None,
+                ),
+            ));
+        }
+    },
+    None => None,
+};
+```
+
+3. Stamp outcomes on every path after the audit write:
+   - engine `Err` branch: `finish_audit(&app_state, audit_id.as_deref(), QueryAuditStatus::Failed, None, Some(&e.to_string())).await;` before returning the error.
+   - `record_batch_to_json` `Err` branch: same, with that error.
+   - success path (where `row_count` is computed): `finish_audit(&app_state, audit_id.as_deref(), QueryAuditStatus::Succeeded, Some(row_count), None).await;`
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test -p skardi-server --test pipeline_audit_http --test pipelines_http --test query_http 2>&1 | tail -6`
+Expected: all pass (pipelines_http and query_http prove no regression).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/server/src/pipeline_handlers.rs crates/server/src/query_handlers.rs crates/server/tests/pipeline_audit_http.rs
+git commit -m "feat(server): audit pipeline executions — record-before-execute, X-Skardi-Session-Id"
+```
+
+---
+
+### Task 3: Handler — failure paths
+
+**Files:**
+- Modify: `crates/server/tests/pipeline_audit_http.rs` (tests only; implementation exists after Task 2 — these tests pin it)
+
+**Interfaces:**
+- Consumes: Task 2's harness, helper, and header contract; `close_for_test` from `QueryAuditStore` (see `tests/query_http.rs:617` for the 503 pattern).
+- Produces: nothing new — behavioral lock only.
+
+- [ ] **Step 1: Write the tests**
+
+```rust
+#[tokio::test]
+async fn engine_failure_is_audited_as_failed() {
+    // Register a pipeline whose SQL references a nonexistent table
+    // (add a second write_yaml with FROM no_such_table in the harness).
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    let resp = execute_broken_pipeline(&state, &[("x-skardi-session-id", "sess-f")]).await;
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let rows = store.list_by_session("sess-f").await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["status"], "failed");
+    assert!(rows[0]["error"].as_str().is_some());
+}
+
+#[tokio::test]
+async fn param_validation_failure_records_nothing() {
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    let resp = execute_with_headers(&state, &[], json!({})).await; // missing required param
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(store.count().await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn malformed_session_header_is_400_and_records_nothing() {
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    for bad in [String::new(), "x".repeat(201)] {
+        let resp = execute_with_headers(
+            &state,
+            &[("x-skardi-session-id", bad.as_str())],
+            json!({"limit": 5}),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = body_to_json(resp).await;
+        assert_eq!(body["error_type"], json!("parameter_validation_error"));
+    }
+    assert_eq!(store.count().await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn audit_write_failure_is_503_and_pipeline_does_not_run() {
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    store.close_for_test().await;
+    let resp = execute_with_headers(&state, &[], json!({"limit": 5})).await;
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let body = body_to_json(resp).await;
+    assert_eq!(body["error_type"], json!("query_audit_error"));
+}
+```
+
+(Empty-string header note: if axum/http rejects constructing an empty header value in the test transport, drop the `String::new()` case and keep the oversize case — the emptiness rule is still enforced server-side for clients that do send one.)
+
+- [ ] **Step 2: Run — all four should pass already** (Task 2 implemented the behavior)
+
+Run: `cargo test -p skardi-server --test pipeline_audit_http 2>&1 | tail -6`
+Expected: PASS. If any fails, the implementation has a real gap — fix `pipeline_handlers.rs`, don't weaken the test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/server/tests/pipeline_audit_http.rs
+git commit -m "test(server): pin pipeline-audit failure paths — failed rows, 400s unrecorded, fail-closed 503"
+```
+
+---
+
+### Task 4: CLI — `skardi run --session-id`
+
+**Files:**
+- Modify: `crates/cli/src/main.rs` (Run variant, ~line 54 area)
+- Modify: `crates/cli/src/commands/run.rs`
+- Modify: `crates/cli/src/client.rs`
+
+**Interfaces:**
+- Consumes: header contract `x-skardi-session-id` from Task 2.
+- Produces: `Client::post_with_headers(&self, path: &str, body: &Value, headers: &[(&str, &str)]) -> Result<Value, ApiError>`; `run::run` gains `session_id: Option<String>`.
+
+- [ ] **Step 1: Write the failing test** (in `run.rs`'s tests, matching its existing wiremock style)
+
+```rust
+#[tokio::test]
+async fn run_with_session_id_sets_header() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/my-pipe/execute"))
+        .and(header("x-skardi-session-id", "sess-9"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({"success": true, "data": [], "rows": 0})),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+    // Build the client + invoke run(...) the same way the neighboring
+    // tests in this file do, passing session_id: Some("sess-9".into()).
+}
+
+#[tokio::test]
+async fn run_without_session_id_sends_no_header() {
+    // Same shape; assert with wiremock's header-absent matching used
+    // elsewhere in this crate (or match only on path and inspect the
+    // received request's headers via server.received_requests()).
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test -p skardi-cli 2>&1 | tail -5`
+Expected: compile error — `run` has no `session_id` parameter.
+
+- [ ] **Step 3: Implement**
+
+`client.rs` — generalize `post` (keep `post`'s signature by delegating):
+
+```rust
+pub async fn post(&self, path: &str, body: &Value) -> Result<Value, ApiError> {
+    self.post_with_headers(path, body, &[]).await
+}
+
+pub async fn post_with_headers(
+    &self,
+    path: &str,
+    body: &Value,
+    headers: &[(&str, &str)],
+) -> Result<Value, ApiError> {
+    let url = format!("{}{}", self.base_url, path);
+    let mut request = self.http.post(&url).json(body);
+    for (name, value) in headers {
+        request = request.header(*name, *value);
+    }
+    request = self.with_auth(request);
+    self.send(request, url).await
+}
+```
+
+`run.rs` — add `session_id: Option<String>` to `run`'s signature; replace the `client.post(...)` call:
+
+```rust
+let response = match &session_id {
+    Some(sid) => {
+        client
+            .post_with_headers(&path, &Value::Object(body), &[("x-skardi-session-id", sid)])
+            .await
+    }
+    None => client.post(&path, &Value::Object(body)).await,
+};
+```
+
+(then keep the existing match-arms on the response as they are — only the call moves).
+
+`main.rs` — on the Run command variant add:
+
+```rust
+/// Session id recorded with this execution in the server's audit ledger
+/// (sent as the X-Skardi-Session-Id header).
+#[arg(long)]
+session_id: Option<String>,
+```
+
+and pass it through the `commands::run::run(...)` call site.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test -p skardi-cli 2>&1 | tail -5`
+Expected: PASS, including both new tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cli/src/main.rs crates/cli/src/commands/run.rs crates/cli/src/client.rs
+git commit -m "feat(cli): skardi run --session-id sends X-Skardi-Session-Id"
+```
+
+---
+
+### Task 5: Docs + full QA sweep
+
+**Files:**
+- Modify: `docs/server.md` (audit-ledger section, after the `/query` request-fields block ~line 124+)
+- Modify: `docs/pipelines.md` (execute-endpoint section)
+- Modify: `docs/cli.md` (`skardi run` flags)
+
+**Interfaces:** none — prose only.
+
+- [ ] **Step 1: `docs/server.md`** — add under the audit-ledger material:
+
+```markdown
+#### Pipeline executions in the ledger
+
+When `--query-audit-db` is configured, `POST /:pipeline/execute` is audited
+with the same record-before-execute and fail-closed semantics as `/query`
+(a failed pre-execution write returns 503 and the pipeline does not run).
+A pipeline row differs from an ad-hoc row in three ways:
+
+- `statement_kind` is `pipeline`, and the `sql` column holds the pipeline
+  *name*, not SQL — the template lives on disk, and the pipeline's
+  `description` carries its purpose.
+- Parameter values are never recorded: params are where PII lives.
+  `ai_context` is always NULL on pipeline rows.
+- `max_rows` is stored as `0` (not applicable to pipelines).
+
+`session_id` comes from the optional `X-Skardi-Session-Id` request header
+(non-empty, ≤ 200 characters). A malformed header is rejected with `400
+parameter_validation_error` rather than silently dropped. With the header
+present, one agent session's ad-hoc queries and pipeline calls interleave
+under a single `session_id` in the ledger, ordered by `created_at`.
+```
+
+- [ ] **Step 2: `docs/pipelines.md`** — in the execute-endpoint docs add:
+
+```markdown
+### Session attribution
+
+Send `X-Skardi-Session-Id: <id>` (non-empty, ≤ 200 chars) with an execute
+request to group this run with the rest of an agent session in the query
+audit ledger (`--query-audit-db`). The header is optional and ignored when
+auditing is off. It is a header rather than a body field because the
+request body is the parameter map itself — a reserved key could collide
+with a SQL parameter of the same name.
+```
+
+- [ ] **Step 3: `docs/cli.md`** — in the `skardi run` section add:
+
+```markdown
+- `--session-id <ID>` — sent as `X-Skardi-Session-Id`; groups this
+  execution with an agent session in the server's query audit ledger.
+```
+
+- [ ] **Step 4: Full QA sweep** (rust-expert checklist)
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets -p skardi-server -p skardi-cli 2>&1 | tail -5   # expect no warnings
+cargo test -p skardi-server -p skardi-cli 2>&1 | grep -E "^test result" | sort | uniq -c
+```
+
+Expected: fmt clean, zero clippy warnings, all suites pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/server.md docs/pipelines.md docs/cli.md
+git commit -m "docs: pipeline executions in the audit ledger, X-Skardi-Session-Id, skardi run --session-id"
+```

--- a/docs/superpowers/specs/2026-08-14-pipeline-audit-design.md
+++ b/docs/superpowers/specs/2026-08-14-pipeline-audit-design.md
@@ -47,9 +47,16 @@ of the same name. `X-Skardi-Session-Id` avoids that, requires no change to
 the inferred request schema, and is ignorable by existing callers.
 
 Validation mirrors `ai_context.session_id` on `/query`: non-empty, ≤ 200
-chars. A malformed header (empty, oversized, or non-UTF-8) → 400
-`parameter_validation_error` — silently dropping it would corrupt session
-stitching, the one job the field has.
+chars. A malformed header (empty, oversized, outside visible ASCII, or
+containing a space, tab or comma — the last three added in review) → 400
+`parameter_validation_error` with `details.header` — silently dropping it
+would corrupt session stitching, the one job the field has. Space and tab
+are rejected because HTTP parsers trim surrounding whitespace, so an
+untrimmed value would be recorded under a different key than the caller
+sent; comma because intermediaries may merge repeated header lines
+comma-separated (RFC 9110 §5.3, §5.5). The CLI enforces the identical
+predicate before transport, so no value can pass client-side and be
+rewritten or rejected server-side.
 
 ### Semantics (mirroring `/query` exactly)
 

--- a/docs/superpowers/specs/2026-08-14-pipeline-audit-design.md
+++ b/docs/superpowers/specs/2026-08-14-pipeline-audit-design.md
@@ -23,7 +23,7 @@ ad-hoc SQL or a named pipeline call.
 
 | column | value for a pipeline row |
 | --- | --- |
-| `statement_kind` | `"pipeline"` (ad-hoc rows keep `select` / `dml` / …) |
+| `statement_kind` | `"pipeline"` (ad-hoc rows keep `Query` / `Other` — the `Debug` form of the server's `StatementKind` classifier, not SQL verbs; correction from review, the original draft wrongly said `select` / `dml`) |
 | `sql` | the **pipeline name** — the template lives on disk with no secrets; the name is the join key to it and to `metadata.description`, which carries the purpose (written at promotion time) |
 | `session_id` | from the optional `X-Skardi-Session-Id` request header |
 | `ai_context` | NULL — purpose lives in the pipeline description; a synthetic object would masquerade as caller-sent data |
@@ -87,6 +87,12 @@ already-noted gap — out of scope here.)
   fact with no static substitute.
 - Auditing the pipeline dashboard's internal reads, health checks, or
   `GET` endpoints — only `POST /:name/execute`.
+- Auditing job runs (`POST /jobs/:name/run`) in this ledger. Jobs already
+  have their own durable run ledger (parameters, status, run id — the
+  SQLite jobs store), so unlike pipelines they were never unobserved; what
+  they lack is `ai_context`/session attribution in the *query* ledger.
+  Unifying the two ledgers is real future work — best coordinated with the
+  identity-column work in #206 rather than bolted on here.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-08-14-pipeline-audit-design.md
+++ b/docs/superpowers/specs/2026-08-14-pipeline-audit-design.md
@@ -1,0 +1,112 @@
+# Pipeline-execution auditing: close the loop's blind spot
+
+**Date:** 2026-08-14
+**Scope:** `crates/server` (pipeline handler + audit store), `crates/cli` (`skardi run --session-id`), `docs/server.md`, `docs/pipelines.md`, `docs/cli.md`
+
+## Problem
+
+The query audit ledger (`--query-audit-db`, #173) records every ad-hoc
+`POST /query` — but pipeline executions are not recorded anywhere
+(`pipeline_handlers.rs` never touches the audit store). This makes the
+self-improving loop degrade its own input as it succeeds: the moment the
+query-log skill promotes a recurring query into a pipeline
+(skardi-skills#25), that query's recurrence signal leaves the ledger. The
+Learn stage goes blind to exactly the tools the Act stage created.
+
+## Design
+
+**One ledger, both kinds of executions.** Every data access the server
+performs gets a row in the same `query_audit` store, whether it arrived as
+ad-hoc SQL or a named pipeline call.
+
+### What a pipeline row records
+
+| column | value for a pipeline row |
+| --- | --- |
+| `statement_kind` | `"pipeline"` (ad-hoc rows keep `select` / `dml` / …) |
+| `sql` | the **pipeline name** — the template lives on disk with no secrets; the name is the join key to it and to `metadata.description`, which carries the purpose (written at promotion time) |
+| `session_id` | from the optional `X-Skardi-Session-Id` request header |
+| `ai_context` | NULL — purpose lives in the pipeline description; a synthetic object would masquerade as caller-sent data |
+| `max_rows` | 0, documented as "not applicable to pipeline rows" (column is NOT NULL; a sentinel beats a schema change) |
+| `created_at` / `finished_at` / `status` / `row_count` / `error` | same lifecycle as ad-hoc rows |
+
+Parameter values are **never recorded** — params are exactly where PII
+lives, consistent with the existing confidentiality stance (raw ad-hoc SQL
+is itself only stored because the operator opted in by configuring the DB).
+
+No schema change and no migration: `statement_kind` and `session_id`
+columns already exist. `--query-audit-db` has never shipped in a tagged
+release, so there are no deployed DBs to migrate anyway — but we don't need
+the freedom.
+
+### Transport: why a header, not a body field
+
+The pipeline request body IS the parameter map (`ExecuteRequest` flattens
+it), so any reserved body key could collide with a legitimate SQL parameter
+of the same name. `X-Skardi-Session-Id` avoids that, requires no change to
+the inferred request schema, and is ignorable by existing callers.
+
+Validation mirrors `ai_context.session_id` on `/query`: non-empty, ≤ 200
+chars. A malformed header (empty, oversized, or non-UTF-8) → 400
+`parameter_validation_error` — silently dropping it would corrupt session
+stitching, the one job the field has.
+
+### Semantics (mirroring `/query` exactly)
+
+- **Record-before-execute.** The `started` row is committed after parameter
+  validation succeeds, before the engine runs. Param-validation failures are
+  not audited (nothing executed), same as `/query`'s rejects.
+- **Fail-closed.** If the pre-execution write fails, respond 503 and do not
+  run the pipeline. An operator who configured an audit trail must never get
+  unaudited executions.
+- **Free rides.** Orphan reconciliation, retention pruning, and
+  `list_by_session` all key on columns pipeline rows share — they cover the
+  new rows with zero changes.
+- **No store configured → no-op.** `query_audit: None` keeps today's
+  behavior exactly.
+
+### Store API
+
+A dedicated `record_pipeline_started(name, session_id)` insert on
+`QueryAuditStore` rather than bending `record_started` (whose signature
+derives `session_id` from an `ai_context` object pipelines don't have).
+`record_outcome` is reused as-is.
+
+### CLI companion
+
+`skardi run` gains `--session-id <ID>`, sent as the header. Optional; no
+default. (`skardi query` ai_context passthrough remains a separate,
+already-noted gap — out of scope here.)
+
+## Non-goals
+
+- Recording rendered SQL or parameter values for pipeline rows.
+- Per-call `purpose` on pipelines — `metadata.description` carries it.
+- `ai_context` object transport for pipelines. If a future need appears,
+  the header can grow a sibling; today `session_id` is the only per-call
+  fact with no static substitute.
+- Auditing the pipeline dashboard's internal reads, health checks, or
+  `GET` endpoints — only `POST /:name/execute`.
+
+## Testing
+
+- **Store unit tests** (`query_audit.rs`): pipeline row round-trip;
+  `list_by_session` interleaves ad-hoc and pipeline rows for one session
+  ordered by `created_at`; orphaned pipeline rows reconcile.
+- **HTTP integration tests** (`tests/pipelines_http.rs` or a new
+  `tests/pipeline_audit_http.rs`): success writes `started`→`succeeded`
+  with name + row_count; engine failure writes `failed` with error; header
+  present → `session_id` recorded; absent → NULL; malformed header → 400
+  and nothing recorded; param-validation failure → nothing recorded; store
+  write failure → 503 and pipeline does not run (reuse the
+  `close_for_test` trick from `query_http.rs`); no store configured →
+  everything works, nothing recorded.
+- **CLI test** (`crates/cli`): `--session-id` sets the header
+  (wiremock header assertion, matching existing CLI test style).
+
+## Docs
+
+- `docs/server.md`: extend the audit-ledger section — pipeline rows, the
+  header, the max_rows sentinel, fail-closed parity.
+- `docs/pipelines.md`: document `X-Skardi-Session-Id` on execute.
+- `docs/cli.md`: `skardi run --session-id`.

--- a/docs/superpowers/specs/2026-08-14-pipeline-audit-design.md
+++ b/docs/superpowers/specs/2026-08-14-pipeline-audit-design.md
@@ -24,7 +24,7 @@ ad-hoc SQL or a named pipeline call.
 | column | value for a pipeline row |
 | --- | --- |
 | `statement_kind` | `"pipeline"` (ad-hoc rows keep `Query` / `Other` — the `Debug` form of the server's `StatementKind` classifier, not SQL verbs; correction from review, the original draft wrongly said `select` / `dml`) |
-| `sql` | the **pipeline name** — the template lives on disk with no secrets; the name is the join key to it and to `metadata.description`, which carries the purpose (written at promotion time) |
+| `sql` | **`name@version`** (from `metadata.version`; revised in review — originally the bare name, but rows outlive template revisions since retention is off by default, so the name alone stops answering *what SQL ran*) — the versioned template lives on disk with no secrets and `metadata.description` carries the purpose (written at promotion time) |
 | `session_id` | from the optional `X-Skardi-Session-Id` request header |
 | `ai_context` | NULL — purpose lives in the pipeline description; a synthetic object would masquerade as caller-sent data |
 | `max_rows` | 0, documented as "not applicable to pipeline rows" (column is NOT NULL; a sentinel beats a schema change) |


### PR DESCRIPTION
## Why

The query audit ledger (`--query-audit-db`, #173) records every ad-hoc `POST /query`, but pipeline executions were recorded nowhere. That makes the self-improving loop degrade its own input as it succeeds: the moment [`skardi-query-log`](https://github.com/SkardiLabs/skardi-skills/pull/25) promotes a recurring query into a pipeline, its recurrence signal leaves the ledger, and the Learn stage goes blind to exactly the tools the Act stage created.

## What

**One ledger, both kinds of executions.** `POST /:pipeline/execute` now writes to the same `query_audit` store, mirroring `/query`'s semantics:

| | ad-hoc row (existing) | pipeline row (new) |
|---|---|---|
| `statement_kind` | `Query` / `Other` (the classifier's `Debug` form — *not* SQL verbs; corrected per review) | `pipeline` |
| `sql` | raw SQL (operator opt-in) | **`name@version`** (rows outlive template revisions, so the bare name stops answering "what ran"; per round-3 review) — the versioned template lives on disk; `description` carries the purpose |
| `session_id` | from `ai_context` | from the optional `X-Skardi-Session-Id` header |
| `ai_context` | caller-sent object | always NULL |
| `error` on failure | engine error text | **fixed value-free kind** (`query_execution_error` / `result_conversion_error`) |

- **Record-before-execute, fail-closed**: the `started` row is committed after param validation and before the engine runs; if the write fails, 503 and the pipeline does not run. No store configured → behavior unchanged (pinned by test).
- **Params never reach the ledger** — including through error text: engine errors can echo substituted parameter literals, so pipeline rows persist a fixed error kind while the HTTP response keeps the full error.
- **Header, not body field**: the execute body IS the flattened params map, so a reserved key could collide with a real SQL parameter. The header is optional; malformed (empty, >200 chars, outside visible ASCII, containing a comma or tab, or duplicated) → 400 regardless of audit state — validated only after the pipeline lookup, so unknown pipelines 404 and the reject metric's label stays bounded to configured names.
- **Bounded fail-closed**: every ledger write carries a 5s timeout inside the store, so a hung fsync becomes a failed write (503) instead of wedging the single serialized writer thread all audited requests share.
- **CLI**: `skardi run --session-id <ID>` sends the header; without the flag the request is byte-identical to before.
- **Free rides**: orphan reconciliation, retention pruning, and `list_by_session` cover pipeline rows with zero changes — one agent session's ad-hoc queries and pipeline calls now interleave under one `session_id`, ordered by `created_at`, which is exactly the shape intention-mining skills want.

No schema change, no migration (`--query-audit-db` has never shipped in a tagged release).

## Tests

- Store unit tests: pipeline-row round-trip, NULL session, ad-hoc+pipeline interleaving under one session, orphan reconcile.
- Integration (`tests/pipeline_audit_http.rs`, 8 tests): success recorded with session; NULL session without header; no-store no-op; engine failure → `failed` row with fixed error kind; param-validation failure records nothing; malformed/duplicate header → 400 + nothing recorded; audit-write failure → 503 and the pipeline does not run.
- CLI wiremock tests: header present with the flag, absent without (asserted via `received_requests`, not a vacuous matcher).
- Full workspace suite green: 951 lib + all integration suites, 0 failures.

## Docs

`docs/server.md` (pipeline rows in the ledger), `docs/pipelines.md` (session attribution + validation rules), `docs/cli.md` (`--session-id`). Design + plan under `docs/superpowers/`.

## Follow-up (pre-existing, deliberately not fixed here)

Filed as #217, expanded per review to four egress points: the DEBUG log of substituted SQL, the ERROR-level unsupported-parameter log (value included, default-on, OTLP fan-out), parameter values in HTTP 400 `error_details`, and engine error text + record-batch schema in HTTP 500 bodies (unlike `/query`, which redacts). `docs/server.md` now explicitly scopes the ledger guarantee around these.

Review round 2 (2026-08-17, per @abbccdda's review): de-vacuified both session-header tests (a valid body so the header is the only reject cause, plus message assertions), exact `row_count` assertion, an end-to-end param-value canary test, coverage for the non-visible-ASCII and audit-off validation branches, a metric on the header reject, `session_id` in the pipeline INFO marker, client-side `--session-id` validation in the CLI (a bad value no longer masquerades as a connection failure with exit 2), corrected `statement_kind` documentation everywhere (real values: `Query` / `Other` / `pipeline`), a ledger disk-sizing note, and a jobs non-goal in the spec (jobs have their own run ledger; unification is future work adjacent to #206).

Review round 3 (2026-08-17, commits bb58f5e / 7360166 / 98173a7): fixed the blocking metric-cardinality finding (header validated after the pipeline lookup, so the reject metric's `pipeline` label is bounded and unknown pipelines 404 — the round-2 fix had made the label attacker-controlled); bounded every ledger write with a 5s in-store timeout so fail-closed means 503, not a hung request wedging the shared writer thread; pipeline rows record `name@version`; comma/tab rejection (proxy header-merging per RFC 9110 §5.3); `list_by_session` gets a total order (`created_at, id`); latency metrics include the outcome write; `finish_audit`/`MAX_SESSION_ID_CHARS` moved into `query_audit` (also shrinks the #206 collision); the 503 test now proves "did not run" via the broken pipeline, `result_conversion_error` is exercised end-to-end via a sparse Union column (Duration is JSON-encodable in arrow-json 57, so the reviewer's suggested fixture returned 200), the interleaving test pins ordering, and `query_audit_error` (503, retryable, pipeline did not run) joined the agent-facing error contract in docs/pipelines.md. The docs scope statement now names all four #217 egress surfaces with the OTLP log flagged as widest, and #218 tracks `skardi query` session passthrough (the docs note the interleaving currently needs direct HTTP for the ad-hoc half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


