### PR TITLE
docs(readme): point the plugin references at auto-context

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@
 
 **The most agent-friendly backend for builders shipping their first AI agent.** The painful part of agent-building isn't the prompt — it's the data plumbing: a vector DB to stand up, an embedding pipeline to maintain, a chunker to debug, a tool-call wrapper to write for every query. Skardi auto-bootstraps the primitives every agent needs so you ship in hours, not weeks:
 
-- **[`auto_rag`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_rag) — Auto-RAG (Retrieval Augmented Generation).** Server-backed hybrid search (vector + full-text + RRF) via `skardi-server` over a datastore you already control (Postgres + pgvector, MongoDB, or Lance). The skill renders the config, starts the server, and drives ingestion and queries through REST. One command from a datastore to a working retrieval API your agent calls as a tool — no Python orchestration layer, no glue code.
-- **[`auto_knowledge_base`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_knowledge_base) — Auto agent knowledge base.** Point it at a directory of documents and you have a queryable, citable local KB one command later. Chunking, embedding, indexing, and hybrid search are exposed to your agent as a `skardi run` verb. Zero infra by default (SQLite + local embeddings), so any Claude Code / Cursor session gets a grounded knowledge base over your files.
+- **[`auto_context`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_context) — governed, searchable context in one command.** Point it at a folder of documents and you have a queryable, citable knowledge base a command later — zero infra by default (SQLite + local embeddings). Point it at a datastore you already control (Postgres + pgvector, MongoDB, or Lance) and you get the same hybrid search (vector + full-text + RRF) served over REST by `skardi-server`. Chunking, embedding, indexing and query are rendered for you; your agent calls the result as a tool. No Python orchestration layer, no glue code.
 - **Zero bootstrap** — `ctx.yaml`, pipelines, schema, server, all rendered for you by **[skardi-skills](https://github.com/SkardiLabs/skardi-skills)**. Install once and your agent has a working data tool the same hour.
 
 You build the agent. Skardi handles the data plane.
@@ -56,9 +55,7 @@ Open any Claude Code session and run:
 
 ```text
 /plugin marketplace add SkardiLabs/skardi-skills
-/plugin install skardi-deploy-and-patterns@skardi-skills
-/plugin install auto-knowledge-base@skardi-skills
-/plugin install auto-rag@skardi-skills
+/plugin install auto-context@skardi-skills
 ```
 
 That's it — the skills are now available across all your projects, and `/plugin marketplace update skardi-skills` pulls future versions. For Cursor and other [Agent Skills](https://agentskills.io/)-compatible tools, plus a manual-copy fallback, see the [skardi-skills README](https://github.com/SkardiLabs/skardi-skills#installation).
@@ -69,7 +66,7 @@ Curious why a uniform plane matters? Read on.
 
 ## ⭐️ Star the Repository
 
-If **skardi-skills** lands well in your agentic stack — auto-RAG up in a minute, a knowledge base your agent actually grounds in — drop a ⭐️ on this repo. It helps other agent builders discover Skardi, makes onboarding their first agent that much shorter, and signals which directions are worth pushing on.
+If **skardi-skills** lands well in your agentic stack — searchable context up in a minute, a knowledge base your agent actually grounds in — drop a ⭐️ on this repo. It helps other agent builders discover Skardi, makes onboarding their first agent that much shorter, and signals which directions are worth pushing on.
 
 <p align="center">
   <a href="https://github.com/SkardiLabs/skardi">
@@ -222,7 +219,7 @@ skardi query -e "SELECT * FROM products LIMIT 10" --table
 YAML from [`demo/llm_wiki/cli/`](demo/llm_wiki/cli/) — the actual file, not
 pseudo-code:
 
-> ⚠️ Unlike Steps 1–2 (zero-dependency), this hybrid-search pipeline also needs a local embedding model at `models/…` + the `sqlite-vec` extension (`SQLITE_VEC_PATH`) and a seeded DB — so it is **not runnable by copy-paste alone**. The [`auto_knowledge_base` skill](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_knowledge_base) sets all of this up for you; use it if you just want the pipeline working.
+> ⚠️ Unlike Steps 1–2 (zero-dependency), this hybrid-search pipeline also needs a local embedding model at `models/…` + the `sqlite-vec` extension (`SQLITE_VEC_PATH`) and a seeded DB — so it is **not runnable by copy-paste alone**. The [`auto_context` skill](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_context) sets all of this up for you; use it if you just want the pipeline working.
 
 ```yaml
 # pipelines/search_hybrid.yaml — declares the SQL once; Skardi infers the params


### PR DESCRIPTION
## Why

[skardi-skills#24](https://github.com/SkardiLabs/skardi-skills/pull/24) merged, folding `auto_knowledge_base` and `auto_rag` into a single `auto_context` and retiring `skardi_on_sealos`. The marketplace now publishes two plugins:

```bash
gh api repos/SkardiLabs/skardi-skills/contents/.claude-plugin/marketplace.json \
  --jq '.content' | base64 -d | jq -r '.plugins[].name'
# auto-context
# feishu-connector
```

Every plugin reference on this page is stale as a result:

- the three `/plugin install` lines name plugins that no longer exist — a reader following the page gets three consecutive failures;
- three `tree/main/{auto_rag,auto_knowledge_base}` links 404;
- the star blurb advertises "auto-RAG", a name that is now unfindable.

## What changed

One file, +4 / −7.

| Location | Change |
|---|---|
| Capability bullets | two bullets collapse into one `auto_context` |
| Install block | three `/plugin install` lines become one |
| Star blurb | `auto-RAG` → `searchable context` |
| Hybrid-pipeline aside | link re-pointed at `auto_context` |

The two capability bullets collapse rather than being renamed in place. They were split because one path needed a server and the other did not; #170 removed the query engine from the CLI, so both need a server now and the only remaining difference is whose database it is — a flag, not a product boundary. That is exactly what #24 acted on, so the page reads better merged than split.

`feishu-connector` is deliberately **not** added. This PR repairs a break; introducing a plugin the README never mentioned is a separate call.

## Verification

```bash
grep -iE 'auto_rag|auto_knowledge|skardi_on_sealos|skardi-deploy' README.md   # empty
curl -s -o /dev/null -w '%{http_code}' https://github.com/SkardiLabs/skardi-skills/tree/main/auto_context   # 200
gh api repos/SkardiLabs/skardi-skills/contents/auto_context --jq '.[].name'   # directory exists on main
```

## Relationship to #205

Narrow on purpose. [#205](https://github.com/SkardiLabs/skardi/pull/205) rewrites this whole page including the Install section, and it is the better long-term home for this wording.

But #205 does not currently fix this: it carries the same three `/plugin install` lines and the same two tree links, inherited unchanged from `main`. So merging #205 as it stands would leave the page just as broken, at different line numbers. I left the same correction as a comment there ([#205 comment](https://github.com/SkardiLabs/skardi/pull/205#issuecomment-5291233206)).

Whichever lands first is fine:

- if this merges first, #205 will conflict here and should resolve in favour of its own rewrite, carrying the corrected plugin names across;
- if #205 merges first **with** the correction applied, close this — it costs nothing.

The one case worth avoiding is #205 merging without it, which is what this PR insures against.
