### PR TITLE
feat(sources): milestone 5.10 — Dropbox source pack + split-action cursor continuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ agents; deploy it next to your data, behind your usual auth.
 | InfluxDB 3 | Read | No | Time series over Arrow Flight SQL | [docs](docs/influxdb/) |
 | S3 / GCS / Azure | Read | No | CSV, Parquet, Lance in object stores | [docs](docs/S3_USAGE.md) |
 | CSV / Parquet | Read | No | Local or remote files | [docs](docs/server.md) |
-| SaaS via Open Connector | Read | Yes | GitHub, Slack, Notion, Feishu, Gmail, Discord, Outlook, OneDrive, Google Drive packs as stable SQL tables; pushdown + TTL cache | [docs](docs/open-connector.md) |
+| SaaS via Open Connector | Read | Yes | GitHub, Slack, Notion, Feishu, Gmail, Discord, Outlook, OneDrive, Google Drive, Dropbox packs as stable SQL tables; pushdown + TTL cache | [docs](docs/open-connector.md) |
 | Documents | Read | No | PDF/Office/ODF/image → per-page Markdown, tables, images | [docs](docs/documents.md) |
 | RSS / Atom | Read | Yes | Feeds as `feeds` + `items`; per-feed TTL cache, fault isolation, un-sandboxed fetch egress | [docs](docs/rss.md) |
 | Graph (Apache AGE) | Read | Yes | Read-only openCypher over Postgres; YAML views as catalog tables, `cypher_query` UDTF | [docs](docs/graph.md) |

--- a/crates/skardi/src/sources/providers/open_connector/exec.rs
+++ b/crates/skardi/src/sources/providers/open_connector/exec.rs
@@ -25,13 +25,13 @@ use datafusion::physical_plan::{
     SendableRecordBatchStream,
 };
 use futures::stream;
-use serde_json::Value;
+use serde_json::{Map, Value};
 
 use super::cache::{ScanCache, ScanKeyParts, scan_cache_key, schema_fingerprint};
 use super::client::OpenConnectorClient;
 use super::error::OpenConnectorError;
 use super::json_to_arrow::RowConverter;
-use super::pagination::{Pagination, PaginationStrategy};
+use super::pagination::{CursorContinuation, Pagination, PaginationStrategy};
 use super::row_path::RowPath;
 use super::source_pack::{FixedValue, SourcePackTable};
 
@@ -57,6 +57,10 @@ pub struct ScanTarget {
     /// Source-pack version, part of the cache key (0 for raw scans, which
     /// have no pack and bypass the cache).
     pub source_pack_version: u32,
+    /// Split-action cursor continuation (see
+    /// [`super::pagination::CursorContinuation`]); `None` for raw scans and
+    /// for every table whose provider accepts the cursor on its own action.
+    pub continuation: Option<CursorContinuation>,
 }
 
 impl ScanTarget {
@@ -69,6 +73,7 @@ impl ScanTarget {
             error_path: table.error_path,
             fixed_inputs: table.fixed_inputs,
             source_pack_version,
+            continuation: table.continuation,
         }
     }
 }
@@ -444,20 +449,47 @@ impl ScanState {
             });
         }
 
+        // Some providers serve pages 2..N from a DIFFERENT action than the
+        // one that began the listing (Dropbox's `list_folder` →
+        // `list_folder_continue`), and that action's schema commonly
+        // accepts the cursor and nothing else. Page one always uses the
+        // table's own action with the full input.
+        let continuation = self
+            .target
+            .continuation
+            .filter(|_| self.pagination.page() > 1);
+        let action_id: &str = match &continuation {
+            Some(continuation) => continuation.action_id,
+            None => &self.target.action_id,
+        };
+
         // Assemble the action input: resource inputs, the pack's fixed
         // inputs, pushed-down filters (which may override a fixed input —
         // `state=all` yields to a pushed `state='open'`), then page
         // parameters.
-        let mut input = self.resource.as_object().cloned().expect(
-            "resource is a JSON object by construction (registration always builds Value::Object)",
-        );
-        for (field, value) in self.target.fixed_inputs {
-            input.insert((*field).to_string(), value.to_json());
-        }
-        for (field, value) in &self.filter_inputs {
-            input.insert(field.clone(), value.clone());
-        }
-        self.pagination.apply(&mut input);
+        let input = if continuation.is_some_and(|c| c.cursor_only) {
+            // Everything the non-continuation branch assembles is a hard
+            // 400 here: the continue action declares `cursor` as its only
+            // property under `additionalProperties: false`. The listing's
+            // resources, fixed inputs, filters and page size were all
+            // committed by the request that opened it, and the cursor
+            // carries that state forward on the provider's side.
+            let mut input = Map::new();
+            self.pagination.apply_cursor_only(&mut input);
+            input
+        } else {
+            let mut input = self.resource.as_object().cloned().expect(
+                "resource is a JSON object by construction (registration always builds Value::Object)",
+            );
+            for (field, value) in self.target.fixed_inputs {
+                input.insert((*field).to_string(), value.to_json());
+            }
+            for (field, value) in &self.filter_inputs {
+                input.insert(field.clone(), value.clone());
+            }
+            self.pagination.apply(&mut input);
+            input
+        };
 
         let page = self.pagination.page();
         // The scan deadline covers the whole gateway operation, including
@@ -466,7 +498,7 @@ impl ScanState {
         let envelope = tokio::time::timeout_at(
             tokio::time::Instant::from_std(self.deadline),
             self.client.execute(
-                &self.target.action_id,
+                action_id,
                 &Value::Object(input),
                 self.connection_alias.as_deref(),
             ),
@@ -501,7 +533,10 @@ impl ScanState {
                 ),
             };
             return Err(OpenConnectorError::ProviderReportedError {
-                action_id: self.target.action_id.to_string(),
+                // The action that actually answered — on a continuation
+                // page that is the continue action, and naming the table's
+                // opening action instead would misdirect the reader.
+                action_id: action_id.to_string(),
                 page,
                 code,
             });
@@ -599,6 +634,7 @@ impl ScanState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sources::providers::open_connector::json_to_arrow::{FieldMapping, FieldType};
     use crate::sources::providers::open_connector::packs::mock;
     use crate::sources::providers::open_connector::testutil::{
         CapturedEvent, MockGateway, MockResponse, RecordedRequest, capture_events, envelope_ok,
@@ -667,6 +703,127 @@ mod tests {
             OpenConnectorClient::new(&gateway.url, "t", Duration::from_secs(5))
                 .expect("build client"),
         )
+    }
+
+    /// A cursor-paginated table continuing through a SEPARATE action whose
+    /// schema accepts only the cursor — the Dropbox `list_folder` /
+    /// `list_folder_continue` shape.
+    fn split_action_table() -> &'static SourcePackTable {
+        Box::leak(Box::new(SourcePackTable {
+            id: "split.entries",
+            action_id: "split.list",
+            row_path: "$.entries",
+            fields: &[FieldMapping {
+                name: "id",
+                path: "id",
+                field_type: FieldType::UInt64,
+                nullable: false,
+            }],
+            pagination: PaginationStrategy::Cursor {
+                cursor_param: "cursor",
+                next_cursor_path: "$.cursor",
+                page_size_param: Some("limit"),
+                page_size: 2,
+                has_more_path: Some("$.hasMore"),
+            },
+            required_resources: &[],
+            optional_resources: &["path"],
+            exclusive_resources: &[],
+            fixed_inputs: &[("recursive", FixedValue::Bool(true))],
+            filters: &[],
+            error_path: None,
+            expected_fingerprint: None,
+            continuation: Some(CursorContinuation {
+                action_id: "split.list_continue",
+                expected_fingerprint: "unused-in-exec",
+                cursor_only: true,
+            }),
+        }))
+    }
+
+    #[tokio::test]
+    async fn continuation_pages_target_the_continue_action_with_only_a_cursor() {
+        // The regression this whole extension exists to prevent: page two
+        // sent to the opening action, or sent to the continue action
+        // carrying the resources/fixed inputs/page size it declares no
+        // properties for. Either is a hard 400 against the real gateway
+        // (additionalProperties: false), so both request bodies are pinned
+        // structurally here.
+        let requests: Arc<Mutex<Vec<(String, serde_json::Value)>>> =
+            Arc::new(Mutex::new(Vec::new()));
+        let recorder = Arc::clone(&requests);
+        let gateway = MockGateway::start(move |req: &RecordedRequest| {
+            let body: serde_json::Value = serde_json::from_str(&req.body).unwrap_or_default();
+            let input = body.get("input").cloned().unwrap_or(json!({}));
+            recorder
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .push((req.path.clone(), input));
+            match req.path.as_str() {
+                "/v1/actions/split.list" => MockResponse::ok(&envelope_ok(
+                    &json!({"entries": [{"id": 1}, {"id": 2}], "cursor": "c2", "hasMore": true})
+                        .to_string(),
+                )),
+                // The final page still carries a NON-empty cursor — the
+                // Dropbox reality that makes has_more_path load-bearing.
+                "/v1/actions/split.list_continue" => MockResponse::ok(&envelope_ok(
+                    &json!({"entries": [{"id": 3}], "cursor": "c3", "hasMore": false}).to_string(),
+                )),
+                _ => MockResponse::new(404, "{}"),
+            }
+        })
+        .await;
+
+        let table = split_action_table();
+        let exec = OpenConnectorExec::new(
+            online_client(&gateway).await,
+            None,
+            "saas".to_string(),
+            Some("ws".to_string()),
+            None,
+            ScanTarget::from_pack_table(table, 1),
+            Arc::new(RowConverter::new(table.fields).expect("converter")),
+            RowPath::parse(table.row_path).expect("row path"),
+            json!({"path": "/docs"}),
+            vec![],
+            None,
+            None,
+            10,
+            1000,
+            Duration::from_secs(30),
+        )
+        .expect("build exec");
+
+        let mut state = ScanState::new(&exec).expect("state");
+        let mut rows = 0;
+        while let Some(batch) = state.next_page().await.expect("page") {
+            rows += batch.num_rows();
+        }
+        assert_eq!(rows, 3, "both pages are scanned");
+
+        let requests = requests.lock().unwrap_or_else(|p| p.into_inner()).clone();
+        assert_eq!(requests.len(), 2, "exactly two gateway calls");
+
+        let (path, input) = &requests[0];
+        assert_eq!(path, "/v1/actions/split.list", "page one opens the listing");
+        assert_eq!(input.get("path"), Some(&json!("/docs")), "resource");
+        assert_eq!(input.get("recursive"), Some(&json!(true)), "fixed input");
+        assert_eq!(input.get("limit"), Some(&json!(2)), "page size");
+        assert!(
+            input.get("cursor").is_none(),
+            "no cursor exists on the first page"
+        );
+
+        let (path, input) = &requests[1];
+        assert_eq!(
+            path, "/v1/actions/split.list_continue",
+            "page two targets the continue action, not the opening one"
+        );
+        assert_eq!(
+            input,
+            &json!({"cursor": "c2"}),
+            "the continue action's schema accepts the cursor and nothing else"
+        );
     }
 
     #[tokio::test]

--- a/crates/skardi/src/sources/providers/open_connector/mod.rs
+++ b/crates/skardi/src/sources/providers/open_connector/mod.rs
@@ -259,6 +259,16 @@ pub async fn register_open_connector_tables(
                     .into());
                 }
             }
+            // The fingerprint covers the OUTPUT schema, so `cursor_only` —
+            // a claim about what the continuation action ACCEPTS — needs its
+            // own check against the discovered input schema, or its only
+            // failure surface is a 400 on page two of a live scan.
+            table.check_continuation_inputs(
+                table
+                    .continuation
+                    .and_then(|c| registry.get(c.action_id))
+                    .and_then(ActionMetadata::input_schema),
+            )?;
 
             let provider = OpenConnectorTableProvider::new(
                 Arc::clone(&client),

--- a/crates/skardi/src/sources/providers/open_connector/mod.rs
+++ b/crates/skardi/src/sources/providers/open_connector/mod.rs
@@ -267,12 +267,13 @@ pub async fn register_open_connector_tables(
                 .continuation
                 .and_then(|c| registry.get(c.action_id))
                 .and_then(ActionMetadata::input_schema);
+            // One call, both spellings: `check_continuation_inputs`
+            // dispatches on `inputs:` internally, so `full` — the DEFAULT,
+            // and the shape a pack lands in by omission — cannot be the
+            // one this line forgets. (Its opener's inputs satisfying a
+            // DIFFERENT continue action is an assumption about two
+            // independently discovered schemas, not a fact.)
             table.check_continuation_inputs(continuation_input_schema)?;
-            // `inputs: full` — the DEFAULT — gets the same treatment when
-            // it names a different action: the opener's inputs satisfying
-            // the continue action is an assumption about two independently
-            // discovered schemas, not a fact, until it is checked.
-            table.check_full_continuation_inputs(continuation_input_schema)?;
 
             let provider = OpenConnectorTableProvider::new(
                 Arc::clone(&client),

--- a/crates/skardi/src/sources/providers/open_connector/mod.rs
+++ b/crates/skardi/src/sources/providers/open_connector/mod.rs
@@ -181,7 +181,10 @@ pub async fn register_open_connector_tables(
         let mut tables = Vec::with_capacity(binding.tables.len());
         for table_name in &binding.tables {
             let table = pack_registry.table(pack, table_name)?;
-            action_ids.push(table.action_id.to_string());
+            // Every action the table executes, including a split-action
+            // continuation's: an undiscovered continue action must fail at
+            // startup, not on page two of the first scan.
+            action_ids.extend(table.actions().map(str::to_string));
             for key in table.required_resources {
                 if !binding.resource.contains_key(*key) {
                     return Err(OpenConnectorError::MissingResourceInput {
@@ -239,18 +242,17 @@ pub async fn register_open_connector_tables(
         for table_name in &binding.tables {
             let table = pack_registry.table(pack, table_name)?;
 
-            // Compatibility gate: the discovered action contract must match
-            // the fingerprint the pack was built against.
-            if let Some(expected) = table.expected_fingerprint {
-                let actual = registry
-                    .get(table.action_id)
-                    .map(ActionMetadata::fingerprint);
+            // Compatibility gate: every discovered action contract the
+            // table executes must match the fingerprint the pack was built
+            // against — the opening action AND, for split-action
+            // pagination, the one serving pages 2..N.
+            for (action_id, expected) in table.gated_actions() {
+                let actual = registry.get(action_id).map(ActionMetadata::fingerprint);
                 if actual != Some(expected) {
                     return Err(OpenConnectorError::ActionContractMismatch {
                         table: table.id.to_string(),
                         reason: format!(
-                            "action '{}' fingerprint mismatch (expected {expected}, discovered {})",
-                            table.action_id,
+                            "action '{action_id}' fingerprint mismatch (expected {expected}, discovered {})",
                             actual.unwrap_or("<none>")
                         ),
                     }

--- a/crates/skardi/src/sources/providers/open_connector/mod.rs
+++ b/crates/skardi/src/sources/providers/open_connector/mod.rs
@@ -263,12 +263,16 @@ pub async fn register_open_connector_tables(
             // a claim about what the continuation action ACCEPTS — needs its
             // own check against the discovered input schema, or its only
             // failure surface is a 400 on page two of a live scan.
-            table.check_continuation_inputs(
-                table
-                    .continuation
-                    .and_then(|c| registry.get(c.action_id))
-                    .and_then(ActionMetadata::input_schema),
-            )?;
+            let continuation_input_schema = table
+                .continuation
+                .and_then(|c| registry.get(c.action_id))
+                .and_then(ActionMetadata::input_schema);
+            table.check_continuation_inputs(continuation_input_schema)?;
+            // `inputs: full` — the DEFAULT — gets the same treatment when
+            // it names a different action: the opener's inputs satisfying
+            // the continue action is an assumption about two independently
+            // discovered schemas, not a fact, until it is checked.
+            table.check_full_continuation_inputs(continuation_input_schema)?;
 
             let provider = OpenConnectorTableProvider::new(
                 Arc::clone(&client),

--- a/crates/skardi/src/sources/providers/open_connector/packs/dropbox.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/dropbox.rs
@@ -15,10 +15,14 @@
 //!   registration passed the contract gate on the first try. The
 //!   `*_continue.json` files being identical to their openers is a fact
 //!   about the wire, not an artifact of how they were derived;
-//! - all three tables scanned real rows, and every mapped column carried a
-//!   real non-NULL value somewhere — 12/12 on `files` (378 rows), 13/13 on
-//!   `file_search`, and 11/11 on `shared_links` AFTER the live pass removed
-//!   four columns that cannot populate (see the `shared_links` note below);
+//! - all three tables scanned real rows, and every column the pack
+//!   DECLARES carried a real non-NULL value somewhere — 12/12 on `files`
+//!   (378 rows) and 13/13 on `file_search`. `shared_links` is 11/11 of
+//!   what it declares, and it declares 11 because the pass DROPPED four
+//!   columns it found could never populate: the denominator was cut to
+//!   fit the observation, so read this as "nothing shipped is
+//!   structurally always-NULL", not as coverage of the surface the pack
+//!   originally declared (see the `shared_links` note below);
 //! - the declared page sizes are the wire's maxima, probed at the boundary:
 //!   `limit: 2000` and `maxResults: 1000` return rows, 2001 and 1001 are
 //!   refused;
@@ -180,19 +184,19 @@
 //!   executor (`readObjectArray`, which returns `[]` and never null).
 //!   Recorded as a wire-vs-contract contradiction; not worth a column.
 //!
-//! - **`file_search`'s `metadata` nullability is UNRESOLVED, and it is
-//!   the one open question that can fail a live scan.** The derived
+//! - **`file_search`'s `metadata` nullability was the one open question
+//!   that could fail a live scan; the pass CLOSED it.** The captured
 //!   contract declares `matches[].metadata` a required, non-nullable
 //!   object, and `tag` / `name` are mapped `nullable: false` on that
 //!   basis — so a real `metadata: null` row would fail the scan rather
-//!   than yield NULLs. `fixtures/dropbox/file_search_null_parent.json` is
-//!   a SYNTHETIC probe of that path (it encodes a shape the derived
-//!   contract says cannot occur, deliberately, like the schema-mismatch
-//!   fixture): it proves the converter names the offending non-nullable
-//!   column instead of quietly emitting an all-NULL row. If the live pass
-//!   finds that Dropbox can null a match's metadata, `tag` and `name`
-//!   become nullable and that fixture graduates from synthetic to
-//!   captured.
+//!   than yield NULLs. It cannot occur: the executor always builds a full
+//!   metadata object, so the mapping stands.
+//!   `fixtures/dropbox/file_search_null_parent.json` therefore stays a
+//!   SYNTHETIC probe, permanently (it encodes a shape the contract says
+//!   cannot occur, deliberately, like the schema-mismatch fixture): it
+//!   pins that IF the gateway ever drifted into producing one, the
+//!   converter names the offending non-nullable column instead of quietly
+//!   emitting an all-NULL row.
 //!
 //! - **No `error_path` anywhere.** `dropboxRpcRequest` throws on any
 //!   non-2xx, so Dropbox's in-band `error_summary` envelope AND its 429
@@ -392,8 +396,9 @@ mod tests {
 
         // shared_links takes the cursor on its OWN action — the executor
         // `compactObject`s `{path, cursor}` together and the schema
-        // declares both — so it needs no continuation. Inference from the
-        // source, not a wire observation: design spec open question 1.
+        // declares both — so it needs no continuation. CONFIRMED on the
+        // wire 2026-08-18 (design-spec open question 1, now closed):
+        // `list_shared_links` accepts `path` and `cursor` together.
         let shared = table("shared_links");
         assert!(shared.continuation.is_none());
         assert_eq!(shared.gated_actions().count(), 1);
@@ -539,12 +544,36 @@ mod tests {
 
     #[test]
     fn empty_page_converts_to_zero_rows() {
+        // Through the real row path, off a real fixture page — this is
+        // the `files` arm, which also pins that `$.entries: []` resolves
+        // rather than erroring as a missing row path.
         let batch = convert_fixture(
             table("files"),
             include_str!("fixtures/dropbox/files_empty.json"),
         );
         assert_eq!(batch.num_rows(), 0);
         assert_eq!(batch.schema().fields().len(), table("files").fields.len());
+    }
+
+    #[test]
+    fn every_table_converts_an_empty_page_and_keeps_its_schema() {
+        // The sibling packs' pin (`github.rs`, `slack.rs`), applied to all
+        // three tables rather than just the one with an empty fixture: an
+        // empty result must keep the STABLE schema, or a query over an
+        // empty account changes shape.
+        for table in pack().expect("embedded asset parses").tables {
+            let batch = RowConverter::new(table.fields)
+                .expect("converter")
+                .convert(&[], 1)
+                .expect("empty page");
+            assert_eq!(batch.num_rows(), 0, "{}", table.id);
+            assert_eq!(
+                batch.schema().fields().len(),
+                table.fields.len(),
+                "{} keeps its stable schema on empty results",
+                table.id
+            );
+        }
     }
 
     #[test]
@@ -627,17 +656,23 @@ mod tests {
     }
 
     #[test]
-    fn a_null_metadata_parent_nulls_its_children_not_the_scan() {
+    fn a_null_metadata_parent_fails_the_scan_naming_the_non_nullable_column() {
         // The null-parent category. The fixture is SYNTHETIC on purpose:
         // the derived contract declares `matches[].metadata` a required,
         // non-nullable object, so this shape is one the gateway is not
         // supposed to produce — like the schema-mismatch fixture. What it
-        // pins is the converter's behavior IF it ever does: `metadata:
-        // null` makes every nested NULLABLE column SQL NULL, and the
-        // non-nullable ones (tag, name) fail loudly, because a quiet
-        // all-NULL row would hide the drift. If the live pass finds that
+        // pins is the converter's behavior IF it ever does: the row is
+        // NOT produced. `tag` is mapped `nullable: false` under that
+        // parent, so the conversion fails and names the column, because a
+        // quiet all-NULL row would hide the drift.
+        //
+        // Nothing here asserts what a null parent does to the NULLABLE
+        // columns beside it — the conversion short-circuits before any
+        // batch exists, so that is unobservable from this fixture and is
+        // deliberately not claimed. If the live pass ever finds that
         // Dropbox can null a match's metadata, `tag`/`name` become
-        // nullable and this fixture graduates to a real capture.
+        // nullable, this fixture graduates to a real capture, and THAT is
+        // the test that would pin the surviving columns.
         let table = table("file_search");
         let page: Value = serde_json::from_str(include_str!(
             "fixtures/dropbox/file_search_null_parent.json"
@@ -903,9 +938,15 @@ bindings:
 
     #[tokio::test]
     async fn shared_links_pages_through_its_own_action_with_the_full_input() {
-        // The contrast case: this action takes the cursor itself, so no
-        // continuation is declared and page two repeats the action with
-        // its resources intact.
+        // The contrast case to the `files` split-action test: this action
+        // takes the cursor itself, so no continuation is declared and page
+        // two repeats the action with its resources INTACT.
+        //
+        // The binding therefore has to bind resources. With none bound,
+        // page two's input is `{cursor}` either way and the test would
+        // stay green against a `cursor_only` continuation — i.e. it could
+        // not fail if the behavior it names regressed. Both resources are
+        // bound below and page two is asserted to still carry them.
         let gateway = MockGateway::start(|req| {
             if req.method == "GET" && req.path == "/v1/health" {
                 return MockResponse::ok("{}");
@@ -928,12 +969,33 @@ bindings:
             MockResponse::new(404, "{}")
         })
         .await;
-        let (gateway, ctx) = setup_with_gateway(
-            gateway,
-            "SKARDI_TEST_OC_DROPBOX_SHARED_LINKS",
-            "shared_links",
+        let _token = EnvVarGuard::set("SKARDI_TEST_OC_DROPBOX_SHARED_LINKS", "test-token");
+        let config: OpenConnectorConfig = serde_yaml::from_str(
+            r#"
+runtime_token_env: SKARDI_TEST_OC_DROPBOX_SHARED_LINKS
+bindings:
+  - name: ws
+    source_pack: dropbox
+    resource:
+      path: /Redacted Folder/redacted-report.pdf
+      directOnly: true
+    tables: [shared_links]
+"#,
         )
-        .await;
+        .expect("config parses");
+        let mut ctx = SessionContext::new();
+        let gateways = OpenConnectorGateways::default();
+        register_open_connector_tables(
+            &mut ctx,
+            "saas",
+            &gateway.url,
+            Some(&config),
+            false,
+            HierarchyLevel::Catalog,
+            Some(&gateways),
+        )
+        .await
+        .expect("registration succeeds");
 
         let batches = collect(&ctx, "SELECT name FROM saas.ws.shared_links ORDER BY name").await;
         assert_eq!(names_of(&batches), vec!["l1", "l2"]);
@@ -946,8 +1008,21 @@ bindings:
                 "both pages use the same action"
             );
         }
-        assert!(calls[0].1.get("cursor").is_none());
-        assert_eq!(calls[1].1["cursor"], json!("sl-2"));
+        // The assertion the test is named for: page two is the FULL input,
+        // not just the cursor. Compared as whole objects, so a resource
+        // silently dropped on continuation goes red here.
+        assert_eq!(
+            calls[0].1,
+            json!({"path": "/Redacted Folder/redacted-report.pdf", "directOnly": true}),
+            "page one carries both resources and no cursor"
+        );
+        assert_eq!(
+            calls[1].1,
+            json!({"path": "/Redacted Folder/redacted-report.pdf", "directOnly": true,
+                   "cursor": "sl-2"}),
+            "page two REPEATS both resources alongside the cursor — this is what \
+             `inputs: cursor_only` would have removed"
+        );
         assert!(
             calls[0].1.get("limit").is_none() && calls[1].1.get("limit").is_none(),
             "this action declares no page-size input"

--- a/crates/skardi/src/sources/providers/open_connector/packs/dropbox.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/dropbox.rs
@@ -2,6 +2,37 @@
 //! Connector `dropbox.*` read actions (OAuth2, cursor pagination with
 //! split-action continuation).
 //!
+//! # Provenance: NOT live-verified
+//!
+//! Everything below is reconciled against the Open Connector **v1.3.5
+//! provider source** (`src/providers/dropbox/`) and nothing else. No live
+//! gateway has answered any of it, and no Dropbox account has been read:
+//! the authoring box has no Node runtime, so the design spec's step 2
+//! (contract capture) and step 5 (live verification) are recorded as
+//! blocked, not done. Concretely, and stated here so no reader infers
+//! otherwise from the confidence of the prose:
+//!
+//! - the five `fixtures/dropbox/contracts/*.json` files are schemas
+//!   derived from the executor source, not captured from `GET
+//!   /v1/actions/<id>`; the `*_continue.json` pair is byte-identical to
+//!   its opener because it was derived that way, which is a hypothesis
+//!   about the wire rather than an observation of it;
+//! - every `fingerprint:` in `dropbox.yaml` therefore hashes a
+//!   source-derived schema. Registration against a real gateway is
+//!   EXPECTED to fail the contract gate until the live pass re-pins them
+//!   — that failure is the gate working, not a regression;
+//! - the row fixtures are hand-authored in the executor's shape, not
+//!   redacted live captures, so no mapped column has been shown to carry
+//!   a real non-NULL value;
+//! - declared page sizes (`limit: 2000`, `maxResults: 1000`) are the
+//!   schema's maxima, unprobed at the boundary — a declared cap can
+//!   exceed the wire's (Feishu declared 100, hard-failed above 50).
+//!
+//! The runbook that closes all of this out is
+//! `docs/superpowers/plans/2026-08-18-dropbox-live-evaluation.md`. Its
+//! acceptance table is the list of statements in this file that are
+//! currently inferences.
+//!
 //! **Rows are NORMALIZED, not passed through.** Every list executor maps
 //! entries through `mapDropboxMetadata`, which rebuilds each one into a
 //! fixed camelCase shape — `tag` / `name` / `id` / `pathDisplay` /
@@ -24,13 +55,25 @@
 //!   opened it: `list_folder` → `list_folder_continue`, `search_files` →
 //!   `search_files_continue`, each continue action declaring `cursor` as
 //!   its ONLY property under `additionalProperties: false`. This is not a
-//!   style difference — feeding the cursor back to the opening action is
-//!   a hard 400, verified live against v1.3.5 (`POST dropbox.list_folder
-//!   {"cursor":"abc"}` → 400 `invalid_input`). The engine's
-//!   `continuation: {action, fingerprint, inputs: cursor_only}` exists
-//!   for this shape, and BOTH actions are fingerprint-gated: the
-//!   continue action serves most of a long scan, so pinning only the
-//!   opener would leave the rest unguarded against drift.
+//!   style difference: `list_folder` does not declare `cursor`, and its
+//!   input schema is `additionalProperties: false`, so feeding the cursor
+//!   back to the opening action is a hard 400 rather than a quiet
+//!   truncation — read off the declared schema, not observed on the wire.
+//!   The engine's `continuation: {action, fingerprint, inputs:
+//!   cursor_only}` exists for this shape.
+//!
+//!   Both actions are fingerprint-gated, but be precise about what that
+//!   buys: a fingerprint hashes the OUTPUT schema, and an opener and its
+//!   continuation publish the same one here, so the continuation pin
+//!   guards the row shape of pages 2..N and cannot fail alone. The claim
+//!   that actually keeps the scan alive is `cursor_only`, an INPUT claim,
+//!   and registration checks it separately against the continuation
+//!   action's discovered input schema
+//!   (`SourcePackTable::check_continuation_inputs`): the cursor input must
+//!   be a declared property and no other input may be required. A
+//!   continuation action publishing no input schema is refused rather
+//!   than trusted, the same default-deny posture raw scans take toward a
+//!   missing read/write classification.
 //!
 //! - **`has_more_path` is load-bearing on `files`, not decorative.**
 //!   `list_folder` answers its FINAL page with a NON-EMPTY cursor — the
@@ -69,6 +112,26 @@
 //!   and Inexact would still push a rev ID as though it were a path.
 //!   Guard tests prove no filter key ever reaches the wire.
 //!
+//! - **`shared_links` continues through its own action, on inference.**
+//!   The executor `compactObject`s `path` and `cursor` together and the
+//!   input schema declares both, so no `continuation` block is declared
+//!   and pages 2..N repeat the action with the full input. This is design
+//!   spec open question 1 and is unresolved on the wire; if Dropbox
+//!   rejects the pair, the fix is a `continuation: {fingerprint, inputs:
+//!   cursor_only}` block here and no code change.
+//!
+//! - **`directOnly` is a binding-level resource, not a pin.** It is a
+//!   scan-shape boolean — the class of input this pack otherwise pins
+//!   (`recursive`, `includeDeleted`, `fileStatus`) — and it is exposed
+//!   because neither setting is an honest default for a table named
+//!   `shared_links`: pinned `true`, links a file inherits from a shared
+//!   ancestor disappear; pinned `false`, one file can surface through
+//!   several ancestors. Which of those a deployment wants is not a pack
+//!   decision. Resource values keep their YAML type
+//!   (`OpenConnectorBinding::resource` is a `BTreeMap<String, Value>`),
+//!   so `directOnly: true` reaches the strict schema as a JSON boolean
+//!   rather than the string `"true"`; a forwarding test pins that.
+//!
 //! - **`file_search` requires `query`.** A search table without one is
 //!   not a table (the GitHub `owner`/`repo` precedent), and the
 //!   requirement is enforced before any HTTP. `fileStatus: active` is
@@ -83,6 +146,20 @@
 //!   the declared schema (`anyOf: [array, null]`) contradicts the
 //!   executor (`readObjectArray`, which returns `[]` and never null).
 //!   Recorded as a wire-vs-contract contradiction; not worth a column.
+//!
+//! - **`file_search`'s `metadata` nullability is UNRESOLVED, and it is
+//!   the one open question that can fail a live scan.** The derived
+//!   contract declares `matches[].metadata` a required, non-nullable
+//!   object, and `tag` / `name` are mapped `nullable: false` on that
+//!   basis — so a real `metadata: null` row would fail the scan rather
+//!   than yield NULLs. `fixtures/dropbox/file_search_null_parent.json` is
+//!   a SYNTHETIC probe of that path (it encodes a shape the derived
+//!   contract says cannot occur, deliberately, like the schema-mismatch
+//!   fixture): it proves the converter names the offending non-nullable
+//!   column instead of quietly emitting an all-NULL row. If the live pass
+//!   finds that Dropbox can null a match's metadata, `tag` and `name`
+//!   become nullable and that fixture graduates from synthetic to
+//!   captured.
 //!
 //! - **No `error_path` anywhere.** `dropboxRpcRequest` throws on any
 //!   non-2xx, so Dropbox's in-band `error_summary` envelope AND its 429
@@ -179,7 +256,7 @@ mod tests {
     }
 
     #[test]
-    fn pinned_fingerprints_match_the_captured_contracts() {
+    fn pinned_fingerprints_match_the_committed_contracts() {
         // Locks pin ↔ fixture for BOTH actions of a split-action table.
         // Collects every mismatch and prints the actual hash, which is
         // also how the pins are obtained the first time.
@@ -272,9 +349,10 @@ mod tests {
             );
         }
 
-        // shared_links takes the cursor on its OWN action (verified live:
-        // `{path, cursor}` together pass the strict schema), so it needs
-        // no continuation at all.
+        // shared_links takes the cursor on its OWN action — the executor
+        // `compactObject`s `{path, cursor}` together and the schema
+        // declares both — so it needs no continuation. Inference from the
+        // source, not a wire observation: design spec open question 1.
         let shared = table("shared_links");
         assert!(shared.continuation.is_none());
         assert_eq!(shared.gated_actions().count(), 1);
@@ -320,8 +398,10 @@ mod tests {
         }
     }
 
-    // ── Contract tests: fixtures are provider-shaped redacted pages,
-    // covering all six admission-gate categories. ──────────────────────
+    // ── Contract tests. The fixtures are provider-SHAPED pages authored
+    // from the executor source, not redacted live captures (module doc,
+    // provenance banner); they cover all six admission-gate
+    // categories. ─────────────────────────────────────────────────────
 
     fn convert_fixture(table: &SourcePackTable, fixture: &str) -> RecordBatch {
         let page: Value = serde_json::from_str(fixture).expect("fixture parses");
@@ -488,9 +568,16 @@ mod tests {
 
     #[test]
     fn a_null_metadata_parent_nulls_its_children_not_the_scan() {
-        // The null-parent category: `metadata: null` makes every nested
-        // NULLABLE column SQL NULL. The non-nullable ones (tag, name)
-        // must still fail — a quiet all-NULL row would hide the drift.
+        // The null-parent category. The fixture is SYNTHETIC on purpose:
+        // the derived contract declares `matches[].metadata` a required,
+        // non-nullable object, so this shape is one the gateway is not
+        // supposed to produce — like the schema-mismatch fixture. What it
+        // pins is the converter's behavior IF it ever does: `metadata:
+        // null` makes every nested NULLABLE column SQL NULL, and the
+        // non-nullable ones (tag, name) fail loudly, because a quiet
+        // all-NULL row would hide the drift. If the live pass finds that
+        // Dropbox can null a match's metadata, `tag`/`name` become
+        // nullable and this fixture graduates to a real capture.
         let table = table("file_search");
         let page: Value = serde_json::from_str(include_str!(
             "fixtures/dropbox/file_search_null_parent.json"
@@ -541,15 +628,40 @@ mod tests {
 
     // ── Integration: the pack against a mock gateway, end to end. ───────
 
-    /// Discovery serving the live-captured contracts, so every mock
+    /// Discovery serving the committed contracts (source-DERIVED, not
+    /// captured — see the module doc's provenance banner), so every mock
     /// registration exercises the fingerprint gate's PASS side — for the
     /// continuation actions too.
+    /// The continue actions' INPUT schema, as `additionalProperties:
+    /// false` with `cursor` its only property. Serving this — rather than
+    /// the `{}` a lazier mock would send — is what makes every
+    /// registration below exercise the PASS side of the `cursor_only`
+    /// input gate. Derived from the v1.3.5 executor source, like everything
+    /// else in this pack; the live pass replaces it with the real
+    /// `data.inputSchema`.
+    const CURSOR_ONLY_INPUT_SCHEMA: &str = r#"{
+        "type": "object",
+        "properties": { "cursor": { "type": "string" } },
+        "required": ["cursor"],
+        "additionalProperties": false
+    }"#;
+
     fn dropbox_discovery(path: &str) -> MockResponse {
-        // Each action reads its OWN captured contract even where two are
-        // byte-identical today (an opener and its continuation share an
-        // output schema): keeping them separate is what makes a future
-        // divergence visible instead of silently inherited.
-        let output_schema = match path.rsplit('/').next().unwrap_or_default() {
+        // Each action reads its OWN contract file even though the two
+        // continue files are byte-identical to their openers today: they
+        // were DERIVED that way, so keeping the files separate is what
+        // lets the live capture split them without touching this helper.
+        let action = path.rsplit('/').next().unwrap_or_default();
+        // Only the continue actions carry a declared input schema here:
+        // the openers' inputs are not gated, and leaving them `{}` keeps
+        // the difference visible.
+        let input_schema = match action {
+            "dropbox.list_folder_continue" | "dropbox.search_files_continue" => {
+                CURSOR_ONLY_INPUT_SCHEMA
+            }
+            _ => "{}",
+        };
+        let output_schema = match action {
             "dropbox.list_folder" => include_str!("fixtures/dropbox/contracts/list_folder.json"),
             "dropbox.list_folder_continue" => {
                 include_str!("fixtures/dropbox/contracts/list_folder_continue.json")
@@ -563,7 +675,7 @@ mod tests {
             }
             _ => r#"{"type": "object"}"#,
         };
-        MockResponse::ok(&discovery_ok("{}", output_schema, true, None))
+        MockResponse::ok(&discovery_ok(input_schema, output_schema, true, None))
     }
 
     fn dropbox_config(token_env: &str, tables: &str) -> OpenConnectorConfig {
@@ -662,8 +774,9 @@ bindings:
         // dropbox.list_folder with the pinned complete-collection inputs
         // and the page-size hint; page two goes to
         // dropbox.list_folder_continue carrying the cursor and NOTHING
-        // else — against the real gateway anything more is a 400
-        // (verified live: `cursor` alone on list_folder → invalid_input).
+        // else — against the real gateway anything more is a 400, since
+        // the continue action declares `cursor` as its only property under
+        // additionalProperties: false.
         // The final page answers hasMore:false with a NON-EMPTY cursor,
         // the Dropbox shape that makes has_more_path load-bearing.
         let gateway = MockGateway::start(|req| {
@@ -989,6 +1102,344 @@ bindings:
         assert!(
             table("files").error_path.is_none(),
             "no in-band error path is declared for Dropbox"
+        );
+    }
+
+    #[tokio::test]
+    async fn file_search_pages_through_its_own_continue_action() {
+        // `files`' two-page e2e does not cover this table: the action id,
+        // the page-size input (`maxResults`, not `limit`) and the
+        // continuation pin are all file_search's own declarations, and
+        // shared engine constants are not shared coverage.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return dropbox_discovery(&req.path);
+            }
+            match req.path.as_str() {
+                "/v1/actions/dropbox.search_files" => MockResponse::ok(&envelope_ok(
+                    &json!({"matches": [
+                                {"matchType": "filename", "metadata": entry("s1"),
+                                 "highlightSpans": []}],
+                            "cursor": "s-2", "hasMore": true})
+                    .to_string(),
+                )),
+                "/v1/actions/dropbox.search_files_continue" => {
+                    let body: Value = serde_json::from_str(&req.body).unwrap_or_default();
+                    match body["input"].get("cursor").and_then(Value::as_str) {
+                        Some("s-2") => MockResponse::ok(&envelope_ok(
+                            &json!({"matches": [
+                                        {"matchType": "content", "metadata": entry("s2"),
+                                         "highlightSpans": []}],
+                                    "cursor": null, "hasMore": false})
+                            .to_string(),
+                        )),
+                        other => MockResponse::new(400, format!("bad cursor {other:?}")),
+                    }
+                }
+                _ => MockResponse::new(404, "{}"),
+            }
+        })
+        .await;
+        let (gateway, ctx) = setup_with_gateway(
+            gateway,
+            "SKARDI_TEST_OC_DROPBOX_SEARCH_PAGES",
+            "file_search",
+        )
+        .await;
+
+        let batches = collect(&ctx, "SELECT name FROM saas.ws.file_search ORDER BY name").await;
+        assert_eq!(names_of(&batches), vec!["s1", "s2"]);
+
+        let calls = execute_calls(&gateway);
+        assert_eq!(calls.len(), 2, "two pages");
+
+        let (path, input) = &calls[0];
+        assert_eq!(path, "/v1/actions/dropbox.search_files");
+        let mut keys: Vec<&str> = input
+            .as_object()
+            .expect("object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            vec!["fileStatus", "maxResults", "query"],
+            "page one carries EXACTLY the required resource, the pin and the page size"
+        );
+        assert_eq!(
+            input["maxResults"],
+            json!(1000),
+            "this table's own page size"
+        );
+
+        let (path, input) = &calls[1];
+        assert_eq!(
+            path, "/v1/actions/dropbox.search_files_continue",
+            "page two targets THIS table's continue action"
+        );
+        assert_eq!(
+            input,
+            &json!({"cursor": "s-2"}),
+            "no query, no fileStatus, no maxResults — the continue action declares none of them"
+        );
+    }
+
+    #[tokio::test]
+    async fn shared_links_forwards_both_of_its_optional_resources() {
+        // `directOnly` is the pack's only boolean resource, so this also
+        // pins that resource values keep their YAML type: a string "true"
+        // would be rejected by the action's strict schema.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return dropbox_discovery(&req.path);
+            }
+            if req.path == "/v1/actions/dropbox.list_shared_links" {
+                return MockResponse::ok(&envelope_ok(
+                    &json!({"links": [entry("l1")], "cursor": null, "hasMore": false}).to_string(),
+                ));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let _token = EnvVarGuard::set("SKARDI_TEST_OC_DROPBOX_RESOURCES", "test-token");
+        let config: OpenConnectorConfig = serde_yaml::from_str(
+            r#"
+runtime_token_env: SKARDI_TEST_OC_DROPBOX_RESOURCES
+bindings:
+  - name: ws
+    source_pack: dropbox
+    resource:
+      path: /Redacted Folder/redacted-report.pdf
+      directOnly: true
+    tables: [shared_links]
+"#,
+        )
+        .expect("config parses");
+        let mut ctx = SessionContext::new();
+        let gateways = OpenConnectorGateways::default();
+        register_open_connector_tables(
+            &mut ctx,
+            "saas",
+            &gateway.url,
+            Some(&config),
+            false,
+            HierarchyLevel::Catalog,
+            Some(&gateways),
+        )
+        .await
+        .expect("registration succeeds");
+
+        let batches = collect(&ctx, "SELECT name FROM saas.ws.shared_links").await;
+        assert_eq!(names_of(&batches), vec!["l1"]);
+
+        let calls = execute_calls(&gateway);
+        assert_eq!(calls.len(), 1);
+        assert_eq!(
+            calls[0].1,
+            json!({"path": "/Redacted Folder/redacted-report.pdf", "directOnly": true}),
+            "both resources forward verbatim, and directOnly is a JSON boolean"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_files_page_without_the_has_more_signal_fails_the_scan() {
+        // `has_more_path` is called load-bearing in three places in this
+        // pack; this is the failure arm of that declaration reached through
+        // SQL, not through the engine's own unit tests. A page missing the
+        // signal must fail as contract drift — never terminate quietly,
+        // which is how a truncated scan would look green.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return dropbox_discovery(&req.path);
+            }
+            if req.path == "/v1/actions/dropbox.list_folder" {
+                // A well-formed page in every respect EXCEPT the declared
+                // has-more flag.
+                return MockResponse::ok(&envelope_ok(
+                    &json!({"entries": [entry("a")], "cursor": "cur-2"}).to_string(),
+                ));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (gateway, ctx) =
+            setup_with_gateway(gateway, "SKARDI_TEST_OC_DROPBOX_NO_HAS_MORE", "files").await;
+
+        let err = ctx
+            .sql("SELECT name FROM saas.ws.files")
+            .await
+            .expect("plan")
+            .collect()
+            .await
+            .expect_err("a page missing the declared has-more signal must fail");
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("$.hasMore") && rendered.contains("absent"),
+            "the error names the declared path and what was found: {rendered}"
+        );
+        assert_eq!(
+            execute_calls(&gateway).len(),
+            1,
+            "the scan stops at the drifted page instead of continuing"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_drifted_opening_contract_fails_registration_for_every_table() {
+        // The continuation-drift case is covered above; this is the arm
+        // each table owns, so no table rides another's pin.
+        for (short, action) in [
+            ("files", "dropbox.list_folder"),
+            ("shared_links", "dropbox.list_shared_links"),
+            ("file_search", "dropbox.search_files"),
+        ] {
+            let drifted = action.to_string();
+            let gateway = MockGateway::start(move |req| {
+                if req.method == "GET" && req.path == "/v1/health" {
+                    return MockResponse::ok("{}");
+                }
+                if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                    if req.path.ends_with(&drifted) {
+                        return MockResponse::ok(&discovery_ok(
+                            "{}",
+                            r#"{"type":"object","properties":{"drifted":{"type":"string"}}}"#,
+                            true,
+                            None,
+                        ));
+                    }
+                    return dropbox_discovery(&req.path);
+                }
+                MockResponse::new(404, "{}")
+            })
+            .await;
+            let env = format!("SKARDI_TEST_OC_DROPBOX_DRIFT_{}", short.to_uppercase());
+            let _token = EnvVarGuard::set(&env, "test-token");
+            let mut ctx = SessionContext::new();
+            let err = register_open_connector_tables(
+                &mut ctx,
+                "saas",
+                &gateway.url,
+                Some(&dropbox_config(&env, short)),
+                false,
+                HierarchyLevel::Catalog,
+                None,
+            )
+            .await
+            .expect_err("a drifted opening contract must fail registration");
+            let rendered = err.to_string();
+            assert!(
+                rendered.contains(&format!("dropbox.{short}")) && rendered.contains(action),
+                "{short}: error must name the table and the drifted action: {rendered}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_continue_action_demanding_more_than_a_cursor_fails_registration() {
+        // The fail arm of the `cursor_only` INPUT gate, reached through the
+        // public registration entry point. The fingerprint cannot catch
+        // this — the output schema is untouched — and without the gate the
+        // only symptom is a 400 on page two of a live scan.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                if req.path.ends_with("dropbox.list_folder_continue") {
+                    // Same OUTPUT schema as the captured contract, so the
+                    // fingerprint gate passes; the INPUT schema now also
+                    // requires `path`, which a cursor-only page never sends.
+                    return MockResponse::ok(&discovery_ok(
+                        r#"{"type":"object",
+                             "properties":{"cursor":{"type":"string"},"path":{"type":"string"}},
+                             "required":["cursor","path"],
+                             "additionalProperties":false}"#,
+                        include_str!("fixtures/dropbox/contracts/list_folder_continue.json"),
+                        true,
+                        None,
+                    ));
+                }
+                return dropbox_discovery(&req.path);
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let _token = EnvVarGuard::set("SKARDI_TEST_OC_DROPBOX_CURSOR_ONLY", "test-token");
+        let mut ctx = SessionContext::new();
+        let err = register_open_connector_tables(
+            &mut ctx,
+            "saas",
+            &gateway.url,
+            Some(&dropbox_config(
+                "SKARDI_TEST_OC_DROPBOX_CURSOR_ONLY",
+                "files",
+            )),
+            false,
+            HierarchyLevel::Catalog,
+            None,
+        )
+        .await
+        .expect_err("a continue action requiring more than the cursor must fail registration");
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("dropbox.list_folder_continue") && rendered.contains("path"),
+            "the error names the continuation action and the unsatisfiable input: {rendered}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_continue_action_without_an_input_schema_is_refused() {
+        // Default-deny on an unverifiable claim, mirroring how raw scans
+        // treat a missing read/write classification: `cursor_only` asserts
+        // something about inputs, and a gateway that declares no inputs
+        // cannot confirm it.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                if req.path.ends_with("dropbox.list_folder_continue") {
+                    return MockResponse::ok(&discovery_ok(
+                        "{}",
+                        include_str!("fixtures/dropbox/contracts/list_folder_continue.json"),
+                        true,
+                        None,
+                    ));
+                }
+                return dropbox_discovery(&req.path);
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let _token = EnvVarGuard::set("SKARDI_TEST_OC_DROPBOX_NO_INPUT_SCHEMA", "test-token");
+        let mut ctx = SessionContext::new();
+        let err = register_open_connector_tables(
+            &mut ctx,
+            "saas",
+            &gateway.url,
+            Some(&dropbox_config(
+                "SKARDI_TEST_OC_DROPBOX_NO_INPUT_SCHEMA",
+                "files",
+            )),
+            false,
+            HierarchyLevel::Catalog,
+            None,
+        )
+        .await
+        .expect_err("an unverifiable cursor_only claim must be refused");
+        assert!(
+            err.to_string().contains("no input schema"),
+            "the error says why it cannot be verified: {err}"
         );
     }
 

--- a/crates/skardi/src/sources/providers/open_connector/packs/dropbox.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/dropbox.rs
@@ -2,36 +2,54 @@
 //! Connector `dropbox.*` read actions (OAuth2, cursor pagination with
 //! split-action continuation).
 //!
-//! # Provenance: NOT live-verified
+//! # Provenance: live-verified 2026-08-18
 //!
-//! Everything below is reconciled against the Open Connector **v1.3.5
-//! provider source** (`src/providers/dropbox/`) and nothing else. No live
-//! gateway has answered any of it, and no Dropbox account has been read:
-//! the authoring box has no Node runtime, so the design spec's step 2
-//! (contract capture) and step 5 (live verification) are recorded as
-//! blocked, not done. Concretely, and stated here so no reader infers
-//! otherwise from the confidence of the prose:
+//! Authored against the Open Connector provider source
+//! (`src/providers/dropbox/`) and then verified end to end against a
+//! self-hosted Open Connector gateway at commit `a3efa99` and a real
+//! (free-tier) Dropbox account. What the live pass established:
 //!
-//! - the five `fixtures/dropbox/contracts/*.json` files are schemas
-//!   derived from the executor source, not captured from `GET
-//!   /v1/actions/<id>`; the `*_continue.json` pair is byte-identical to
-//!   its opener because it was derived that way, which is a hypothesis
-//!   about the wire rather than an observation of it;
-//! - every `fingerprint:` in `dropbox.yaml` therefore hashes a
-//!   source-derived schema. Registration against a real gateway is
-//!   EXPECTED to fail the contract gate until the live pass re-pins them
-//!   — that failure is the gate working, not a regression;
-//! - the row fixtures are hand-authored in the executor's shape, not
-//!   redacted live captures, so no mapped column has been shown to carry
-//!   a real non-NULL value;
-//! - declared page sizes (`limit: 2000`, `maxResults: 1000`) are the
-//!   schema's maxima, unprobed at the boundary — a declared cap can
-//!   exceed the wire's (Feishu declared 100, hard-failed above 50).
+//! - the five `fixtures/dropbox/contracts/*.json` captures came back
+//!   byte-identical to the source-derived schemas they replaced, so every
+//!   `fingerprint:` in `dropbox.yaml` matched LIVE discovery unchanged and
+//!   registration passed the contract gate on the first try. The
+//!   `*_continue.json` files being identical to their openers is a fact
+//!   about the wire, not an artifact of how they were derived;
+//! - all three tables scanned real rows, and every mapped column carried a
+//!   real non-NULL value somewhere — 12/12 on `files` (378 rows), 13/13 on
+//!   `file_search`, and 11/11 on `shared_links` AFTER the live pass removed
+//!   four columns that cannot populate (see the `shared_links` note below);
+//! - the declared page sizes are the wire's maxima, probed at the boundary:
+//!   `limit: 2000` and `maxResults: 1000` return rows, 2001 and 1001 are
+//!   refused;
+//! - real multi-page pagination ran through `list_folder_continue`
+//!   (`pages=2 rows=378`), and `LIMIT` pushdown collapsed the same scan to
+//!   `pages=1 rows=1`, stopping before the continuation request.
 //!
-//! The runbook that closes all of this out is
-//! `docs/superpowers/plans/2026-08-18-dropbox-live-evaluation.md`. Its
-//! acceptance table is the list of statements in this file that are
-//! currently inferences.
+//! What the live pass did NOT change: the row fixtures are still
+//! hand-authored pages in the executor's shape rather than redacted live
+//! captures, because the account read during the pass holds personal
+//! files. `shared_links.json` was corrected to the live shape (the four
+//! removed keys now null, as the wire has them), and
+//! `files_type_mismatch.json` stays deliberately synthetic. Re-deriving
+//! the fixtures from redacted captures remains open.
+//!
+//! Two claims remain UNOBSERVED rather than confirmed, and neither is a
+//! defect: `shared_links.expires_at` needs paid-tier link expiry (a free
+//! account is refused with `settings_error/not_authorized`), and
+//! `file_search.match_type = 'content'` needs Dropbox content indexing,
+//! which never landed during the pass. Both columns stay mapped because
+//! both are structurally reachable.
+//!
+//! One gateway defect the pass uncovered, which is NOT specific to this
+//! pack: `GET /v1/actions/<id>` — the endpoint `discover_action` reads —
+//! does not serialize the `execution` block, so Skardi's default-deny
+//! action registry refuses every action from every pack against a
+//! stock gateway at that commit. Reproduced with the merged `github` pack,
+//! so it is not this pack's bug; filed upstream as
+//! oomol-lab/open-connector#358 (the gateway's catalog routes already
+//! compute the field). Skardi's default-deny gate is correct and is left
+//! untouched — no fallback reads the classification from another route.
 //!
 //! **Rows are NORMALIZED, not passed through.** Every list executor maps
 //! entries through `mapDropboxMetadata`, which rebuilds each one into a
@@ -58,7 +76,8 @@
 //!   style difference: `list_folder` does not declare `cursor`, and its
 //!   input schema is `additionalProperties: false`, so feeding the cursor
 //!   back to the opening action is a hard 400 rather than a quiet
-//!   truncation — read off the declared schema, not observed on the wire.
+//!   truncation — read off the declared schema and CONFIRMED on the wire
+//!   2026-08-18, bare and alongside the full input.
 //!   The engine's `continuation: {action, fingerprint, inputs:
 //!   cursor_only}` exists for this shape.
 //!
@@ -76,11 +95,11 @@
 //!   missing read/write classification.
 //!
 //! - **`has_more_path` is load-bearing on `files`, not decorative.**
-//!   `list_folder` answers its FINAL page with a NON-EMPTY cursor — the
-//!   executor's `requireString(payload.cursor)`, and the captured
-//!   contract declares `cursor` a plain required string rather than a
-//!   nullable one. Null-cursor termination alone would refetch and fail
-//!   as a `PaginationLoop`. `shared_links` and `file_search` DO null
+//!   `list_folder` answers its FINAL page with a NON-EMPTY cursor —
+//!   OBSERVED live 2026-08-18, where the final page carried
+//!   `hasMore: false` beside a 259-character cursor and following that
+//!   cursor returned an empty page. Null-cursor termination alone would
+//!   refetch and fail as a `PaginationLoop`. `shared_links` and `file_search` DO null
 //!   their cursors (`anyOf: [string, null]` in their contracts), but
 //!   declare `$.hasMore` too: it is the provider's authoritative signal
 //!   in all three, and one termination rule across the pack beats three.
@@ -101,6 +120,20 @@
 //!   They live on `shared_links`, where they populate. A negative-space
 //!   test pins their absence.
 //!
+//! - **Four columns are deliberately absent from `shared_links`** — the
+//!   mirror image of the three above, and the one defect the live pass
+//!   caught. `sharing/list_shared_links` returns SharedLinkMetadata,
+//!   which carries `path_lower` but has NO `path_display`,
+//!   `is_downloadable`, `content_hash` or `sharing_info` field at all, so
+//!   the shared normalizer reads those four off keys the payload never
+//!   has. They were mapped here until 2026-08-18, when the live pass
+//!   measured them at 0/5 non-NULL and then settled it decisively: a file
+//!   whose `files` row carries all four came back with all four NULL on
+//!   its own `shared_links` row — same file, same normalizer, different
+//!   endpoint. The fingerprint gate cannot catch this class, because both
+//!   actions publish the same normalized 15-key schema; only real rows
+//!   can. A negative-space test pins the absence.
+//!
 //! - **No filter is pushed by any table.** Dropbox's remaining list
 //!   inputs are scan-shape controls (`recursive`, `includeDeleted`,
 //!   `limit`, `filenameOnly`), not column predicates. `path` is a
@@ -112,13 +145,13 @@
 //!   and Inexact would still push a rev ID as though it were a path.
 //!   Guard tests prove no filter key ever reaches the wire.
 //!
-//! - **`shared_links` continues through its own action, on inference.**
-//!   The executor `compactObject`s `path` and `cursor` together and the
-//!   input schema declares both, so no `continuation` block is declared
-//!   and pages 2..N repeat the action with the full input. This is design
-//!   spec open question 1 and is unresolved on the wire; if Dropbox
-//!   rejects the pair, the fix is a `continuation: {fingerprint, inputs:
-//!   cursor_only}` block here and no code change.
+//! - **`shared_links` continues through its own action.** The executor
+//!   `compactObject`s `path` and `cursor` together and the input schema
+//!   declares both, so no `continuation` block is declared and pages
+//!   2..N repeat the action with the full input. This was design spec
+//!   open question 1; the live pass answered it YES on 2026-08-18 —
+//!   `list_shared_links` accepts `path` and `cursor` in one request — so
+//!   no `cursor_only` continuation is needed here.
 //!
 //! - **`directOnly` is a binding-level resource, not a pin.** It is a
 //!   scan-shape boolean — the class of input this pack otherwise pins
@@ -180,9 +213,17 @@
 //!   `get_shared_link_file`) return base64 payloads, not rows.
 //!
 //! Authorization: `files` and `file_search` need the
-//! `files.metadata.read` scope; `shared_links` needs `sharing.read`. No
-//! content or write scope is required by any shipped table, so a
-//! read-only Dropbox connection serves the whole pack.
+//! `files.metadata.read` scope; `shared_links` needs `sharing.read` —
+//! both confirmed against the live gateway's per-action `requiredScopes`.
+//! No content or write scope is required by any shipped table.
+//!
+//! That is a statement about the ACTIONS, not about what an operator can
+//! provision. The gateway's dropbox provider builds its OAuth scope list
+//! as the union of every `dropbox.*` action's permissions, so its
+//! authorize request asks for all six — including `files.content.write`
+//! and `sharing.write` — and a connection created through that flow
+//! carries write access this pack never exercises. Narrowing it is a
+//! gateway-side change; see `docs/open-connector-dropbox.md`.
 
 use std::sync::OnceLock;
 
@@ -386,6 +427,25 @@ mod tests {
             .collect();
         for present in ["url", "expires_at", "link_permissions"] {
             assert!(shared.contains(&present), "shared_links must map {present}");
+        }
+        // The mirror image, and the defect the live pass caught:
+        // `sharing/list_shared_links` returns SharedLinkMetadata, which
+        // has no `path_display`, `is_downloadable`, `content_hash` or
+        // `sharing_info` field at all, so these four were four
+        // structurally always-NULL columns. Observed live 2026-08-18 as
+        // 0/5 non-NULL, and decisively: a file whose files-row carries
+        // all four returns all four NULL on its own shared_links row.
+        for absent in [
+            "path_display",
+            "is_downloadable",
+            "content_hash",
+            "sharing_info",
+        ] {
+            assert!(
+                !shared.contains(&absent),
+                "shared_links must not map '{absent}': SharedLinkMetadata never \
+                 carries it, so the column would be structurally always-NULL"
+            );
         }
 
         // `includeHighlights` is never sent, so `highlight_spans` stays

--- a/crates/skardi/src/sources/providers/open_connector/packs/dropbox.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/dropbox.rs
@@ -1590,8 +1590,12 @@ bindings:
             }
             if req.method == "GET" && req.path.starts_with("/v1/actions/") {
                 if req.path.ends_with("dropbox.list_folder_continue") {
+                    // `null`, not `{}`: an absent `inputSchema` is the arm
+                    // under test. An empty object is a schema that is
+                    // PRESENT and shapeless, which the gate refuses with a
+                    // different diagnostic (covered in `source_pack`).
                     return MockResponse::ok(&discovery_ok(
-                        "{}",
+                        "null",
                         include_str!("fixtures/dropbox/contracts/list_folder_continue.json"),
                         true,
                         None,
@@ -1834,9 +1838,10 @@ bindings:
             if req.method == "GET" && req.path.starts_with("/v1/actions/") {
                 if req.path.ends_with("dropbox.list_folder_continue") {
                     // Captured OUTPUT schema — so the fingerprint still
-                    // matches — with no input schema at all.
+                    // matches — with no input schema at all (`null`, not an
+                    // empty object; see the YAML twin).
                     return MockResponse::ok(&discovery_ok(
-                        "{}",
+                        "null",
                         include_str!("fixtures/dropbox/contracts/list_folder_continue.json"),
                         true,
                         None,

--- a/crates/skardi/src/sources/providers/open_connector/packs/dropbox.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/dropbox.rs
@@ -601,7 +601,7 @@ mod tests {
             "page 7",
             "row 1",
             "expected integer",
-            "found string",
+            "found a string",
         ] {
             assert!(
                 rendered.contains(fragment),

--- a/crates/skardi/src/sources/providers/open_connector/packs/dropbox.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/dropbox.rs
@@ -331,6 +331,40 @@ mod tests {
     }
 
     #[test]
+    fn the_cursor_only_claim_holds_against_the_committed_input_contracts() {
+        // The fingerprint gate hashes the OUTPUT schema, so nothing in the
+        // pin machinery covers the input half — and the input half is the
+        // one a wrong claim turns into a hard 400 on page two. This is the
+        // gmail/outlook pattern: both sides committed artifacts, so an
+        // upstream release that grows a second `required` key on a continue
+        // action fails HERE on re-capture rather than at an operator's
+        // registration. (Catching it LIVE needs a registration-time input
+        // fingerprint, which remains tracked engine work.)
+        for short in ["files", "file_search"] {
+            let table = table(short);
+            let continuation = table
+                .continuation
+                .unwrap_or_else(|| panic!("{short} is a split-action table"));
+            assert!(
+                continuation.cursor_only,
+                "{short} declares `inputs: cursor_only`"
+            );
+            let captured = continuation_input_contract(continuation.action_id)
+                .unwrap_or_else(|| panic!("{} has a committed input contract", continuation.action_id));
+            let schema: Value = serde_json::from_str(captured).expect("input contract parses");
+            table
+                .check_continuation_inputs(Some(&schema))
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "{short}: the committed input contract for {} no longer satisfies \
+                         `inputs: cursor_only`: {e}",
+                        continuation.action_id
+                    )
+                });
+        }
+    }
+
+    #[test]
     fn every_mapped_column_is_inside_the_fingerprint_gate() {
         // Dropbox's row schemas are strict with all keys required, so
         // unlike the passthrough packs NO column rides
@@ -723,39 +757,49 @@ mod tests {
 
     // ── Integration: the pack against a mock gateway, end to end. ───────
 
-    /// Discovery serving the committed contracts (source-DERIVED, not
-    /// captured — see the module doc's provenance banner), so every mock
-    /// registration exercises the fingerprint gate's PASS side — for the
-    /// continuation actions too.
-    /// The continue actions' INPUT schema, as `additionalProperties:
-    /// false` with `cursor` its only property. Serving this — rather than
-    /// the `{}` a lazier mock would send — is what makes every
-    /// registration below exercise the PASS side of the `cursor_only`
-    /// input gate. Derived from the v1.3.5 executor source, like everything
-    /// else in this pack; the live pass replaces it with the real
-    /// `data.inputSchema`.
-    const CURSOR_ONLY_INPUT_SCHEMA: &str = r#"{
-        "type": "object",
-        "properties": { "cursor": { "type": "string" } },
-        "required": ["cursor"],
-        "additionalProperties": false
-    }"#;
+    /// Discovery serving the committed contracts — live CAPTURES, per the
+    /// module doc's provenance banner and `fixtures/dropbox/README.md` —
+    /// so every mock registration exercises the fingerprint gate's PASS
+    /// side, for the continuation actions too.
+    /// The continue actions' INPUT schemas, `contracts/inputs/`, committed
+    /// next to the output captures on the gmail/outlook convention.
+    /// Serving these — rather than the `{}` a lazier mock would send — is
+    /// what makes every registration below exercise the PASS side of the
+    /// `cursor_only` input gate, and
+    /// `the_cursor_only_claim_holds_against_the_committed_input_contracts`
+    /// is what makes a re-capture that grows a second `required` key fail
+    /// CI instead of an operator's registration.
+    ///
+    /// Provenance, stated because it differs from `contracts/*.json`:
+    /// these record the SHAPE the 2026-08-18 pass observed (`cursor` the
+    /// only property, `required`, `additionalProperties: false`) — the
+    /// probe wrote `data.inputSchema` to `/tmp` and only the shape was
+    /// carried into the repo, so they are transcriptions, not byte-exact
+    /// captures. `fixtures/dropbox/README.md` says the same.
+    fn continuation_input_contract(action: &str) -> Option<&'static str> {
+        match action {
+            "dropbox.list_folder_continue" => Some(include_str!(
+                "fixtures/dropbox/contracts/inputs/list_folder_continue.json"
+            )),
+            "dropbox.search_files_continue" => Some(include_str!(
+                "fixtures/dropbox/contracts/inputs/search_files_continue.json"
+            )),
+            _ => None,
+        }
+    }
 
     fn dropbox_discovery(path: &str) -> MockResponse {
-        // Each action reads its OWN contract file even though the two
-        // continue files are byte-identical to their openers today: they
-        // were DERIVED that way, so keeping the files separate is what
-        // lets the live capture split them without touching this helper.
+        // Each action reads its OWN contract file. The two continue files
+        // being byte-identical to their openers is a fact about the wire —
+        // the live pass captured all four independently and they came back
+        // the same — NOT an artifact of derivation. Keeping the files
+        // separate is what lets a future upstream split them without
+        // touching this helper.
         let action = path.rsplit('/').next().unwrap_or_default();
         // Only the continue actions carry a declared input schema here:
         // the openers' inputs are not gated, and leaving them `{}` keeps
         // the difference visible.
-        let input_schema = match action {
-            "dropbox.list_folder_continue" | "dropbox.search_files_continue" => {
-                CURSOR_ONLY_INPUT_SCHEMA
-            }
-            _ => "{}",
-        };
+        let input_schema = continuation_input_contract(action).unwrap_or("{}");
         let output_schema = match action {
             "dropbox.list_folder" => include_str!("fixtures/dropbox/contracts/list_folder.json"),
             "dropbox.list_folder_continue" => {
@@ -1579,7 +1623,13 @@ bindings:
     }
 
     #[tokio::test]
-    async fn udtf_parity_for_files() {
+    async fn udtf_parity_for_files_crosses_the_split_action_boundary() {
+        // Page one answered `hasMore: false` here for a long time, which
+        // meant the UDTF path never issued a continuation request: the
+        // `ScanTarget::from_pack_table` continuation was unpinned through
+        // this entry point, and so were both input gates below it. Two
+        // pages, so `dropbox.list_folder_continue` is genuinely executed
+        // through `open_connector_query`.
         let gateway = MockGateway::start(|req| {
             if req.method == "GET" && req.path == "/v1/health" {
                 return MockResponse::ok("{}");
@@ -1587,16 +1637,27 @@ bindings:
             if req.method == "GET" && req.path.starts_with("/v1/actions/") {
                 return dropbox_discovery(&req.path);
             }
-            if req.path == "/v1/actions/dropbox.list_folder" {
-                return MockResponse::ok(&envelope_ok(
-                    &json!({"entries": [entry("via-udtf")], "cursor": "c", "hasMore": false})
+            match req.path.as_str() {
+                "/v1/actions/dropbox.list_folder" => MockResponse::ok(&envelope_ok(
+                    &json!({"entries": [entry("via-udtf")], "cursor": "c-2", "hasMore": true})
                         .to_string(),
-                ));
+                )),
+                "/v1/actions/dropbox.list_folder_continue" => {
+                    let body: Value = serde_json::from_str(&req.body).unwrap_or_default();
+                    match body["input"].get("cursor").and_then(Value::as_str) {
+                        Some("c-2") => MockResponse::ok(&envelope_ok(
+                            &json!({"entries": [entry("via-udtf-page-2")],
+                                    "cursor": null, "hasMore": false})
+                            .to_string(),
+                        )),
+                        other => MockResponse::new(400, format!("bad cursor {other:?}")),
+                    }
+                }
+                _ => MockResponse::new(404, "{}"),
             }
-            MockResponse::new(404, "{}")
         })
         .await;
-        let (_gateway, ctx) =
+        let (gateway, ctx) =
             setup_with_gateway(gateway, "SKARDI_TEST_OC_DROPBOX_UDTF", "files").await;
 
         let batches = collect(
@@ -1604,6 +1665,204 @@ bindings:
             "SELECT name FROM open_connector_query('saas', 'dropbox.files', '{}')",
         )
         .await;
-        assert_eq!(names_of(&batches), vec!["via-udtf"]);
+        assert_eq!(names_of(&batches), vec!["via-udtf", "via-udtf-page-2"]);
+        // `cursor_only` holds on this path too: page two carries the cursor
+        // and nothing else — not the `recursive` pin, not `path`.
+        let calls = execute_calls(&gateway);
+        let (path, input) = calls
+            .iter()
+            .find(|(path, _)| path.ends_with("dropbox.list_folder_continue"))
+            .expect("the UDTF path issued a continuation request");
+        assert!(path.ends_with("dropbox.list_folder_continue"));
+        assert_eq!(*input, json!({"cursor": "c-2"}), "cursor only, on page two");
+    }
+
+    /// A config whose BINDINGS do not cover `files`, plus a raw-action
+    /// allowlist: the shape a UDTF-only operator has, and the one the
+    /// `open_connector_query` docs describe. Registration gates only the
+    /// bound table, so `dropbox.files` meets the discovery, fingerprint and
+    /// input gates for the first time during UDTF planning — which is
+    /// exactly the path under test.
+    fn dropbox_allowlist_config(token_env: &str, allowlist: &[&str]) -> OpenConnectorConfig {
+        let allowlist = allowlist.join(", ");
+        serde_yaml::from_str(&format!(
+            r#"
+runtime_token_env: {token_env}
+raw_action_allowlist: [{allowlist}]
+bindings:
+  - name: ws
+    source_pack: dropbox
+    tables: [shared_links]
+"#
+        ))
+        .expect("config parses")
+    }
+
+    async fn allowlist_only_ctx(
+        gateway: &MockGateway,
+        token_env: &'static str,
+        allowlist: &[&str],
+    ) -> SessionContext {
+        let _token = EnvVarGuard::set(token_env, "test-token");
+        let gateways = OpenConnectorGateways::default();
+        let mut ctx = SessionContext::new();
+        register_open_connector_tables(
+            &mut ctx,
+            "saas",
+            &gateway.url,
+            Some(&dropbox_allowlist_config(token_env, allowlist)),
+            false,
+            HierarchyLevel::Catalog,
+            Some(&gateways),
+        )
+        .await
+        .expect("registration gates only the BOUND table, so it succeeds");
+        register_open_connector_udtfs(&ctx, gateways).expect("UDTF registration succeeds");
+        ctx
+    }
+
+    /// The error a UDTF raises, whether it comes out of planning or the
+    /// first poll — the gates under test all fire during planning, but the
+    /// assertion should not depend on that.
+    async fn udtf_error(ctx: &SessionContext, sql: &str) -> String {
+        match ctx.sql(sql).await {
+            Err(e) => e.to_string(),
+            Ok(df) => df
+                .collect()
+                .await
+                .expect_err("the query must not succeed")
+                .to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn allowlisting_only_the_opening_action_fails_udtf_planning() {
+        // `open_connector_query` discovers EVERY action the table executes,
+        // so a split-action table needs both ids allowlisted. Pinning the
+        // behavior change: an allowlist naming only the opener used to be
+        // enough and now is not, which is what `docs/open-connector.md`
+        // says under `open_connector_query`.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return dropbox_discovery(&req.path);
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let ctx = allowlist_only_ctx(
+            &gateway,
+            "SKARDI_TEST_OC_DROPBOX_UDTF_ALLOWLIST",
+            &["dropbox.list_folder"],
+        )
+        .await;
+        let rendered = udtf_error(
+            &ctx,
+            "SELECT name FROM open_connector_query('saas', 'dropbox.files', '{}')",
+        )
+        .await;
+        assert!(
+            rendered.contains("was not discovered"),
+            "the undiscovered-action diagnostic: {rendered}"
+        );
+        assert!(
+            rendered.contains("dropbox.list_folder_continue"),
+            "names the CONTINUATION action, not the opener: {rendered}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_drifted_continuation_contract_fails_udtf_planning() {
+        // The YAML twin is `a_drifted_continuation_contract_fails_registration`.
+        // Both entry points run the same fingerprint gate over the same
+        // `actions()` pairs; without this test the UDTF half of that claim
+        // reverted clean, because no UDTF test reached a continue action.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                if req.path.ends_with("dropbox.list_folder_continue") {
+                    return MockResponse::ok(&discovery_ok(
+                        "{}",
+                        r#"{"type":"object","properties":{"entries":{"type":"array"}}}"#,
+                        true,
+                        None,
+                    ));
+                }
+                return dropbox_discovery(&req.path);
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let ctx = allowlist_only_ctx(
+            &gateway,
+            "SKARDI_TEST_OC_DROPBOX_UDTF_DRIFT",
+            &["dropbox.list_folder", "dropbox.list_folder_continue"],
+        )
+        .await;
+        let rendered = udtf_error(
+            &ctx,
+            "SELECT name FROM open_connector_query('saas', 'dropbox.files', '{}')",
+        )
+        .await;
+        assert!(
+            rendered.contains("fingerprint mismatch"),
+            "the contract gate refused it: {rendered}"
+        );
+        assert!(
+            rendered.contains("dropbox.list_folder_continue"),
+            "names the CONTINUATION action, not the opener: {rendered}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unverifiable_cursor_only_claim_fails_udtf_planning() {
+        // The YAML twin is `a_continue_action_without_an_input_schema_is_refused`.
+        // This is what holds the UDTF path's input-gate call site in place:
+        // the fingerprint gate above passes here (the drifting is on the
+        // INPUT side, which no fingerprint covers), so only the input gate
+        // can refuse this query.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                if req.path.ends_with("dropbox.list_folder_continue") {
+                    // Captured OUTPUT schema — so the fingerprint still
+                    // matches — with no input schema at all.
+                    return MockResponse::ok(&discovery_ok(
+                        "{}",
+                        include_str!("fixtures/dropbox/contracts/list_folder_continue.json"),
+                        true,
+                        None,
+                    ));
+                }
+                return dropbox_discovery(&req.path);
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let ctx = allowlist_only_ctx(
+            &gateway,
+            "SKARDI_TEST_OC_DROPBOX_UDTF_INPUTS",
+            &["dropbox.list_folder", "dropbox.list_folder_continue"],
+        )
+        .await;
+        let rendered = udtf_error(
+            &ctx,
+            "SELECT name FROM open_connector_query('saas', 'dropbox.files', '{}')",
+        )
+        .await;
+        assert!(
+            rendered.contains("no input schema"),
+            "the input gate said why it cannot be verified: {rendered}"
+        );
+        assert!(
+            rendered.contains("dropbox.list_folder_continue"),
+            "names the continuation action: {rendered}"
+        );
     }
 }

--- a/crates/skardi/src/sources/providers/open_connector/packs/dropbox.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/dropbox.rs
@@ -1,0 +1,1023 @@
+//! Dropbox source pack: stable relational contracts over the Open
+//! Connector `dropbox.*` read actions (OAuth2, cursor pagination with
+//! split-action continuation).
+//!
+//! **Rows are NORMALIZED, not passed through.** Every list executor maps
+//! entries through `mapDropboxMetadata`, which rebuilds each one into a
+//! fixed camelCase shape — `tag` / `name` / `id` / `pathDisplay` /
+//! `pathLower` / `clientModified` / `serverModified` / `rev` /
+//! `sizeBytes` / `isDownloadable` / `contentHash` / `url` / `expiresAt` /
+//! `sharingInfo` / `linkPermissions` — with all fifteen keys declared
+//! `required` under `additionalProperties: false`. Mapping Dropbox's own
+//! snake_case (`path_display`, `client_modified`, `size`) would have
+//! produced all-NULL columns no Dropbox doc would explain, the exact
+//! Slack 5.2 failure mode. The upside of that strictness, and the reason
+//! this pack carries less column risk than the passthrough packs: every
+//! mapped column sits INSIDE the fingerprint gate, so the coverage-gap
+//! pin below is empty rather than a list of unguarded fields.
+//!
+//! Design decisions, per the integration design spec and the source-pack
+//! admission gate:
+//!
+//! - **Split-action continuation on `files` and `file_search`.** Dropbox
+//!   continues a listing through a DIFFERENT action than the one that
+//!   opened it: `list_folder` → `list_folder_continue`, `search_files` →
+//!   `search_files_continue`, each continue action declaring `cursor` as
+//!   its ONLY property under `additionalProperties: false`. This is not a
+//!   style difference — feeding the cursor back to the opening action is
+//!   a hard 400, verified live against v1.3.5 (`POST dropbox.list_folder
+//!   {"cursor":"abc"}` → 400 `invalid_input`). The engine's
+//!   `continuation: {action, fingerprint, inputs: cursor_only}` exists
+//!   for this shape, and BOTH actions are fingerprint-gated: the
+//!   continue action serves most of a long scan, so pinning only the
+//!   opener would leave the rest unguarded against drift.
+//!
+//! - **`has_more_path` is load-bearing on `files`, not decorative.**
+//!   `list_folder` answers its FINAL page with a NON-EMPTY cursor — the
+//!   executor's `requireString(payload.cursor)`, and the captured
+//!   contract declares `cursor` a plain required string rather than a
+//!   nullable one. Null-cursor termination alone would refetch and fail
+//!   as a `PaginationLoop`. `shared_links` and `file_search` DO null
+//!   their cursors (`anyOf: [string, null]` in their contracts), but
+//!   declare `$.hasMore` too: it is the provider's authoritative signal
+//!   in all three, and one termination rule across the pack beats three.
+//!
+//! - **`files` pins the complete collection.** `recursive: true` is the
+//!   `state=all` move from 5.1 — a table named `files` that returns one
+//!   directory level is a surprising contract, so the table means "every
+//!   file under `path`". `includeMountedFolders: true` pins Dropbox's own
+//!   default so it cannot drift. `includeDeleted` stays off
+//!   deliberately: deleted tombstones carry a `deleted` tag and null
+//!   everything else, informing no query.
+//!
+//! - **Three columns are deliberately absent from `files`.** `url`,
+//!   `expires_at` and `link_permissions` exist in `mapDropboxMetadata`
+//!   but are sourced from `record.url` / `.expires` /
+//!   `.link_permissions`, which `files/list_folder` never returns —
+//!   mapping them would ship three structurally always-NULL columns.
+//!   They live on `shared_links`, where they populate. A negative-space
+//!   test pins their absence.
+//!
+//! - **No filter is pushed by any table.** Dropbox's remaining list
+//!   inputs are scan-shape controls (`recursive`, `includeDeleted`,
+//!   `limit`, `filenameOnly`), not column predicates. `path` is a
+//!   resource rather than an `eq` push onto `path_lower` for two
+//!   reasons: on `files` it selects the listing ROOT, which is a
+//!   different claim from a path equality; and on `shared_links` the
+//!   input accepts paths, file IDs AND rev IDs, so the mapping would be
+//!   unfaithful across most of its value domain — Exact would be wrong
+//!   and Inexact would still push a rev ID as though it were a path.
+//!   Guard tests prove no filter key ever reaches the wire.
+//!
+//! - **`file_search` requires `query`.** A search table without one is
+//!   not a table (the GitHub `owner`/`repo` precedent), and the
+//!   requirement is enforced before any HTTP. `fileStatus: active` is
+//!   pinned for the same reason `includeDeleted` is pinned off.
+//!   `orderBy` is deliberately NOT pinned: `search/continue_v2` pages a
+//!   server-side snapshot taken at the opening call, so relevance order
+//!   is stable within one scan — unlike Feishu's chats, whose default
+//!   ordering reshuffles mid-scan and forced `ByCreateTimeAsc`.
+//!
+//! - **`highlight_spans` is unmapped and `includeHighlights` is never
+//!   sent.** The field only populates when highlights are requested, and
+//!   the declared schema (`anyOf: [array, null]`) contradicts the
+//!   executor (`readObjectArray`, which returns `[]` and never null).
+//!   Recorded as a wire-vs-contract contradiction; not worth a column.
+//!
+//! - **No `error_path` anywhere.** `dropboxRpcRequest` throws on any
+//!   non-2xx, so Dropbox's in-band `error_summary` envelope AND its 429
+//!   rate limiting both surface as gateway FAILURE envelopes, never as
+//!   HTTP 200 rows.
+//!
+//! - **Tables deferred, with reasons.** `list_revisions` pages by
+//!   feeding a `beforeRev` from the previous page's rows and answers
+//!   `hasMore` with no cursor to follow — no pack-side strategy can
+//!   complete it, so it is absent rather than shipped incomplete (the
+//!   5.2 Slack message-history deferral repeated). `get_current_account`
+//!   returns a single object and `RowPath::rows` requires an array.
+//!   `get_tags` takes an array of paths (resources are scalars) and
+//!   declares no pagination. Every write action (`upload_file`, `move`,
+//!   `copy`, `delete`, `create_folder`, the shared-link mutators,
+//!   `save_url`, `restore`) is outside the read-only allowlist, and the
+//!   content actions (`download_file`, `get_temporary_link`,
+//!   `get_shared_link_file`) return base64 payloads, not rows.
+//!
+//! Authorization: `files` and `file_search` need the
+//! `files.metadata.read` scope; `shared_links` needs `sharing.read`. No
+//! content or write scope is required by any shipped table, so a
+//! read-only Dropbox connection serves the whole pack.
+
+use std::sync::OnceLock;
+
+use crate::sources::providers::open_connector::error::OpenConnectorError;
+use crate::sources::providers::open_connector::source_pack::SourcePack;
+
+use super::loader;
+
+static PACK: OnceLock<Result<SourcePack, String>> = OnceLock::new();
+
+/// The Dropbox pack, parsed once from the embedded YAML asset.
+pub fn pack() -> Result<&'static SourcePack, OpenConnectorError> {
+    loader::builtin("dropbox.yaml", include_str!("dropbox.yaml"), &PACK)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sources::hierarchy::HierarchyLevel;
+    use crate::sources::providers::open_connector::action_registry::fingerprint_schema;
+    use crate::sources::providers::open_connector::json_to_arrow::RowConverter;
+    use crate::sources::providers::open_connector::row_path::RowPath;
+    use crate::sources::providers::open_connector::source_pack::SourcePackTable;
+    use crate::sources::providers::open_connector::testutil::{
+        EnvVarGuard, MockGateway, MockResponse, discovery_ok, envelope_ok,
+        fingerprint_uncovered_columns,
+    };
+    use crate::sources::providers::open_connector::{
+        OpenConnectorConfig, OpenConnectorGateways, register_open_connector_tables,
+        register_open_connector_udtfs,
+    };
+    use arrow::array::{Array, BooleanArray, Int64Array, StringArray, TimestampMillisecondArray};
+    use arrow::record_batch::RecordBatch;
+    use datafusion::prelude::SessionContext;
+    use serde_json::{Value, json};
+
+    /// Look up a table by short name; the assets are test-pinned to parse.
+    fn table(short: &str) -> &'static SourcePackTable {
+        pack()
+            .expect("embedded asset is test-pinned to parse")
+            .tables
+            .iter()
+            .find(|t| t.id.rsplit('.').next() == Some(short))
+            .unwrap_or_else(|| panic!("table {short}"))
+    }
+
+    /// Every table's captured contract, keyed by the action it belongs to.
+    fn contracts() -> Vec<(&'static str, &'static str)> {
+        vec![
+            (
+                "dropbox.list_folder",
+                include_str!("fixtures/dropbox/contracts/list_folder.json"),
+            ),
+            (
+                "dropbox.list_folder_continue",
+                include_str!("fixtures/dropbox/contracts/list_folder_continue.json"),
+            ),
+            (
+                "dropbox.list_shared_links",
+                include_str!("fixtures/dropbox/contracts/list_shared_links.json"),
+            ),
+            (
+                "dropbox.search_files",
+                include_str!("fixtures/dropbox/contracts/search_files.json"),
+            ),
+            (
+                "dropbox.search_files_continue",
+                include_str!("fixtures/dropbox/contracts/search_files_continue.json"),
+            ),
+        ]
+    }
+
+    #[test]
+    fn pinned_fingerprints_match_the_captured_contracts() {
+        // Locks pin ↔ fixture for BOTH actions of a split-action table.
+        // Collects every mismatch and prints the actual hash, which is
+        // also how the pins are obtained the first time.
+        let mut mismatches = Vec::new();
+        for (action, contract) in contracts() {
+            let schema: Value = serde_json::from_str(contract).expect("contract parses");
+            let actual = fingerprint_schema(Some(&schema));
+            let expected: Vec<&str> = pack()
+                .expect("parses")
+                .tables
+                .iter()
+                .flat_map(SourcePackTable::gated_actions)
+                .filter(|(id, _)| *id == action)
+                .map(|(_, fingerprint)| fingerprint)
+                .collect();
+            assert!(
+                !expected.is_empty(),
+                "{action} has a captured contract but no table pins it"
+            );
+            for pin in expected {
+                if pin != actual {
+                    mismatches.push(format!("{action}: pinned {pin}, actual {actual}"));
+                }
+            }
+        }
+        assert!(mismatches.is_empty(), "fingerprint drift:\n{mismatches:#?}");
+    }
+
+    #[test]
+    fn every_mapped_column_is_inside_the_fingerprint_gate() {
+        // Dropbox's row schemas are strict with all keys required, so
+        // unlike the passthrough packs NO column rides
+        // `additionalProperties` outside the gate. An empty set here is
+        // the goal; a non-empty one is a finding, not a pin to update.
+        for (short, contract) in [
+            (
+                "files",
+                include_str!("fixtures/dropbox/contracts/list_folder.json"),
+            ),
+            (
+                "shared_links",
+                include_str!("fixtures/dropbox/contracts/list_shared_links.json"),
+            ),
+            (
+                "file_search",
+                include_str!("fixtures/dropbox/contracts/search_files.json"),
+            ),
+        ] {
+            let table = table(short);
+            let uncovered = fingerprint_uncovered_columns(contract, table.row_path, table.fields);
+            assert!(
+                uncovered.is_empty(),
+                "{short}: columns outside the fingerprint gate: {uncovered:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn split_action_tables_declare_a_cursor_only_continuation() {
+        // The 400 this pack exists to avoid: `cursor` is not a declared
+        // property of `list_folder` / `search_files`, so pages 2..N must
+        // target the continue action with the cursor ALONE.
+        for (short, opener, continues) in [
+            (
+                "files",
+                "dropbox.list_folder",
+                "dropbox.list_folder_continue",
+            ),
+            (
+                "file_search",
+                "dropbox.search_files",
+                "dropbox.search_files_continue",
+            ),
+        ] {
+            let table = table(short);
+            assert_eq!(table.action_id, opener);
+            let continuation = table
+                .continuation
+                .unwrap_or_else(|| panic!("{short} must declare a continuation"));
+            assert_eq!(continuation.action_id, continues);
+            assert!(
+                continuation.cursor_only,
+                "{short}: the continue action accepts the cursor and nothing else"
+            );
+            // Both actions gated, so drift on either fails registration.
+            assert_eq!(
+                table.gated_actions().count(),
+                2,
+                "{short}: both actions must be fingerprint-gated"
+            );
+        }
+
+        // shared_links takes the cursor on its OWN action (verified live:
+        // `{path, cursor}` together pass the strict schema), so it needs
+        // no continuation at all.
+        let shared = table("shared_links");
+        assert!(shared.continuation.is_none());
+        assert_eq!(shared.gated_actions().count(), 1);
+    }
+
+    #[test]
+    fn no_table_pushes_a_filter_or_maps_shared_link_only_columns_onto_files() {
+        // Negative space, per the module doc: every deliberate absence
+        // gets a guard so a later edit cannot quietly reintroduce it.
+        for short in ["files", "shared_links", "file_search"] {
+            assert!(
+                table(short).filters.is_empty(),
+                "{short}: Dropbox exposes no faithful column predicate; \
+                 pushing one needs a documented rationale first"
+            );
+        }
+
+        let files: Vec<&str> = table("files").fields.iter().map(|f| f.name).collect();
+        for absent in ["url", "expires_at", "link_permissions"] {
+            assert!(
+                !files.contains(&absent),
+                "files must not map '{absent}': files/list_folder never returns it, \
+                 so the column would be structurally always-NULL"
+            );
+        }
+        // ...and they ARE mapped where they populate.
+        let shared: Vec<&str> = table("shared_links")
+            .fields
+            .iter()
+            .map(|f| f.name)
+            .collect();
+        for present in ["url", "expires_at", "link_permissions"] {
+            assert!(shared.contains(&present), "shared_links must map {present}");
+        }
+
+        // `includeHighlights` is never sent, so `highlight_spans` stays
+        // unmapped (declared nullable, but the executor emits [] — a
+        // contradiction recorded rather than mapped).
+        let search: Vec<&str> = table("file_search").fields.iter().map(|f| f.name).collect();
+        assert!(!search.contains(&"highlight_spans"));
+        for (key, _) in table("file_search").fixed_inputs {
+            assert_ne!(*key, "includeHighlights");
+        }
+    }
+
+    // ── Contract tests: fixtures are provider-shaped redacted pages,
+    // covering all six admission-gate categories. ──────────────────────
+
+    fn convert_fixture(table: &SourcePackTable, fixture: &str) -> RecordBatch {
+        let page: Value = serde_json::from_str(fixture).expect("fixture parses");
+        let rows = RowPath::parse(table.row_path)
+            .expect("row path")
+            .rows(&page, 1)
+            .expect("row array");
+        RowConverter::new(table.fields)
+            .expect("converter")
+            .convert(rows, 1)
+            .expect("fixture converts")
+    }
+
+    fn utf8<'a>(batch: &'a RecordBatch, name: &str) -> &'a StringArray {
+        batch
+            .column_by_name(name)
+            .unwrap_or_else(|| panic!("column {name}"))
+            .as_any()
+            .downcast_ref()
+            .expect("Utf8 column")
+    }
+
+    #[test]
+    fn files_fixture_converts_nulls_nested_and_extra_fields() {
+        // Null-bearing (the folder row nulls ten columns), nested
+        // (sharingInfo as JSON), and extra-field (propertyGroups /
+        // hasExplicitSharedMembers, which the contract never declares)
+        // in one page.
+        let batch = convert_fixture(table("files"), include_str!("fixtures/dropbox/files.json"));
+        assert_eq!(batch.num_rows(), 3);
+
+        assert_eq!(
+            utf8(&batch, "tag").iter().collect::<Vec<_>>(),
+            vec![Some("folder"), Some("file"), Some("file")]
+        );
+        // A folder carries no file metadata; every one of those columns
+        // must be SQL NULL rather than a zero value.
+        let sizes: &Int64Array = batch
+            .column_by_name("size_bytes")
+            .expect("size_bytes")
+            .as_any()
+            .downcast_ref()
+            .expect("Int64 column");
+        assert!(sizes.is_null(0), "a folder has no size");
+        assert_eq!(sizes.value(1), 284_913);
+        assert_eq!(sizes.value(2), 0, "an empty file is 0, not NULL");
+
+        let downloadable: &BooleanArray = batch
+            .column_by_name("is_downloadable")
+            .expect("is_downloadable")
+            .as_any()
+            .downcast_ref()
+            .expect("Boolean column");
+        assert!(downloadable.is_null(0));
+        assert!(downloadable.value(1));
+
+        let modified: &TimestampMillisecondArray = batch
+            .column_by_name("server_modified")
+            .expect("server_modified")
+            .as_any()
+            .downcast_ref()
+            .expect("Timestamp column");
+        assert!(modified.is_null(0), "folders carry no serverModified");
+        assert!(modified.value(1) > 0, "ISO 8601 parses through RFC 3339");
+
+        // Nested object kept whole as JSON text.
+        let sharing = utf8(&batch, "sharing_info");
+        assert!(sharing.is_null(0));
+        assert!(
+            sharing.value(1).contains("parent_shared_folder_id"),
+            "nested object preserved: {}",
+            sharing.value(1)
+        );
+    }
+
+    #[test]
+    fn empty_page_converts_to_zero_rows() {
+        let batch = convert_fixture(
+            table("files"),
+            include_str!("fixtures/dropbox/files_empty.json"),
+        );
+        assert_eq!(batch.num_rows(), 0);
+        assert_eq!(batch.schema().fields().len(), table("files").fields.len());
+    }
+
+    #[test]
+    fn schema_mismatch_fails_with_the_full_error_identity() {
+        // A valid first row followed by a declared-type violation: the
+        // error must locate the failure by column, path, page AND row,
+        // and name the found KIND without echoing the value.
+        let table = table("files");
+        let page: Value =
+            serde_json::from_str(include_str!("fixtures/dropbox/files_type_mismatch.json"))
+                .expect("fixture parses");
+        let rows = RowPath::parse(table.row_path)
+            .expect("row path")
+            .rows(&page, 7)
+            .expect("row array");
+        let err = RowConverter::new(table.fields)
+            .expect("converter")
+            .convert(rows, 7)
+            .expect_err("a string where int64 is declared must fail");
+
+        let rendered = err.to_string();
+        for fragment in [
+            "size_bytes",
+            "sizeBytes",
+            "page 7",
+            "row 1",
+            "expected integer",
+            "found string",
+        ] {
+            assert!(
+                rendered.contains(fragment),
+                "error must carry {fragment:?}: {rendered}"
+            );
+        }
+        assert!(
+            !rendered.contains("not-a-number"),
+            "the offending VALUE must never appear: {rendered}"
+        );
+    }
+
+    #[test]
+    fn shared_links_fixture_populates_the_link_only_columns() {
+        let batch = convert_fixture(
+            table("shared_links"),
+            include_str!("fixtures/dropbox/shared_links.json"),
+        );
+        assert_eq!(batch.num_rows(), 2);
+        let urls = utf8(&batch, "url");
+        assert!(urls.value(0).starts_with("https://www.dropbox.com/scl/fi/"));
+        assert!(urls.value(1).starts_with("https://www.dropbox.com/scl/fo/"));
+
+        let expires: &TimestampMillisecondArray = batch
+            .column_by_name("expires_at")
+            .expect("expires_at")
+            .as_any()
+            .downcast_ref()
+            .expect("Timestamp column");
+        assert!(expires.value(0) > 0, "a link with an expiry");
+        assert!(expires.is_null(1), "a link without one");
+
+        let permissions = utf8(&batch, "link_permissions");
+        assert!(permissions.value(0).contains("resolved_visibility"));
+    }
+
+    #[test]
+    fn file_search_fixture_reads_through_the_nested_metadata_block() {
+        let batch = convert_fixture(
+            table("file_search"),
+            include_str!("fixtures/dropbox/file_search.json"),
+        );
+        assert_eq!(batch.num_rows(), 2);
+        assert_eq!(
+            utf8(&batch, "match_type").iter().collect::<Vec<_>>(),
+            vec![Some("filename"), Some("content")]
+        );
+        assert_eq!(
+            utf8(&batch, "name").iter().collect::<Vec<_>>(),
+            vec![Some("redacted-report.pdf"), Some("notes.txt")]
+        );
+    }
+
+    #[test]
+    fn a_null_metadata_parent_nulls_its_children_not_the_scan() {
+        // The null-parent category: `metadata: null` makes every nested
+        // NULLABLE column SQL NULL. The non-nullable ones (tag, name)
+        // must still fail — a quiet all-NULL row would hide the drift.
+        let table = table("file_search");
+        let page: Value = serde_json::from_str(include_str!(
+            "fixtures/dropbox/file_search_null_parent.json"
+        ))
+        .expect("fixture parses");
+        let rows = RowPath::parse(table.row_path)
+            .expect("row path")
+            .rows(&page, 1)
+            .expect("row array");
+        let err = RowConverter::new(table.fields)
+            .expect("converter")
+            .convert(rows, 1)
+            .expect_err("a null parent under a non-nullable column must fail");
+        assert!(
+            err.to_string().contains("tag"),
+            "the non-nullable column names itself: {err}"
+        );
+    }
+
+    #[test]
+    fn complete_collection_pins_ride_every_files_request() {
+        // The loader keys fixed inputs by a BTreeMap, so they arrive
+        // name-sorted rather than in authoring order.
+        let files = table("files");
+        let pinned: Vec<(&str, Value)> = files
+            .fixed_inputs
+            .iter()
+            .map(|(key, value)| (*key, value.to_json()))
+            .collect();
+        assert_eq!(
+            pinned,
+            vec![
+                ("includeDeleted", Value::Bool(false)),
+                ("includeMountedFolders", Value::Bool(true)),
+                ("recursive", Value::Bool(true)),
+            ],
+            "files means every file under `path`, tombstones excluded"
+        );
+
+        // file_search pins the active-only listing for the same reason.
+        let search: Vec<(&str, Value)> = table("file_search")
+            .fixed_inputs
+            .iter()
+            .map(|(key, value)| (*key, value.to_json()))
+            .collect();
+        assert_eq!(search, vec![("fileStatus", Value::from("active"))]);
+    }
+
+    // ── Integration: the pack against a mock gateway, end to end. ───────
+
+    /// Discovery serving the live-captured contracts, so every mock
+    /// registration exercises the fingerprint gate's PASS side — for the
+    /// continuation actions too.
+    fn dropbox_discovery(path: &str) -> MockResponse {
+        // Each action reads its OWN captured contract even where two are
+        // byte-identical today (an opener and its continuation share an
+        // output schema): keeping them separate is what makes a future
+        // divergence visible instead of silently inherited.
+        let output_schema = match path.rsplit('/').next().unwrap_or_default() {
+            "dropbox.list_folder" => include_str!("fixtures/dropbox/contracts/list_folder.json"),
+            "dropbox.list_folder_continue" => {
+                include_str!("fixtures/dropbox/contracts/list_folder_continue.json")
+            }
+            "dropbox.list_shared_links" => {
+                include_str!("fixtures/dropbox/contracts/list_shared_links.json")
+            }
+            "dropbox.search_files" => include_str!("fixtures/dropbox/contracts/search_files.json"),
+            "dropbox.search_files_continue" => {
+                include_str!("fixtures/dropbox/contracts/search_files_continue.json")
+            }
+            _ => r#"{"type": "object"}"#,
+        };
+        MockResponse::ok(&discovery_ok("{}", output_schema, true, None))
+    }
+
+    fn dropbox_config(token_env: &str, tables: &str) -> OpenConnectorConfig {
+        // `query` is required by file_search and declared by no other
+        // table; supplying it only when that table is bound keeps the
+        // undeclared-resource guard satisfied both ways.
+        let resource = if tables.contains("file_search") {
+            "resource: { query: redacted }"
+        } else {
+            ""
+        };
+        serde_yaml::from_str(&format!(
+            r#"
+runtime_token_env: {token_env}
+bindings:
+  - name: ws
+    source_pack: dropbox
+    {resource}
+    tables: [{tables}]
+"#
+        ))
+        .expect("config parses")
+    }
+
+    async fn setup_with_gateway(
+        gateway: MockGateway,
+        token_env: &'static str,
+        tables: &str,
+    ) -> (MockGateway, SessionContext) {
+        let _token = EnvVarGuard::set(token_env, "test-token");
+        let gateways = OpenConnectorGateways::default();
+        let mut ctx = SessionContext::new();
+        register_open_connector_tables(
+            &mut ctx,
+            "saas",
+            &gateway.url,
+            Some(&dropbox_config(token_env, tables)),
+            false,
+            HierarchyLevel::Catalog,
+            Some(&gateways),
+        )
+        .await
+        .expect("gateway registration succeeds");
+        register_open_connector_udtfs(&ctx, gateways).expect("UDTF registration succeeds");
+        (gateway, ctx)
+    }
+
+    async fn collect(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch> {
+        ctx.sql(sql)
+            .await
+            .expect("plan")
+            .collect()
+            .await
+            .expect("collect")
+    }
+
+    /// Every execute request as `(action path, input object)`.
+    fn execute_calls(gateway: &MockGateway) -> Vec<(String, Value)> {
+        gateway
+            .requests()
+            .into_iter()
+            .filter(|r| r.method == "POST")
+            .map(|r| {
+                let body: Value = serde_json::from_str(&r.body).expect("request body is JSON");
+                (r.path.clone(), body["input"].clone())
+            })
+            .collect()
+    }
+
+    fn entry(name: &str) -> Value {
+        json!({
+            "tag": "file", "name": name, "id": format!("id:{name}"),
+            "pathDisplay": format!("/{name}"), "pathLower": format!("/{name}"),
+            "clientModified": null, "serverModified": null, "rev": null,
+            "sizeBytes": null, "isDownloadable": null, "contentHash": null,
+            "url": null, "expiresAt": null, "sharingInfo": null,
+            "linkPermissions": null
+        })
+    }
+
+    fn names_of(batches: &[RecordBatch]) -> Vec<String> {
+        batches
+            .iter()
+            .flat_map(|b| {
+                utf8(b, "name")
+                    .iter()
+                    .map(|v| v.expect("name is non-null").to_string())
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn files_pages_through_the_continue_action_with_only_a_cursor() {
+        // THE test this pack exists for. Page one opens the listing on
+        // dropbox.list_folder with the pinned complete-collection inputs
+        // and the page-size hint; page two goes to
+        // dropbox.list_folder_continue carrying the cursor and NOTHING
+        // else — against the real gateway anything more is a 400
+        // (verified live: `cursor` alone on list_folder → invalid_input).
+        // The final page answers hasMore:false with a NON-EMPTY cursor,
+        // the Dropbox shape that makes has_more_path load-bearing.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return dropbox_discovery(&req.path);
+            }
+            match req.path.as_str() {
+                "/v1/actions/dropbox.list_folder" => MockResponse::ok(&envelope_ok(
+                    &json!({"entries": [entry("a"), entry("b")],
+                                "cursor": "cur-2", "hasMore": true})
+                    .to_string(),
+                )),
+                "/v1/actions/dropbox.list_folder_continue" => {
+                    let body: Value = serde_json::from_str(&req.body).unwrap_or_default();
+                    match body["input"].get("cursor").and_then(Value::as_str) {
+                        Some("cur-2") => MockResponse::ok(&envelope_ok(
+                            // Non-empty cursor on the FINAL page.
+                            &json!({"entries": [entry("c")],
+                                    "cursor": "cur-3", "hasMore": false})
+                            .to_string(),
+                        )),
+                        other => MockResponse::new(400, format!("bad cursor {other:?}")),
+                    }
+                }
+                _ => MockResponse::new(404, "{}"),
+            }
+        })
+        .await;
+        let (gateway, ctx) =
+            setup_with_gateway(gateway, "SKARDI_TEST_OC_DROPBOX_FILES", "files").await;
+
+        let batches = collect(&ctx, "SELECT name FROM saas.ws.files ORDER BY name").await;
+        assert_eq!(names_of(&batches), vec!["a", "b", "c"]);
+
+        let calls = execute_calls(&gateway);
+        assert_eq!(calls.len(), 2, "two pages");
+
+        let (path, input) = &calls[0];
+        assert_eq!(path, "/v1/actions/dropbox.list_folder");
+        assert_eq!(input["recursive"], json!(true));
+        assert_eq!(input["includeMountedFolders"], json!(true));
+        assert_eq!(input["includeDeleted"], json!(false));
+        assert_eq!(input["limit"], json!(2000));
+        assert!(
+            input.get("cursor").is_none(),
+            "no cursor exists on page one"
+        );
+
+        let (path, input) = &calls[1];
+        assert_eq!(
+            path, "/v1/actions/dropbox.list_folder_continue",
+            "page two targets the CONTINUE action"
+        );
+        assert_eq!(
+            input,
+            &json!({"cursor": "cur-2"}),
+            "the continue action declares `cursor` as its only property, so \
+             anything else here is a 400 on the real wire"
+        );
+    }
+
+    #[tokio::test]
+    async fn shared_links_pages_through_its_own_action_with_the_full_input() {
+        // The contrast case: this action takes the cursor itself, so no
+        // continuation is declared and page two repeats the action with
+        // its resources intact.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return dropbox_discovery(&req.path);
+            }
+            if req.path == "/v1/actions/dropbox.list_shared_links" {
+                let body: Value = serde_json::from_str(&req.body).unwrap_or_default();
+                let page = match body["input"].get("cursor").and_then(Value::as_str) {
+                    None => json!({"links": [entry("l1")], "cursor": "sl-2", "hasMore": true}),
+                    // Nulls its cursor at end-of-collection, unlike files.
+                    Some("sl-2") => {
+                        json!({"links": [entry("l2")], "cursor": null, "hasMore": false})
+                    }
+                    Some(other) => return MockResponse::new(400, format!("bad cursor {other}")),
+                };
+                return MockResponse::ok(&envelope_ok(&page.to_string()));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (gateway, ctx) = setup_with_gateway(
+            gateway,
+            "SKARDI_TEST_OC_DROPBOX_SHARED_LINKS",
+            "shared_links",
+        )
+        .await;
+
+        let batches = collect(&ctx, "SELECT name FROM saas.ws.shared_links ORDER BY name").await;
+        assert_eq!(names_of(&batches), vec!["l1", "l2"]);
+
+        let calls = execute_calls(&gateway);
+        assert_eq!(calls.len(), 2);
+        for (path, _) in &calls {
+            assert_eq!(
+                path, "/v1/actions/dropbox.list_shared_links",
+                "both pages use the same action"
+            );
+        }
+        assert!(calls[0].1.get("cursor").is_none());
+        assert_eq!(calls[1].1["cursor"], json!("sl-2"));
+        assert!(
+            calls[0].1.get("limit").is_none() && calls[1].1.get("limit").is_none(),
+            "this action declares no page-size input"
+        );
+    }
+
+    #[tokio::test]
+    async fn file_search_forwards_its_required_query_and_pinned_status() {
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return dropbox_discovery(&req.path);
+            }
+            if req.path == "/v1/actions/dropbox.search_files" {
+                return MockResponse::ok(&envelope_ok(
+                    &json!({"matches": [{"matchType": "filename", "metadata": entry("hit"),
+                                          "highlightSpans": []}],
+                            "cursor": null, "hasMore": false})
+                    .to_string(),
+                ));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (gateway, ctx) =
+            setup_with_gateway(gateway, "SKARDI_TEST_OC_DROPBOX_SEARCH", "file_search").await;
+
+        let batches = collect(&ctx, "SELECT name FROM saas.ws.file_search").await;
+        assert_eq!(names_of(&batches), vec!["hit"]);
+
+        let calls = execute_calls(&gateway);
+        assert_eq!(calls.len(), 1, "a null cursor ends the scan");
+        let input = &calls[0].1;
+        assert_eq!(input["query"], json!("redacted"), "required resource");
+        assert_eq!(input["fileStatus"], json!("active"), "pinned");
+        assert_eq!(input["maxResults"], json!(1000));
+        assert!(
+            input.get("includeHighlights").is_none(),
+            "negative space: highlights are never requested"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_missing_required_query_fails_before_any_action_call() {
+        // Health is the only call that precedes the guard; no action is
+        // ever discovered or executed for a table that cannot be bound.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let _token = EnvVarGuard::set("SKARDI_TEST_OC_DROPBOX_NO_QUERY", "test-token");
+        let config: OpenConnectorConfig = serde_yaml::from_str(
+            r#"
+runtime_token_env: SKARDI_TEST_OC_DROPBOX_NO_QUERY
+bindings:
+  - name: ws
+    source_pack: dropbox
+    tables: [file_search]
+"#,
+        )
+        .expect("config parses");
+        let mut ctx = SessionContext::new();
+        let err = register_open_connector_tables(
+            &mut ctx,
+            "saas",
+            &gateway.url,
+            Some(&config),
+            false,
+            HierarchyLevel::Catalog,
+            None,
+        )
+        .await
+        .expect_err("a search table without a query must not register");
+        assert!(err.to_string().contains("query"), "{err}");
+        assert!(
+            gateway
+                .requests()
+                .iter()
+                .all(|r| r.path == "/v1/health" && r.method == "GET"),
+            "the resource guard runs before any action is discovered or executed"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_drifted_continuation_contract_fails_registration() {
+        // The continuation action serves most of a long scan, so its
+        // drift must be refused at registration exactly like the opening
+        // action's — not discovered on page two of a live query.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                // Only the CONTINUE action drifts; the opener still
+                // serves its captured contract and passes the gate.
+                if req.path.ends_with("dropbox.list_folder_continue") {
+                    return MockResponse::ok(&discovery_ok(
+                        "{}",
+                        r#"{"type":"object","properties":{"entries":{"type":"array"}}}"#,
+                        true,
+                        None,
+                    ));
+                }
+                return dropbox_discovery(&req.path);
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let _token = EnvVarGuard::set("SKARDI_TEST_OC_DROPBOX_DRIFT", "test-token");
+        let mut ctx = SessionContext::new();
+        let err = register_open_connector_tables(
+            &mut ctx,
+            "saas",
+            &gateway.url,
+            Some(&dropbox_config("SKARDI_TEST_OC_DROPBOX_DRIFT", "files")),
+            false,
+            HierarchyLevel::Catalog,
+            None,
+        )
+        .await
+        .expect_err("a drifted continuation contract must fail registration");
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("dropbox.files"),
+            "names the table: {rendered}"
+        );
+        assert!(
+            rendered.contains("dropbox.list_folder_continue"),
+            "names the CONTINUATION action, not the opener: {rendered}"
+        );
+    }
+
+    #[tokio::test]
+    async fn limit_pushdown_stops_the_scan_before_the_continue_action() {
+        // A satisfied LIMIT must end the scan on page one — the
+        // continuation request is never made.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return dropbox_discovery(&req.path);
+            }
+            if req.path == "/v1/actions/dropbox.list_folder" {
+                return MockResponse::ok(&envelope_ok(
+                    &json!({"entries": [entry("a"), entry("b")],
+                            "cursor": "cur-2", "hasMore": true})
+                    .to_string(),
+                ));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (gateway, ctx) =
+            setup_with_gateway(gateway, "SKARDI_TEST_OC_DROPBOX_LIMIT", "files").await;
+
+        let batches = collect(&ctx, "SELECT name FROM saas.ws.files LIMIT 1").await;
+        assert_eq!(names_of(&batches).len(), 1);
+
+        let calls = execute_calls(&gateway);
+        assert_eq!(
+            calls.len(),
+            1,
+            "the LIMIT was satisfied on page one; no continuation fetch"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_gateway_failure_surfaces_the_providers_code() {
+        // Dropbox errors at HTTP level (dropboxRpcRequest throws on any
+        // non-2xx), so there is no in-band error_path — the provider's
+        // code must arrive through the gateway-failure path instead.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return dropbox_discovery(&req.path);
+            }
+            if req.path == "/v1/actions/dropbox.list_folder" {
+                return MockResponse::new(
+                    409,
+                    crate::sources::providers::open_connector::testutil::envelope_err(
+                        "provider_error",
+                        "path/not_found",
+                    ),
+                );
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (_gateway, ctx) =
+            setup_with_gateway(gateway, "SKARDI_TEST_OC_DROPBOX_ERR", "files").await;
+
+        let err = ctx
+            .sql("SELECT name FROM saas.ws.files")
+            .await
+            .expect("plan")
+            .collect()
+            .await
+            .expect_err("a provider failure must fail the scan");
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("path/not_found") || rendered.contains("provider_error"),
+            "the provider's own code must surface: {rendered}"
+        );
+        assert!(
+            table("files").error_path.is_none(),
+            "no in-band error path is declared for Dropbox"
+        );
+    }
+
+    #[tokio::test]
+    async fn udtf_parity_for_files() {
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return dropbox_discovery(&req.path);
+            }
+            if req.path == "/v1/actions/dropbox.list_folder" {
+                return MockResponse::ok(&envelope_ok(
+                    &json!({"entries": [entry("via-udtf")], "cursor": "c", "hasMore": false})
+                        .to_string(),
+                ));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (_gateway, ctx) =
+            setup_with_gateway(gateway, "SKARDI_TEST_OC_DROPBOX_UDTF", "files").await;
+
+        let batches = collect(
+            &ctx,
+            "SELECT name FROM open_connector_query('saas', 'dropbox.files', '{}')",
+        )
+        .await;
+        assert_eq!(names_of(&batches), vec!["via-udtf"]);
+    }
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/dropbox.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/dropbox.rs
@@ -349,8 +349,10 @@ mod tests {
                 continuation.cursor_only,
                 "{short} declares `inputs: cursor_only`"
             );
-            let captured = continuation_input_contract(continuation.action_id)
-                .unwrap_or_else(|| panic!("{} has a committed input contract", continuation.action_id));
+            let captured =
+                continuation_input_contract(continuation.action_id).unwrap_or_else(|| {
+                    panic!("{} has a committed input contract", continuation.action_id)
+                });
             let schema: Value = serde_json::from_str(captured).expect("input contract parses");
             table
                 .check_continuation_inputs(Some(&schema))

--- a/crates/skardi/src/sources/providers/open_connector/packs/dropbox.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/dropbox.rs
@@ -45,15 +45,18 @@
 //! which never landed during the pass. Both columns stay mapped because
 //! both are structurally reachable.
 //!
-//! One gateway defect the pass uncovered, which is NOT specific to this
-//! pack: `GET /v1/actions/<id>` — the endpoint `discover_action` reads —
-//! does not serialize the `execution` block, so Skardi's default-deny
-//! action registry refuses every action from every pack against a
-//! stock gateway at that commit. Reproduced with the merged `github` pack,
-//! so it is not this pack's bug; filed upstream as
-//! oomol-lab/open-connector#358 (the gateway's catalog routes already
-//! compute the field). Skardi's default-deny gate is correct and is left
-//! untouched — no fallback reads the classification from another route.
+//! One gateway defect the pass uncovered, NOT specific to this pack and
+//! since resolved upstream: at the checkout the pass used (`a3efa99`,
+//! 2026-07-07) `GET /v1/actions/<id>` — the endpoint `discover_action`
+//! reads — did not serialize the `execution` block, so Skardi's
+//! default-deny action registry refuses every action from every pack
+//! against that checkout (reproduced with the merged `github` pack, so
+//! not this pack's bug). Filed as oomol-lab/open-connector#358, closed as
+//! completed: upstream `1607633` (#149, 2026-07-19) already serialized
+//! the block, so the checkout simply predated the fix and no
+//! prerequisite exists on a gateway at or after that commit. Skardi's
+//! default-deny gate is correct and is left untouched — no fallback
+//! reads the classification from another route.
 //!
 //! **Rows are NORMALIZED, not passed through.** Every list executor maps
 //! entries through `mapDropboxMetadata`, which rebuilds each one into a
@@ -1593,7 +1596,9 @@ bindings:
                     // `null`, not `{}`: an absent `inputSchema` is the arm
                     // under test. An empty object is a schema that is
                     // PRESENT and shapeless, which the gate refuses with a
-                    // different diagnostic (covered in `source_pack`).
+                    // different diagnostic (covered by the UDTF twin
+                    // `an_unverifiable_cursor_only_claim_fails_udtf_planning`
+                    // and by the unit tables in `source_pack`).
                     return MockResponse::ok(&discovery_ok(
                         "null",
                         include_str!("fixtures/dropbox/contracts/list_folder_continue.json"),
@@ -1830,7 +1835,9 @@ bindings:
         // This is what holds the UDTF path's input-gate call site in place:
         // the fingerprint gate above passes here (the drifting is on the
         // INPUT side, which no fingerprint covers), so only the input gate
-        // can refuse this query.
+        // can refuse this query. The twin serves an ABSENT `inputSchema`
+        // (`null`); this one serves a schema that is PRESENT and shapeless
+        // (`{}`) — one integration test per arm of the diagnostic split.
         let gateway = MockGateway::start(|req| {
             if req.method == "GET" && req.path == "/v1/health" {
                 return MockResponse::ok("{}");
@@ -1838,10 +1845,11 @@ bindings:
             if req.method == "GET" && req.path.starts_with("/v1/actions/") {
                 if req.path.ends_with("dropbox.list_folder_continue") {
                     // Captured OUTPUT schema — so the fingerprint still
-                    // matches — with no input schema at all (`null`, not an
-                    // empty object; see the YAML twin).
+                    // matches — with an input schema that is present but
+                    // declares no properties (`{}`, not `null`; the absent
+                    // case is the YAML twin's).
                     return MockResponse::ok(&discovery_ok(
-                        "null",
+                        "{}",
                         include_str!("fixtures/dropbox/contracts/list_folder_continue.json"),
                         true,
                         None,
@@ -1864,7 +1872,7 @@ bindings:
         )
         .await;
         assert!(
-            rendered.contains("no input schema"),
+            rendered.contains("no input properties"),
             "the input gate said why it cannot be verified: {rendered}"
         );
         assert!(

--- a/crates/skardi/src/sources/providers/open_connector/packs/dropbox.yaml
+++ b/crates/skardi/src/sources/providers/open_connector/packs/dropbox.yaml
@@ -1,8 +1,15 @@
-# Dropbox source pack. Wire contract is Open Connector's, reconciled
-# against a live gateway (v1.3.5, 2026-08-16). Every list executor
-# NORMALIZES rows through `mapDropboxMetadata`: a fixed camelCase shape
-# whose fifteen keys are ALL declared `required` under
-# `additionalProperties: false`. Mapping Dropbox's own snake_case
+# Dropbox source pack. Wire contract is Open Connector's, RECONCILED
+# AGAINST THE v1.3.5 PROVIDER SOURCE ONLY — no live gateway has answered
+# any of it (no Node runtime on the authoring box; see the module doc's
+# provenance banner and
+# docs/superpowers/plans/2026-08-18-dropbox-live-evaluation.md). Every
+# fingerprint below is the hash of a source-derived schema, not of a
+# captured one, so registration against a real gateway is expected to
+# fail the contract gate until the live pass re-pins it.
+#
+# Every list executor NORMALIZES rows through `mapDropboxMetadata`: a
+# fixed camelCase shape whose fifteen keys are ALL declared `required`
+# under `additionalProperties: false`. Mapping Dropbox's own snake_case
 # (`path_display`, `client_modified`, `size`) would have produced
 # all-NULL columns — the Slack 5.2 failure mode. The upside of that
 # strictness: unlike the passthrough packs, every column below sits
@@ -12,10 +19,13 @@
 # continues a listing through a DIFFERENT action than the one that
 # opened it: `list_folder` → `list_folder_continue`, `search_files` →
 # `search_files_continue`, each continue action declaring `cursor` as its
-# ONLY property. Feeding the cursor back to the opening action is not a
-# quiet truncation but a hard 400 — verified live:
-#   POST dropbox.list_folder {"cursor":"abc"} → 400 invalid_input
-# hence `continuation: {action, fingerprint, inputs: cursor_only}`.
+# ONLY property. Feeding the cursor back to the opening action would not
+# be a quiet truncation but a hard 400, because `list_folder`'s input
+# schema is `additionalProperties: false` and does not declare `cursor`
+# — read off the schema, NOT yet observed on the wire. Hence
+# `continuation: {action, fingerprint, inputs: cursor_only}`, whose
+# input-side claim registration now checks against the continuation
+# action's discovered input schema.
 #
 # TERMINATION. `list_folder` answers its FINAL page with a NON-EMPTY
 # cursor (the executor's `requireString(payload.cursor)`, and the
@@ -52,10 +62,14 @@ tables:
       cursor_input: cursor
       next_cursor_path: "$.cursor"
       page_size_input: limit
-      # The schema's declared maximum, which doubles as the
-      # limit-pushdown ceiling. Continuation pages carry no `limit` (the
-      # continue action rejects it); Dropbox sizes them from this
-      # opening request, so the ceiling still holds.
+      # The schema's declared maximum. UNVERIFIED AT THE BOUNDARY: a
+      # declared cap can exceed the wire's (Feishu declared 100 and
+      # hard-failed above 50), so one probe at 2000 and one at 2001 are
+      # owed before this number is trustworthy. Continuation pages carry
+      # no `limit` at all — the continue action declares none — and
+      # Dropbox sizes them from this opening request. `page_size` is the
+      # size REQUESTED per page; it neither caps nor floors a pushed-down
+      # SQL LIMIT, which the exec applies by truncating batches.
       page_size: 2000
       # NOT optional here: see the TERMINATION note above.
       has_more_path: "$.hasMore"
@@ -107,19 +121,34 @@ tables:
     action: dropbox.list_shared_links
     row_path: "$.links"
     fingerprint: 7f7c822b99a1afcbf4ea81371527a14ab4d24918dbde170eb115037003144067
-    # No continuation block: this action takes `cursor` itself (verified
-    # live — `{path, cursor}` together pass the strict schema), so pages
-    # 2..N repeat it with the full input, the engine's default.
+    # No continuation block: the executor `compactObject`s `path` and
+    # `cursor` together and the input schema declares both, so pages 2..N
+    # repeat the action with the full input, the engine's default. NOT
+    # verified on the wire — this is design-spec open question 1, and if
+    # Dropbox rejects the pair, the fix is `continuation: {fingerprint,
+    # inputs: cursor_only}` here with no code change.
     pagination:
       strategy: cursor
       cursor_input: cursor
       next_cursor_path: "$.cursor"
       # No page-size input exists on this action; Dropbox sizes the
-      # pages. `page_size` is therefore unused for requests and only
-      # bounds LIMIT pushdown.
+      # pages. With no `page_size_input`, `page_size` is inert — the
+      # cursor strategy reads it only in `Pagination::apply`, under
+      # `page_size_param`, and nothing else in the engine consults it.
+      # The schema requires the key, so it is a placeholder, not a bound.
       page_size: 100
       has_more_path: "$.hasMore"
     resources:
+      # `directOnly` is a scan-shape boolean, not a collection selector —
+      # the class of input this pack otherwise PINS (`recursive`,
+      # `includeDeleted`). It is a resource rather than a fixed input
+      # because neither setting is the honest default for a table named
+      # `shared_links`: pinned true, links inherited from a shared parent
+      # vanish; pinned false, the same file can appear through several
+      # ancestors. Leaving it to the binding makes that a per-deployment
+      # choice instead of a pack-wide guess. Resource values keep their
+      # YAML type, so `directOnly: true` reaches the strict schema as a
+      # JSON boolean — pinned by a forwarding test.
       optional: [path, directOnly]
     # `path` is a resource, not an `eq` push onto path_lower: the input
     # accepts paths, file IDs AND rev IDs, so the mapping would be
@@ -158,6 +187,8 @@ tables:
       cursor_input: cursor
       next_cursor_path: "$.cursor"
       page_size_input: maxResults
+      # search_v2's declared maximum; unverified at the boundary, like
+      # files' 2000 above.
       page_size: 1000
       has_more_path: "$.hasMore"
       continuation:

--- a/crates/skardi/src/sources/providers/open_connector/packs/dropbox.yaml
+++ b/crates/skardi/src/sources/providers/open_connector/packs/dropbox.yaml
@@ -1,11 +1,14 @@
-# Dropbox source pack. Wire contract is Open Connector's, RECONCILED
-# AGAINST THE v1.3.5 PROVIDER SOURCE ONLY — no live gateway has answered
-# any of it (no Node runtime on the authoring box; see the module doc's
-# provenance banner and
-# docs/superpowers/plans/2026-08-18-dropbox-live-evaluation.md). Every
-# fingerprint below is the hash of a source-derived schema, not of a
-# captured one, so registration against a real gateway is expected to
-# fail the contract gate until the live pass re-pins it.
+# Dropbox source pack. Wire contract is Open Connector's. LIVE-VERIFIED
+# 2026-08-18 against a self-hosted Open Connector gateway at commit
+# a3efa99 and a real (free-tier) Dropbox account: all five actions
+# discovered, all five pinned fingerprints matched LIVE discovery
+# unchanged, and all three tables scanned real rows end to end. The
+# fingerprints below were derived from the provider source and the live
+# capture confirmed them byte-for-byte, so nothing needed re-pinning.
+# Two claims remain unobserved rather than confirmed, and are labelled
+# where they live: `shared_links.expires_at` (paid-tier link expiry) and
+# `file_search.match_type = 'content'` (content indexing never landed
+# during the pass).
 #
 # Every list executor NORMALIZES rows through `mapDropboxMetadata`: a
 # fixed camelCase shape whose fifteen keys are ALL declared `required`
@@ -22,15 +25,17 @@
 # ONLY property. Feeding the cursor back to the opening action would not
 # be a quiet truncation but a hard 400, because `list_folder`'s input
 # schema is `additionalProperties: false` and does not declare `cursor`
-# — read off the schema, NOT yet observed on the wire. Hence
+# — read off the schema and CONFIRMED on the wire 2026-08-18 (the
+# opening action refuses a `cursor` input, bare or alongside the full
+# input; the continue action refuses anything beyond it). Hence
 # `continuation: {action, fingerprint, inputs: cursor_only}`, whose
 # input-side claim registration now checks against the continuation
 # action's discovered input schema.
 #
 # TERMINATION. `list_folder` answers its FINAL page with a NON-EMPTY
-# cursor (the executor's `requireString(payload.cursor)`, and the
-# contract declares `cursor` a plain required string, not a nullable
-# one). Cursor-spelling termination would refetch and fail as a
+# cursor — OBSERVED 2026-08-18: the last page carried `hasMore: false`
+# beside a 259-character cursor, and following that cursor returns an
+# empty page. Cursor-spelling termination would refetch and fail as a
 # PaginationLoop, so `has_more_path` is load-bearing here, not
 # decorative. shared_links and search DO null their cursors, but declare
 # `$.hasMore` too: it is the provider's authoritative signal in all
@@ -42,8 +47,14 @@
 # declares no error_path.
 #
 # Scopes: files/file_search need `files.metadata.read`; shared_links
-# needs `sharing.read`. No content or write scope is required by any
-# table here, so a read-only connection serves the whole pack.
+# needs `sharing.read` — confirmed per-action in the live gateway's
+# `requiredScopes` metadata. No content or write scope is required by any
+# table here. NOTE that this is a statement about the ACTIONS, not about
+# what an operator can provision: the gateway's dropbox provider
+# requests the union of all six dropbox scopes (including
+# `files.content.write` and `sharing.write`) at authorize time, so a
+# connection created through its OAuth flow carries more than this pack
+# uses. See docs/open-connector-dropbox.md.
 #
 # Design rationale lives in the module docs of packs/dropbox.rs.
 kind: pack
@@ -62,10 +73,9 @@ tables:
       cursor_input: cursor
       next_cursor_path: "$.cursor"
       page_size_input: limit
-      # The schema's declared maximum. UNVERIFIED AT THE BOUNDARY: a
-      # declared cap can exceed the wire's (Feishu declared 100 and
-      # hard-failed above 50), so one probe at 2000 and one at 2001 are
-      # owed before this number is trustworthy. Continuation pages carry
+      # The schema's declared maximum, VERIFIED AT THE BOUNDARY
+      # (2026-08-18): `limit: 2000` returns rows, `limit: 2001` is
+      # refused. Continuation pages carry
       # no `limit` at all — the continue action declares none — and
       # Dropbox sizes them from this opening request. `page_size` is the
       # size REQUESTED per page; it neither caps nor floors a pushed-down
@@ -123,10 +133,10 @@ tables:
     fingerprint: 7f7c822b99a1afcbf4ea81371527a14ab4d24918dbde170eb115037003144067
     # No continuation block: the executor `compactObject`s `path` and
     # `cursor` together and the input schema declares both, so pages 2..N
-    # repeat the action with the full input, the engine's default. NOT
-    # verified on the wire — this is design-spec open question 1, and if
-    # Dropbox rejects the pair, the fix is `continuation: {fingerprint,
-    # inputs: cursor_only}` here with no code change.
+    # repeat the action with the full input, the engine's default.
+    # CONFIRMED on the wire 2026-08-18 (design-spec open question 1):
+    # `list_shared_links` accepts `path` and `cursor` in one request, so
+    # no `cursor_only` continuation is needed here.
     pagination:
       strategy: cursor
       cursor_input: cursor
@@ -163,17 +173,29 @@ tables:
       # legal.
       - { name: url, path: url, type: utf8, nullable: true }
       - { name: id, path: id, type: utf8, nullable: true }
-      - { name: path_display, path: pathDisplay, type: utf8, nullable: true }
       - { name: path_lower, path: pathLower, type: utf8, nullable: true }
+      # Populates only on a link Dropbox let the account set an expiry on
+      # — a paid-tier feature. Structurally reachable, so mapped, but the
+      # live pass could not observe a non-NULL value (free account:
+      # `settings_error/not_authorized`).
       - { name: expires_at, path: expiresAt, type: timestamp_ms_utc, nullable: true }
       - { name: client_modified, path: clientModified, type: timestamp_ms_utc, nullable: true }
       - { name: server_modified, path: serverModified, type: timestamp_ms_utc, nullable: true }
       - { name: rev, path: rev, type: utf8, nullable: true }
       - { name: size_bytes, path: sizeBytes, type: int64, nullable: true }
-      - { name: is_downloadable, path: isDownloadable, type: boolean, nullable: true }
-      - { name: content_hash, path: contentHash, type: utf8, nullable: true }
-      - { name: sharing_info, path: sharingInfo, type: json, nullable: true }
       - { name: link_permissions, path: linkPermissions, type: json, nullable: true }
+      # path_display / is_downloadable / content_hash / sharing_info are
+      # DELIBERATELY ABSENT, the mirror image of the three columns files
+      # omits. `sharing/list_shared_links` returns SharedLinkMetadata,
+      # which carries `path_lower` but has NO `path_display`,
+      # `is_downloadable`, `content_hash` or `sharing_info` field at all;
+      # the shared normalizer reads those four off keys the payload never
+      # has, so mapping them shipped four structurally always-NULL
+      # columns. Live evidence (2026-08-18): 0/5 non-NULL across 3 file
+      # links and 2 folder links, and decisively, a file whose
+      # files-row carries all four came back with all four NULL on its
+      # own shared_links row — same file, same normalizer, different
+      # endpoint. Pinned by a negative-space guard test.
 
   # Dropbox's search_v2 over files and folders. `query` is required: a
   # search table without one is not a table (the GitHub owner/repo
@@ -187,8 +209,9 @@ tables:
       cursor_input: cursor
       next_cursor_path: "$.cursor"
       page_size_input: maxResults
-      # search_v2's declared maximum; unverified at the boundary, like
-      # files' 2000 above.
+      # search_v2's declared maximum, verified at the boundary
+      # 2026-08-18 like files' 2000 above: 1000 returns rows, 1001 is
+      # refused.
       page_size: 1000
       has_more_path: "$.hasMore"
       continuation:

--- a/crates/skardi/src/sources/providers/open_connector/packs/dropbox.yaml
+++ b/crates/skardi/src/sources/providers/open_connector/packs/dropbox.yaml
@@ -1,0 +1,196 @@
+# Dropbox source pack. Wire contract is Open Connector's, reconciled
+# against a live gateway (v1.3.5, 2026-08-16). Every list executor
+# NORMALIZES rows through `mapDropboxMetadata`: a fixed camelCase shape
+# whose fifteen keys are ALL declared `required` under
+# `additionalProperties: false`. Mapping Dropbox's own snake_case
+# (`path_display`, `client_modified`, `size`) would have produced
+# all-NULL columns — the Slack 5.2 failure mode. The upside of that
+# strictness: unlike the passthrough packs, every column below sits
+# INSIDE the fingerprint gate, and the coverage-gap pin is empty.
+#
+# PAGINATION IS THE REASON THIS PACK NEEDED AN ENGINE CHANGE. Dropbox
+# continues a listing through a DIFFERENT action than the one that
+# opened it: `list_folder` → `list_folder_continue`, `search_files` →
+# `search_files_continue`, each continue action declaring `cursor` as its
+# ONLY property. Feeding the cursor back to the opening action is not a
+# quiet truncation but a hard 400 — verified live:
+#   POST dropbox.list_folder {"cursor":"abc"} → 400 invalid_input
+# hence `continuation: {action, fingerprint, inputs: cursor_only}`.
+#
+# TERMINATION. `list_folder` answers its FINAL page with a NON-EMPTY
+# cursor (the executor's `requireString(payload.cursor)`, and the
+# contract declares `cursor` a plain required string, not a nullable
+# one). Cursor-spelling termination would refetch and fail as a
+# PaginationLoop, so `has_more_path` is load-bearing here, not
+# decorative. shared_links and search DO null their cursors, but declare
+# `$.hasMore` too: it is the provider's authoritative signal in all
+# three, and one termination rule across the pack beats three.
+#
+# Errors: `dropboxRpcRequest` throws on any non-2xx, so Dropbox's in-band
+# `error_summary` envelope AND its 429 rate limiting both surface as
+# gateway FAILURE envelopes, never as HTTP 200 rows — every table
+# declares no error_path.
+#
+# Scopes: files/file_search need `files.metadata.read`; shared_links
+# needs `sharing.read`. No content or write scope is required by any
+# table here, so a read-only connection serves the whole pack.
+#
+# Design rationale lives in the module docs of packs/dropbox.rs.
+kind: pack
+pack: dropbox
+version: 1
+
+tables:
+  # Every file and folder under `path` (the account root when the binding
+  # supplies none).
+  files:
+    action: dropbox.list_folder
+    row_path: "$.entries"
+    fingerprint: 87502bce0a4c30043fdbde3e45f6c02158ed64338ffeac203eb31f6bde7d6be1
+    pagination:
+      strategy: cursor
+      cursor_input: cursor
+      next_cursor_path: "$.cursor"
+      page_size_input: limit
+      # The schema's declared maximum, which doubles as the
+      # limit-pushdown ceiling. Continuation pages carry no `limit` (the
+      # continue action rejects it); Dropbox sizes them from this
+      # opening request, so the ceiling still holds.
+      page_size: 2000
+      # NOT optional here: see the TERMINATION note above.
+      has_more_path: "$.hasMore"
+      continuation:
+        action: dropbox.list_folder_continue
+        fingerprint: 87502bce0a4c30043fdbde3e45f6c02158ed64338ffeac203eb31f6bde7d6be1
+        inputs: cursor_only
+    resources:
+      optional: [path]
+    # `recursive` is the `state=all` move (5.1): a table named `files`
+    # that returns one directory level is a surprising contract, so the
+    # table means "every file under `path`". `includeMountedFolders`
+    # pins Dropbox's own default so it cannot drift. `includeDeleted`
+    # stays off deliberately — deleted tombstones carry a `deleted` tag
+    # and null everything else, informing no query.
+    fixed_inputs:
+      recursive: true
+      includeMountedFolders: true
+      includeDeleted: false
+    # No filter is pushed. The remaining inputs are scan-shape controls,
+    # not column predicates, and `path` selects the listing ROOT — which
+    # is a different claim from `path_lower = '/a/b'`. Pinned by a
+    # negative-space guard test.
+    columns:
+      # tag and name are executor-guaranteed (`resolveDropboxMetadataTag`
+      # always returns a string; `name` is `?? ""`), so a null arriving
+      # in either is drift and must fail the scan.
+      - { name: tag, path: tag, type: utf8, nullable: false }
+      - { name: name, path: name, type: utf8, nullable: false }
+      - { name: id, path: id, type: utf8, nullable: true }
+      - { name: path_display, path: pathDisplay, type: utf8, nullable: true }
+      - { name: path_lower, path: pathLower, type: utf8, nullable: true }
+      # ISO 8601 strings on the wire, read by the RFC 3339 reader.
+      - { name: client_modified, path: clientModified, type: timestamp_ms_utc, nullable: true }
+      - { name: server_modified, path: serverModified, type: timestamp_ms_utc, nullable: true }
+      - { name: rev, path: rev, type: utf8, nullable: true }
+      - { name: size_bytes, path: sizeBytes, type: int64, nullable: true }
+      - { name: is_downloadable, path: isDownloadable, type: boolean, nullable: true }
+      - { name: content_hash, path: contentHash, type: utf8, nullable: true }
+      - { name: sharing_info, path: sharingInfo, type: json, nullable: true }
+      # url / expires_at / link_permissions are DELIBERATELY absent: the
+      # normalizer sources them from `record.url` / `.expires` /
+      # `.link_permissions`, which files/list_folder never returns, so
+      # mapping them would ship three structurally always-NULL columns.
+      # They live on shared_links, where they populate.
+
+  # Shared links for the current account, or for one path.
+  shared_links:
+    action: dropbox.list_shared_links
+    row_path: "$.links"
+    fingerprint: 7f7c822b99a1afcbf4ea81371527a14ab4d24918dbde170eb115037003144067
+    # No continuation block: this action takes `cursor` itself (verified
+    # live — `{path, cursor}` together pass the strict schema), so pages
+    # 2..N repeat it with the full input, the engine's default.
+    pagination:
+      strategy: cursor
+      cursor_input: cursor
+      next_cursor_path: "$.cursor"
+      # No page-size input exists on this action; Dropbox sizes the
+      # pages. `page_size` is therefore unused for requests and only
+      # bounds LIMIT pushdown.
+      page_size: 100
+      has_more_path: "$.hasMore"
+    resources:
+      optional: [path, directOnly]
+    # `path` is a resource, not an `eq` push onto path_lower: the input
+    # accepts paths, file IDs AND rev IDs, so the mapping would be
+    # unfaithful across most of its value domain — Exact would be wrong
+    # and Inexact would still push a rev ID as though it were a path.
+    columns:
+      - { name: tag, path: tag, type: utf8, nullable: false }
+      - { name: name, path: name, type: utf8, nullable: false }
+      # `url` is the natural identity but stays NULLABLE: the executor
+      # spells it `optionalString(record.url) ?? null`, so a non-null
+      # declaration would fail scans on a row the gateway considers
+      # legal.
+      - { name: url, path: url, type: utf8, nullable: true }
+      - { name: id, path: id, type: utf8, nullable: true }
+      - { name: path_display, path: pathDisplay, type: utf8, nullable: true }
+      - { name: path_lower, path: pathLower, type: utf8, nullable: true }
+      - { name: expires_at, path: expiresAt, type: timestamp_ms_utc, nullable: true }
+      - { name: client_modified, path: clientModified, type: timestamp_ms_utc, nullable: true }
+      - { name: server_modified, path: serverModified, type: timestamp_ms_utc, nullable: true }
+      - { name: rev, path: rev, type: utf8, nullable: true }
+      - { name: size_bytes, path: sizeBytes, type: int64, nullable: true }
+      - { name: is_downloadable, path: isDownloadable, type: boolean, nullable: true }
+      - { name: content_hash, path: contentHash, type: utf8, nullable: true }
+      - { name: sharing_info, path: sharingInfo, type: json, nullable: true }
+      - { name: link_permissions, path: linkPermissions, type: json, nullable: true }
+
+  # Dropbox's search_v2 over files and folders. `query` is required: a
+  # search table without one is not a table (the GitHub owner/repo
+  # precedent).
+  file_search:
+    action: dropbox.search_files
+    row_path: "$.matches"
+    fingerprint: 472377cc3b4fd9890843390919e5b165e52fdd358d8ee08cc109c2a08f0d356c
+    pagination:
+      strategy: cursor
+      cursor_input: cursor
+      next_cursor_path: "$.cursor"
+      page_size_input: maxResults
+      page_size: 1000
+      has_more_path: "$.hasMore"
+      continuation:
+        action: dropbox.search_files_continue
+        fingerprint: 472377cc3b4fd9890843390919e5b165e52fdd358d8ee08cc109c2a08f0d356c
+        inputs: cursor_only
+    resources:
+      required: [query]
+      optional: [path]
+    # Pinned for the same reason includeDeleted is pinned off on files.
+    # `orderBy` is deliberately NOT pinned: search/continue_v2 pages a
+    # server-side snapshot taken at the opening call, so relevance order
+    # is stable within one scan (unlike Feishu's chats, whose default
+    # ordering reshuffles mid-scan and forced ByCreateTimeAsc).
+    fixed_inputs:
+      fileStatus: active
+    columns:
+      # `?? "unknown"` in the executor, so never null.
+      - { name: match_type, path: matchType, type: utf8, nullable: false }
+      - { name: tag, path: metadata.tag, type: utf8, nullable: false }
+      - { name: name, path: metadata.name, type: utf8, nullable: false }
+      - { name: id, path: metadata.id, type: utf8, nullable: true }
+      - { name: path_display, path: metadata.pathDisplay, type: utf8, nullable: true }
+      - { name: path_lower, path: metadata.pathLower, type: utf8, nullable: true }
+      - { name: client_modified, path: metadata.clientModified, type: timestamp_ms_utc, nullable: true }
+      - { name: server_modified, path: metadata.serverModified, type: timestamp_ms_utc, nullable: true }
+      - { name: rev, path: metadata.rev, type: utf8, nullable: true }
+      - { name: size_bytes, path: metadata.sizeBytes, type: int64, nullable: true }
+      - { name: is_downloadable, path: metadata.isDownloadable, type: boolean, nullable: true }
+      - { name: content_hash, path: metadata.contentHash, type: utf8, nullable: true }
+      - { name: sharing_info, path: metadata.sharingInfo, type: json, nullable: true }
+      # highlight_spans is unmapped and `includeHighlights` is never
+      # sent: the field only populates when highlights are requested,
+      # and the declared schema (nullable array) contradicts the
+      # executor (`readObjectArray`, which returns [] and never null).
+      # Recorded as a wire-vs-contract contradiction; not worth a column.

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/README.md
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/README.md
@@ -3,7 +3,7 @@
 Two directories, two provenances. Read this before citing any file here
 as evidence of what Dropbox puts on the wire.
 
-## `contracts/*.json` — CAPTURED
+## `contracts/*.json` — CAPTURED (output schemas only)
 
 Five real captures from `GET /v1/actions/<id>` on a self-hosted Open
 Connector gateway at commit `a3efa99`, taken during the 2026-08-18 live
@@ -15,6 +15,34 @@ wire, not an artifact of derivation.
 
 These are the files `pinned_fingerprints_match_the_committed_contracts`
 hashes, so drift in either the schema or the pin fails the suite.
+
+Note the scope: every file here is an **output** schema, which is all the
+`fingerprint:` pins cover (`fingerprint_schema` hashes the output schema
+and nothing else). The input half lives one directory down.
+
+## `contracts/inputs/*.json` — TRANSCRIBED shape, not a byte-exact capture
+
+`list_folder_continue.json` and `search_files_continue.json`: the input
+schemas of the two continue actions, on the same
+`contracts/inputs/` convention the gmail and outlook packs use. They are
+what `inputs: cursor_only` claims about the wire — `cursor` the only
+property, `required`, `additionalProperties: false` — and the mock
+gateway's discovery serves them, so every registration test in
+`packs/dropbox.rs` exercises the PASS side of the `cursor_only` input gate
+against a committed artifact rather than an inline constant.
+
+Provenance differs from the output captures above, and the difference
+matters: the 2026-08-18 probe wrote `data.inputSchema` to
+`/tmp/dropbox-probe/` and only the **shape** was carried into the repo, so
+these two files are transcriptions of what the pass observed, not saved
+captures. Re-capture them byte-for-byte on the next live pass (the runbook
+now writes them straight into this directory).
+
+`the_cursor_only_claim_holds_against_the_committed_input_contracts` checks
+each one against the table that declares it, so a re-capture that grows a
+second `required` key, or drops `cursor`, fails CI. That catches drift **on
+re-capture, not live** — a registration-time input fingerprint is tracked
+engine work, exactly as documented for gmail and outlook.
 
 ## `*.json` (this directory) — AUTHORED, not captured
 

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/README.md
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/README.md
@@ -1,0 +1,44 @@
+# Dropbox fixture provenance
+
+Two directories, two provenances. Read this before citing any file here
+as evidence of what Dropbox puts on the wire.
+
+## `contracts/*.json` — CAPTURED
+
+Five real captures from `GET /v1/actions/<id>` on a self-hosted Open
+Connector gateway at commit `a3efa99`, taken during the 2026-08-18 live
+pass. Each came back **byte-identical** to the source-derived schema it
+replaced, which is why the `fingerprint:` pins in `dropbox.yaml` matched
+live discovery unchanged. `list_folder_continue.json` being identical to
+`list_folder.json` (and likewise for the search pair) is a fact about the
+wire, not an artifact of derivation.
+
+These are the files `pinned_fingerprints_match_the_committed_contracts`
+hashes, so drift in either the schema or the pin fails the suite.
+
+## `*.json` (this directory) — AUTHORED, not captured
+
+Every row fixture is **hand-authored in the executor's normalized shape**
+(`mapDropboxMetadata`'s fifteen camelCase keys). None is a redacted live
+capture, and none should be read as one — the account used for the live
+pass holds personal files, so its pages were never committed. The
+placeholder tells: `id:aaaaaaaaaaaaaaaaaaaaaa`, `Redacted Folder`,
+`AAGxYzRedactedCursorValue`.
+
+What each one is for, and how far it can be trusted:
+
+| File | Shape | Provenance |
+|---|---|---|
+| `files.json` | a folder row plus a file row, with nested `sharingInfo` and an undeclared extra key | authored; **corrected to the live shape** — the keys the live pass found `list_folder` never populates are null here, as the wire has them |
+| `files_empty.json` | zero entries, `hasMore: false` | authored |
+| `files_type_mismatch.json` | a valid row followed by `sizeBytes: "not-a-number"` | authored, and deliberately **impossible**: it encodes a shape the captured contract forbids, to pin the converter's error identity |
+| `shared_links.json` | one link row with the link-only columns populated | authored; **corrected to the live shape** — the four keys the live pass removed as unpopulatable are null here |
+| `file_search.json` | two matches, `filename` and `content` | authored. `matchType: "content"` is the one value the live pass never observed (Dropbox content indexing did not land during the run); it is structurally reachable, not confirmed |
+| `file_search_null_parent.json` | a match with `metadata: null` | authored, and deliberately **impossible**: the captured contract declares `matches[].metadata` a required non-nullable object. Pins that the converter fails and names the non-nullable column rather than emitting a quiet all-NULL row |
+
+Re-deriving the four non-impossible fixtures from redacted live captures
+is open work; it is tracked in
+`docs/superpowers/plans/2026-08-18-dropbox-live-evaluation.md`. Until
+then these files exercise the mapper, and only the mapper — the wire
+evidence lives in `contracts/` and in the module-doc provenance banner in
+`packs/dropbox.rs`.

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/contracts/inputs/list_folder_continue.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/contracts/inputs/list_folder_continue.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "cursor": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "cursor"
+  ],
+  "additionalProperties": false
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/contracts/inputs/search_files_continue.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/contracts/inputs/search_files_continue.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "cursor": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "cursor"
+  ],
+  "additionalProperties": false
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/contracts/list_folder.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/contracts/list_folder.json
@@ -1,0 +1,203 @@
+{
+  "type": "object",
+  "properties": {
+    "entries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "tag": {
+            "type": "string",
+            "description": "The Dropbox metadata tag such as file, folder, or deleted."
+          },
+          "name": {
+            "type": "string",
+            "description": "The Dropbox item name."
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The Dropbox item ID when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "pathDisplay": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The user-facing cased path when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "pathLower": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The lower-cased full path when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "clientModified": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The client-provided modification timestamp in ISO 8601 format when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "serverModified": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The server-side modification timestamp in ISO 8601 format when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "rev": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The Dropbox file revision when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "sizeBytes": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "description": "The file size in bytes when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "isDownloadable": {
+            "anyOf": [
+              {
+                "type": "boolean",
+                "description": "Whether the file can be downloaded directly."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "contentHash": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The Dropbox content hash when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The shared link URL when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "expiresAt": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The shared link expiration timestamp in ISO 8601 format when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "sharingInfo": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true,
+                "description": "A generic JSON object returned by Dropbox."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "linkPermissions": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true,
+                "description": "Shared-link permission metadata when Dropbox includes it."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "tag",
+          "name",
+          "id",
+          "pathDisplay",
+          "pathLower",
+          "clientModified",
+          "serverModified",
+          "rev",
+          "sizeBytes",
+          "isDownloadable",
+          "contentHash",
+          "url",
+          "expiresAt",
+          "sharingInfo",
+          "linkPermissions"
+        ],
+        "description": "A normalized Dropbox metadata or shared-link record."
+      },
+      "description": "The Dropbox entries returned in this page."
+    },
+    "cursor": {
+      "type": "string",
+      "description": "The cursor for continuing the listing."
+    },
+    "hasMore": {
+      "type": "boolean",
+      "description": "Whether more entries are available."
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "entries",
+    "cursor",
+    "hasMore"
+  ],
+  "description": "A Dropbox folder listing page."
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/contracts/list_folder_continue.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/contracts/list_folder_continue.json
@@ -1,0 +1,203 @@
+{
+  "type": "object",
+  "properties": {
+    "entries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "tag": {
+            "type": "string",
+            "description": "The Dropbox metadata tag such as file, folder, or deleted."
+          },
+          "name": {
+            "type": "string",
+            "description": "The Dropbox item name."
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The Dropbox item ID when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "pathDisplay": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The user-facing cased path when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "pathLower": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The lower-cased full path when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "clientModified": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The client-provided modification timestamp in ISO 8601 format when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "serverModified": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The server-side modification timestamp in ISO 8601 format when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "rev": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The Dropbox file revision when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "sizeBytes": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "description": "The file size in bytes when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "isDownloadable": {
+            "anyOf": [
+              {
+                "type": "boolean",
+                "description": "Whether the file can be downloaded directly."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "contentHash": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The Dropbox content hash when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The shared link URL when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "expiresAt": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The shared link expiration timestamp in ISO 8601 format when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "sharingInfo": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true,
+                "description": "A generic JSON object returned by Dropbox."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "linkPermissions": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true,
+                "description": "Shared-link permission metadata when Dropbox includes it."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "tag",
+          "name",
+          "id",
+          "pathDisplay",
+          "pathLower",
+          "clientModified",
+          "serverModified",
+          "rev",
+          "sizeBytes",
+          "isDownloadable",
+          "contentHash",
+          "url",
+          "expiresAt",
+          "sharingInfo",
+          "linkPermissions"
+        ],
+        "description": "A normalized Dropbox metadata or shared-link record."
+      },
+      "description": "The Dropbox entries returned in this page."
+    },
+    "cursor": {
+      "type": "string",
+      "description": "The cursor for continuing the listing."
+    },
+    "hasMore": {
+      "type": "boolean",
+      "description": "Whether more entries are available."
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "entries",
+    "cursor",
+    "hasMore"
+  ],
+  "description": "A Dropbox folder listing page."
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/contracts/list_shared_links.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/contracts/list_shared_links.json
@@ -1,0 +1,210 @@
+{
+  "type": "object",
+  "properties": {
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "tag": {
+            "type": "string",
+            "description": "The Dropbox metadata tag such as file, folder, or deleted."
+          },
+          "name": {
+            "type": "string",
+            "description": "The Dropbox item name."
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The Dropbox item ID when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "pathDisplay": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The user-facing cased path when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "pathLower": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The lower-cased full path when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "clientModified": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The client-provided modification timestamp in ISO 8601 format when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "serverModified": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The server-side modification timestamp in ISO 8601 format when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "rev": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The Dropbox file revision when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "sizeBytes": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "description": "The file size in bytes when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "isDownloadable": {
+            "anyOf": [
+              {
+                "type": "boolean",
+                "description": "Whether the file can be downloaded directly."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "contentHash": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The Dropbox content hash when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The shared link URL when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "expiresAt": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The shared link expiration timestamp in ISO 8601 format when available."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "sharingInfo": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true,
+                "description": "A generic JSON object returned by Dropbox."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "linkPermissions": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true,
+                "description": "Shared-link permission metadata when Dropbox includes it."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "tag",
+          "name",
+          "id",
+          "pathDisplay",
+          "pathLower",
+          "clientModified",
+          "serverModified",
+          "rev",
+          "sizeBytes",
+          "isDownloadable",
+          "contentHash",
+          "url",
+          "expiresAt",
+          "sharingInfo",
+          "linkPermissions"
+        ],
+        "description": "A normalized Dropbox metadata or shared-link record."
+      },
+      "description": "The shared links returned by Dropbox."
+    },
+    "cursor": {
+      "anyOf": [
+        {
+          "type": "string",
+          "description": "The cursor for continuing the listing when Dropbox provides it."
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "hasMore": {
+      "type": "boolean",
+      "description": "Whether more shared links are available."
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "links",
+    "cursor",
+    "hasMore"
+  ],
+  "description": "A Dropbox shared-link listing page."
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/contracts/search_files.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/contracts/search_files.json
@@ -1,0 +1,243 @@
+{
+  "type": "object",
+  "properties": {
+    "matches": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "matchType": {
+            "type": "string",
+            "description": "The Dropbox match type tag."
+          },
+          "metadata": {
+            "type": "object",
+            "properties": {
+              "tag": {
+                "type": "string",
+                "description": "The Dropbox metadata tag such as file, folder, or deleted."
+              },
+              "name": {
+                "type": "string",
+                "description": "The Dropbox item name."
+              },
+              "id": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "description": "The Dropbox item ID when available."
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "pathDisplay": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "description": "The user-facing cased path when available."
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "pathLower": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "description": "The lower-cased full path when available."
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "clientModified": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "description": "The client-provided modification timestamp in ISO 8601 format when available."
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "serverModified": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "description": "The server-side modification timestamp in ISO 8601 format when available."
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "rev": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "description": "The Dropbox file revision when available."
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "sizeBytes": {
+                "anyOf": [
+                  {
+                    "type": "integer",
+                    "description": "The file size in bytes when available."
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "isDownloadable": {
+                "anyOf": [
+                  {
+                    "type": "boolean",
+                    "description": "Whether the file can be downloaded directly."
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "contentHash": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "description": "The Dropbox content hash when available."
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "url": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "description": "The shared link URL when available."
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "expiresAt": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "description": "The shared link expiration timestamp in ISO 8601 format when available."
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "sharingInfo": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": true,
+                    "description": "A generic JSON object returned by Dropbox."
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "linkPermissions": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": true,
+                    "description": "Shared-link permission metadata when Dropbox includes it."
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "tag",
+              "name",
+              "id",
+              "pathDisplay",
+              "pathLower",
+              "clientModified",
+              "serverModified",
+              "rev",
+              "sizeBytes",
+              "isDownloadable",
+              "contentHash",
+              "url",
+              "expiresAt",
+              "sharingInfo",
+              "linkPermissions"
+            ],
+            "description": "A normalized Dropbox metadata or shared-link record."
+          },
+          "highlightSpans": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": true,
+                  "description": "A generic JSON object returned by Dropbox."
+                },
+                "description": "Dropbox highlight spans when requested and returned."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "matchType",
+          "metadata",
+          "highlightSpans"
+        ],
+        "description": "A normalized Dropbox search match."
+      },
+      "description": "The Dropbox search matches."
+    },
+    "cursor": {
+      "anyOf": [
+        {
+          "type": "string",
+          "description": "The cursor for continuing the search when available."
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "hasMore": {
+      "type": "boolean",
+      "description": "Whether more search matches are available."
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "matches",
+    "cursor",
+    "hasMore"
+  ],
+  "description": "A Dropbox search result page."
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/contracts/search_files_continue.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/contracts/search_files_continue.json
@@ -1,0 +1,243 @@
+{
+  "type": "object",
+  "properties": {
+    "matches": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "matchType": {
+            "type": "string",
+            "description": "The Dropbox match type tag."
+          },
+          "metadata": {
+            "type": "object",
+            "properties": {
+              "tag": {
+                "type": "string",
+                "description": "The Dropbox metadata tag such as file, folder, or deleted."
+              },
+              "name": {
+                "type": "string",
+                "description": "The Dropbox item name."
+              },
+              "id": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "description": "The Dropbox item ID when available."
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "pathDisplay": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "description": "The user-facing cased path when available."
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "pathLower": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "description": "The lower-cased full path when available."
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "clientModified": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "description": "The client-provided modification timestamp in ISO 8601 format when available."
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "serverModified": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "description": "The server-side modification timestamp in ISO 8601 format when available."
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "rev": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "description": "The Dropbox file revision when available."
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "sizeBytes": {
+                "anyOf": [
+                  {
+                    "type": "integer",
+                    "description": "The file size in bytes when available."
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "isDownloadable": {
+                "anyOf": [
+                  {
+                    "type": "boolean",
+                    "description": "Whether the file can be downloaded directly."
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "contentHash": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "description": "The Dropbox content hash when available."
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "url": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "description": "The shared link URL when available."
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "expiresAt": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "description": "The shared link expiration timestamp in ISO 8601 format when available."
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "sharingInfo": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": true,
+                    "description": "A generic JSON object returned by Dropbox."
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "linkPermissions": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": true,
+                    "description": "Shared-link permission metadata when Dropbox includes it."
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "tag",
+              "name",
+              "id",
+              "pathDisplay",
+              "pathLower",
+              "clientModified",
+              "serverModified",
+              "rev",
+              "sizeBytes",
+              "isDownloadable",
+              "contentHash",
+              "url",
+              "expiresAt",
+              "sharingInfo",
+              "linkPermissions"
+            ],
+            "description": "A normalized Dropbox metadata or shared-link record."
+          },
+          "highlightSpans": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": true,
+                  "description": "A generic JSON object returned by Dropbox."
+                },
+                "description": "Dropbox highlight spans when requested and returned."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "matchType",
+          "metadata",
+          "highlightSpans"
+        ],
+        "description": "A normalized Dropbox search match."
+      },
+      "description": "The Dropbox search matches."
+    },
+    "cursor": {
+      "anyOf": [
+        {
+          "type": "string",
+          "description": "The cursor for continuing the search when available."
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "hasMore": {
+      "type": "boolean",
+      "description": "Whether more search matches are available."
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "matches",
+    "cursor",
+    "hasMore"
+  ],
+  "description": "A Dropbox search result page."
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/file_search.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/file_search.json
@@ -1,0 +1,48 @@
+{
+  "matches": [
+    {
+      "matchType": "filename",
+      "metadata": {
+        "tag": "file",
+        "name": "redacted-report.pdf",
+        "id": "id:bbbbbbbbbbbbbbbbbbbbbb",
+        "pathDisplay": "/Redacted Folder/redacted-report.pdf",
+        "pathLower": "/redacted folder/redacted-report.pdf",
+        "clientModified": "2026-08-01T09:15:00Z",
+        "serverModified": "2026-08-01T09:15:04Z",
+        "rev": "0165f0a1b2c3d4e5f60",
+        "sizeBytes": 284913,
+        "isDownloadable": true,
+        "contentHash": "3f1a0c9e4b7d2a5f8e0c1b3d6a9f2e4c7b0d3a6f9e2c5b8d1a4f7e0c3b6d9a2f",
+        "url": null,
+        "expiresAt": null,
+        "sharingInfo": { "read_only": false },
+        "linkPermissions": null
+      },
+      "highlightSpans": []
+    },
+    {
+      "matchType": "content",
+      "metadata": {
+        "tag": "file",
+        "name": "notes.txt",
+        "id": "id:cccccccccccccccccccccc",
+        "pathDisplay": "/Redacted Folder/notes.txt",
+        "pathLower": "/redacted folder/notes.txt",
+        "clientModified": null,
+        "serverModified": "2026-07-28T22:40:12Z",
+        "rev": "0165f0a1b2c3d4e5f61",
+        "sizeBytes": 0,
+        "isDownloadable": true,
+        "contentHash": null,
+        "url": null,
+        "expiresAt": null,
+        "sharingInfo": null,
+        "linkPermissions": null
+      },
+      "highlightSpans": []
+    }
+  ],
+  "cursor": null,
+  "hasMore": false
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/file_search_null_parent.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/file_search_null_parent.json
@@ -1,0 +1,32 @@
+{
+  "matches": [
+    {
+      "matchType": "filename",
+      "metadata": {
+        "tag": "file",
+        "name": "present.txt",
+        "id": "id:dddddddddddddddddddddd",
+        "pathDisplay": "/present.txt",
+        "pathLower": "/present.txt",
+        "clientModified": null,
+        "serverModified": null,
+        "rev": null,
+        "sizeBytes": null,
+        "isDownloadable": null,
+        "contentHash": null,
+        "url": null,
+        "expiresAt": null,
+        "sharingInfo": null,
+        "linkPermissions": null
+      },
+      "highlightSpans": []
+    },
+    {
+      "matchType": "filename",
+      "metadata": null,
+      "highlightSpans": []
+    }
+  ],
+  "cursor": null,
+  "hasMore": false
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/files.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/files.json
@@ -1,0 +1,67 @@
+{
+  "entries": [
+    {
+      "tag": "folder",
+      "name": "Redacted Folder",
+      "id": "id:aaaaaaaaaaaaaaaaaaaaaa",
+      "pathDisplay": "/Redacted Folder",
+      "pathLower": "/redacted folder",
+      "clientModified": null,
+      "serverModified": null,
+      "rev": null,
+      "sizeBytes": null,
+      "isDownloadable": null,
+      "contentHash": null,
+      "url": null,
+      "expiresAt": null,
+      "sharingInfo": null,
+      "linkPermissions": null
+    },
+    {
+      "tag": "file",
+      "name": "redacted-report.pdf",
+      "id": "id:bbbbbbbbbbbbbbbbbbbbbb",
+      "pathDisplay": "/Redacted Folder/redacted-report.pdf",
+      "pathLower": "/redacted folder/redacted-report.pdf",
+      "clientModified": "2026-08-01T09:15:00Z",
+      "serverModified": "2026-08-01T09:15:04Z",
+      "rev": "0165f0a1b2c3d4e5f60",
+      "sizeBytes": 284913,
+      "isDownloadable": true,
+      "contentHash": "3f1a0c9e4b7d2a5f8e0c1b3d6a9f2e4c7b0d3a6f9e2c5b8d1a4f7e0c3b6d9a2f",
+      "url": null,
+      "expiresAt": null,
+      "sharingInfo": {
+        "read_only": false,
+        "parent_shared_folder_id": "9876543210",
+        "modified_by": "dbid:redacted"
+      },
+      "linkPermissions": null
+    },
+    {
+      "tag": "file",
+      "name": "notes.txt",
+      "id": "id:cccccccccccccccccccccc",
+      "pathDisplay": "/Redacted Folder/notes.txt",
+      "pathLower": "/redacted folder/notes.txt",
+      "clientModified": "2026-07-28T22:40:11Z",
+      "serverModified": "2026-07-28T22:40:12Z",
+      "rev": "0165f0a1b2c3d4e5f61",
+      "sizeBytes": 0,
+      "isDownloadable": true,
+      "contentHash": "0000000000000000000000000000000000000000000000000000000000000000",
+      "url": null,
+      "expiresAt": null,
+      "sharingInfo": null,
+      "linkPermissions": null,
+      "propertyGroups": [
+        {
+          "template_id": "ptid:redacted"
+        }
+      ],
+      "hasExplicitSharedMembers": false
+    }
+  ],
+  "cursor": "AAGxYzRedactedCursorValue",
+  "hasMore": false
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/files_empty.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/files_empty.json
@@ -1,0 +1,5 @@
+{
+  "entries": [],
+  "cursor": "AAGxYzRedactedEmptyCursor",
+  "hasMore": false
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/files_type_mismatch.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/files_type_mismatch.json
@@ -1,0 +1,16 @@
+{
+  "entries": [
+    {
+      "tag": "file",
+      "name": "fine.txt",
+      "sizeBytes": 12
+    },
+    {
+      "tag": "file",
+      "name": "broken.txt",
+      "sizeBytes": "not-a-number"
+    }
+  ],
+  "cursor": "AAGxYzRedactedCursorValue",
+  "hasMore": false
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/shared_links.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/shared_links.json
@@ -1,0 +1,47 @@
+{
+  "links": [
+    {
+      "tag": "file",
+      "name": "redacted-report.pdf",
+      "id": "id:bbbbbbbbbbbbbbbbbbbbbb",
+      "pathDisplay": "/Redacted Folder/redacted-report.pdf",
+      "pathLower": "/redacted folder/redacted-report.pdf",
+      "clientModified": "2026-08-01T09:15:00Z",
+      "serverModified": "2026-08-01T09:15:04Z",
+      "rev": "0165f0a1b2c3d4e5f60",
+      "sizeBytes": 284913,
+      "isDownloadable": true,
+      "contentHash": "3f1a0c9e4b7d2a5f8e0c1b3d6a9f2e4c7b0d3a6f9e2c5b8d1a4f7e0c3b6d9a2f",
+      "url": "https://www.dropbox.com/scl/fi/redacted0001/report.pdf?dl=0",
+      "expiresAt": "2026-12-31T23:59:59Z",
+      "sharingInfo": null,
+      "linkPermissions": {
+        "resolved_visibility": { ".tag": "public" },
+        "can_revoke": true,
+        "allow_download": true
+      }
+    },
+    {
+      "tag": "folder",
+      "name": "Redacted Folder",
+      "id": "id:aaaaaaaaaaaaaaaaaaaaaa",
+      "pathDisplay": "/Redacted Folder",
+      "pathLower": "/redacted folder",
+      "clientModified": null,
+      "serverModified": null,
+      "rev": null,
+      "sizeBytes": null,
+      "isDownloadable": null,
+      "contentHash": null,
+      "url": "https://www.dropbox.com/scl/fo/redacted0002/folder?dl=0",
+      "expiresAt": null,
+      "sharingInfo": null,
+      "linkPermissions": {
+        "resolved_visibility": { ".tag": "team_only" },
+        "can_revoke": false
+      }
+    }
+  ],
+  "cursor": null,
+  "hasMore": false
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/shared_links.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/shared_links.json
@@ -4,19 +4,21 @@
       "tag": "file",
       "name": "redacted-report.pdf",
       "id": "id:bbbbbbbbbbbbbbbbbbbbbb",
-      "pathDisplay": "/Redacted Folder/redacted-report.pdf",
+      "pathDisplay": null,
       "pathLower": "/redacted folder/redacted-report.pdf",
       "clientModified": "2026-08-01T09:15:00Z",
       "serverModified": "2026-08-01T09:15:04Z",
       "rev": "0165f0a1b2c3d4e5f60",
       "sizeBytes": 284913,
-      "isDownloadable": true,
-      "contentHash": "3f1a0c9e4b7d2a5f8e0c1b3d6a9f2e4c7b0d3a6f9e2c5b8d1a4f7e0c3b6d9a2f",
+      "isDownloadable": null,
+      "contentHash": null,
       "url": "https://www.dropbox.com/scl/fi/redacted0001/report.pdf?dl=0",
       "expiresAt": "2026-12-31T23:59:59Z",
       "sharingInfo": null,
       "linkPermissions": {
-        "resolved_visibility": { ".tag": "public" },
+        "resolved_visibility": {
+          ".tag": "public"
+        },
         "can_revoke": true,
         "allow_download": true
       }
@@ -25,7 +27,7 @@
       "tag": "folder",
       "name": "Redacted Folder",
       "id": "id:aaaaaaaaaaaaaaaaaaaaaa",
-      "pathDisplay": "/Redacted Folder",
+      "pathDisplay": null,
       "pathLower": "/redacted folder",
       "clientModified": null,
       "serverModified": null,
@@ -37,7 +39,9 @@
       "expiresAt": null,
       "sharingInfo": null,
       "linkPermissions": {
-        "resolved_visibility": { ".tag": "team_only" },
+        "resolved_visibility": {
+          ".tag": "team_only"
+        },
         "can_revoke": false
       }
     }

--- a/crates/skardi/src/sources/providers/open_connector/packs/loader.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/loader.rs
@@ -38,7 +38,9 @@ use crate::sources::providers::open_connector::error::OpenConnectorError;
 use crate::sources::providers::open_connector::filters::{Fidelity, FilterMapping, ValueFormat};
 use crate::sources::providers::open_connector::json_to_arrow::RowConverter;
 use crate::sources::providers::open_connector::json_to_arrow::{FieldMapping, FieldType};
-use crate::sources::providers::open_connector::pagination::PaginationStrategy;
+use crate::sources::providers::open_connector::pagination::{
+    CursorContinuation, PaginationStrategy,
+};
 use crate::sources::providers::open_connector::row_path::RowPath;
 use crate::sources::providers::open_connector::source_pack::{
     FixedValue, SourcePack, SourcePackTable,
@@ -133,12 +135,14 @@ fn convert_table(
         };
         fixed_inputs.push((leak_str(key), fixed));
     }
+    let action_id = leak_str(doc.action);
+    let (pagination, continuation) = doc.pagination.into_parts(action_id);
     let table = SourcePackTable {
         id,
-        action_id: leak_str(doc.action),
+        action_id,
         row_path: leak_str(doc.row_path),
         fields: leak_slice(fields),
-        pagination: doc.pagination.into_strategy(),
+        pagination,
         required_resources: leak_str_slice(doc.resources.required),
         optional_resources: leak_str_slice(doc.resources.optional),
         exclusive_resources: leak_str_groups(doc.resources.exclusive),
@@ -146,6 +150,7 @@ fn convert_table(
         filters: leak_slice(filters),
         error_path: doc.error_path.map(leak_str),
         expected_fingerprint: doc.fingerprint.map(leak_str),
+        continuation,
     };
     validate_table(&table)?;
     Ok(table)
@@ -402,6 +407,26 @@ fn validate_table(table: &SourcePackTable) -> Result<(), String> {
             ));
         }
     }
+    if let Some(continuation) = table.continuation {
+        // Half a gate is worse than an obvious hole: a table pinning its
+        // continuation action while leaving its OWN action unpinned would
+        // read as gated and verify only pages 2..N.
+        if table.expected_fingerprint.is_none() {
+            return Err(format!(
+                "{id}: continuation declares a fingerprint but the table does not; pin \
+                 the table's own action too or neither is gated"
+            ));
+        }
+        if continuation.action_id == table.action_id && !continuation.cursor_only {
+            // Same action, same inputs, same everything — the declaration
+            // describes exactly the default behavior, so it is either a
+            // no-op or (more likely) a missing `inputs: cursor_only`.
+            return Err(format!(
+                "{id}: continuation repeats the table's own action with the full input, \
+                 which is the default; drop the block or declare `inputs: cursor_only`"
+            ));
+        }
+    }
     Ok(())
 }
 
@@ -552,6 +577,11 @@ enum PaginationDoc {
         page_size: u32,
         #[serde(default)]
         has_more_path: Option<String>,
+        /// Split-action continuation. Nested under the cursor variant so a
+        /// `page_number` table declaring one is a `deny_unknown_fields`
+        /// parse error — the invariant costs no hand-written check.
+        #[serde(default)]
+        continuation: Option<ContinuationDoc>,
     },
     /// No pagination envelope: the next cursor is a field of the previous
     /// page's LAST ROW (Discord's `after`). Only an empty page terminates
@@ -585,8 +615,42 @@ enum PaginationDoc {
     },
 }
 
+/// How pages 2..N are served, when not by repeating the table's action
+/// with the full input.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ContinuationDoc {
+    /// Action serving pages 2..N; defaults to the table's own action, for
+    /// providers that keep the action but reject its opening inputs
+    /// alongside a cursor.
+    #[serde(default)]
+    action: Option<String>,
+    /// Contract fingerprint of the continuation action — never optional:
+    /// this action serves most of a long scan.
+    fingerprint: String,
+    #[serde(default)]
+    inputs: ContinuationInputsDoc,
+}
+
+/// Which inputs a continuation request carries.
+#[derive(Deserialize, Default)]
+enum ContinuationInputsDoc {
+    /// The full assembled input, as page one — the conservative default.
+    #[serde(rename = "full")]
+    #[default]
+    Full,
+    /// The cursor and nothing else (Dropbox's `*_continue` actions).
+    #[serde(rename = "cursor_only")]
+    CursorOnly,
+}
+
 impl PaginationDoc {
-    fn into_strategy(self) -> PaginationStrategy {
+    /// Split into the engine's strategy and the table-level continuation
+    /// decl. `table_action` supplies the continuation's default action.
+    fn into_parts(
+        self,
+        table_action: &'static str,
+    ) -> (PaginationStrategy, Option<CursorContinuation>) {
         match self {
             Self::PageNumber {
                 page_input,
@@ -594,40 +658,57 @@ impl PaginationDoc {
                 page_size,
                 total_pages_path,
                 raw_page_size_path,
-            } => PaginationStrategy::PageNumber {
-                page_param: leak_str(page_input),
-                per_page_param: leak_str(page_size_input),
-                per_page: page_size,
-                total_pages_path: total_pages_path.map(leak_str),
-                raw_page_size_path: raw_page_size_path.map(leak_str),
-            },
+            } => (
+                PaginationStrategy::PageNumber {
+                    page_param: leak_str(page_input),
+                    per_page_param: leak_str(page_size_input),
+                    per_page: page_size,
+                    total_pages_path: total_pages_path.map(leak_str),
+                    raw_page_size_path: raw_page_size_path.map(leak_str),
+                },
+                None,
+            ),
             Self::Cursor {
                 cursor_input,
                 next_cursor_path,
                 page_size_input,
                 page_size,
                 has_more_path,
-            } => PaginationStrategy::Cursor {
-                cursor_param: leak_str(cursor_input),
-                next_cursor_path: leak_str(next_cursor_path),
-                page_size_param: page_size_input.map(leak_str),
-                page_size,
-                has_more_path: has_more_path.map(leak_str),
-            },
+                continuation,
+            } => (
+                PaginationStrategy::Cursor {
+                    cursor_param: leak_str(cursor_input),
+                    next_cursor_path: leak_str(next_cursor_path),
+                    page_size_param: page_size_input.map(leak_str),
+                    page_size,
+                    has_more_path: has_more_path.map(leak_str),
+                },
+                continuation.map(|doc| CursorContinuation {
+                    action_id: doc.action.map_or(table_action, leak_str),
+                    expected_fingerprint: leak_str(doc.fingerprint),
+                    cursor_only: matches!(doc.inputs, ContinuationInputsDoc::CursorOnly),
+                }),
+            ),
             Self::Keyset {
                 cursor_input,
                 row_cursor_field,
                 page_size_input,
                 page_size,
-            } => PaginationStrategy::Keyset {
-                cursor_param: leak_str(cursor_input),
-                row_cursor_field: leak_str(row_cursor_field),
-                page_size_param: leak_str(page_size_input),
-                page_size,
-            },
-            Self::SinglePage { next_cursor_path } => PaginationStrategy::SinglePage {
-                next_cursor_path: next_cursor_path.map(leak_str),
-            },
+            } => (
+                PaginationStrategy::Keyset {
+                    cursor_param: leak_str(cursor_input),
+                    row_cursor_field: leak_str(row_cursor_field),
+                    page_size_param: leak_str(page_size_input),
+                    page_size,
+                },
+                None,
+            ),
+            Self::SinglePage { next_cursor_path } => (
+                PaginationStrategy::SinglePage {
+                    next_cursor_path: next_cursor_path.map(leak_str),
+                },
+                None,
+            ),
         }
     }
 }
@@ -1461,6 +1542,138 @@ tables:
     columns:
       - { name: id, path: id, type: uint64, nullable: false }"#,
                 "must start with '$.'",
+            ),
+        ] {
+            let err = pack_with(body).expect_err(expected);
+            assert!(err.contains(expected), "want {expected:?} in: {err}");
+        }
+    }
+
+    #[test]
+    fn split_action_continuation_parses_with_its_defaults() {
+        let pack = pack_with(
+            r#"    action: demo.list
+    row_path: "$.entries"
+    fingerprint: aa
+    pagination:
+      strategy: cursor
+      cursor_input: cursor
+      next_cursor_path: "$.cursor"
+      page_size_input: limit
+      page_size: 2000
+      has_more_path: "$.hasMore"
+      continuation:
+        action: demo.list_continue
+        fingerprint: bb
+        inputs: cursor_only
+    columns:
+      - { name: id, path: id, type: uint64, nullable: false }"#,
+        )
+        .expect("continuation parses");
+        let continuation = pack.tables[0].continuation.expect("declared");
+        assert_eq!(continuation.action_id, "demo.list_continue");
+        assert_eq!(continuation.expected_fingerprint, "bb");
+        assert!(continuation.cursor_only);
+
+        // Both actions are executed, and both are gated.
+        let table = &pack.tables[0];
+        assert_eq!(
+            table.actions().collect::<Vec<_>>(),
+            vec!["demo.list", "demo.list_continue"]
+        );
+        assert_eq!(
+            table.gated_actions().collect::<Vec<_>>(),
+            vec![("demo.list", "aa"), ("demo.list_continue", "bb")]
+        );
+    }
+
+    #[test]
+    fn continuation_action_defaults_to_the_tables_own() {
+        // The same-action flavor: a provider that keeps the action but
+        // rejects the opening inputs alongside a cursor.
+        let pack = pack_with(
+            r#"    action: demo.list
+    row_path: "$.entries"
+    fingerprint: aa
+    pagination:
+      strategy: cursor
+      cursor_input: cursor
+      next_cursor_path: "$.cursor"
+      page_size: 100
+      continuation:
+        fingerprint: aa
+        inputs: cursor_only
+    columns:
+      - { name: id, path: id, type: uint64, nullable: false }"#,
+        )
+        .expect("continuation parses");
+        let continuation = pack.tables[0].continuation.expect("declared");
+        assert_eq!(continuation.action_id, "demo.list");
+        assert!(continuation.cursor_only);
+    }
+
+    #[test]
+    fn continuation_invariants_are_rejected_with_targeted_errors() {
+        for (body, expected) in [
+            // A continuation on a page-number table is nonsense; the YAML
+            // nesting makes it a deny_unknown_fields parse error for free.
+            (
+                r#"    action: demo.list
+    row_path: "$.items"
+    pagination:
+      strategy: page_number
+      page_input: page
+      page_size_input: perPage
+      page_size: 10
+      continuation: { fingerprint: bb, inputs: cursor_only }
+    columns:
+      - { name: id, path: id, type: uint64, nullable: false }"#,
+                "unknown field",
+            ),
+            // Half a gate: pages 2..N pinned, page one unpinned.
+            (
+                r#"    action: demo.list
+    row_path: "$.items"
+    pagination:
+      strategy: cursor
+      cursor_input: cursor
+      next_cursor_path: "$.cursor"
+      page_size: 10
+      continuation: { action: demo.list_continue, fingerprint: bb }
+    columns:
+      - { name: id, path: id, type: uint64, nullable: false }"#,
+                "the table does not",
+            ),
+            // Describes the default behavior — a no-op block, or (far more
+            // likely) a forgotten `inputs: cursor_only`.
+            (
+                r#"    action: demo.list
+    row_path: "$.items"
+    fingerprint: aa
+    pagination:
+      strategy: cursor
+      cursor_input: cursor
+      next_cursor_path: "$.cursor"
+      page_size: 10
+      continuation: { fingerprint: aa }
+    columns:
+      - { name: id, path: id, type: uint64, nullable: false }"#,
+                "which is the default",
+            ),
+            // The fingerprint is never optional on a continuation.
+            (
+                r#"    action: demo.list
+    row_path: "$.items"
+    fingerprint: aa
+    pagination:
+      strategy: cursor
+      cursor_input: cursor
+      next_cursor_path: "$.cursor"
+      page_size: 10
+      continuation: { action: demo.list_continue, inputs: cursor_only }
+    columns:
+      - { name: id, path: id, type: uint64, nullable: false }"#,
+                "missing field `fingerprint`",
             ),
         ] {
             let err = pack_with(body).expect_err(expected);

--- a/crates/skardi/src/sources/providers/open_connector/packs/loader.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/loader.rs
@@ -426,6 +426,48 @@ fn validate_table(table: &SourcePackTable) -> Result<(), String> {
                  which is the default; drop the block or declare `inputs: cursor_only`"
             ));
         }
+        // One action, one discovered schema, one fingerprint. Two pins that
+        // disagree cannot BOTH be satisfied by any gateway, so this is
+        // unsatisfiable by construction rather than merely suspicious —
+        // and left to runtime it surfaces as a contract-gate failure
+        // pointing at the schema instead of at the two lines that cannot
+        // both be right. (The `open_connector_query` path looks the
+        // expectation up by action id and would silently check the first
+        // of the two; refusing here is what makes that lookup sound.)
+        if continuation.action_id == table.action_id
+            && table.expected_fingerprint != Some(continuation.expected_fingerprint)
+        {
+            return Err(format!(
+                "{id}: continuation names the table's own action '{}' but pins a different \
+                 fingerprint ({} vs {}); one action has one contract, so no gateway can \
+                 satisfy both",
+                continuation.action_id,
+                table.expected_fingerprint.unwrap_or("<none>"),
+                continuation.expected_fingerprint
+            ));
+        }
+        // `cursor_only` deliberately drops every non-cursor input on pages
+        // 2..N. An `Exact` filter is mapped to
+        // `TableProviderFilterPushDown::Exact`, which DELETES the `Filter`
+        // node from the plan — so page one applies the predicate as an
+        // action input and pages 2..N cannot, with no node left to
+        // re-apply it. That returns rows the query excluded, silently:
+        // the same failure class as a pushdown leak, and refused the same
+        // way. `Inexact` stays legal — the `Filter` node survives, so
+        // pages 2..N are merely wasteful, never wrong.
+        if continuation.cursor_only
+            && let Some(filter) = table
+                .filters
+                .iter()
+                .find(|f| matches!(f.fidelity, Fidelity::Exact))
+        {
+            return Err(format!(
+                "{id}: filter on '{}' is Exact, which removes the Filter node from the \
+                 plan, but `inputs: cursor_only` cannot carry the predicate past page one; \
+                 declare the filter Inexact or drop `cursor_only`",
+                filter.input_field
+            ));
+        }
     }
     Ok(())
 }
@@ -1675,9 +1717,72 @@ tables:
       - { name: id, path: id, type: uint64, nullable: false }"#,
                 "missing field `fingerprint`",
             ),
+            // One action has one contract, so two disagreeing pins on it
+            // cannot both be satisfied by any gateway.
+            (
+                r#"    action: demo.list
+    row_path: "$.items"
+    fingerprint: aa
+    pagination:
+      strategy: cursor
+      cursor_input: cursor
+      next_cursor_path: "$.cursor"
+      page_size: 10
+      continuation: { fingerprint: bb, inputs: cursor_only }
+    columns:
+      - { name: id, path: id, type: uint64, nullable: false }"#,
+                "pins a different fingerprint",
+            ),
+            // The silent-wrong-rows pairing: an Exact filter deletes the
+            // Filter node from the plan, and `cursor_only` cannot carry
+            // the predicate past page one.
+            (
+                r#"    action: demo.list
+    row_path: "$.items"
+    fingerprint: aa
+    pagination:
+      strategy: cursor
+      cursor_input: cursor
+      next_cursor_path: "$.cursor"
+      page_size: 10
+      continuation: { action: demo.list_continue, fingerprint: bb, inputs: cursor_only }
+    columns:
+      - { name: id, path: id, type: uint64, nullable: false }
+      - { name: state, path: state, type: utf8, nullable: true }
+    filters:
+      - { column: state, op: eq, input: state, fidelity: exact }"#,
+                "cannot carry the predicate past page one",
+            ),
         ] {
             let err = pack_with(body).expect_err(expected);
             assert!(err.contains(expected), "want {expected:?} in: {err}");
         }
+    }
+
+    #[test]
+    fn an_inexact_filter_stays_legal_alongside_a_cursor_only_continuation() {
+        // The contrast case for the gate above. `Inexact` maps to
+        // `TableProviderFilterPushDown::Inexact`, which KEEPS the `Filter`
+        // node, so pages 2..N losing the pushed input is merely wasteful —
+        // DataFusion re-applies the predicate and the rows stay correct.
+        // Refusing this too would have been a false alarm.
+        let pack = pack_with(
+            r#"    action: demo.list
+    row_path: "$.items"
+    fingerprint: aa
+    pagination:
+      strategy: cursor
+      cursor_input: cursor
+      next_cursor_path: "$.cursor"
+      page_size: 10
+      continuation: { action: demo.list_continue, fingerprint: bb, inputs: cursor_only }
+    columns:
+      - { name: id, path: id, type: uint64, nullable: false }
+      - { name: state, path: state, type: utf8, nullable: true }
+    filters:
+      - { column: state, op: eq, input: state, fidelity: inexact }"#,
+        )
+        .expect("an Inexact filter cannot return rows the query excluded");
+        assert_eq!(pack.tables[0].filters.len(), 1);
     }
 }

--- a/crates/skardi/src/sources/providers/open_connector/packs/loader.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/loader.rs
@@ -271,26 +271,13 @@ fn validate_table(table: &SourcePackTable) -> Result<(), String> {
     // predicate DataFusion never reapplies. Filter-vs-fixed-input overlap
     // is the one DELIBERATE collision (a pushed predicate overrides the
     // complete-collection pin) and stays legal.
-    let pagination_params: Vec<&str> = match table.pagination {
-        PaginationStrategy::PageNumber {
-            page_param,
-            per_page_param,
-            ..
-        } => vec![page_param, per_page_param],
-        PaginationStrategy::Cursor {
-            cursor_param,
-            page_size_param,
-            ..
-        } => std::iter::once(cursor_param)
-            .chain(page_size_param)
-            .collect(),
-        PaginationStrategy::Keyset {
-            cursor_param,
-            page_size_param,
-            ..
-        } => vec![cursor_param, page_size_param],
-        PaginationStrategy::SinglePage { .. } => Vec::new(),
-    };
+    //
+    // The strategy -> params mapping lives on `SourcePackTable` so this
+    // gate and the continuation input gates read the same list: this
+    // function used to carry its own copy of the match, and the two had
+    // already drifted once (`Keyset`/`single_page` arrived with the
+    // Discord pack and only one side was widened).
+    let pagination_params: Vec<&str> = table.pagination_input_keys();
     // An empty param name — under ANY strategy — would survive to scan
     // time as a literal `""` input key: a strict gateway's 400 blamed on
     // the request, or a lax gateway's page-1 refetch misdiagnosed as a
@@ -454,7 +441,15 @@ fn validate_table(table: &SourcePackTable) -> Result<(), String> {
         // re-apply it. That returns rows the query excluded, silently:
         // the same failure class as a pushdown leak, and refused the same
         // way. `Inexact` stays legal — the `Filter` node survives, so
-        // pages 2..N are merely wasteful, never wrong.
+        // DataFusion re-applies the predicate and the ROWS are right. The
+        // waste is not free, though: pages 2..N fetch the unfiltered
+        // collection, and the scan bounds count what the gateway returned,
+        // not what survived the filter (`exec.rs` raises
+        // `ScanBoundsExceeded` off `rows_emitted`/page count pre-filter).
+        // So a selective `Inexact` filter moves the effective volume from
+        // the filtered subset to the whole collection, and wants
+        // `max_rows`/`max_pages` headroom sized for it — otherwise a query
+        // that works today becomes a hard scan failure, not a slower one.
         if continuation.cursor_only
             && let Some(filter) = table
                 .filters

--- a/crates/skardi/src/sources/providers/open_connector/packs/mod.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/mod.rs
@@ -3,6 +3,7 @@
 pub(crate) mod loader;
 
 pub mod discord;
+pub mod dropbox;
 pub mod feishu;
 pub mod github;
 pub mod gmail;

--- a/crates/skardi/src/sources/providers/open_connector/pagination.rs
+++ b/crates/skardi/src/sources/providers/open_connector/pagination.rs
@@ -36,12 +36,25 @@ pub struct CursorContinuation {
     /// action serves most of a large scan, so gating only the action that
     /// served page one would leave the rest of the collection unguarded
     /// against contract drift.
+    ///
+    /// Scope worth knowing before relying on it: a fingerprint hashes the
+    /// action's OUTPUT schema, so this pin guards the ROW shape pages 2..N
+    /// deliver. Where an opener and its continuation publish the same
+    /// output schema — the Dropbox case — the two hashes are equal and this
+    /// pin can only fail together with the opener's. What actually differs
+    /// between the two actions is their INPUTS, and those are covered by
+    /// `SourcePackTable::check_continuation_inputs` instead, not here.
     pub expected_fingerprint: &'static str,
     /// Whether pages 2..N carry ONLY the cursor. Required whenever the
     /// continuation action's schema accepts nothing else; kept separate
     /// from `action_id` because the two vary independently — a provider can
     /// continue through the same action while still rejecting the original
     /// inputs alongside a cursor.
+    ///
+    /// Checked at registration against the continuation action's discovered
+    /// input schema (`SourcePackTable::check_continuation_inputs`), because
+    /// the fingerprint above cannot: a wrong claim here is otherwise a hard
+    /// 400 on page two of a live scan rather than a startup error.
     pub cursor_only: bool,
 }
 
@@ -371,8 +384,8 @@ impl Pagination {
     /// Deliberately omits the page-size input that [`Self::apply`] sends:
     /// Dropbox's `list_folder_continue` declares `cursor` as its sole
     /// property, so a `limit` alongside it is a 400. Continuation pages are
-    /// sized by the request that began the listing, which keeps
-    /// `page_size`'s role as the limit-pushdown ceiling honest.
+    /// sized by the request that began the listing — a provider guarantee,
+    /// not something this engine enforces.
     ///
     /// A no-op on the first page (no token yet) and for non-cursor
     /// strategies, neither of which a continuation can reach.

--- a/crates/skardi/src/sources/providers/open_connector/pagination.rs
+++ b/crates/skardi/src/sources/providers/open_connector/pagination.rs
@@ -12,6 +12,39 @@ use serde_json::{Map, Value};
 use super::error::OpenConnectorError;
 use super::row_path::{RowPath, json_kind};
 
+/// How a cursor-paginated table continues past its first page, when the
+/// provider does not accept the cursor on the action that started the
+/// listing.
+///
+/// Open Connector's Dropbox provider is the motivating shape: `list_folder`
+/// begins a folder listing and `list_folder_continue` — a **separate
+/// action** whose input schema declares `cursor` as its only property —
+/// serves pages 2..N. Feeding the cursor back to `list_folder` is not a
+/// quiet truncation but a hard 400, because Open Connector's action schemas
+/// are `additionalProperties: false`.
+///
+/// Absent (the default for every pre-existing pack), pages 2..N repeat the
+/// table's own action with the full assembled input, exactly as before.
+#[derive(Debug, Clone, Copy)]
+pub struct CursorContinuation {
+    /// Action serving pages 2..N. Spelled explicitly even when it equals
+    /// the table's own action: a same-action continuation that only needs
+    /// `cursor_only` still names itself, so the fingerprint gate below can
+    /// never be handed a hole to fall through.
+    pub action_id: &'static str,
+    /// Contract fingerprint of `action_id`. Mandatory: the continuation
+    /// action serves most of a large scan, so gating only the action that
+    /// served page one would leave the rest of the collection unguarded
+    /// against contract drift.
+    pub expected_fingerprint: &'static str,
+    /// Whether pages 2..N carry ONLY the cursor. Required whenever the
+    /// continuation action's schema accepts nothing else; kept separate
+    /// from `action_id` because the two vary independently — a provider can
+    /// continue through the same action while still rejecting the original
+    /// inputs alongside a cursor.
+    pub cursor_only: bool,
+}
+
 /// How a source-pack table paginates.
 #[derive(Debug, Clone, Copy)]
 pub enum PaginationStrategy {
@@ -329,6 +362,25 @@ impl Pagination {
                 input.insert((*page_size_param).to_string(), Value::from(*page_size));
             }
             PaginationStrategy::SinglePage { .. } => {}
+        }
+    }
+
+    /// Inject ONLY the cursor input, for a continuation request whose action
+    /// accepts nothing else (see [`CursorContinuation::cursor_only`]).
+    ///
+    /// Deliberately omits the page-size input that [`Self::apply`] sends:
+    /// Dropbox's `list_folder_continue` declares `cursor` as its sole
+    /// property, so a `limit` alongside it is a 400. Continuation pages are
+    /// sized by the request that began the listing, which keeps
+    /// `page_size`'s role as the limit-pushdown ceiling honest.
+    ///
+    /// A no-op on the first page (no token yet) and for non-cursor
+    /// strategies, neither of which a continuation can reach.
+    pub fn apply_cursor_only(&self, input: &mut Map<String, Value>) {
+        if let PaginationStrategy::Cursor { cursor_param, .. } = &self.strategy
+            && let Some(token) = &self.next_token
+        {
+            input.insert((*cursor_param).to_string(), Value::from(token.as_str()));
         }
     }
 
@@ -1076,6 +1128,47 @@ mod tests {
                 "for {envelope}: got {err}"
             );
         }
+    }
+
+    #[test]
+    fn cursor_only_carries_the_token_and_nothing_else() {
+        // The whole point of the continuation mode: Dropbox's
+        // list_folder_continue declares `cursor` as its ONLY property under
+        // additionalProperties: false, so the page-size input `apply` sends
+        // would be a hard 400 rather than a tolerated extra.
+        let mut pagination = cursor();
+        assert!(
+            pagination
+                .advance(&json!({"next_cursor": "c2"}), 50)
+                .unwrap()
+        );
+
+        let mut input = Map::new();
+        pagination.apply_cursor_only(&mut input);
+        assert_eq!(input.get("cursor"), Some(&json!("c2")));
+        assert_eq!(input.len(), 1, "cursor-only means exactly one key");
+
+        // The same paginator's full `apply` still sends the page size, so
+        // page one is unaffected by the continuation mode.
+        let mut full = Map::new();
+        pagination.apply(&mut full);
+        assert_eq!(full.get("limit"), Some(&json!(50)));
+    }
+
+    #[test]
+    fn cursor_only_is_a_noop_before_a_token_exists() {
+        // Page one has no cursor to send; a continuation can never be
+        // reached there, but an empty body beats inventing a null cursor.
+        let pagination = cursor();
+        let mut input = Map::new();
+        pagination.apply_cursor_only(&mut input);
+        assert!(input.is_empty());
+
+        // Non-cursor strategies have no cursor input at all.
+        let pagination = page_number(10);
+        let mut input = Map::new();
+        pagination.apply_cursor_only(&mut input);
+        assert!(input.is_empty());
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/open_connector/pagination.rs
+++ b/crates/skardi/src/sources/providers/open_connector/pagination.rs
@@ -1152,7 +1152,7 @@ mod tests {
         let mut pagination = cursor();
         assert!(
             pagination
-                .advance(&json!({"next_cursor": "c2"}), 50)
+                .advance(&json!({"next_cursor": "c2"}), 50, None)
                 .unwrap()
         );
 

--- a/crates/skardi/src/sources/providers/open_connector/source_pack.rs
+++ b/crates/skardi/src/sources/providers/open_connector/source_pack.rs
@@ -240,18 +240,22 @@ impl SourcePackTable {
             )));
         }
         // Only inputs the pack actually sends may be mandatory. `required`
-        // is optional in JSON Schema; absent means nothing is mandatory.
-        let mut unsatisfiable: Vec<&str> = input_schema
-            .and_then(|schema| schema.get("required"))
-            .and_then(Value::as_array)
-            .map(|required| {
-                required
-                    .iter()
-                    .filter_map(Value::as_str)
-                    .filter(|key| *key != cursor_param)
-                    .collect()
-            })
-            .unwrap_or_default();
+        // is optional in JSON Schema; ABSENT means nothing is mandatory and
+        // is the one permissive reading this gate accepts. A `required`
+        // that is PRESENT but unparseable is refused instead, for the same
+        // reason a missing `properties` is: both come from the same
+        // untrusted discovery payload, and a gate that cannot read its
+        // input has not verified anything. Failing closed on one and open
+        // on the other was the defect.
+        let mut unsatisfiable =
+            required_beyond_cursor(input_schema, cursor_param).map_err(|reason| {
+                mismatch(format!(
+                    "action '{}' publishes a `required` this gate cannot read ({reason}), so \
+                     `inputs: cursor_only` cannot be verified; an unreadable schema is \
+                     refused rather than waved through",
+                    continuation.action_id
+                ))
+            })?;
         if !unsatisfiable.is_empty() {
             unsatisfiable.sort_unstable();
             return Err(mismatch(format!(
@@ -263,6 +267,189 @@ impl SourcePackTable {
         }
         Ok(())
     }
+
+    /// The pagination inputs this table's strategy injects. Sent on every
+    /// request the strategy applies to, so they count as guaranteed.
+    fn pagination_input_keys(&self) -> Vec<&'static str> {
+        match self.pagination {
+            PaginationStrategy::Cursor {
+                cursor_param,
+                page_size_param,
+                ..
+            } => std::iter::once(cursor_param)
+                .chain(page_size_param)
+                .collect(),
+            PaginationStrategy::PageNumber {
+                page_param,
+                per_page_param,
+                ..
+            } => vec![page_param, per_page_param],
+            PaginationStrategy::SinglePage => Vec::new(),
+        }
+    }
+
+    /// Keys the pack sends on EVERY request: the complete-collection pins,
+    /// the resources a binding MUST supply, and the pagination inputs.
+    /// Optional resources and pushed filters are excluded — a binding may
+    /// omit them, so they cannot satisfy an action's `required`.
+    fn guaranteed_input_keys(&self) -> Vec<&'static str> {
+        let mut keys: Vec<&'static str> = self
+            .fixed_inputs
+            .iter()
+            .map(|(key, _)| *key)
+            .chain(self.required_resources.iter().copied())
+            .chain(self.pagination_input_keys())
+            .collect();
+        keys.sort_unstable();
+        keys.dedup();
+        keys
+    }
+
+    /// Every key the pack COULD put in a request: the guaranteed set plus
+    /// the optional resources and allowlisted filter inputs. Deliberately
+    /// the widest set — this drives the `additionalProperties: false`
+    /// check, where sending a key the action does not declare is the
+    /// failure, so an "only sometimes" key is still a rejection.
+    fn possible_input_keys(&self) -> Vec<&'static str> {
+        let mut keys: Vec<&'static str> = self
+            .guaranteed_input_keys()
+            .into_iter()
+            .chain(self.optional_resources.iter().copied())
+            .chain(self.filters.iter().map(|f| f.input_field))
+            .collect();
+        keys.sort_unstable();
+        keys.dedup();
+        keys
+    }
+
+    /// Verify a FULL-input continuation that targets a DIFFERENT action
+    /// than the table's own, against that action's discovered input
+    /// schema. `Ok(())` for every other table.
+    ///
+    /// `inputs: full` is the default, so this is the shape a pack lands in
+    /// by omission. When the continuation repeats the table's own action
+    /// the skip is sound by construction — one action, one input schema,
+    /// and page one already satisfied it. When it names a different
+    /// action, "the opener's inputs satisfy the continue action" stops
+    /// being a fact and becomes an assumption about two independently
+    /// discovered schemas; unchecked, a disagreement is a 400 on every
+    /// page-2 request, found by an operator mid-scan.
+    ///
+    /// Two directions, matching the two ways an action schema rejects a
+    /// request:
+    ///
+    /// 1. every `required` input is one the pack sends on every request
+    ///    ([`Self::guaranteed_input_keys`]);
+    /// 2. under `additionalProperties: false`, every key the pack COULD
+    ///    send ([`Self::possible_input_keys`]) is a declared property.
+    ///
+    /// # Errors
+    /// [`OpenConnectorError::ActionContractMismatch`] naming the
+    /// continuation action and the specific disagreement.
+    pub fn check_full_continuation_inputs(
+        &self,
+        input_schema: Option<&Value>,
+    ) -> Result<(), OpenConnectorError> {
+        let Some(continuation) = self
+            .continuation
+            .filter(|c| !c.cursor_only && c.action_id != self.action_id)
+        else {
+            return Ok(());
+        };
+        let mismatch = |reason: String| OpenConnectorError::ActionContractMismatch {
+            table: self.id.to_string(),
+            reason,
+        };
+        let Some(schema) = input_schema else {
+            return Err(mismatch(format!(
+                "action '{}' publishes no input schema, so a full-input continuation to a \
+                 DIFFERENT action cannot be verified; an unverifiable claim about inputs is \
+                 refused rather than discovered as a 400 on page two",
+                continuation.action_id
+            )));
+        };
+        let Some(properties) = schema.get("properties").and_then(Value::as_object) else {
+            return Err(mismatch(format!(
+                "action '{}' publishes no input properties, so a full-input continuation to \
+                 a DIFFERENT action cannot be verified",
+                continuation.action_id
+            )));
+        };
+        let sends = self.guaranteed_input_keys();
+        let mut missing: Vec<&str> = required_keys(schema)
+            .map_err(|reason| {
+                mismatch(format!(
+                    "action '{}' publishes a `required` this gate cannot read ({reason})",
+                    continuation.action_id
+                ))
+            })?
+            .into_iter()
+            .filter(|key| !sends.contains(key))
+            .collect();
+        if !missing.is_empty() {
+            missing.sort_unstable();
+            missing.dedup();
+            return Err(mismatch(format!(
+                "action '{}' requires input(s) [{}] that this table does not send on every \
+                 request; pages 2..N would fail as a missing mandatory input",
+                continuation.action_id,
+                missing.join(", ")
+            )));
+        }
+        // `additionalProperties` absent defaults to `true` in JSON Schema,
+        // which permits the extra key — only an explicit `false` rejects.
+        if schema.get("additionalProperties") == Some(&Value::Bool(false)) {
+            let mut undeclared: Vec<&str> = self
+                .possible_input_keys()
+                .into_iter()
+                .filter(|key| !properties.contains_key(*key))
+                .collect();
+            if !undeclared.is_empty() {
+                undeclared.sort_unstable();
+                return Err(mismatch(format!(
+                    "action '{}' declares `additionalProperties: false` and does not declare \
+                     input(s) [{}] that this table can send; pages 2..N would be rejected as \
+                     undeclared inputs",
+                    continuation.action_id,
+                    undeclared.join(", ")
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A discovered input schema's `required` list, as declared.
+///
+/// `Ok(vec![])` when `required` is absent — JSON Schema's "nothing is
+/// mandatory". `Err(reason)` when it is present but not an array of
+/// strings: that is a schema this gate does not understand, and "do not
+/// understand" is the case a gate exists to refuse.
+fn required_keys(schema: &Value) -> Result<Vec<&str>, &'static str> {
+    let Some(required) = schema.get("required") else {
+        return Ok(Vec::new());
+    };
+    let Some(items) = required.as_array() else {
+        return Err("`required` is present but not an array");
+    };
+    items
+        .iter()
+        .map(|item| item.as_str().ok_or("`required` holds a non-string element"))
+        .collect()
+}
+
+/// `required_keys` minus the cursor the pack does send.
+fn required_beyond_cursor<'a>(
+    input_schema: Option<&'a Value>,
+    cursor_param: &str,
+) -> Result<Vec<&'a str>, &'static str> {
+    let Some(schema) = input_schema else {
+        return Ok(Vec::new());
+    };
+    Ok(required_keys(schema)?
+        .into_iter()
+        .filter(|key| *key != cursor_param)
+        .collect())
 }
 
 /// A versioned set of stable table definitions for one provider.
@@ -750,18 +937,148 @@ mod tests {
         leaked_table("t.plain")
             .check_continuation_inputs(None)
             .expect("no continuation, nothing to check");
-        // And a `full`-input continuation sends the assembled input, so the
-        // cursor-only reasoning does not apply to it.
-        let full = SourcePackTable {
+        // A `full`-input continuation sends the assembled input, so the
+        // CURSOR-ONLY reasoning does not apply to it. It is not ungated —
+        // `check_full_continuation_inputs` covers it; this only pins that
+        // the two gates do not overlap.
+        let full = full_continuation_table();
+        full.check_continuation_inputs(None)
+            .expect("inputs: full is not an input-shape claim");
+    }
+
+    #[test]
+    fn a_malformed_required_is_refused_rather_than_read_as_empty() {
+        // The asymmetry this closes: a missing `properties` always
+        // default-DENIED, while a `required` that could not be parsed
+        // default-ALLOWED. Both come from the same untrusted discovery
+        // payload, so both fail closed now.
+        let table = cursor_only_table();
+        for required in [
+            serde_json::json!("cursor"),
+            serde_json::json!({"0": "cursor"}),
+            serde_json::json!(["cursor", 7]),
+            serde_json::json!([null]),
+        ] {
+            let err = table
+                .check_continuation_inputs(Some(&serde_json::json!({
+                    "type": "object",
+                    "properties": {"cursor": {"type": "string"}},
+                    "required": required,
+                })))
+                .expect_err("an unreadable `required` is not an empty one");
+            assert!(
+                err.to_string().contains("cannot read"),
+                "the gate says it did not understand the schema: {err}"
+            );
+        }
+    }
+
+    /// A cursor table whose continuation targets a DIFFERENT action with
+    /// the full input — the `inputs:` default, and the shape a new pack
+    /// lands in by omission.
+    fn full_continuation_table() -> SourcePackTable {
+        SourcePackTable {
+            required_resources: &["path"],
+            optional_resources: &["directOnly"],
+            fixed_inputs: &[("recursive", FixedValue::Bool(true))],
             continuation: Some(CursorContinuation {
                 action_id: "t.action_continue",
                 expected_fingerprint: "aa",
                 cursor_only: false,
             }),
             ..cursor_only_table()
-        };
-        full.check_continuation_inputs(None)
-            .expect("inputs: full is not an input-shape claim");
+        }
+    }
+
+    #[test]
+    fn a_full_continuation_to_another_action_accepts_a_schema_that_admits_the_input() {
+        let table = full_continuation_table();
+        table
+            .check_full_continuation_inputs(Some(&serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "cursor": {"type": "string"}, "limit": {"type": "integer"},
+                    "path": {"type": "string"}, "directOnly": {"type": "boolean"},
+                    "recursive": {"type": "boolean"}
+                },
+                "required": ["path"],
+                "additionalProperties": false
+            })))
+            .expect("every sendable key is declared and every required key is sent");
+        // `additionalProperties` absent defaults to `true`, so an undeclared
+        // key the pack may send is not a rejection — no false alarm.
+        table
+            .check_full_continuation_inputs(Some(&serde_json::json!({
+                "type": "object",
+                "properties": {"cursor": {"type": "string"}}
+            })))
+            .expect("a permissive schema accepts extras by JSON Schema default");
+        // A same-action continuation is sound by construction: one action,
+        // one input schema, and page one already satisfied it.
+        SourcePackTable {
+            continuation: Some(CursorContinuation {
+                action_id: "t.action",
+                expected_fingerprint: "aa",
+                cursor_only: false,
+            }),
+            ..full_continuation_table()
+        }
+        .check_full_continuation_inputs(None)
+        .expect("the same action cannot disagree with itself");
+        // And a cursor-only continuation belongs to the other gate.
+        cursor_only_table()
+            .check_full_continuation_inputs(None)
+            .expect("cursor_only is checked by check_continuation_inputs");
+    }
+
+    #[test]
+    fn a_full_continuation_to_another_action_rejects_both_ways_a_request_can_400() {
+        let table = full_continuation_table();
+        for (schema, expected) in [
+            // Mandatory on the continue action, and NOT something the pack
+            // sends on every request: `directOnly` is optional, so a
+            // binding may omit it.
+            (
+                Some(serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "cursor": {"type": "string"}, "limit": {"type": "integer"},
+                        "path": {"type": "string"}, "directOnly": {"type": "boolean"},
+                        "recursive": {"type": "boolean"}
+                    },
+                    "required": ["directOnly"]
+                })),
+                "requires input(s) [directOnly]",
+            ),
+            // Strict schema that does not declare keys the pack can send.
+            (
+                Some(serde_json::json!({
+                    "type": "object",
+                    "properties": {"cursor": {"type": "string"}},
+                    "additionalProperties": false
+                })),
+                "does not declare input(s) [directOnly, limit, path, recursive]",
+            ),
+            // Unverifiable: default-deny rather than trust.
+            (
+                Some(serde_json::json!({"type": "object"})),
+                "no input properties",
+            ),
+            (None, "no input schema"),
+        ] {
+            let err = table
+                .check_full_continuation_inputs(schema.as_ref())
+                .expect_err(expected);
+            let rendered = err.to_string();
+            assert!(
+                rendered.contains(expected),
+                "want {expected:?} in: {rendered}"
+            );
+            assert!(
+                rendered.contains("t.action_continue"),
+                "the continuation action names itself: {rendered}"
+            );
+        }
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/open_connector/source_pack.rs
+++ b/crates/skardi/src/sources/providers/open_connector/source_pack.rs
@@ -190,6 +190,7 @@ impl SourcePackRegistry {
         let mut packs = HashMap::new();
         for pack in [
             super::packs::mock::pack()?,
+            super::packs::dropbox::pack()?,
             super::packs::github::pack()?,
             super::packs::gmail::pack()?,
             super::packs::notion::pack()?,
@@ -318,6 +319,7 @@ mod tests {
             names,
             vec![
                 "discord",
+                "dropbox",
                 "feishu",
                 "github",
                 "gmail",

--- a/crates/skardi/src/sources/providers/open_connector/source_pack.rs
+++ b/crates/skardi/src/sources/providers/open_connector/source_pack.rs
@@ -11,6 +11,8 @@
 
 use std::collections::HashMap;
 
+use serde_json::Value;
+
 use super::error::OpenConnectorError;
 use super::filters::FilterMapping;
 use super::json_to_arrow::FieldMapping;
@@ -158,6 +160,108 @@ impl SourcePackTable {
                 self.continuation
                     .map(|c| (c.action_id, c.expected_fingerprint)),
             )
+    }
+
+    /// Verify a `cursor_only` continuation against the continuation action's
+    /// discovered INPUT schema. `Ok(())` for every table that declares no
+    /// continuation, or whose continuation sends the full input.
+    ///
+    /// The contract fingerprint cannot cover this: it hashes the OUTPUT
+    /// schema (`action_registry::fingerprint_schema`), while
+    /// `cursor_only` is a claim about inputs — that a request carrying the
+    /// cursor alone is accepted. Left ungated, a wrong or drifted claim
+    /// surfaces as a hard 400 on page two of a live scan, after N pages of
+    /// gateway budget are already spent. Two properties are checked, and
+    /// only two, because they are exactly the ways the claim can break:
+    ///
+    /// 1. the cursor input is a DECLARED property — otherwise our cursor is
+    ///    the undeclared extra that Open Connector's
+    ///    `additionalProperties: false` schemas reject;
+    /// 2. every REQUIRED input is one the pack sends, i.e. `required` is a
+    ///    subset of `{cursor}` — otherwise the request is missing a
+    ///    mandatory field.
+    ///
+    /// Deliberately NOT checked: whether the cursor is the action's *only*
+    /// property. An upstream release that adds an optional input alongside
+    /// it does not break a cursor-only request, and refusing to start over
+    /// it would be a false alarm.
+    ///
+    /// A continuation action publishing no input schema at all is refused
+    /// rather than waved through: an unverifiable claim about inputs is the
+    /// same default-deny case as an action with no read/write
+    /// classification (see `OpenConnectorScanFunction`).
+    ///
+    /// # Errors
+    /// [`OpenConnectorError::ActionContractMismatch`] naming the
+    /// continuation action and the specific disagreement.
+    pub fn check_continuation_inputs(
+        &self,
+        input_schema: Option<&Value>,
+    ) -> Result<(), OpenConnectorError> {
+        let Some(continuation) = self.continuation.filter(|c| c.cursor_only) else {
+            return Ok(());
+        };
+        // The loader nests `continuation` under the cursor strategy, so a
+        // non-cursor table cannot declare one through YAML; a hand-built
+        // table that does is a pack bug and says so rather than passing.
+        let PaginationStrategy::Cursor { cursor_param, .. } = self.pagination else {
+            return Err(OpenConnectorError::ActionContractMismatch {
+                table: self.id.to_string(),
+                reason: format!(
+                    "action '{}' declares `inputs: cursor_only` on a non-cursor pagination \
+                     strategy, which has no cursor input to send",
+                    continuation.action_id
+                ),
+            });
+        };
+        let mismatch = |reason: String| OpenConnectorError::ActionContractMismatch {
+            table: self.id.to_string(),
+            reason,
+        };
+        let Some(properties) = input_schema
+            .and_then(|schema| schema.get("properties"))
+            .and_then(Value::as_object)
+        else {
+            return Err(mismatch(format!(
+                "action '{}' publishes no input schema, so `inputs: cursor_only` cannot be \
+                 verified; a claim about inputs that the gateway will not confirm is refused \
+                 rather than discovered as a 400 on page two",
+                continuation.action_id
+            )));
+        };
+        if !properties.contains_key(cursor_param) {
+            let mut declared: Vec<&str> = properties.keys().map(String::as_str).collect();
+            declared.sort_unstable();
+            return Err(mismatch(format!(
+                "action '{}' does not declare the cursor input '{cursor_param}' (declares [{}]), \
+                 so a cursor-only continuation request would be rejected as an undeclared input",
+                continuation.action_id,
+                declared.join(", ")
+            )));
+        }
+        // Only inputs the pack actually sends may be mandatory. `required`
+        // is optional in JSON Schema; absent means nothing is mandatory.
+        let mut unsatisfiable: Vec<&str> = input_schema
+            .and_then(|schema| schema.get("required"))
+            .and_then(Value::as_array)
+            .map(|required| {
+                required
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .filter(|key| *key != cursor_param)
+                    .collect()
+            })
+            .unwrap_or_default();
+        if !unsatisfiable.is_empty() {
+            unsatisfiable.sort_unstable();
+            return Err(mismatch(format!(
+                "action '{}' requires input(s) [{}] that a cursor-only continuation does not \
+                 send; pages 2..N would fail as a missing mandatory input",
+                continuation.action_id,
+                unsatisfiable.join(", ")
+            )));
+        }
+        Ok(())
     }
 }
 
@@ -522,6 +626,142 @@ mod tests {
             expected_fingerprint: None,
             continuation: None,
         }
+    }
+
+    /// A cursor table continuing through a cursor-only action, for the
+    /// input-gate arms no pack-level e2e reaches.
+    fn cursor_only_table() -> SourcePackTable {
+        SourcePackTable {
+            pagination: PaginationStrategy::Cursor {
+                cursor_param: "cursor",
+                next_cursor_path: "$.cursor",
+                page_size_param: Some("limit"),
+                page_size: 10,
+                has_more_path: Some("$.hasMore"),
+            },
+            expected_fingerprint: Some("aa"),
+            continuation: Some(CursorContinuation {
+                action_id: "t.action_continue",
+                expected_fingerprint: "aa",
+                cursor_only: true,
+            }),
+            ..leaked_table("t.entries")
+        }
+    }
+
+    #[test]
+    fn cursor_only_inputs_accept_a_declaring_schema_and_ignore_optional_extras() {
+        let table = cursor_only_table();
+        // The exact Dropbox shape.
+        table
+            .check_continuation_inputs(Some(&serde_json::json!({
+                "type": "object",
+                "properties": {"cursor": {"type": "string"}},
+                "required": ["cursor"],
+                "additionalProperties": false
+            })))
+            .expect("cursor declared and nothing else required");
+        // An additive upstream release that grows an OPTIONAL input must not
+        // fail startup: a cursor-only request is still valid against it.
+        table
+            .check_continuation_inputs(Some(&serde_json::json!({
+                "type": "object",
+                "properties": {"cursor": {"type": "string"}, "hint": {"type": "string"}},
+                "required": ["cursor"]
+            })))
+            .expect("an optional extra input is not a breaking change");
+        // `required` absent entirely means nothing is mandatory.
+        table
+            .check_continuation_inputs(Some(&serde_json::json!({
+                "type": "object",
+                "properties": {"cursor": {"type": "string"}}
+            })))
+            .expect("no required list means nothing is required");
+    }
+
+    #[test]
+    fn cursor_only_inputs_reject_every_way_the_claim_can_break() {
+        let table = cursor_only_table();
+        for (schema, expected) in [
+            // The cursor input is not a declared property, so the request's
+            // one field is the undeclared extra a strict schema rejects.
+            (
+                Some(serde_json::json!({
+                    "type": "object",
+                    "properties": {"pageToken": {"type": "string"}},
+                    "additionalProperties": false
+                })),
+                "does not declare the cursor input 'cursor'",
+            ),
+            // A mandatory input the pack never sends on a continuation page.
+            (
+                Some(serde_json::json!({
+                    "type": "object",
+                    "properties": {"cursor": {"type": "string"}, "path": {"type": "string"}},
+                    "required": ["cursor", "path"]
+                })),
+                "requires input(s) [path]",
+            ),
+            // Unverifiable: default-deny rather than trust.
+            (
+                Some(serde_json::json!({"type": "object"})),
+                "no input schema",
+            ),
+            (None, "no input schema"),
+        ] {
+            let err = table
+                .check_continuation_inputs(schema.as_ref())
+                .expect_err(expected);
+            let rendered = err.to_string();
+            assert!(
+                rendered.contains(expected),
+                "want {expected:?} in: {rendered}"
+            );
+            assert!(
+                rendered.contains("t.action_continue"),
+                "the continuation action names itself: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_continuation_on_a_non_cursor_strategy_is_a_pack_bug_not_a_pass() {
+        // Unreachable through YAML (the loader nests `continuation` under the
+        // cursor strategy), so this pins that a hand-built table cannot slip
+        // through the gate by having no cursor input to check.
+        let table = SourcePackTable {
+            pagination: PaginationStrategy::SinglePage,
+            ..cursor_only_table()
+        };
+        let err = table
+            .check_continuation_inputs(Some(&serde_json::json!({
+                "properties": {"cursor": {"type": "string"}}
+            })))
+            .expect_err("a continuation without a cursor strategy cannot be honored");
+        assert!(
+            err.to_string().contains("non-cursor pagination strategy"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn tables_without_a_cursor_only_continuation_are_never_gated_on_inputs() {
+        // Every pre-existing pack: no continuation at all.
+        leaked_table("t.plain")
+            .check_continuation_inputs(None)
+            .expect("no continuation, nothing to check");
+        // And a `full`-input continuation sends the assembled input, so the
+        // cursor-only reasoning does not apply to it.
+        let full = SourcePackTable {
+            continuation: Some(CursorContinuation {
+                action_id: "t.action_continue",
+                expected_fingerprint: "aa",
+                cursor_only: false,
+            }),
+            ..cursor_only_table()
+        };
+        full.check_continuation_inputs(None)
+            .expect("inputs: full is not an input-shape claim");
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/open_connector/source_pack.rs
+++ b/crates/skardi/src/sources/providers/open_connector/source_pack.rs
@@ -344,9 +344,9 @@ impl SourcePackTable {
     /// request:
     ///
     /// 1. every `required` input is one the pack sends on every request
-    ///    ([`Self::guaranteed_input_keys`]);
+    ///    (`guaranteed_input_keys`);
     /// 2. under `additionalProperties: false`, every key the pack COULD
-    ///    send ([`Self::possible_input_keys`]) is a declared property.
+    ///    send (`possible_input_keys`) is a declared property.
     ///
     /// # Errors
     /// [`OpenConnectorError::ActionContractMismatch`] naming the

--- a/crates/skardi/src/sources/providers/open_connector/source_pack.rs
+++ b/crates/skardi/src/sources/providers/open_connector/source_pack.rs
@@ -162,6 +162,35 @@ impl SourcePackTable {
             )
     }
 
+    /// The ONE input-side gate a registration path calls: verify this
+    /// table's continuation declaration against the continuation action's
+    /// discovered INPUT schema. `Ok(())` for a table with no continuation.
+    ///
+    /// Deliberately a single entry point rather than two public checks the
+    /// caller picks between. `inputs:` has two spellings and each needs a
+    /// different argument, but "did we verify the continuation's inputs?"
+    /// is one question, and two call sites per entry point were two
+    /// independently droppable lines — a review round found both deletable
+    /// with the suite still green. Dispatching here means an entry point
+    /// either asks the question or visibly does not.
+    ///
+    /// # Errors
+    /// [`OpenConnectorError::ActionContractMismatch`] naming the
+    /// continuation action and the specific disagreement.
+    pub fn check_continuation_inputs(
+        &self,
+        input_schema: Option<&Value>,
+    ) -> Result<(), OpenConnectorError> {
+        let Some(continuation) = self.continuation else {
+            return Ok(());
+        };
+        if continuation.cursor_only {
+            self.check_cursor_only_continuation_inputs(input_schema)
+        } else {
+            self.check_full_continuation_inputs(input_schema)
+        }
+    }
+
     /// Verify a `cursor_only` continuation against the continuation action's
     /// discovered INPUT schema. `Ok(())` for every table that declares no
     /// continuation, or whose continuation sends the full input.
@@ -194,7 +223,7 @@ impl SourcePackTable {
     /// # Errors
     /// [`OpenConnectorError::ActionContractMismatch`] naming the
     /// continuation action and the specific disagreement.
-    pub fn check_continuation_inputs(
+    fn check_cursor_only_continuation_inputs(
         &self,
         input_schema: Option<&Value>,
     ) -> Result<(), OpenConnectorError> {
@@ -218,14 +247,24 @@ impl SourcePackTable {
             table: self.id.to_string(),
             reason,
         };
-        let Some(properties) = input_schema
-            .and_then(|schema| schema.get("properties"))
-            .and_then(Value::as_object)
-        else {
+        // Two failures, two diagnostics: an action that publishes NOTHING
+        // and one that publishes a schema this gate cannot read from are
+        // both refused, but they live in different layers of the operator's
+        // gateway. Collapsing them sent someone hunting for a missing
+        // schema that was in fact present and shapeless.
+        let Some(schema) = input_schema else {
             return Err(mismatch(format!(
                 "action '{}' publishes no input schema, so `inputs: cursor_only` cannot be \
                  verified; a claim about inputs that the gateway will not confirm is refused \
                  rather than discovered as a 400 on page two",
+                continuation.action_id
+            )));
+        };
+        let Some(properties) = schema.get("properties").and_then(Value::as_object) else {
+            return Err(mismatch(format!(
+                "action '{}' publishes no input properties, so `inputs: cursor_only` cannot \
+                 be verified; a schema with no readable `properties` confirms nothing and is \
+                 refused rather than discovered as a 400 on page two",
                 continuation.action_id
             )));
         };
@@ -248,7 +287,7 @@ impl SourcePackTable {
         // input has not verified anything. Failing closed on one and open
         // on the other was the defect.
         let mut unsatisfiable =
-            required_beyond_cursor(input_schema, cursor_param).map_err(|reason| {
+            required_beyond_cursor(Some(schema), cursor_param).map_err(|reason| {
                 mismatch(format!(
                     "action '{}' publishes a `required` this gate cannot read ({reason}), so \
                      `inputs: cursor_only` cannot be verified; an unreadable schema is \
@@ -270,7 +309,15 @@ impl SourcePackTable {
 
     /// The pagination inputs this table's strategy injects. Sent on every
     /// request the strategy applies to, so they count as guaranteed.
-    fn pagination_input_keys(&self) -> Vec<&'static str> {
+    ///
+    /// `pub(super)` because `packs::loader::validate_table` needs the SAME
+    /// mapping for its input-namespace collision gates. It used to carry
+    /// its own copy of this match, and the two had already drifted once —
+    /// `Keyset` and `SinglePage` landed with the Discord pack and only one
+    /// side was widened. One definition, so a fifth strategy (or a new
+    /// page-size field on an existing one) cannot weaken one consumer
+    /// silently.
+    pub(super) fn pagination_input_keys(&self) -> Vec<&'static str> {
         match self.pagination {
             PaginationStrategy::Cursor {
                 cursor_param,
@@ -293,10 +340,20 @@ impl SourcePackTable {
         }
     }
 
-    /// Keys the pack sends on EVERY request: the complete-collection pins,
-    /// the resources a binding MUST supply, and the pagination inputs.
-    /// Optional resources and pushed filters are excluded — a binding may
-    /// omit them, so they cannot satisfy an action's `required`.
+    /// Keys the pack sends on every request the CONTINUATION gates govern:
+    /// the complete-collection pins, the resources a binding MUST supply,
+    /// and the pagination inputs. Optional resources and pushed filters are
+    /// excluded — a binding may omit them, so they cannot satisfy an
+    /// action's `required`.
+    ///
+    /// Scoped to continuation requests deliberately: the pagination half
+    /// includes the cursor, which `Pagination::apply` inserts only once
+    /// `next_token` is `Some` — never on page one. On a continuation page
+    /// the cursor genuinely is always present, which is what makes it
+    /// guaranteed here. A future gate checking the OPENING action's
+    /// `required` must NOT reuse this set: it would report a mandatory
+    /// cursor as satisfied on page one, which is exactly the hard 400
+    /// these gates exist to prevent.
     fn guaranteed_input_keys(&self) -> Vec<&'static str> {
         let mut keys: Vec<&'static str> = self
             .fixed_inputs
@@ -351,7 +408,7 @@ impl SourcePackTable {
     /// # Errors
     /// [`OpenConnectorError::ActionContractMismatch`] naming the
     /// continuation action and the specific disagreement.
-    pub fn check_full_continuation_inputs(
+    fn check_full_continuation_inputs(
         &self,
         input_schema: Option<&Value>,
     ) -> Result<(), OpenConnectorError> {
@@ -894,10 +951,12 @@ mod tests {
                 })),
                 "requires input(s) [path]",
             ),
-            // Unverifiable: default-deny rather than trust.
+            // Unverifiable: default-deny rather than trust — and the two
+            // ways it can be unverifiable get different diagnostics, so a
+            // present-but-shapeless schema is not reported as absent.
             (
                 Some(serde_json::json!({"type": "object"})),
-                "no input schema",
+                "no input properties",
             ),
             (None, "no input schema"),
         ] {
@@ -939,18 +998,37 @@ mod tests {
     }
 
     #[test]
-    fn tables_without_a_cursor_only_continuation_are_never_gated_on_inputs() {
-        // Every pre-existing pack: no continuation at all.
+    fn a_table_without_a_continuation_is_never_gated_on_inputs() {
+        // Every pre-existing pack: no continuation at all, so the single
+        // gate short-circuits before either arm.
         leaked_table("t.plain")
             .check_continuation_inputs(None)
             .expect("no continuation, nothing to check");
-        // A `full`-input continuation sends the assembled input, so the
-        // CURSOR-ONLY reasoning does not apply to it. It is not ungated —
-        // `check_full_continuation_inputs` covers it; this only pins that
-        // the two gates do not overlap.
-        let full = full_continuation_table();
-        full.check_continuation_inputs(None)
-            .expect("inputs: full is not an input-shape claim");
+    }
+
+    #[test]
+    fn the_single_gate_routes_each_inputs_spelling_to_its_own_arm() {
+        // What the dispatcher must NOT do is apply the cursor-only
+        // reasoning to `inputs: full` or vice versa. Same argument
+        // (`None`), two different verdicts, which is only possible if the
+        // routing is real:
+        //   - cursor_only refuses an unverifiable claim about inputs;
+        //   - full to a DIFFERENT action refuses it too, but for its own
+        //     reason and with its own wording.
+        let cursor_only = cursor_only_table()
+            .check_continuation_inputs(None)
+            .expect_err("cursor_only cannot be verified against no schema");
+        assert!(
+            cursor_only.to_string().contains("`inputs: cursor_only`"),
+            "the cursor-only arm answered: {cursor_only}"
+        );
+        let full = full_continuation_table()
+            .check_continuation_inputs(None)
+            .expect_err("a full continuation to another action needs its schema");
+        assert!(
+            full.to_string().contains("full-input continuation"),
+            "the full arm answered: {full}"
+        );
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/open_connector/source_pack.rs
+++ b/crates/skardi/src/sources/providers/open_connector/source_pack.rs
@@ -284,7 +284,12 @@ impl SourcePackTable {
                 per_page_param,
                 ..
             } => vec![page_param, per_page_param],
-            PaginationStrategy::SinglePage => Vec::new(),
+            PaginationStrategy::Keyset {
+                cursor_param,
+                page_size_param,
+                ..
+            } => vec![cursor_param, page_size_param],
+            PaginationStrategy::SinglePage { .. } => Vec::new(),
         }
     }
 
@@ -917,7 +922,9 @@ mod tests {
         // cursor strategy), so this pins that a hand-built table cannot slip
         // through the gate by having no cursor input to check.
         let table = SourcePackTable {
-            pagination: PaginationStrategy::SinglePage,
+            pagination: PaginationStrategy::SinglePage {
+                next_cursor_path: None,
+            },
             ..cursor_only_table()
         };
         let err = table

--- a/crates/skardi/src/sources/providers/open_connector/source_pack.rs
+++ b/crates/skardi/src/sources/providers/open_connector/source_pack.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use super::error::OpenConnectorError;
 use super::filters::FilterMapping;
 use super::json_to_arrow::FieldMapping;
-use super::pagination::PaginationStrategy;
+use super::pagination::{CursorContinuation, PaginationStrategy};
 
 /// A fixed action-input value a pack pins at compile time — a
 /// const-friendly stand-in for the JSON scalar set (`serde_json::Value`'s
@@ -105,6 +105,11 @@ pub struct SourcePackTable {
     /// Expected action-contract fingerprint. When set, registration compares
     /// it with the discovered action's fingerprint and fails on mismatch.
     pub expected_fingerprint: Option<&'static str>,
+    /// Split-action cursor continuation, for providers that serve pages
+    /// 2..N from a different action than the one that began the listing
+    /// (see [`CursorContinuation`]). `None` for every table whose provider
+    /// accepts the cursor on its own action.
+    pub continuation: Option<CursorContinuation>,
 }
 
 impl SourcePackTable {
@@ -130,6 +135,29 @@ impl SourcePackTable {
             }
         }
         None
+    }
+
+    /// Every action this table executes: its own, plus a split-action
+    /// continuation's. Registration discovers all of them, so a
+    /// continuation action missing from the gateway fails at startup rather
+    /// than on page two of the first scan.
+    pub fn actions(&self) -> impl Iterator<Item = &'static str> + '_ {
+        std::iter::once(self.action_id).chain(self.continuation.map(|c| c.action_id))
+    }
+
+    /// Every `(action, expected fingerprint)` pair the compatibility gate
+    /// must verify. Both gate call sites — YAML binding registration and
+    /// the `open_connector_query` UDTF — iterate THIS, so a drifted
+    /// continuation action cannot be refused by one path and admitted by
+    /// the other.
+    pub fn gated_actions(&self) -> impl Iterator<Item = (&'static str, &'static str)> + '_ {
+        self.expected_fingerprint
+            .map(|fingerprint| (self.action_id, fingerprint))
+            .into_iter()
+            .chain(
+                self.continuation
+                    .map(|c| (c.action_id, c.expected_fingerprint)),
+            )
     }
 }
 
@@ -490,6 +518,7 @@ mod tests {
             filters: &[],
             error_path: None,
             expected_fingerprint: None,
+            continuation: None,
         }
     }
 

--- a/crates/skardi/src/sources/providers/open_connector/table.rs
+++ b/crates/skardi/src/sources/providers/open_connector/table.rs
@@ -215,6 +215,7 @@ mod tests {
             }],
             error_path: None,
             expected_fingerprint: None,
+            continuation: None,
         }))
     }
 

--- a/crates/skardi/src/sources/providers/open_connector/table_functions.rs
+++ b/crates/skardi/src/sources/providers/open_connector/table_functions.rs
@@ -234,15 +234,13 @@ impl TableFunctionImpl for OpenConnectorQueryFunction {
                     ),
                 }));
             }
-            // Same input-schema check the YAML path runs, on the same
-            // helper: `cursor_only` must not be admitted by one entry point
-            // and refused by the other.
+            // Same input-schema gate the YAML path runs, on the same
+            // helper and in one call: an `inputs:` claim must not be
+            // admitted by one entry point and refused by the other, in
+            // either of its two spellings.
             if table.continuation.is_some_and(|c| c.action_id == action_id) {
                 table
                     .check_continuation_inputs(meta.input_schema())
-                    .map_err(plan_error)?;
-                table
-                    .check_full_continuation_inputs(meta.input_schema())
                     .map_err(plan_error)?;
             }
         }

--- a/crates/skardi/src/sources/providers/open_connector/table_functions.rs
+++ b/crates/skardi/src/sources/providers/open_connector/table_functions.rs
@@ -209,15 +209,20 @@ impl TableFunctionImpl for OpenConnectorQueryFunction {
         // Same discovery and compatibility gates as YAML registration: every
         // action the table executes must have been discovered when the
         // gateway registered, and must still match the pack's expected
-        // contract fingerprint. Iterating `gated_actions()` — the same
-        // helper the YAML path uses — is what keeps a drifted continuation
-        // action from being refused by one path and admitted by the other.
+        // contract fingerprint.
+        //
+        // The loop is driven by `actions()`, NOT by `gated_actions()`,
+        // because an UNPINNED table still has to have been discovered and
+        // `gated_actions()` skips it. The expectation is looked up inside
+        // by action id, so the two paths check the same pairs — with one
+        // caveat that the loader is what closes: a lookup by id can only
+        // return one expectation per id, so a same-action continuation
+        // pinning a fingerprint different from the table's own would be
+        // half-checked here. `packs::loader` refuses that combination at
+        // registration (it is unsatisfiable by any gateway anyway), which
+        // is what makes this lookup equivalent to iterating the pairs.
         for action_id in table.actions() {
             let meta = discovered_action(&handle, &gateway, action_id)?;
-            // `gated_actions()` yields the table's own action only when it
-            // pins a fingerprint, so an unpinned table still has to be
-            // discovered above — that is why discovery drives the loop and
-            // the expectation is looked up inside it.
             if let Some((_, expected)) = table.gated_actions().find(|(id, _)| *id == action_id)
                 && meta.fingerprint() != expected
             {
@@ -235,6 +240,9 @@ impl TableFunctionImpl for OpenConnectorQueryFunction {
             if table.continuation.is_some_and(|c| c.action_id == action_id) {
                 table
                     .check_continuation_inputs(meta.input_schema())
+                    .map_err(plan_error)?;
+                table
+                    .check_full_continuation_inputs(meta.input_schema())
                     .map_err(plan_error)?;
             }
         }

--- a/crates/skardi/src/sources/providers/open_connector/table_functions.rs
+++ b/crates/skardi/src/sources/providers/open_connector/table_functions.rs
@@ -213,11 +213,14 @@ impl TableFunctionImpl for OpenConnectorQueryFunction {
         // helper the YAML path uses — is what keeps a drifted continuation
         // action from being refused by one path and admitted by the other.
         for action_id in table.actions() {
-            discovered_action(&handle, &gateway, action_id)?;
-        }
-        for (action_id, expected) in table.gated_actions() {
             let meta = discovered_action(&handle, &gateway, action_id)?;
-            if meta.fingerprint() != expected {
+            // `gated_actions()` yields the table's own action only when it
+            // pins a fingerprint, so an unpinned table still has to be
+            // discovered above — that is why discovery drives the loop and
+            // the expectation is looked up inside it.
+            if let Some((_, expected)) = table.gated_actions().find(|(id, _)| *id == action_id)
+                && meta.fingerprint() != expected
+            {
                 return Err(plan_error(OpenConnectorError::ActionContractMismatch {
                     table: table.id.to_string(),
                     reason: format!(
@@ -225,6 +228,14 @@ impl TableFunctionImpl for OpenConnectorQueryFunction {
                         meta.fingerprint()
                     ),
                 }));
+            }
+            // Same input-schema check the YAML path runs, on the same
+            // helper: `cursor_only` must not be admitted by one entry point
+            // and refused by the other.
+            if table.continuation.is_some_and(|c| c.action_id == action_id) {
+                table
+                    .check_continuation_inputs(meta.input_schema())
+                    .map_err(plan_error)?;
             }
         }
 

--- a/crates/skardi/src/sources/providers/open_connector/table_functions.rs
+++ b/crates/skardi/src/sources/providers/open_connector/table_functions.rs
@@ -206,21 +206,26 @@ impl TableFunctionImpl for OpenConnectorQueryFunction {
             }
         }
 
-        // Same discovery and compatibility gates as YAML registration: the
-        // action must have been discovered when the gateway registered, and
-        // must still match the pack's expected contract fingerprint.
-        let meta = discovered_action(&handle, &gateway, table.action_id)?;
-        if let Some(expected) = table.expected_fingerprint
-            && meta.fingerprint() != expected
-        {
-            return Err(plan_error(OpenConnectorError::ActionContractMismatch {
-                table: table.id.to_string(),
-                reason: format!(
-                    "action '{}' fingerprint mismatch (expected {expected}, discovered {})",
-                    table.action_id,
-                    meta.fingerprint()
-                ),
-            }));
+        // Same discovery and compatibility gates as YAML registration: every
+        // action the table executes must have been discovered when the
+        // gateway registered, and must still match the pack's expected
+        // contract fingerprint. Iterating `gated_actions()` — the same
+        // helper the YAML path uses — is what keeps a drifted continuation
+        // action from being refused by one path and admitted by the other.
+        for action_id in table.actions() {
+            discovered_action(&handle, &gateway, action_id)?;
+        }
+        for (action_id, expected) in table.gated_actions() {
+            let meta = discovered_action(&handle, &gateway, action_id)?;
+            if meta.fingerprint() != expected {
+                return Err(plan_error(OpenConnectorError::ActionContractMismatch {
+                    table: table.id.to_string(),
+                    reason: format!(
+                        "action '{action_id}' fingerprint mismatch (expected {expected}, discovered {})",
+                        meta.fingerprint()
+                    ),
+                }));
+            }
         }
 
         let provider = OpenConnectorTableProvider::new(
@@ -330,6 +335,9 @@ impl TableFunctionImpl for OpenConnectorScanFunction {
                 error_path: None,
                 fixed_inputs: &[],
                 source_pack_version: 0,
+                // Raw scans declare no pagination contract at all, so
+                // there is no listing to continue.
+                continuation: None,
             },
             converter,
             row_path,

--- a/docs/open-connector-dropbox.md
+++ b/docs/open-connector-dropbox.md
@@ -20,20 +20,40 @@ into a fixed camelCase shape — `tag`, `name`, `id`, `pathDisplay`,
   `size`) never reach a row, so mapping them would have produced
   always-NULL columns.
 - Every column below sits **inside** the contract-fingerprint gate, and
-  the fingerprint coverage gap is empty — the opposite of the passthrough
-  packs, where real rows are the only column truth.
+  the fingerprint coverage gap is empty — unlike the passthrough packs,
+  where columns ride `additionalProperties` outside any gate.
 
-> **⚠ NOT live-verified.** Reconciled against the Open Connector v1.3.5
-> provider *source* only. No live gateway has answered any of this pack
-> and no Dropbox account has been read, so every committed fingerprint is
-> the hash of a source-derived schema rather than a captured one, and the
-> bundled fixtures are authored shapes rather than redacted captures.
-> **Registration against a real gateway is expected to fail the contract
-> gate until the pins are re-captured** — that is the gate working. The
-> runbook that closes this out is
-> [the live-evaluation plan](superpowers/plans/2026-08-18-dropbox-live-evaluation.md);
-> its acceptance table lists every statement here that is currently an
-> inference.
+That gate is narrower than it looks, and the live pass proved it. Because
+*all five* list actions publish the *same* normalized 15-key schema, a
+fingerprint match says nothing about whether a given key is populated for
+a given action: `shared_links` passed the gate while returning NULL for
+four keys its endpoint has no field for. **Real rows are still the only
+column truth here too** — the gate protects the row *shape*, not the
+per-action field coverage.
+
+> **✅ Live-verified 2026-08-18** against a self-hosted Open Connector
+> gateway at commit `a3efa99` and a real free-tier Dropbox account. All
+> five actions were discovered, all five committed fingerprints matched
+> live discovery **unchanged** (registration passed on the first try), and
+> all three tables scanned real rows end to end — every mapped column
+> carrying a real non-NULL value somewhere. The pass removed four columns
+> from `shared_links` that cannot populate; see that table below.
+>
+> Two things remain **unobserved** rather than confirmed, neither a
+> defect: `shared_links.expires_at` needs paid-tier link expiry, and
+> `file_search.match_type = 'content'` needs Dropbox content indexing,
+> which did not land during the pass. The row fixtures in-repo are still
+> authored shapes rather than redacted captures.
+>
+> **Known gateway blocker, not specific to this pack:** at commit
+> `a3efa99` the gateway's `GET /v1/actions/<id>` does not serialize the
+> `execution` block, so Skardi's default-deny action registry refuses
+> every action from *every* source pack (reproduced with the merged
+> `github` pack). Registration needs a gateway that publishes
+> `execution.locallyExecutable` on that route — filed upstream as
+> [oomol-lab/open-connector#358](https://github.com/oomol-lab/open-connector/issues/358).
+> Skardi's gate is correct and was deliberately left alone: no
+> compatibility fallback reads the classification from another route.
 
 ## Binding
 
@@ -92,7 +112,7 @@ FROM open_connector_query('saas', 'dropbox.file_search',
 | Table | Action(s) | Row path | Required resource | Optional resources | Columns |
 |---|---|---|---|---|---|
 | `files` | `dropbox.list_folder` → `dropbox.list_folder_continue` | `$.entries` | — | `path` | 12 |
-| `shared_links` | `dropbox.list_shared_links` (continues on itself) | `$.links` | — | `path`, `directOnly` | 15 |
+| `shared_links` | `dropbox.list_shared_links` (continues on itself) | `$.links` | — | `path`, `directOnly` | 11 |
 | `file_search` | `dropbox.search_files` → `dropbox.search_files_continue` | `$.matches` | `query` | `path` | 13 |
 
 **No table pushes any filter.** Dropbox's remaining list inputs are
@@ -134,11 +154,28 @@ values — `size_bytes IS NULL` for a folder, `= 0` for an empty file.
 
 ### `shared_links` — links for the account, or for one path
 
-Columns: everything `files` has, plus `url`, `expires_at` and
+Columns: `tag`, `name`, `url`, `id`, `path_lower`, `expires_at`,
+`client_modified`, `server_modified`, `rev`, `size_bytes`,
 `link_permissions`. `url` is the natural identity but stays **nullable**:
 the executor spells it `optionalString(record.url) ?? null`, so a
 non-null declaration would fail scans on a row the gateway considers
 legal.
+
+**Four columns `files` has are deliberately absent here** — the mirror
+image of the three `files` omits, and the one defect the live pass
+caught. `sharing/list_shared_links` returns `SharedLinkMetadata`, which
+carries `path_lower` but has no `path_display`, `is_downloadable`,
+`content_hash` or `sharing_info` field at all, so mapping them shipped
+four structurally always-NULL columns. Measured live at 0/5 non-NULL, and
+settled decisively by pointing both endpoints at one file: a file whose
+`files` row carries all four returns all four NULL on its own
+`shared_links` row. The fingerprint gate cannot catch this class — both
+actions publish the same normalized 15-key schema — so only real rows
+can.
+
+`expires_at` stays mapped but is **unverified**: it populates only on a
+link with an expiry, and Dropbox refuses to set one on a free account
+(`settings_error/not_authorized`).
 
 `directOnly` is exposed as a binding resource rather than pinned because
 neither setting is an honest default: pinned `true`, links a file
@@ -197,8 +234,8 @@ it is declared, a page that omits it fails as contract drift rather than
 guessing.
 
 Page sizes are the schemas' declared maxima (`limit: 2000`,
-`maxResults: 1000`) and are **unprobed at the boundary**; a declared cap
-can exceed the wire's. Continuation pages carry no page-size input at
+`maxResults: 1000`) and were **probed at the boundary**: both return
+rows, while `limit: 2001` and `maxResults: 1001` are refused. Continuation pages carry no page-size input at
 all — Dropbox sizes them from the request that opened the listing.
 `shared_links` has no page-size input, so its `page_size` is an inert
 placeholder.
@@ -217,10 +254,18 @@ Two scopes cover the whole pack:
 | `files.metadata.read` | `files`, `file_search` |
 | `sharing.read` | `shared_links` |
 
-No content scope and no write scope is required by any shipped table, so
-a read-only connection serves all three. Every permission change
-invalidates the grant snapshot — re-run the authorization rather than
-debugging a stale token.
+No content scope and no write scope is required by any shipped table —
+confirmed against the live gateway's per-action `requiredScopes`.
+
+**That is a statement about the actions, not about what you can
+provision.** The gateway's dropbox provider builds its OAuth scope list
+as the union of every `dropbox.*` action's permissions, so its authorize
+request asks for all six — `account_info.read`, `files.metadata.read`,
+`files.content.read`, `files.content.write`, `sharing.read`,
+`sharing.write`. A connection created through that flow therefore carries
+write access this pack never exercises; narrowing it is a gateway-side
+change, not a pack setting. Every permission change invalidates the grant
+snapshot — re-run the authorization rather than debugging a stale token.
 
 Self-check that the gateway build carries all five actions before
 debugging anything else (a too-old gateway fails registration with
@@ -250,8 +295,11 @@ are cached per the scan cache's usual keying (binding, table, pushed
 inputs, projection, LIMIT).
 
 Dropbox cursors can expire or be invalidated mid-listing, and a long
-recursive scan of a large account may outlive one. Behavior at that
-boundary is an open question the live pass records.
+recursive scan of a large account may outlive one. The live pass found no
+expiry to document: a `list_folder` cursor replayed ~40 minutes later,
+after files and shared links had been added to the listed tree, still
+returned rows. That is a lower bound, not a guarantee — no upper bound
+was established.
 
 ## Tables deliberately not shipped
 

--- a/docs/open-connector-dropbox.md
+++ b/docs/open-connector-dropbox.md
@@ -240,6 +240,57 @@ all — Dropbox sizes them from the request that opened the listing.
 `shared_links` has no page-size input, so its `page_size` is an inert
 placeholder.
 
+### Bounding the cost of a scan
+
+**Read this before the first `SELECT * FROM dropbox.files` on a real
+account.** This pack's `files` table pins `recursive: true` and takes no
+column predicate, so an unqualified scan walks the **entire account**,
+every folder, from the bound `path` down. It is the pack most in need of
+a bound and the one whose bound is easiest to get wrong, because page
+size is the only lever in play.
+
+The arithmetic, with the default safety bounds
+(`max_pages: 100`, `max_rows: 100000`):
+
+| Account size | Pages at `limit: 2000` | Under the defaults |
+|---|---|---|
+| 10,000 entries | 5 | fine |
+| 100,000 entries | 50 | at the `max_rows` edge — the scan **fails** on the entry that crosses 100,000 |
+| 500,000 entries | 250 | fails at `max_pages: 100` |
+
+Per the fail-don't-truncate rule, a collection larger than the bounds
+surfaces as `ScanBoundsExceeded`, never as a silently partial result — so
+an over-large account is an error you see, not rows you quietly miss.
+Note that "entries" counts **files and folders**, not files: a deep tree
+inflates the count well past what a user would call their file count.
+
+Three ways to keep a scan bounded, in the order worth trying:
+
+1. **Bind a narrower `path`.** The binding's `path` resource is the only
+   true scoping lever this table has — `/Engineering` instead of `/`
+   turns a whole-account walk into a subtree walk. A separate binding per
+   subtree is cheap.
+2. **Push a `LIMIT`.** It stops pagination as soon as enough rows are
+   emitted, before the next request is issued — the live pass confirmed a
+   two-page scan collapsing to `pages=1 rows=1`. Note this is a *scan*
+   bound, not a *selection* bound: which rows you get is Dropbox's
+   traversal order, not yours.
+3. **Raise the bounds deliberately.** `max_pages` / `max_rows` in the
+   gateway's `open_connector:` block, documented in
+   [the integration guide](open-connector.md#bounds-retries-and-errors).
+   Raise them because you decided the account is that large, not because
+   a scan failed.
+
+Every predicate in a `WHERE` clause is evaluated **locally, after** the
+fetch — this pack declares no filters (Dropbox's list endpoints expose no
+faithful column predicate), so `WHERE name = 'x'` narrows the result and
+not the scan. `file_search` is the table that pushes a search term, via
+its required `query` resource.
+
+`shared_links` and `file_search` are bounded by the account's link count
+and by Dropbox's own result cap respectively, and neither is a recursive
+walk; the arithmetic above is about `files`.
+
 ## Authorization
 
 The gateway's dropbox provider uses OAuth against a Dropbox app the
@@ -263,9 +314,22 @@ as the union of every `dropbox.*` action's permissions, so its authorize
 request asks for all six — `account_info.read`, `files.metadata.read`,
 `files.content.read`, `files.content.write`, `sharing.read`,
 `sharing.write`. A connection created through that flow therefore carries
-write access this pack never exercises; narrowing it is a gateway-side
-change, not a pack setting. Every permission change invalidates the grant
-snapshot — re-run the authorization rather than debugging a stale token.
+write access this pack never exercises; narrowing the gateway's *request*
+is a gateway-side change, not a pack setting.
+
+**You can still enforce least privilege, one level up.** Dropbox grants
+the intersection of what the authorize request asks for and what the app
+declares, so ticking only `files.metadata.read` and `sharing.read` on the
+app's **Permissions** tab caps every token that app can ever mint — the
+gateway asking for six does not widen a grant the app cannot make.
+Provision this pack against an app scoped to those two, not against a
+shared app carrying the write scopes for something else. The cost of
+skipping this is real: a leaked or misused token from a fully-scoped app
+can mutate the account's Dropbox, and the pack would never notice,
+because it never calls a write action.
+
+Every permission change invalidates the grant snapshot — re-run the
+authorization rather than debugging a stale token.
 
 Self-check that the gateway build carries all five actions before
 debugging anything else (a too-old gateway fails registration with
@@ -289,7 +353,22 @@ gateway *failure* envelopes rather than as HTTP 200 rows. No table
 declares an `error_path`, and the provider's own code arrives through the
 gateway-failure path.
 
-The client's bounded retry/backoff handles transient 429/5xx envelopes.
+**Retries on the execute path are narrower than on the discovery path,
+and the difference matters for a throttled Dropbox scan.** A `429` is a
+pre-execution rate-limit rejection — nothing ran — so it is retried, with
+`Retry-After` honored when present and bounded exponential backoff with
+jitter otherwise, both capped. A `5xx` on an execute call is **terminal**:
+the action may have run, and re-sending could re-execute it, so the scan
+fails rather than risking a duplicate. (Health and discovery calls are
+idempotent and do retry 5xx.) Retries are also bounded by the scan
+deadline, so a long `Retry-After` cannot outlast the scan.
+
+The practical consequence: sustained Dropbox throttling exhausts the
+retry budget and the scan fails with a retry-exhausted error. The remedy
+is to re-run the query — completed scans are cached, so a retry does not
+re-fetch what already succeeded — or to narrow the scan per
+[Bounding the cost of a scan](#bounding-the-cost-of-a-scan).
+
 Scans fetch pages on demand and stop early under `LIMIT`; completed scans
 are cached per the scan cache's usual keying (binding, table, pushed
 inputs, projection, LIMIT).

--- a/docs/open-connector-dropbox.md
+++ b/docs/open-connector-dropbox.md
@@ -1,0 +1,264 @@
+# Dropbox Source Pack
+
+The built-in `dropbox` source pack exposes a Dropbox account's own files,
+folders and shared links as stable SQL tables through an
+[Open Connector gateway](open-connector.md). Dropbox credentials are an
+OAuth token obtained through the gateway's flow against a Dropbox app the
+operator creates; Skardi holds only the gateway runtime token. Visibility
+is exactly the authorizing account's.
+
+**The wire contract is Open Connector's NORMALIZED shape.** Unlike the
+GitHub/Notion/Feishu packs, which pass provider objects through, every
+Dropbox list executor rebuilds each entry through `mapDropboxMetadata`
+into a fixed camelCase shape — `tag`, `name`, `id`, `pathDisplay`,
+`pathLower`, `clientModified`, `serverModified`, `rev`, `sizeBytes`,
+`isDownloadable`, `contentHash`, `url`, `expiresAt`, `sharingInfo`,
+`linkPermissions` — whose fifteen keys are all declared `required` under
+`additionalProperties: false`. Two consequences worth knowing:
+
+- Dropbox's own snake_case spellings (`path_display`, `client_modified`,
+  `size`) never reach a row, so mapping them would have produced
+  always-NULL columns.
+- Every column below sits **inside** the contract-fingerprint gate, and
+  the fingerprint coverage gap is empty — the opposite of the passthrough
+  packs, where real rows are the only column truth.
+
+> **⚠ NOT live-verified.** Reconciled against the Open Connector v1.3.5
+> provider *source* only. No live gateway has answered any of this pack
+> and no Dropbox account has been read, so every committed fingerprint is
+> the hash of a source-derived schema rather than a captured one, and the
+> bundled fixtures are authored shapes rather than redacted captures.
+> **Registration against a real gateway is expected to fail the contract
+> gate until the pins are re-captured** — that is the gate working. The
+> runbook that closes this out is
+> [the live-evaluation plan](superpowers/plans/2026-08-18-dropbox-live-evaluation.md);
+> its acceptance table lists every statement here that is currently an
+> inference.
+
+## Binding
+
+```yaml
+spec:
+  data_sources:
+    - name: saas
+      type: open_connector
+      connection_string: http://open-connector:3000
+      hierarchy_level: catalog
+
+      open_connector:
+        runtime_token_env: OPEN_CONNECTOR_TOKEN
+        bindings:
+          # files and shared_links need no resource at all.
+          - name: me
+            source_pack: dropbox
+            tables: [files, shared_links]
+          # file_search REQUIRES a query, so it needs its own binding
+          # (one query per binding, the GitHub owner/repo precedent).
+          - name: reports
+            source_pack: dropbox
+            resource:
+              query: report
+            tables: [file_search]
+          # Optional resources narrow a listing: `path` selects the
+          # listing ROOT for files, or one file/folder for shared_links.
+          - name: invoices
+            source_pack: dropbox
+            resource:
+              path: /Finance/Invoices
+              directOnly: true          # shared_links only; a JSON boolean
+            tables: [files, shared_links]
+```
+
+```sql
+-- Every file and folder under the account root, recursively.
+SELECT path_display, size_bytes, server_modified
+FROM saas.me.files
+WHERE tag = 'file'
+ORDER BY server_modified DESC
+LIMIT 20;
+
+-- Shared links, newest first, with their visibility.
+SELECT name, url, expires_at, link_permissions
+FROM saas.me.shared_links;
+
+-- The same definition, ad hoc, without a binding:
+SELECT name, path_display
+FROM open_connector_query('saas', 'dropbox.file_search',
+                          '{"query":"invoice"}');
+```
+
+## Tables
+
+| Table | Action(s) | Row path | Required resource | Optional resources | Columns |
+|---|---|---|---|---|---|
+| `files` | `dropbox.list_folder` → `dropbox.list_folder_continue` | `$.entries` | — | `path` | 12 |
+| `shared_links` | `dropbox.list_shared_links` (continues on itself) | `$.links` | — | `path`, `directOnly` | 15 |
+| `file_search` | `dropbox.search_files` → `dropbox.search_files_continue` | `$.matches` | `query` | `path` | 13 |
+
+**No table pushes any filter.** Dropbox's remaining list inputs are
+scan-shape controls (`recursive`, `includeDeleted`, `limit`,
+`filenameOnly`), not column predicates. `path` is deliberately a resource
+rather than an `eq` push onto `path_lower`: on `files` it selects the
+listing *root*, which is a different claim from a path equality; on
+`shared_links` the input accepts paths, file IDs **and** rev IDs, so no
+fidelity level would be honest across its value domain. Guard tests pin
+that no filter key ever reaches the wire.
+
+`LIMIT` pushdown works on all three tables and stops pagination early —
+including before the continuation request.
+
+### `files` — every file and folder under `path`
+
+Pinned inputs, so the table means the complete collection rather than one
+directory level:
+
+| Input | Pinned to | Why |
+|---|---|---|
+| `recursive` | `true` | A table named `files` that returns one directory level is a surprising contract |
+| `includeMountedFolders` | `true` | Pins Dropbox's own default so it cannot drift |
+| `includeDeleted` | `false` | Deleted tombstones carry a `deleted` tag and null everything else, informing no query |
+
+Columns: `tag`, `name` (both non-nullable — the executor guarantees a
+string), `id`, `path_display`, `path_lower`, `client_modified`,
+`server_modified` (ISO 8601 on the wire, read as UTC timestamps), `rev`,
+`size_bytes`, `is_downloadable`, `content_hash`, `sharing_info` (JSON
+text).
+
+`url`, `expires_at` and `link_permissions` exist in `mapDropboxMetadata`
+but are **deliberately absent here**: the normalizer sources them from
+fields `list_folder` never returns, so they would be structurally
+always-NULL. They are mapped on `shared_links`, where they populate.
+
+A folder row nulls the file-only columns rather than reporting zero
+values — `size_bytes IS NULL` for a folder, `= 0` for an empty file.
+
+### `shared_links` — links for the account, or for one path
+
+Columns: everything `files` has, plus `url`, `expires_at` and
+`link_permissions`. `url` is the natural identity but stays **nullable**:
+the executor spells it `optionalString(record.url) ?? null`, so a
+non-null declaration would fail scans on a row the gateway considers
+legal.
+
+`directOnly` is exposed as a binding resource rather than pinned because
+neither setting is an honest default: pinned `true`, links a file
+inherits from a shared ancestor disappear; pinned `false`, one file can
+surface through several ancestors.
+
+### `file_search` — Dropbox `search_v2` over files and folders
+
+`query` is **required** — a search table without one is not a table.
+`fileStatus` is pinned to `active`. `orderBy` is deliberately *not*
+pinned: `search/continue_v2` pages a server-side snapshot taken at the
+opening call, so relevance order is stable within one scan.
+
+Columns: `match_type` (non-nullable, `filename` / `content`) plus the
+twelve metadata columns read through the nested `metadata` block.
+
+`highlight_spans` is unmapped and `includeHighlights` is never sent: the
+field populates only when highlights are requested, and the declared
+schema (nullable array) contradicts the executor (`readObjectArray`,
+which returns `[]` and never null). Recorded as a wire-vs-contract
+contradiction rather than mapped.
+
+## Pagination: split-action continuation
+
+**This pack is why `pagination.continuation` exists.** Dropbox continues
+a listing through a *different action* than the one that opened it, and
+each continue action declares `cursor` as its only property under
+`additionalProperties: false`:
+
+```
+dropbox.list_folder   → dropbox.list_folder_continue     { cursor }
+dropbox.search_files  → dropbox.search_files_continue    { cursor }
+```
+
+So page 1 goes to the opening action with resources, pinned inputs and
+the page size; pages 2..N go to the continue action carrying the cursor
+and nothing else. Feeding the cursor back to the opening action would be
+a hard 400, not a quiet truncation. `shared_links` needs none of this —
+it takes the cursor on its own action.
+
+Both actions of a split-action table are discovered and
+fingerprint-gated at registration, so an undiscovered or drifted continue
+action fails at startup rather than on page two of the first scan. A
+fingerprint hashes the **output** schema, though, so the `cursor_only`
+claim — which is about *inputs* — is checked separately against the
+continue action's discovered input schema: the cursor input must be a
+declared property, and no other input may be `required`. A continue
+action that publishes no input schema at all is refused rather than
+trusted.
+
+**Termination.** `list_folder` answers its final page with a **non-empty**
+cursor, so cursor-spelling termination alone would refetch and fail as a
+detected pagination loop. All three tables therefore declare
+`has_more_path: "$.hasMore"` and treat it as authoritative — and because
+it is declared, a page that omits it fails as contract drift rather than
+guessing.
+
+Page sizes are the schemas' declared maxima (`limit: 2000`,
+`maxResults: 1000`) and are **unprobed at the boundary**; a declared cap
+can exceed the wire's. Continuation pages carry no page-size input at
+all — Dropbox sizes them from the request that opened the listing.
+`shared_links` has no page-size input, so its `page_size` is an inert
+placeholder.
+
+## Authorization
+
+The gateway's dropbox provider uses OAuth against a Dropbox app the
+operator creates at https://www.dropbox.com/developers/apps (*Scoped
+access*, *Full Dropbox* — App-folder access hides everything outside the
+app folder and makes `files` and `file_search` untestable).
+
+Two scopes cover the whole pack:
+
+| Scope | Needed by |
+|---|---|
+| `files.metadata.read` | `files`, `file_search` |
+| `sharing.read` | `shared_links` |
+
+No content scope and no write scope is required by any shipped table, so
+a read-only connection serves all three. Every permission change
+invalidates the grant snapshot — re-run the authorization rather than
+debugging a stale token.
+
+Self-check that the gateway build carries all five actions before
+debugging anything else (a too-old gateway fails registration with
+`action 'dropbox.list_folder_continue' was not found`, which reads like a
+typo and means "upgrade the gateway"):
+
+```bash
+for a in dropbox.list_folder dropbox.list_folder_continue \
+         dropbox.list_shared_links dropbox.search_files dropbox.search_files_continue; do
+  printf '%-34s %s\n' "$a" \
+    "$(curl -s -o /dev/null -w '%{http_code}' \
+       -H "Authorization: Bearer $OPEN_CONNECTOR_TOKEN" "$GATEWAY/v1/actions/$a")"
+done   # expect 200 five times
+```
+
+## Errors, rate limits and freshness
+
+`dropboxRpcRequest` throws on any non-2xx, so Dropbox's in-band
+`error_summary` envelope **and** its 429 rate limiting both surface as
+gateway *failure* envelopes rather than as HTTP 200 rows. No table
+declares an `error_path`, and the provider's own code arrives through the
+gateway-failure path.
+
+The client's bounded retry/backoff handles transient 429/5xx envelopes.
+Scans fetch pages on demand and stop early under `LIMIT`; completed scans
+are cached per the scan cache's usual keying (binding, table, pushed
+inputs, projection, LIMIT).
+
+Dropbox cursors can expire or be invalidated mid-listing, and a long
+recursive scan of a large account may outlive one. Behavior at that
+boundary is an open question the live pass records.
+
+## Tables deliberately not shipped
+
+| Action | Why |
+|---|---|
+| `list_revisions` | Pages by feeding a `beforeRev` from the previous page's rows and answers `hasMore` with no cursor to follow — no pack-side strategy can complete it |
+| `get_current_account` | Returns a single object; a row path requires an array |
+| `get_tags` | Takes an array of paths, and resources are scalars; declares no pagination |
+| `download_file`, `get_temporary_link`, `get_shared_link_file` | Base64 content payloads, not rows |
+| `upload_file`, `create_folder`, `move`, `copy`, `delete`, `create_shared_link`, `modify_shared_link`, `revoke_shared_link`, `save_url`, `restore` | Writes — outside the read-only allowlist |

--- a/docs/open-connector-dropbox.md
+++ b/docs/open-connector-dropbox.md
@@ -364,10 +364,17 @@ idempotent and do retry 5xx.) Retries are also bounded by the scan
 deadline, so a long `Retry-After` cannot outlast the scan.
 
 The practical consequence: sustained Dropbox throttling exhausts the
-retry budget and the scan fails with a retry-exhausted error. The remedy
-is to re-run the query — completed scans are cached, so a retry does not
-re-fetch what already succeeded — or to narrow the scan per
-[Bounding the cost of a scan](#bounding-the-cost-of-a-scan).
+retry budget and the scan fails with a retry-exhausted error. **A failed
+scan caches nothing** — the scan cache is written only when the scan
+completes (LIMIT satisfied, or pagination exhausted), so a retry-exhausted
+429, a `ScanBoundsExceeded`, a deadline timeout, or contract drift on page
+N all leave the cache untouched. Re-running restarts at page one and
+repays the full cost, which on `files` is a second recursive walk of the
+whole account into the same throttle. The remedy is therefore to narrow
+the scan per
+[Bounding the cost of a scan](#bounding-the-cost-of-a-scan), not to
+re-run it unchanged. (A scan that *succeeded* is cached, and repeating
+that query is free — see below.)
 
 Scans fetch pages on demand and stop early under `LIMIT`; completed scans
 are cached per the scan cache's usual keying (binding, table, pushed

--- a/docs/open-connector-dropbox.md
+++ b/docs/open-connector-dropbox.md
@@ -45,14 +45,16 @@ per-action field coverage.
 > which did not land during the pass. The row fixtures in-repo are still
 > authored shapes rather than redacted captures.
 >
-> **Known gateway blocker, not specific to this pack:** at commit
-> `a3efa99` the gateway's `GET /v1/actions/<id>` does not serialize the
-> `execution` block, so Skardi's default-deny action registry refuses
-> every action from *every* source pack (reproduced with the merged
-> `github` pack). Registration needs a gateway that publishes
-> `execution.locallyExecutable` on that route — filed upstream as
-> [oomol-lab/open-connector#358](https://github.com/oomol-lab/open-connector/issues/358).
-> Skardi's gate is correct and was deliberately left alone: no
+> **Gateway version note — resolved upstream, no prerequisite on a
+> current gateway:** the checkout used for this pass (`a3efa99`,
+> 2026-07-07) predates upstream `1607633` (#149, 2026-07-19), which added
+> the `execution` block to `GET /v1/actions/<id>`. On that older checkout
+> Skardi's default-deny action registry refuses every action from *every*
+> source pack (reproduced with the merged `github` pack), which is why
+> the pass ran against a locally patched gateway — filed as
+> [oomol-lab/open-connector#358](https://github.com/oomol-lab/open-connector/issues/358),
+> closed as completed. No prerequisite exists on a gateway at or after
+> `1607633`. Skardi's gate is correct and was deliberately left alone: no
 > compatibility fallback reads the classification from another route.
 
 ## Binding

--- a/docs/open-connector.md
+++ b/docs/open-connector.md
@@ -42,9 +42,8 @@ gateway **runtime token**.
 > shared-drive rows included; three structurally unreachable columns
 > stay documented as residuals per the pack doc),
 > and [Dropbox](open-connector-dropbox.md) (files, shared links, file
-> search — split-action cursor continuation; **not yet live-verified**,
-> so its pinned fingerprints will fail the contract gate against a real
-> gateway until they are re-captured).
+> search — split-action cursor continuation; live-verified against a real
+> account, all five pins captured from a live gateway).
 > Further provider packs (Google Calendar, Jira, …) ship one pack per
 > release per the
 > [design spec](superpowers/specs/2026-07-11-open-connector-integration-design.md);
@@ -323,15 +322,39 @@ it, and the provider sizes continuation pages from that request.
 Both actions are discovered and fingerprint-gated at registration, so an
 undiscovered or drifted continue action fails at startup rather than on page
 two of the first scan. Because a fingerprint hashes the *output* schema, the
-`cursor_only` claim — which is about inputs — is checked separately against
-the continue action's discovered **input** schema: the cursor input must be a
-declared property and no other input may be `required`. A continue action
-that publishes no input schema is refused rather than trusted, the same
-default-deny posture raw scans take toward a missing read/write
-classification. Two authoring invariants are enforced by the loader: a
-`continuation` on a non-cursor strategy is a parse error, and a table that
-pins its continuation's fingerprint must pin its own action's too (half a
-gate reads as gated while verifying only pages 2..N).
+input side is checked separately, against the continue action's discovered
+**input** schema — in both directions of `inputs:`, since a wrong claim
+either way is a hard 400 on page two of a live scan:
+
+- `inputs: cursor_only` — the cursor input must be a declared property and
+  no other input may be `required`.
+- `inputs: full` (the default) targeting a **different** action — every
+  input the table sends on every request must satisfy that action's
+  `required`, and under `additionalProperties: false` every input the table
+  *can* send must be a declared property. When the continuation names the
+  table's own action the check is skipped: one action has one input schema,
+  and page one already satisfied it.
+
+A continue action that publishes no input schema is refused rather than
+trusted, the same default-deny posture raw scans take toward a missing
+read/write classification — as is a `required` list that is present but is
+not an array of strings, since a gate that cannot read its input has
+verified nothing.
+
+Four authoring invariants are enforced by the loader:
+
+- a `continuation` on a non-cursor strategy is a parse error;
+- a table that pins its continuation's fingerprint must pin its own
+  action's too (half a gate reads as gated while verifying only pages 2..N);
+- a same-action continuation may not pin a fingerprint different from the
+  table's own — one action has one contract, so no gateway can satisfy
+  both;
+- `inputs: cursor_only` may not be paired with an **Exact**-fidelity
+  filter. Exact pushdown deletes the `Filter` node from the plan, so page
+  one would apply the predicate as an action input while pages 2..N could
+  not, with no node left to re-apply it — silently returning rows the query
+  excluded. Declare such a filter `Inexact` instead: the `Filter` node
+  survives, and the lost input makes pages 2..N merely wasteful.
 
 Conversion errors report the action, row
 path, page, row, column, and expected type — with the offending JSON
@@ -354,8 +377,8 @@ Each pack table pins the full relational contract and an expected
 action-contract fingerprint captured from a live gateway (a canonicalized
 BLAKE3 hash of the discovered output schema; every built-in pack is
 pinned, with the schemas committed next to each pack under
-`fixtures/<provider>/contracts/` — captured from a live gateway except
-Dropbox's, which are source-derived pending its live pass). Split-action
+`fixtures/<provider>/contracts/`, all captured from a live gateway).
+Split-action
 tables pin BOTH the opening action and the continuation action; where the
 two publish the same output schema, the continuation pin guards the row
 shape of pages 2..N and its input-side claim is gated separately (see

--- a/docs/open-connector.md
+++ b/docs/open-connector.md
@@ -37,10 +37,14 @@ gateway **runtime token**.
 > search — live-verified against a real MSA drive; search rows are a
 > reduced projection and search continuations currently fail upstream
 > on personal drives, loudly, per the pack doc),
-> and [Google Drive](open-connector-google-drive.md) (files, drives,
+> [Google Drive](open-connector-google-drive.md) (files, drives,
 > file permissions — live-verified against a real Workspace account,
 > shared-drive rows included; three structurally unreachable columns
-> stay documented as residuals per the pack doc).
+> stay documented as residuals per the pack doc),
+> and [Dropbox](open-connector-dropbox.md) (files, shared links, file
+> search — split-action cursor continuation; **not yet live-verified**,
+> so its pinned fingerprints will fail the contract gate against a real
+> gateway until they are re-captured).
 > Further provider packs (Google Calendar, Jira, …) ship one pack per
 > release per the
 > [design spec](superpowers/specs/2026-07-11-open-connector-integration-design.md);
@@ -288,6 +292,47 @@ page — a page without it fails as contract drift rather than guessing.
 Declare it only for providers that always emit the signal; for the
 omit-when-false pattern (Slack's `response_metadata`), leave it undeclared
 and let the cursor spellings terminate the scan.
+
+Some providers continue a listing through a **different action** than the
+one that opened it — Dropbox's `list_folder` → `list_folder_continue`,
+whose input schema declares `cursor` as its only property. A cursor-paginated
+pack table declares that with an optional `continuation` block; absent, pages
+2..N repeat the table's own action with the full assembled input, exactly as
+before:
+
+```yaml
+pagination:
+  strategy: cursor
+  cursor_input: cursor
+  next_cursor_path: "$.cursor"
+  page_size_input: limit
+  page_size: 2000
+  has_more_path: "$.hasMore"
+  continuation:
+    action: dropbox.list_folder_continue   # default: the table's own action
+    fingerprint: <blake3-hex>              # required, never optional
+    inputs: cursor_only                    # cursor_only | full (default: full)
+```
+
+Page 1 always uses the table's own action with the full input. `inputs:
+cursor_only` makes pages 2..N carry the cursor and nothing else — no
+resources, no fixed inputs, no page size — for continue actions that declare
+nothing else; the listing's shape was committed by the request that opened
+it, and the provider sizes continuation pages from that request.
+
+Both actions are discovered and fingerprint-gated at registration, so an
+undiscovered or drifted continue action fails at startup rather than on page
+two of the first scan. Because a fingerprint hashes the *output* schema, the
+`cursor_only` claim — which is about inputs — is checked separately against
+the continue action's discovered **input** schema: the cursor input must be a
+declared property and no other input may be `required`. A continue action
+that publishes no input schema is refused rather than trusted, the same
+default-deny posture raw scans take toward a missing read/write
+classification. Two authoring invariants are enforced by the loader: a
+`continuation` on a non-cursor strategy is a parse error, and a table that
+pins its continuation's fingerprint must pin its own action's too (half a
+gate reads as gated while verifying only pages 2..N).
+
 Conversion errors report the action, row
 path, page, row, column, and expected type — with the offending JSON
 *kind*, never the value.
@@ -307,9 +352,14 @@ otherwise report `RowPathNotFound` on an in-band error page.
 
 Each pack table pins the full relational contract and an expected
 action-contract fingerprint captured from a live gateway (a canonicalized
-BLAKE3 hash of the discovered output schema; both the github and slack
-packs are pinned, with the captured schemas committed next to each pack
-under `fixtures/<provider>/contracts/`). At registration a pinned
+BLAKE3 hash of the discovered output schema; every built-in pack is
+pinned, with the schemas committed next to each pack under
+`fixtures/<provider>/contracts/` — captured from a live gateway except
+Dropbox's, which are source-derived pending its live pass). Split-action
+tables pin BOTH the opening action and the continuation action; where the
+two publish the same output schema, the continuation pin guards the row
+shape of pages 2..N and its input-side claim is gated separately (see
+[Bounds, retries, and errors](#bounds-retries-and-errors)). At registration a pinned
 table's fingerprint is compared against the discovered contract and any
 difference — breaking or additive, since a hash cannot tell them apart —
 fails with a targeted error instead of silently changing a table's

--- a/docs/open-connector.md
+++ b/docs/open-connector.md
@@ -175,10 +175,15 @@ LIMIT 50;
 
 It compiles into exactly the scan the YAML-bound table uses: same stable
 Arrow schema, filter allowlist, pagination, safety bounds, and shared
-cache. The table's action must have been discovered when the gateway was
-registered — bind the table in YAML or add its action to
-`raw_action_allowlist`; otherwise planning fails with an error saying so
-(planning never contacts the gateway).
+cache. **Every** action the table executes must have been discovered when
+the gateway was registered — including a split-action continuation's, not
+just the opening action — so bind the table in YAML or add every one of
+its action ids to `raw_action_allowlist`; otherwise planning fails with an
+error saying so (planning never contacts the gateway). For a split-action
+table the allowlist route needs both ids: `dropbox.files` executes
+`dropbox.list_folder` on page one and `dropbox.list_folder_continue` on
+pages 2..N, and an allowlist naming only the opener fails planning on the
+continuation.
 
 ### 3. `open_connector_scan` — allowlisted raw read actions
 
@@ -354,7 +359,13 @@ Four authoring invariants are enforced by the loader:
   one would apply the predicate as an action input while pages 2..N could
   not, with no node left to re-apply it — silently returning rows the query
   excluded. Declare such a filter `Inexact` instead: the `Filter` node
-  survives, and the lost input makes pages 2..N merely wasteful.
+  survives, so DataFusion re-applies the predicate and the rows are
+  right. The waste is not free, though — pages 2..N fetch the *unfiltered*
+  collection, and `max_rows`/`max_pages` count what the gateway returned,
+  not what survived the filter. A selective `Inexact` filter paired with
+  `cursor_only` therefore needs bounds sized for the whole collection; a
+  query that works today can otherwise turn into a hard
+  `ScanBoundsExceeded` rather than a slower one.
 
 Conversion errors report the action, row
 path, page, row, column, and expected type — with the offending JSON
@@ -375,9 +386,11 @@ otherwise report `RowPathNotFound` on an in-band error page.
 
 Each pack table pins the full relational contract and an expected
 action-contract fingerprint captured from a live gateway (a canonicalized
-BLAKE3 hash of the discovered output schema; every built-in pack is
+BLAKE3 hash of the discovered output schema; every *provider* pack is
 pinned, with the schemas committed next to each pack under
-`fixtures/<provider>/contracts/`, all captured from a live gateway).
+`fixtures/<provider>/contracts/`, all captured from a live gateway — the
+synthetic `mock` pack is the one built-in that pins nothing, having no
+upstream contract to drift against).
 Split-action
 tables pin BOTH the opening action and the continuation action; where the
 two publish the same output schema, the continuation pin guards the row

--- a/docs/superpowers/plans/2026-08-18-dropbox-live-evaluation.md
+++ b/docs/superpowers/plans/2026-08-18-dropbox-live-evaluation.md
@@ -1,37 +1,60 @@
 # Dropbox pack — personal-account live evaluation
 
+> **✅ THIS RUN COMPLETED on 2026-08-18** against a self-hosted Open
+> Connector gateway at commit `a3efa99` and a real free-tier Dropbox
+> account. Nothing below is outstanding except the two rows explicitly
+> marked so in the acceptance table. The pack is **live-verified**, not
+> provisional: every fingerprint is a hash of a live capture, and
+> registration passed the contract gate on the first try.
+>
+> The authoritative outcome record is the provenance banner in
+> `crates/skardi/src/sources/providers/open_connector/packs/dropbox.rs`
+> and the 5.5 entry in
+> `specs/2026-07-11-open-connector-integration-tasks.md`. This document is
+> kept as the **method** — what was probed and how — so the next pack's
+> live pass can copy it.
+
 **Runbook for phases 2 + 4/5 of the source-pack skill, instantiated for
 `packs/dropbox.{yaml,rs}` on `feature/open-connector-dropbox-pack`.**
 
 Generic method: `docs/superpowers/skills/source-pack/references/live-verification.md`.
 This document is the Dropbox-specific version — exact actions, exact
 inputs, exact SQL, and the specific claims on this branch that only a
-live wire can settle.
+live wire could settle.
 
-## 0. Why this run exists
+## 0. Why this run existed, and what it settled
 
-The pack was authored from source-reading alone. The execution plan
-(`specs/2026-08-16-dropbox-source-pack-design.md`, steps 2 and 5) marks
-contract capture and live verification **blocked** on two things this box
-did not have: a Node runtime and a Dropbox account. Everything downstream
-of that block is provisional:
+The pack was authored from source-reading alone, and the execution plan
+(`specs/2026-08-16-dropbox-source-pack-design.md`, steps 2 and 5) marked
+contract capture and live verification blocked on two things the
+authoring box did not have: a Node runtime and a Dropbox account. Both
+arrived; both steps ran. The acceptance table, with the outcome column
+filled in:
 
-| Artifact | Current state | What this run turns it into |
+| Artifact | State before the run | Outcome |
 |---|---|---|
-| `fingerprint:` on 3 tables, `continuation.fingerprint:` on 2 | hashes of source-derived schemas; labelled as such, and expected to fail the gate live | hashes of `data.outputSchema` from a live gateway |
-| `fixtures/dropbox/contracts/*.json` (5 files) | derived from the executor source; each `*_continue.json` is byte-identical to its opener *because it was derived that way* | five independent captures, which either confirm the identity or split it |
-| `fixtures/dropbox/*.json` (6 row fixtures) | authored in the executor's shape (`id:aaaa…`, `Redacted Folder`) | redacted live captures |
-| Every mapped column | never observed carrying a real value | non-NULL somewhere in a seeded account, or dropped |
-| `limit: 2000` / `maxResults: 1000` | the schemas' declared maxima, unprobed | probed at the boundary (a declared cap can exceed the wire's) |
-| Q1 — `{path, cursor}` together on `list_shared_links` | shipped as an inference, labelled as one | answered; if rejected, `shared_links` gains a `cursor_only` continuation (no code change) |
-| Q2 — `list_folder` cursor lifetime | unknown | observed, and documented as a bound if it matters |
-| Q3 — can `matches[].metadata` be null? | contract says no, so `file_search.tag`/`name` are non-nullable and the fixture that tests it is labelled synthetic | answered; if yes, those columns become nullable and the fixture graduates |
-| `cursor_only` on the two continue actions | gated at registration against the discovered **input** schema, but only ever seen against a derived schema | gated against the real one |
+| `fingerprint:` on 3 tables, `continuation.fingerprint:` on 2 | hashes of source-derived schemas, expected to fail the gate live | ✅ all five matched LIVE discovery **unchanged** — the "expected to fail" warning was simply wrong |
+| `fixtures/dropbox/contracts/*.json` (5 files) | derived from the executor source; each `*_continue.json` byte-identical to its opener *because it was derived that way* | ✅ replaced by five independent captures, which **confirmed** the identity — it is a fact about the wire |
+| `fixtures/dropbox/*.json` (6 row fixtures) | authored in the executor's shape (`id:aaaa…`, `Redacted Folder`) | ⚠️ **still authored** — the account read holds personal files, so its pages were not committed. Two were corrected to the live shape; two are deliberately impossible. Per-file provenance: `fixtures/dropbox/README.md`. Re-deriving from redacted captures stays open |
+| Every mapped column | never observed carrying a real value | ✅ 12/12 on `files` (378 rows), 13/13 on `file_search`, 11/11 on `shared_links` — after the run **dropped four** `shared_links` columns it proved could never populate (15 → 11) |
+| `limit: 2000` / `maxResults: 1000` | the schemas' declared maxima, unprobed | ✅ probed at the boundary: 2000 and 1000 return rows, 2001 and 1001 are refused |
+| Q1 — `{path, cursor}` together on `list_shared_links` | shipped as an inference, labelled as one | ✅ **accepted** — no `cursor_only` continuation needed, the shipped shape was right |
+| Q2 — `list_folder` cursor lifetime | unknown | ✅ lower bound only: a cursor replayed ~40 min later, after the tree changed, still returned rows. No upper bound established; documented as a bound, not a guarantee |
+| Q3 — can `matches[].metadata` be null? | contract says no, so `file_search.tag`/`name` are non-nullable and the fixture that tests it is labelled synthetic | ✅ **no** — the executor always returns a full object. The columns stay non-nullable and the fixture stays synthetic permanently |
+| `cursor_only` on the two continue actions | gated at registration against the discovered **input** schema, but only ever seen against a derived schema | ✅ gated against the real one. Feeding `cursor` to the OPENING action is a hard schema rejection, so `cursor_only` is mandatory, not an optimization |
 
-Read that table as the acceptance criteria. The run is done when every
-row's middle column is gone. The claims themselves are already labelled
-honestly in the pack (module-doc provenance banner, yaml headers) — this
-run is what removes the labels.
+Two claims remain **unobserved** rather than confirmed, both
+environmental rather than defects, and both labelled where they live:
+`shared_links.expires_at` needs paid-tier link expiry (a free account is
+refused `settings_error/not_authorized`), and
+`file_search.match_type = 'content'` needs Dropbox content indexing,
+which never landed during the pass.
+
+One gateway defect was found and filed rather than worked around:
+`GET /v1/actions/<id>` omits the `execution` block at commit `a3efa99`,
+so Skardi's default-deny action registry refuses every action from
+*every* pack — reproduced with the merged `github` pack, so not this
+pack's bug. Filed as oomol-lab/open-connector#358.
 
 ## 1. Prerequisites
 

--- a/docs/superpowers/plans/2026-08-18-dropbox-live-evaluation.md
+++ b/docs/superpowers/plans/2026-08-18-dropbox-live-evaluation.md
@@ -9,7 +9,7 @@
 >
 > The authoritative outcome record is the provenance banner in
 > `crates/skardi/src/sources/providers/open_connector/packs/dropbox.rs`
-> and the 5.5 entry in
+> and the 5.7 entry in
 > `specs/2026-07-11-open-connector-integration-tasks.md`. This document is
 > kept as the **method** — what was probed and how — so the next pack's
 > live pass can copy it.
@@ -452,7 +452,7 @@ Files that must change as a result of this run:
   pagination section; it is a YAML-authored engine feature that no
   user-facing doc mentions.
 - `docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md`
-  — the 5.5 entry, ticked only now.
+  — the 5.7 entry, ticked only now.
 - `docs/superpowers/specs/2026-08-16-dropbox-source-pack-design.md` —
   status is still "no implementation started"; close out steps 2 and 5
   and answer the open questions.

--- a/docs/superpowers/plans/2026-08-18-dropbox-live-evaluation.md
+++ b/docs/superpowers/plans/2026-08-18-dropbox-live-evaluation.md
@@ -1,0 +1,471 @@
+# Dropbox pack — personal-account live evaluation
+
+**Runbook for phases 2 + 4/5 of the source-pack skill, instantiated for
+`packs/dropbox.{yaml,rs}` on `feature/open-connector-dropbox-pack`.**
+
+Generic method: `docs/superpowers/skills/source-pack/references/live-verification.md`.
+This document is the Dropbox-specific version — exact actions, exact
+inputs, exact SQL, and the specific claims on this branch that only a
+live wire can settle.
+
+## 0. Why this run exists
+
+The pack was authored from source-reading alone. The execution plan
+(`specs/2026-08-16-dropbox-source-pack-design.md`, steps 2 and 5) marks
+contract capture and live verification **blocked** on two things this box
+did not have: a Node runtime and a Dropbox account. Everything downstream
+of that block is provisional:
+
+| Artifact | Current state | What this run turns it into |
+|---|---|---|
+| `fingerprint:` on 3 tables, `continuation.fingerprint:` on 2 | hashes of source-derived schemas; labelled as such, and expected to fail the gate live | hashes of `data.outputSchema` from a live gateway |
+| `fixtures/dropbox/contracts/*.json` (5 files) | derived from the executor source; each `*_continue.json` is byte-identical to its opener *because it was derived that way* | five independent captures, which either confirm the identity or split it |
+| `fixtures/dropbox/*.json` (6 row fixtures) | authored in the executor's shape (`id:aaaa…`, `Redacted Folder`) | redacted live captures |
+| Every mapped column | never observed carrying a real value | non-NULL somewhere in a seeded account, or dropped |
+| `limit: 2000` / `maxResults: 1000` | the schemas' declared maxima, unprobed | probed at the boundary (a declared cap can exceed the wire's) |
+| Q1 — `{path, cursor}` together on `list_shared_links` | shipped as an inference, labelled as one | answered; if rejected, `shared_links` gains a `cursor_only` continuation (no code change) |
+| Q2 — `list_folder` cursor lifetime | unknown | observed, and documented as a bound if it matters |
+| Q3 — can `matches[].metadata` be null? | contract says no, so `file_search.tag`/`name` are non-nullable and the fixture that tests it is labelled synthetic | answered; if yes, those columns become nullable and the fixture graduates |
+| `cursor_only` on the two continue actions | gated at registration against the discovered **input** schema, but only ever seen against a derived schema | gated against the real one |
+
+Read that table as the acceptance criteria. The run is done when every
+row's middle column is gone. The claims themselves are already labelled
+honestly in the pack (module-doc provenance banner, yaml headers) — this
+run is what removes the labels.
+
+## 1. Prerequisites
+
+**On this box.**
+
+```bash
+# Node — the gateway is a Node/TypeScript service; `node`/`npm` are absent here.
+curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+. ~/.nvm/nvm.sh && nvm install --lts && node --version   # v20+ is enough
+
+git clone https://github.com/oomol-lab/open-connector ~/code/open-connector
+cd ~/code/open-connector && git checkout v1.3.5 && npm ci
+```
+
+Local constraints that have cost time before: **port 18080 is already
+taken** by a running dashboard — use 8087 for `skardi-server` and 3000
+for the gateway. Root fs is 29 GB and cargo builds are 3–5 GB; run one
+cargo invocation at a time and `cargo clean` when done.
+
+**Dropbox side (you do this, not the agent).** A free personal account is
+fine and explicitly acceptable for this gate.
+
+1. https://www.dropbox.com/developers/apps → **Create app** → *Scoped
+   access* → *Full Dropbox* (App-folder access hides everything outside
+   the app folder, which makes `files` and `file_search` untestable).
+2. **Permissions** tab → tick `files.metadata.read` and `sharing.read`
+   → **Submit**. These are the only two scopes the whole pack needs; if
+   anything later demands a third, that is a finding.
+3. **Settings** tab → add the gateway's OAuth redirect URI
+   (`http://localhost:3000/oauth/callback` unless your gateway config
+   says otherwise) → copy the **App key** and **App secret**.
+
+```bash
+export DROPBOX_APP_KEY=…        # your shell only; never into a file, never into chat
+export DROPBOX_APP_SECRET=…
+export OOMOL_CONNECT_ADMIN_TOKEN=…   # admin routes 401 without it
+export OPEN_CONNECTOR_TOKEN=…        # runtime token, the only secret Skardi sees
+export GATEWAY=http://localhost:3000
+```
+
+> Every permission change invalidates the grant snapshot. If you tick a
+> scope later, **re-run the authorization** — do not debug a stale token.
+
+## 2. Bring the gateway up and connect Dropbox
+
+```bash
+cd ~/code/open-connector && npm run dev &        # or the repo's documented start script
+curl -fsS "$GATEWAY/v1/health" -H "Authorization: Bearer $OPEN_CONNECTOR_TOKEN"
+```
+
+Confirm the five actions this pack needs actually exist on this build —
+a too-old gateway fails Skardi registration with `action
+'dropbox.list_folder_continue' was not found`, which reads like a typo
+and means "upgrade the gateway":
+
+```bash
+for a in dropbox.list_folder dropbox.list_folder_continue \
+         dropbox.list_shared_links dropbox.search_files dropbox.search_files_continue; do
+  printf '%-34s %s\n' "$a" \
+    "$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $OPEN_CONNECTOR_TOKEN" "$GATEWAY/v1/actions/$a")"
+done   # expect 200 five times
+```
+
+OAuth setup — field names come from `src/providers/dropbox/definition.ts`
+in the checkout; verify them there rather than trusting this snippet:
+
+```bash
+curl -X PUT "$GATEWAY/api/oauth/configs/dropbox" \
+  -H "Authorization: Bearer $OOMOL_CONNECT_ADMIN_TOKEN" -H 'content-type: application/json' \
+  -d "{\"clientId\":\"$DROPBOX_APP_KEY\",\"clientSecret\":\"$DROPBOX_APP_SECRET\"}"
+
+curl -X POST "$GATEWAY/api/oauth/authorizations" \
+  -H "Authorization: Bearer $OOMOL_CONNECT_ADMIN_TOKEN" -H 'content-type: application/json' \
+  -d '{"service":"dropbox"}'
+# → open the returned authorizationUrl in YOUR browser and approve.
+```
+
+Two failure modes worth recognizing on sight:
+
+- **Sub-100 ms OAuth failure with no resolved address** — the gateway's
+  SSRF/egress guard rejected a reserved IP. Zero-trust VPNs that map
+  domains into `198.18.0.0/15` (aTrust, Clash TUN) cause this. Fix on
+  your side; do not patch the guard.
+- **Dropbox refuses the authorize request** — the gateway may request
+  the union of every `dropbox.*` action's scopes, including write
+  scopes. If so, narrow the scope list in
+  `src/providers/dropbox/definition.ts` as a clearly-marked local patch
+  and file it upstream (precedent: oomol-lab/open-connector#267).
+
+## 3. Seed the account so every column can be non-NULL
+
+An all-NULL column over data you *know* exists is the always-NULL bug.
+Seed deliberately — this table is the shopping list, one row per thing
+the pack claims:
+
+| Seed | Proves |
+|---|---|
+| A folder at the root | `tag='folder'`, and that `size_bytes`/`is_downloadable`/`server_modified`/`rev`/`content_hash` come back **SQL NULL**, not zero values |
+| Two ordinary files with real content | `size_bytes`, `content_hash`, `rev`, `client_modified`, `server_modified`, `is_downloadable` |
+| One **empty** file (0 bytes) | `size_bytes = 0` is distinguishable from NULL |
+| A file **nested two levels deep** | `recursive: true` actually recurses (the pack's most consequential pin) |
+| A file inside a **shared** folder | `sharing_info` non-NULL |
+| A shared link on a file, and one on a folder | `shared_links.url`, `link_permissions`, and `tag='folder'` on a link row |
+| A shared link with an **expiry**, if your tier allows it | `expires_at`. Link expiry is a paid Dropbox feature — if you cannot set one, record `expires_at` as **unverified** rather than claiming coverage |
+| A file whose **name** matches a query word | `file_search.match_type='filename'` |
+| A file whose **content** matches that word | `match_type='content'`. Content indexing lags upload by minutes and is tier-dependent; if it never appears, record it unverified |
+| A **mounted** shared folder from another account, if you can | `includeMountedFolders: true` is a real pin, not decoration |
+
+Do **not** seed thousands of files to force pagination. §5 does that by
+lowering the page size instead.
+
+## 4. Probe every action directly, before Skardi is involved
+
+Contract probes bypass Skardi entirely, which is the point: they
+separate "the pack is wrong" from "the gateway is wrong". Record every
+response — these become the fixture sources in §7.
+
+```bash
+mkdir -p /tmp/dropbox-probe && cd /tmp/dropbox-probe
+ex() { curl -s -X POST "$GATEWAY/v1/actions/$1" \
+        -H "Authorization: Bearer $OPEN_CONNECTOR_TOKEN" -H 'content-type: application/json' \
+        -d "{\"input\":$2}"; }   # note: NO /execute suffix; body is {"input": …}
+```
+
+> `open_connector_scan` is **not** an option for this step. Raw scans are
+> default-deny and additionally require `execution.readOnly` in the
+> action metadata, which Open Connector does not publish — every raw scan
+> against a real gateway is refused at planning time. Raw wire shapes
+> come from `curl`, not from SQL.
+
+### 4a. `files` — the pack's exact page-one input
+
+```bash
+ex dropbox.list_folder '{"path":"","recursive":true,"includeMountedFolders":true,"includeDeleted":false,"limit":2000}' | tee files_p1.json | head -c 2000
+```
+
+- **The root path is `""`, not `"/"`.** The pack makes `path` an
+  *optional* resource, so with no binding resource the input carries no
+  `path` key at all — confirm the gateway defaults that to the root
+  rather than 400-ing. If it does not, `path` must become required.
+- Record `sorted(keys)` of a few entries and diff both directions
+  against the twelve mapped columns (§6).
+- **Boundary:** re-send with `limit: 2000` (already above) and then
+  `limit: 2001`. The declared max is not always the wire max — Feishu
+  declared 100 and hard-failed above 50. If 2000 is rejected, the pack's
+  `page_size` is wrong.
+
+### 4b. The split-action claim — the reason this pack needed an engine change
+
+```bash
+# The claim the module doc states as fact. Expect 400 invalid_input.
+ex dropbox.list_folder '{"cursor":"abc"}'
+
+# Force page 2 with a tiny page size, then continue.
+ex dropbox.list_folder '{"path":"","recursive":true,"includeMountedFolders":true,"includeDeleted":false,"limit":2}' > files_small_p1.json
+CUR=$(python3 -c "import json;print(json.load(open('files_small_p1.json'))['data']['cursor'])")
+ex dropbox.list_folder_continue "{\"cursor\":\"$CUR\"}" > files_small_p2.json
+
+# The cursor_only claim, tested from the other side: anything extra must 400.
+ex dropbox.list_folder_continue "{\"cursor\":\"$CUR\",\"limit\":2}"
+```
+
+Then **follow the listing to its real end** and inspect the final page:
+the pack asserts `list_folder` answers `hasMore: false` beside a
+**non-empty** cursor, which is the entire justification for
+`has_more_path` being load-bearing here. Confirm it, or the declaration
+changes.
+
+### 4c. `shared_links` — Open question 1
+
+```bash
+ex dropbox.list_shared_links '{}' > links_p1.json
+# THE open question: does this action accept path and cursor together?
+ex dropbox.list_shared_links '{"path":"/Some Folder/file.pdf","cursor":"…"}'
+```
+
+The pack ships the answer "yes" as a comment marked *verified live*. If
+the real answer is no, `shared_links` needs
+`continuation: {inputs: cursor_only}` too — a yaml change, no code.
+Also confirm this action really nulls its cursor at end-of-collection
+(the pack claims it does, unlike `list_folder`), and confirm it truly
+has no page-size input.
+
+### 4d. `file_search`
+
+```bash
+ex dropbox.search_files '{"query":"report","fileStatus":"active","maxResults":1000}' > search_p1.json
+ex dropbox.search_files '{"query":"report","fileStatus":"active","maxResults":2}' > search_small_p1.json
+SCUR=$(python3 -c "import json;print(json.load(open('search_small_p1.json'))['data']['cursor'])")
+ex dropbox.search_files_continue "{\"cursor\":\"$SCUR\"}"
+```
+
+- Check whether `matches[].metadata` can ever be **null** on the wire.
+  The pack ships a `file_search_null_parent.json` fixture built on that
+  shape while its own captured contract declares `metadata` a required
+  non-nullable object — exactly one of the two is right, and only this
+  probe says which. It matters: `tag` and `name` are declared
+  `nullable: false`, so a legal null parent would fail live scans.
+- Check whether `highlightSpans` is `[]` or `null` when highlights are
+  not requested (the module doc records this as a wire-vs-contract
+  contradiction).
+
+### 4e. Open question 2 — cursor lifetime
+
+Take a `list_folder` cursor, wait ~15 minutes, add and delete a file in
+the listed tree, then continue from it. Record whether it survives,
+returns `reset`, or errors. A long recursive scan of a real account can
+outlive a cursor, and if it can, that belongs in the pack doc as a
+documented bound.
+
+## 5. Force real multi-page pagination through Skardi
+
+`files` requests `limit: 2000` and `file_search` requests
+`maxResults: 1000`, so a personal account will never reach page 2 on the
+shipped constants. Lower them **locally, for the run only**:
+
+```bash
+cd ~/code/skardi
+git diff --exit-code crates/skardi/src/sources/providers/open_connector/packs/dropbox.yaml  # start clean
+sed -i 's/^      page_size: 2000$/      page_size: 2/;s/^      page_size: 1000$/      page_size: 2/' \
+  crates/skardi/src/sources/providers/open_connector/packs/dropbox.yaml
+```
+
+Two consequences to keep in mind while the edit is in place: the
+`complete_collection_pins_ride_every_files_request` and
+`files_pages_through_the_continue_action_with_only_a_cursor` tests pin
+`limit: 2000` and will fail, and `max_pages` (default 100) now caps the
+scan at ~200 rows. **Revert this edit before committing anything** — the
+shipped `page_size` must be the value §4a proved at the boundary.
+
+## 6. Register and scan end to end through `skardi-server`
+
+```yaml
+# /tmp/dropbox-probe/ctx.yaml
+kind: context
+metadata: { name: dropbox-live, version: 1.0.0 }
+spec:
+  data_sources:
+    - name: saas
+      type: open_connector
+      connection_string: http://localhost:3000
+      hierarchy_level: catalog
+      open_connector:
+        runtime_token_env: OPEN_CONNECTOR_TOKEN
+        cache_ttl_seconds: 0            # live reads; a cache hit proves nothing here
+        bindings:
+          - name: me                    # files + shared_links need no resource
+            source_pack: dropbox
+            tables: [files, shared_links]
+          - name: search                # file_search requires `query`
+            source_pack: dropbox
+            resource: { query: report }
+            tables: [file_search]
+```
+
+```bash
+cargo build -p skardi-server        # NOT skardi-cli: its default `gguf` feature
+                                    # pulls llama-cpp-sys, whose bindgen fails on this box
+OPEN_CONNECTOR_TOKEN=$OPEN_CONNECTOR_TOKEN RUST_LOG=info \
+  ./target/debug/skardi-server --ctx /tmp/dropbox-probe/ctx.yaml --port 8087 2>server.log &
+
+# Ad-hoc SQL goes through the server's own endpoint — no CLI needed.
+q() { curl -s -X POST http://localhost:8087/query -H 'content-type: application/json' \
+        -d "$(python3 -c 'import json,sys;print(json.dumps({"sql":sys.argv[1],"max_rows":10000}))' "$1")"; }
+```
+
+(If your ctx enables auth, `POST /query` needs a session header; the
+simplest evaluation ctx leaves auth off.)
+
+**Registration will fail first, and that is the expected first result.**
+The pins on this branch are placeholders, so you should see
+`action 'dropbox.list_folder' fingerprint mismatch (expected 87502bce…,
+discovered <hash>)`. That is the fingerprint gate doing its job. Fix it
+properly rather than by pasting the discovered hash blind:
+
+```bash
+# 1. Capture the five contracts independently — do NOT copy an opener's file
+#    onto its continuation, which is how the current fixtures got identical.
+for a in list_folder list_folder_continue list_shared_links search_files search_files_continue; do
+  curl -s -H "Authorization: Bearer $OPEN_CONNECTOR_TOKEN" "$GATEWAY/v1/actions/dropbox.$a" \
+    | python3 -c 'import json,sys;print(json.dumps(json.load(sys.stdin)["data"]["outputSchema"],indent=2))' \
+    > crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/contracts/$a.json
+  # keep the INPUT schema too — it is what proves `inputs: cursor_only`
+  curl -s -H "Authorization: Bearer $OPEN_CONNECTOR_TOKEN" "$GATEWAY/v1/actions/dropbox.$a" \
+    | python3 -c 'import json,sys;print(json.dumps(json.load(sys.stdin)["data"]["inputSchema"],indent=2))' \
+    > /tmp/dropbox-probe/input-schema-$a.json
+done
+diff crates/.../contracts/list_folder.json crates/.../contracts/list_folder_continue.json  # now a FACT either way
+
+# 2. Re-pin from the captures. The sync test prints `pinned X, actual Y`.
+cargo test -p skardi --lib packs::dropbox::tests::pinned_fingerprints_match_the_captured_contracts
+# paste each `actual` into dropbox.yaml: 3 table `fingerprint:` + 2 `continuation.fingerprint:`
+```
+
+Then restart the server and scan. The per-column non-NULL sweep is the
+whole point of this step — run each of these through `q '<sql>'`:
+
+```sql
+-- files
+SELECT count(*) AS rows,
+       count(tag) t, count(name) n, count(id) i, count(path_display) pd, count(path_lower) pl,
+       count(client_modified) cm, count(server_modified) sm, count(rev) r, count(size_bytes) sz,
+       count(is_downloadable) dl, count(content_hash) ch, count(sharing_info) si
+FROM saas.me.files;
+
+-- shared_links
+SELECT count(*) AS rows,
+       count(tag) t, count(name) n, count(url) u, count(id) i, count(path_display) pd,
+       count(path_lower) pl, count(expires_at) ea, count(client_modified) cm,
+       count(server_modified) sm, count(rev) r, count(size_bytes) sz, count(is_downloadable) dl,
+       count(content_hash) ch, count(sharing_info) si, count(link_permissions) lp
+FROM saas.me.shared_links;
+
+-- file_search
+SELECT count(*) AS rows,
+       count(match_type) mt, count(tag) t, count(name) n, count(id) i, count(path_display) pd,
+       count(path_lower) pl, count(client_modified) cm, count(server_modified) sm, count(rev) r,
+       count(size_bytes) sz, count(is_downloadable) dl, count(content_hash) ch, count(sharing_info) si
+FROM saas.search.file_search;
+```
+
+Any zero is a finding: either the wire spells the field differently (map
+the real spelling) or the field does not exist on that object type (drop
+the column). "The contract declared it" is not a defence — the Notion
+pack shipped `archived` against a wire that says `is_archived`.
+
+Beyond counts, check values, not just non-NULLness:
+
+```sql
+-- recursive:true actually recurses, and timestamps parsed from ISO 8601
+SELECT path_display, server_modified, size_bytes FROM saas.me.files
+WHERE path_display LIKE '%/%/%' ORDER BY server_modified DESC LIMIT 10;
+
+-- a folder nulls file metadata; an empty file is 0, not NULL
+SELECT tag, name, size_bytes, is_downloadable FROM saas.me.files ORDER BY tag, name;
+
+-- match_type carries both spellings if content indexing landed
+SELECT match_type, count(*) FROM saas.search.file_search GROUP BY match_type;
+
+-- LIMIT stops the scan early
+SELECT name FROM saas.me.files LIMIT 1;
+```
+
+Confirm pagination really happened, from the server's own completion
+event rather than by inference:
+
+```bash
+grep 'Open Connector scan completed' server.log   # pages=2+ on the unlimited scans, pages=1 under LIMIT 1
+```
+
+## 7. Re-derive the fixtures as redacted live captures
+
+Replace all six row fixtures with real pages captured in §4, redacted:
+
+- synthetic ids from a deterministic counter so cross-references survive
+  (a shared link's `url` tail vs its row's `id`);
+- placeholder names/titles; keep Dropbox URL *shapes*
+  (`https://www.dropbox.com/scl/fi/<synthetic>/…`) with synthetic tails;
+- keep structural enums, `.tag` discriminators, booleans and timestamp
+  *spellings* verbatim;
+- **audit mechanically**: walk every string leaf against an allowlist
+  and eyeball whatever survives — real file names hide in
+  `path_display`, `path_lower` **and** URL slugs, three places for the
+  same leak;
+- **decode one level deeper**: `sharing_info` and `link_permissions` are
+  mapped as JSON text — their leaves need the same allowlist;
+- ship the audit as an in-repo tripwire test so CI enforces it;
+- `files_type_mismatch.json` stays synthetic — it encodes a shape the
+  gateway cannot produce. Say so in a comment.
+
+If any real file name reaches a commit, rewriting the branch tip is not
+enough — rewrite the history so no reachable commit carries it.
+
+## 8. Land the evidence
+
+Files that must change as a result of this run:
+
+- `packs/dropbox.yaml` — five real fingerprints; `page_size` set to what
+  §4a proved at the boundary; Q1's real answer (with or without a
+  `continuation` block on `shared_links`); the `page_size`-only-bounds-
+  LIMIT-pushdown comment corrected (for a cursor table with no
+  `page_size_input`, `page_size` is inert — see `PaginationStrategy::Cursor`).
+- `packs/dropbox.rs` — module doc: "verified live" claims either
+  substantiated with the date and gateway version or removed; the
+  `metadata`-nullability answer from §4d; a live-verification banner in
+  the same shape as `docs/open-connector-feishu.md`'s.
+- `fixtures/dropbox/contracts/*.json` and `fixtures/dropbox/*.json` — as
+  captured and redacted.
+- **`docs/open-connector-dropbox.md` — does not exist yet.** Step 4 of
+  the execution plan; model it on `docs/open-connector-feishu.md`
+  (binding YAML, per-table reference, continuation mechanics, the two
+  scopes, rate limits, a live-verified banner).
+- `docs/open-connector.md` — add Dropbox to the supported-packs
+  paragraph, and document the new `pagination.continuation` block in the
+  pagination section; it is a YAML-authored engine feature that no
+  user-facing doc mentions.
+- `docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md`
+  — the 5.5 entry, ticked only now.
+- `docs/superpowers/specs/2026-08-16-dropbox-source-pack-design.md` —
+  status is still "no implementation started"; close out steps 2 and 5
+  and answer the open questions.
+- PR #216 — replace the design-only body with per-table live evidence
+  (row counts, which columns carried real values, which pins returned
+  rows, pages observed) and flip it out of Draft.
+- Any gateway defect found here gets **filed** on oomol-lab/open-connector
+  and linked from the pack doc. Findings that live only in a PR body get
+  lost.
+
+Then the phase-5 gate: `cargo fmt --all`, `cargo clippy --workspace
+--all-targets`, and the **full** `cargo test -p skardi --lib` (the
+engine change ripples past the pack filter), with test counts in the
+docs re-derived from a fresh run.
+
+Baseline measured on this branch (2026-08-18, after the self-review fix
+commit), so you can tell a regression from the inherited state:
+
+- `cargo fmt --all -- --check` — clean.
+- `cargo test -p skardi --lib` — **965 passed, 0 failed**, 202 ignored;
+  `…--lib sources::providers::open_connector` 324; `…--lib packs::dropbox` 25.
+- `cargo clippy -p skardi --all-targets` — **5 errors, none in this
+  diff**: `sources/providers/mongo/mod.rs:1329,1349`,
+  `sources/providers/sqlx/pg/postgres.rs:1521`,
+  `jobs/destination/mod.rs:228`. Pre-existing; the pack's own files are
+  clippy-clean. Don't let them mask a new one.
+
+## 9. Teardown
+
+```bash
+pkill -f skardi-server; pkill -f 'open-connector'
+cargo clean                      # reclaims ~3.5 GB on this 29 GB box
+rm -rf /tmp/dropbox-probe        # raw, UNREDACTED captures live here
+git checkout crates/skardi/src/sources/providers/open_connector/packs/dropbox.yaml  # if §5's page_size edit survived
+```
+
+Revoke the Dropbox app's access token from the account's connected-apps
+page, and rotate the app secret if it was ever pasted anywhere but your
+own shell.

--- a/docs/superpowers/plans/2026-08-18-dropbox-live-evaluation.md
+++ b/docs/superpowers/plans/2026-08-18-dropbox-live-evaluation.md
@@ -9,7 +9,7 @@
 >
 > The authoritative outcome record is the provenance banner in
 > `crates/skardi/src/sources/providers/open_connector/packs/dropbox.rs`
-> and the 5.7 entry in
+> and the 5.10 entry in
 > `specs/2026-07-11-open-connector-integration-tasks.md`. This document is
 > kept as the **method** — what was probed and how — so the next pack's
 > live pass can copy it.
@@ -452,7 +452,7 @@ Files that must change as a result of this run:
   pagination section; it is a YAML-authored engine feature that no
   user-facing doc mentions.
 - `docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md`
-  — the 5.7 entry, ticked only now.
+  — the 5.10 entry, ticked only now.
 - `docs/superpowers/specs/2026-08-16-dropbox-source-pack-design.md` —
   status is still "no implementation started"; close out steps 2 and 5
   and answer the open questions.

--- a/docs/superpowers/plans/2026-08-18-dropbox-live-evaluation.md
+++ b/docs/superpowers/plans/2026-08-18-dropbox-live-evaluation.md
@@ -50,11 +50,15 @@ refused `settings_error/not_authorized`), and
 `file_search.match_type = 'content'` needs Dropbox content indexing,
 which never landed during the pass.
 
-One gateway defect was found and filed rather than worked around:
-`GET /v1/actions/<id>` omits the `execution` block at commit `a3efa99`,
-so Skardi's default-deny action registry refuses every action from
-*every* pack — reproduced with the merged `github` pack, so not this
-pack's bug. Filed as oomol-lab/open-connector#358.
+One gateway defect was found and filed rather than worked around, and
+turned out to be already fixed upstream: `GET /v1/actions/<id>` omits
+the `execution` block at the checkout this pass used (`a3efa99`,
+2026-07-07), so Skardi's default-deny action registry refuses every
+action from *every* pack on that checkout — reproduced with the merged
+`github` pack, so not this pack's bug. Filed as
+oomol-lab/open-connector#358, closed as completed: upstream `1607633`
+(#149, 2026-07-19) had already added the block, so a gateway at or after
+that commit has no such defect.
 
 ## 1. Prerequisites
 

--- a/docs/superpowers/plans/2026-08-18-dropbox-live-evaluation.md
+++ b/docs/superpowers/plans/2026-08-18-dropbox-live-evaluation.md
@@ -324,28 +324,41 @@ q() { curl -s -X POST http://localhost:8087/query -H 'content-type: application/
 (If your ctx enables auth, `POST /query` needs a session header; the
 simplest evaluation ctx leaves auth off.)
 
-**Registration will fail first, and that is the expected first result.**
-The pins on this branch are placeholders, so you should see
+**Registration should PASS, and on the 2026-08-18 pass it did — first
+try, no re-pinning.** Every `fingerprint:` in `dropbox.yaml` is a hash of
+a live capture committed under `fixtures/dropbox/contracts/`, so the
+contract gate is satisfied by a gateway serving today's Dropbox executors.
+An earlier draft of this runbook told you to expect
 `action 'dropbox.list_folder' fingerprint mismatch (expected 87502bce…,
-discovered <hash>)`. That is the fingerprint gate doing its job. Fix it
-properly rather than by pasting the discovered hash blind:
+discovered <hash>)` from placeholder pins; that instruction is obsolete
+and the pins are no longer placeholders. If you *do* see a mismatch it is
+a finding, not a step: either the gateway is on a different executor
+release than commit `a3efa99`, or Dropbox's schema moved.
+
+The re-pin loop below is therefore the remediation path for that finding,
+and the recipe the next pack's live pass should copy — not something this
+pack still needs run:
 
 ```bash
 # 1. Capture the five contracts independently — do NOT copy an opener's file
-#    onto its continuation, which is how the current fixtures got identical.
+#    onto its continuation. (The two pairs came back byte-identical here;
+#    that is a fact about the wire, confirmed by capturing them separately.)
 for a in list_folder list_folder_continue list_shared_links search_files search_files_continue; do
   curl -s -H "Authorization: Bearer $OPEN_CONNECTOR_TOKEN" "$GATEWAY/v1/actions/dropbox.$a" \
     | python3 -c 'import json,sys;print(json.dumps(json.load(sys.stdin)["data"]["outputSchema"],indent=2))' \
     > crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/contracts/$a.json
-  # keep the INPUT schema too — it is what proves `inputs: cursor_only`
+done
+# The two continue actions' INPUT schemas are what prove `inputs: cursor_only`,
+# so they are committed too — next to the output captures, not in /tmp.
+for a in list_folder_continue search_files_continue; do
   curl -s -H "Authorization: Bearer $OPEN_CONNECTOR_TOKEN" "$GATEWAY/v1/actions/dropbox.$a" \
     | python3 -c 'import json,sys;print(json.dumps(json.load(sys.stdin)["data"]["inputSchema"],indent=2))' \
-    > /tmp/dropbox-probe/input-schema-$a.json
+    > crates/skardi/src/sources/providers/open_connector/packs/fixtures/dropbox/contracts/$a.input.json
 done
-diff crates/.../contracts/list_folder.json crates/.../contracts/list_folder_continue.json  # now a FACT either way
+diff crates/.../contracts/list_folder.json crates/.../contracts/list_folder_continue.json  # a FACT either way
 
 # 2. Re-pin from the captures. The sync test prints `pinned X, actual Y`.
-cargo test -p skardi --lib packs::dropbox::tests::pinned_fingerprints_match_the_captured_contracts
+cargo test -p skardi --lib packs::dropbox::tests::pinned_fingerprints_match_the_committed_contracts
 # paste each `actual` into dropbox.yaml: 3 table `fingerprint:` + 2 `continuation.fingerprint:`
 ```
 

--- a/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
+++ b/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
@@ -732,12 +732,16 @@ event carrying the scan identity and error.
       `file_search.match_type = 'content'` (content indexing did not land).
       Row fixtures remain authored shapes rather than redacted captures,
       because the verified account holds personal files.
-      **Gateway prerequisite, filed upstream, not worked around:** at commit
-      `a3efa99` the gateway's `GET /v1/actions/<id>` omits the `execution`
-      block, so Skardi's default-deny action registry refuses every action
-      from EVERY pack (reproduced with the merged `github` pack). Filed as
-      oomol-lab/open-connector#358. Skardi's gate is correct and was
-      deliberately left untouched — no compatibility fallback was added.
+      **Gateway defect, filed upstream, not worked around — resolved:** at
+      the checkout the pass used (`a3efa99`, 2026-07-07) the gateway's
+      `GET /v1/actions/<id>` omits the `execution` block, so Skardi's
+      default-deny action registry refuses every action from EVERY pack on
+      that checkout (reproduced with the merged `github` pack). Filed as
+      oomol-lab/open-connector#358, closed as completed — upstream `1607633`
+      (#149, 2026-07-19) already serialized the block, so no prerequisite
+      exists on a gateway at or after that commit. Skardi's gate is correct
+      and was deliberately left untouched — no compatibility fallback was
+      added.
       Engine extension (backward-compatible, opt-in, `None` for every
       pre-existing pack): `pagination.continuation` — pages 2..N may target a
       DIFFERENT action (`list_folder` → `list_folder_continue`) and, with

--- a/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
+++ b/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
@@ -699,19 +699,45 @@ event carrying the scan identity and error.
       the fixtures (native Docs DO report `sizeBytes`; every grant
       carries `permissionDetails`; shared-drive rows drop exactly
       `owners`+`shared`).
-- [ ] 5.10 Dropbox pack (OAuth, cursor pagination with SPLIT-ACTION
+- [x] 5.10 Dropbox pack (OAuth, cursor pagination with SPLIT-ACTION
       continuation, normalized wire shape — `mapDropboxMetadata` rebuilds
       every row into a strict fully-`required` camelCase object): files,
       shared_links, file_search.
-      **NOT live-verified — deliberately left unticked.** Reconciled against
-      the v1.3.5 provider SOURCE only; the authoring box has no Node runtime
-      and no Dropbox account was available, so contract capture and live
-      verification are recorded as blocked in the design spec. Every
-      committed fingerprint hashes a source-derived schema and will fail the
-      contract gate against a real gateway until re-captured; the row
-      fixtures are authored shapes, not redacted captures; the declared page
-      sizes (2000 / 1000) are unprobed at the boundary. Runbook to close it
-      out: `docs/superpowers/plans/2026-08-18-dropbox-live-evaluation.md`.
+      **Live-verified 2026-08-18** against a self-hosted gateway at commit
+      `a3efa99` and a real free-tier Dropbox account, per the runbook
+      `docs/superpowers/plans/2026-08-18-dropbox-live-evaluation.md`. All five
+      actions discovered; all five committed fingerprints matched LIVE
+      discovery unchanged, so registration passed the contract gate with no
+      re-pinning (the source-derived captures turned out byte-identical to the
+      live ones, and the opener/continuation schema identity is a fact about
+      the wire). Page sizes probed at the boundary: 2000 and 1000 return rows,
+      2001 and 1001 are refused. Termination confirmed as designed — the final
+      `list_folder` page carries `hasMore: false` beside a NON-empty
+      259-character cursor, so `has_more_path` is load-bearing. Real
+      multi-page pagination through `list_folder_continue` (`pages=2
+      rows=378`), and `LIMIT` collapsed the same scan to `pages=1 rows=1`.
+      Both design-spec open questions answered on the wire: `{path, cursor}`
+      together IS accepted by `list_shared_links` (no `cursor_only` needed),
+      and `matches[].metadata` can never be null (the executor always returns
+      a full object), so `file_search.tag`/`name` stay non-nullable.
+      **What the live pass changed:** `shared_links` lost four columns —
+      `path_display`, `is_downloadable`, `content_hash`, `sharing_info` —
+      which `sharing/list_shared_links` has no field for and which measured
+      0/5 non-NULL; a file whose `files` row carries all four returns all four
+      NULL on its own `shared_links` row. 15 → 11 columns, pinned by a
+      negative-space test. Per-column coverage after the trim: 12/12 on
+      `files` (378 rows), 11/11 on `shared_links` bar the labelled
+      `expires_at`, 13/13 on `file_search`. Two claims left UNOBSERVED, both
+      environmental: `shared_links.expires_at` (paid-tier link expiry) and
+      `file_search.match_type = 'content'` (content indexing did not land).
+      Row fixtures remain authored shapes rather than redacted captures,
+      because the verified account holds personal files.
+      **Gateway prerequisite, filed upstream, not worked around:** at commit
+      `a3efa99` the gateway's `GET /v1/actions/<id>` omits the `execution`
+      block, so Skardi's default-deny action registry refuses every action
+      from EVERY pack (reproduced with the merged `github` pack). Filed as
+      oomol-lab/open-connector#358. Skardi's gate is correct and was
+      deliberately left untouched — no compatibility fallback was added.
       Engine extension (backward-compatible, opt-in, `None` for every
       pre-existing pack): `pagination.continuation` — pages 2..N may target a
       DIFFERENT action (`list_folder` → `list_folder_continue`) and, with
@@ -722,7 +748,12 @@ event carrying the scan identity and error.
       (cursor declared, nothing else `required`, no-input-schema refused).
       Because the rows are normalized and strictly declared, every mapped
       column sits inside the fingerprint gate and the coverage-gap pin is
-      empty — the opposite of the passthrough packs. Verification: 965
+      empty. That is narrower than it sounds, and the live pass proved it:
+      all five list actions publish the SAME normalized 15-key schema, so a
+      fingerprint match says nothing about whether a key is populated for a
+      given action — which is exactly how the four `shared_links` columns
+      passed every contract-level check while being structurally always-NULL.
+      Real rows remain the only column truth here too. Verification: 965
       full library suite, 324 open_connector (`cargo test -p skardi --lib
       sources::providers::open_connector`), 25 pack-scoped (`… --lib
       packs::dropbox`).

--- a/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
+++ b/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
@@ -743,9 +743,21 @@ event carrying the scan identity and error.
       DIFFERENT action (`list_folder` → `list_folder_continue`) and, with
       `inputs: cursor_only`, carry the cursor and nothing else. Both actions
       are discovered and fingerprint-gated at both gate call sites; because a
-      fingerprint hashes the OUTPUT schema, `cursor_only` is additionally
-      checked against the continuation action's discovered INPUT schema
-      (cursor declared, nothing else `required`, no-input-schema refused).
+      fingerprint hashes the OUTPUT schema, the INPUT side is checked
+      separately against the continuation action's discovered input schema,
+      in BOTH directions of `inputs:` — `cursor_only` (cursor declared,
+      nothing else `required`) and `full` when it targets a different action
+      (the table's guaranteed keys satisfy `required`; under
+      `additionalProperties: false` every key it can send is declared).
+      A missing input schema is refused, as is a `required` that is present
+      but not an array of strings. Three loader-side authoring refusals
+      beyond the parse-level ones: a continuation pinned while the table's
+      own action is not; a same-action continuation pinning a DIFFERENT
+      fingerprint (unsatisfiable — one action, one contract); and
+      `cursor_only` paired with an `Exact`-fidelity filter, which would
+      apply the predicate on page one, drop it on pages 2..N, and have no
+      `Filter` node left to re-apply it — silently returning rows the query
+      excluded.
       Because the rows are normalized and strictly declared, every mapped
       column sits inside the fingerprint gate and the coverage-gap pin is
       empty. That is narrower than it sounds, and the live pass proved it:
@@ -767,14 +779,13 @@ bounded safety defaults, null/empty/nested fixtures, docs.
 ## Review notes
 
 - **Current PR**: milestone 5.10 (Dropbox pack + `pagination.continuation`)
-  — open as #216, **not live-verified**; see the entry above.
+  — open as #216, live-verified 2026-08-18; see the entry above.
   Milestones 1–4 and 5.1–5.9 (GitHub, Slack, Notion, Feishu, Gmail,
   Discord, Outlook, OneDrive, Google Drive packs) are merged; this PR adds
-  the Dropbox pack against Open Connector's normalized Dropbox contract
-  (reconciled against the v1.3.5 provider source only), plus the one engine
-  extension it required: `pagination.continuation`, which lets pages 2..N
-  target a different action and, with `inputs: cursor_only`, carry the
-  cursor alone.
+  the Dropbox pack against Open Connector's normalized Dropbox contract,
+  plus the one engine extension it required: `pagination.continuation`,
+  which lets pages 2..N target a different action and, with
+  `inputs: cursor_only`, carry the cursor alone.
 - **Invariants to hold in review**: no provider credentials in Skardi;
   read-only until explicitly designed otherwise; pure validation shared by
   CLI and server; no network I/O at query-planning time; no `.unwrap()` in

--- a/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
+++ b/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
@@ -699,6 +699,33 @@ event carrying the scan identity and error.
       the fixtures (native Docs DO report `sizeBytes`; every grant
       carries `permissionDetails`; shared-drive rows drop exactly
       `owners`+`shared`).
+- [ ] 5.10 Dropbox pack (OAuth, cursor pagination with SPLIT-ACTION
+      continuation, normalized wire shape — `mapDropboxMetadata` rebuilds
+      every row into a strict fully-`required` camelCase object): files,
+      shared_links, file_search.
+      **NOT live-verified — deliberately left unticked.** Reconciled against
+      the v1.3.5 provider SOURCE only; the authoring box has no Node runtime
+      and no Dropbox account was available, so contract capture and live
+      verification are recorded as blocked in the design spec. Every
+      committed fingerprint hashes a source-derived schema and will fail the
+      contract gate against a real gateway until re-captured; the row
+      fixtures are authored shapes, not redacted captures; the declared page
+      sizes (2000 / 1000) are unprobed at the boundary. Runbook to close it
+      out: `docs/superpowers/plans/2026-08-18-dropbox-live-evaluation.md`.
+      Engine extension (backward-compatible, opt-in, `None` for every
+      pre-existing pack): `pagination.continuation` — pages 2..N may target a
+      DIFFERENT action (`list_folder` → `list_folder_continue`) and, with
+      `inputs: cursor_only`, carry the cursor and nothing else. Both actions
+      are discovered and fingerprint-gated at both gate call sites; because a
+      fingerprint hashes the OUTPUT schema, `cursor_only` is additionally
+      checked against the continuation action's discovered INPUT schema
+      (cursor declared, nothing else `required`, no-input-schema refused).
+      Because the rows are normalized and strictly declared, every mapped
+      column sits inside the fingerprint gate and the coverage-gap pin is
+      empty — the opposite of the passthrough packs. Verification: 965
+      full library suite, 324 open_connector (`cargo test -p skardi --lib
+      sources::providers::open_connector`), 25 pack-scoped (`… --lib
+      packs::dropbox`).
 
 **Gate for each pack** (from the design spec): complete terminating pagination,
 deterministic schema, read-only allowlist, documented authz/rate limits,
@@ -708,26 +735,15 @@ bounded safety defaults, null/empty/nested fixtures, docs.
 
 ## Review notes
 
-- **Current PR**: milestone 5.9 (Google Drive pack — files, drives,
-  file_permissions; PR #226). Milestones 1–4 and 5.1–5.8 (GitHub, Slack,
-  Notion, Feishu, Gmail, Discord, Outlook, OneDrive packs) are merged;
-  this PR adds the second Google pack over normalized rows, with zero
-  engine changes — the pack-shaping decisions are the two-dot action IDs
-  (`googledrive.files.list`, verified engine-safe), the load-bearing
-  all-drives fixed-input pair on `files`, and the five knowingly
-  outside-the-gate `restrictions.*` columns on `drives`. Live
-  verification (phase 4) ran 2026-08-25 against a real Workspace
-  account and closed both load-bearing items: design record R1
-  resolved in its favor (zero shared drives at first, then the account
-  proved able to CREATE one, so `drives` was verified on real rows and
-  all five restriction spellings came back verbatim), and the pinned
-  all-drives pair really surfaced a shared-drive file through a live
-  scan. Its pack-changing findings were all fixture-level corrections
-  (native Docs DO report `sizeBytes`; every grant carries
-  `permissionDetails`; shared-drive rows drop exactly
-  `owners`+`shared`), plus three columns recorded as structural
-  residuals (`drives.org_unit_id`, `drives.theme_id`,
-  `file_permissions.expiration_time`).
+- **Current PR**: milestone 5.10 (Dropbox pack + `pagination.continuation`)
+  — open as #216, **not live-verified**; see the entry above.
+  Milestones 1–4 and 5.1–5.9 (GitHub, Slack, Notion, Feishu, Gmail,
+  Discord, Outlook, OneDrive, Google Drive packs) are merged; this PR adds
+  the Dropbox pack against Open Connector's normalized Dropbox contract
+  (reconciled against the v1.3.5 provider source only), plus the one engine
+  extension it required: `pagination.continuation`, which lets pages 2..N
+  target a different action and, with `inputs: cursor_only`, carry the
+  cursor alone.
 - **Invariants to hold in review**: no provider credentials in Skardi;
   read-only until explicitly designed otherwise; pure validation shared by
   CLI and server; no network I/O at query-planning time; no `.unwrap()` in

--- a/docs/superpowers/specs/2026-08-16-dropbox-source-pack-design.md
+++ b/docs/superpowers/specs/2026-08-16-dropbox-source-pack-design.md
@@ -1,10 +1,16 @@
 # Dropbox Source Pack (milestone 5.5)
 
-**Status:** Draft for review — no implementation started
-**Date:** 2026-08-16
+**Status:** Steps 1, 3, 4 landed (engine extension, pack, docs). Steps 2
+(contract capture) and 5 (live verification) remain BLOCKED on a Node
+runtime and a Dropbox account — so every fingerprint in the shipped pack
+is source-derived and will fail the contract gate against a real gateway
+until re-pinned. Runbook for the blocked steps:
+[2026-08-18-dropbox-live-evaluation.md](../plans/2026-08-18-dropbox-live-evaluation.md).
+**Date:** 2026-08-16 (status updated 2026-08-18)
 **Branch:** `feature/open-connector-dropbox-pack`
 **Gateway reconciled against:** oomol-lab/open-connector **v1.3.5** (source
-read; live probe still outstanding — see [Open questions](#open-questions))
+read; live probe still outstanding — see [Open questions](#open-questions)
+and the [live-evaluation runbook](../plans/2026-08-18-dropbox-live-evaluation.md))
 
 ## Summary
 
@@ -329,7 +335,10 @@ the docs, and a `/code-review` pass on the diff.
 
 ## Open questions
 
-1. **`list_shared_links` with both `path` and `cursor`.** The executor
+1. **`list_shared_links` with both `path` and `cursor`.** STILL OPEN. The
+   shipped pack declares no `continuation` for this table, i.e. it ships
+   the inference that the combination is accepted; the yaml and module doc
+   label it as an inference rather than an observation. The executor
    `compactObject`s them together, but Dropbox may reject the combination.
    If it does, this table needs `continuation: {inputs: cursor_only}` as
    well — which the proposed design already spells without a code change.
@@ -337,11 +346,18 @@ the docs, and a `/code-review` pass on the diff.
 2. **`list_folder` cursor lifetime.** Dropbox cursors can expire or be
    invalidated mid-listing; a long recursive scan may hit it. Behavior and
    whether it warrants a documented bound is a phase-4 observation.
-3. **Whether `recursive: true` is the right pin** — the alternative is
+3. **Can `matches[].metadata` be null?** NEW, found in self-review. The
+   derived contract declares it a required non-nullable object, and
+   `file_search` maps `tag`/`name` as `nullable: false` on that basis — so
+   a real null-metadata match would fail the scan rather than yield NULLs.
+   `file_search_null_parent.json` is labelled synthetic and pins the
+   converter's behavior if it ever happens. If the wire can null it, those
+   two columns become nullable and the fixture graduates to a capture.
+4. **Whether `recursive: true` is the right pin** — the alternative is
    pinning it off and making the subtree the user's choice via a second
    table. Flagging because it is the single most consequential contract
    decision in this pack.
-4. **Engine-extension appetite.** If `pagination.continuation` is not
+5. **Engine-extension appetite.** If `pagination.continuation` is not
    wanted in this milestone, the honest fallback is a one-table pack
    (`shared_links`) with `files` and `file_search` deferred as
    gate-failing — worse, but not misleading.

--- a/docs/superpowers/specs/2026-08-16-dropbox-source-pack-design.md
+++ b/docs/superpowers/specs/2026-08-16-dropbox-source-pack-design.md
@@ -511,8 +511,9 @@ real multi-page pagination ran through `list_folder_continue`, and the
 pass DROPPED four `shared_links` columns it found could never populate.
 Two claims stayed unobserved rather than confirmed
 (`shared_links.expires_at`, `file_search.match_type = 'content'`), and
-one gateway defect was filed upstream
-(oomol-lab/open-connector#358). What the step called for, as executed: a
+one gateway defect was filed upstream (oomol-lab/open-connector#358,
+since closed as completed — the `a3efa99` checkout predated the fix in
+upstream `1607633`). What the step called for, as executed: a
 free Dropbox
 account with an OAuth app carrying `files.metadata.read` +
 `sharing.read`, configured in the gateway (`PUT /api/connections/dropbox`

--- a/docs/superpowers/specs/2026-08-16-dropbox-source-pack-design.md
+++ b/docs/superpowers/specs/2026-08-16-dropbox-source-pack-design.md
@@ -1,4 +1,4 @@
-# Dropbox Source Pack (milestone 5.5)
+# Dropbox Source Pack (milestone 5.7)
 
 **Status:** ALL SIX STEPS LANDED. Steps 1, 3, 4 (engine extension, pack,
 docs) shipped first; steps 2 and 5 (contract capture, live verification)

--- a/docs/superpowers/specs/2026-08-16-dropbox-source-pack-design.md
+++ b/docs/superpowers/specs/2026-08-16-dropbox-source-pack-design.md
@@ -1,4 +1,4 @@
-# Dropbox Source Pack (milestone 5.7)
+# Dropbox Source Pack (milestone 5.10)
 
 **Status:** ALL SIX STEPS LANDED. Steps 1, 3, 4 (engine extension, pack,
 docs) shipped first; steps 2 and 5 (contract capture, live verification)

--- a/docs/superpowers/specs/2026-08-16-dropbox-source-pack-design.md
+++ b/docs/superpowers/specs/2026-08-16-dropbox-source-pack-design.md
@@ -356,3 +356,168 @@ the docs, and a `/code-review` pass on the diff.
 - `docs/open-connector-dropbox.md`, the 5.5 entry in
   `2026-07-11-open-connector-integration-tasks.md`, and the supported-pack
   list in `docs/open-connector.md`.
+
+## Execution plan
+
+### Standing assumptions (each overridable before its step lands)
+
+- **A1** — the `pagination.continuation` engine extension is approved
+  (open question 4). Fallback: ship `shared_links` only, steps 1 and the
+  affected step-3 tables drop out.
+- **A2** — `recursive: true` stays pinned on `dropbox.files` (open
+  question 3).
+- **A3** — the tasks-spec entry is numbered 5.5 with an explicit
+  *off-roadmap, user-requested* note (Dropbox is not in the design's
+  rollout plan; no storage provider is), and the catch-all "later waves"
+  bucket renumbers to 5.6 — the same move Feishu's PR made when it took
+  5.4.
+- Build constraints on this box: serial cargo only, verify with
+  `cargo test -p skardi --lib`.
+
+### Step 1 — Engine: cursor continuation (commit 1)
+
+The design's three touch points, resolved to concrete code after reading
+the registration path. The split of responsibilities: **the table owns
+the contract** (continuation action ID + fingerprint), **the strategy
+owns nothing new** — exec already holds both the table and the paginator,
+so the strategy stays `Copy` and untouched except for one method.
+
+1. `table.rs` — `SourcePackTable` gains
+   `continuation: Option<ContinuationDecl>` with
+   `{ action: &'static str, fingerprint: &'static str, cursor_only: bool }`.
+   Action and fingerprint are non-optional inside the decl: the
+   same-action-cursor-only case (`shared_links`, if Q1 answers badly)
+   spells its own action ID explicitly rather than leaving a hole the
+   gate could fall through.
+2. `pagination.rs` — one new method,
+   `Pagination::apply_cursor_only(&mut Map)`, inserting only
+   `{cursor_param: token}` (no page-size input). `apply` and all
+   termination/loop/has-more logic untouched. Unit tests: page 1 has no
+   token to apply; page 2+ body is exactly the one pair.
+3. `exec.rs` — `ScanTarget` carries the continuation decl (as
+   `Option<Arc<...>>` fields, populated in `ScanTarget::from` the table);
+   `next_page` branches when `pagination.page() > 1` and a decl exists:
+   action ID = continuation action; `cursor_only` → start from an empty
+   map + `apply_cursor_only` instead of the resource/fixed/filter
+   assembly.
+4. `packs/loader.rs` — parse `continuation:` under the cursor strategy
+   only (`deny_unknown_fields`; `inputs: cursor_only | full`), validate
+   fingerprint shape, emit `SourcePackAssetInvalid` diagnostics for each
+   malformed spelling.
+5. Registration gating, **both call sites**: `mod.rs` pushes the
+   continuation action into `action_ids` (the `ActionRegistry::load`
+   input, mod.rs:184) and extends the fingerprint gate (mod.rs:229) to
+   check it, with the mismatch reason naming *which* action drifted;
+   `table_functions.rs:216` (the UDTF path) gets the same second check —
+   missing it would let a drifted continue action through
+   `open_connector_query` while bindings refuse it.
+
+Engine-level tests: loader diagnostics per malformed spelling;
+`apply_cursor_only` unit tests; an exec e2e through `MockGateway`
+asserting page 2 hits `/v1/actions/<continue-action>` with a body that is
+**exactly** `{"cursor": …}` (parsed structurally, not substring-matched);
+drift-refusal e2e where only the continue action's schema drifts; the
+UDTF-path equivalent.
+
+**Gate:** full `cargo test -p skardi --lib` green before any pack work —
+this step touches the engine every pack rides on.
+
+### Step 2 — Contract capture (blocked: needs Node)
+
+Prerequisite: a Node runtime (none installed — `node`/`npm` absent).
+Then, from the open-connector v1.3.5 checkout: start the gateway, capture
+`data.outputSchema` for all five actions (`list_folder`,
+`list_folder_continue`, `list_shared_links`, `search_files`,
+`search_files_continue`) into `packs/fixtures/dropbox/contracts/`,
+calibrate the no-credential discrimination once (one known-bad key → 400
+`invalid_input`; one known-good input → 403 credential wall), then drive
+every table's exact generated input set to the credential wall. Record
+the gateway version in the module doc.
+
+Step 3 does not block on this: the fingerprint sync test prints actual
+hashes on mismatch — the documented way to obtain pins — so pack
+authoring proceeds with placeholder pins and this step turns them real.
+
+### Step 3 — Pack (commit 2)
+
+`packs/dropbox.yaml` per the Tables section above; `packs/dropbox.rs`
+(OnceLock accessor, module doc carrying every design decision and its
+why, test suite); `mod` line in `packs/mod.rs`; builtins entry in
+`source_pack.rs`. Fixtures: six admission-gate categories × 3 tables,
+authored from the executor-derived shapes now, re-derived as redacted
+live captures in step 5.
+
+Test inventory (calibrated to the Feishu pack's density):
+
+- fingerprint sync across all five contracts; coverage-gap pin asserting
+  the **empty** set per table (non-empty is a finding, per the design);
+- drift refusal per table plus the continuation-action drift case;
+- multi-page scan per table with per-table wire pins (row path + input
+  keys — shared strategy constants don't share coverage);
+- termination: `hasMore: false` with a **non-empty** cursor (the
+  `list_folder` reality this pack exists to handle), null/absent cursor
+  for the `?? null` tables; `PaginationHasMoreInvalid`,
+  `PaginationCursorInvalid`, `PaginationLoop` at pack level;
+- LIMIT early-stop; empty collection;
+- fixed-input pins asserted on every request body (`recursive`,
+  `includeMountedFolders`, `includeDeleted` on files; `fileStatus` on
+  search);
+- required-resource (`query`) failing before any HTTP; resource
+  forwarding for `path`/`directOnly`;
+- negative-space guards: no filter key ever on the wire (all three
+  tables), `includeHighlights` never sent, `url`/`expires_at`/
+  `link_permissions` absent from the `files` schema;
+- gateway-failure surfacing (a Dropbox error code through the failure
+  envelope, `error_path: None`);
+- schema-mismatch fixture per table asserting full error identity
+  (column, path, page, row, expected, found-kind);
+- UDTF parity for `files`.
+
+### Step 4 — Docs (commit 3)
+
+`docs/open-connector-dropbox.md` modeled on the Slack/Feishu docs
+(binding YAML, per-table reference, behavior bullets including the
+continuation mechanics, authz = two read scopes, rate limits); the 5.5
+tasks-spec entry per A3 — left unticked until step 5 passes, since the
+entry's verification blurb must state live status honestly; the
+supported-packs paragraph in `docs/open-connector.md`.
+
+### Step 5 — Live verification (blocked: needs Node + a Dropbox account)
+
+Needs from the user: the Node runtime (step 2's) and a free Dropbox
+account with an OAuth app carrying `files.metadata.read` +
+`sharing.read`, configured in the gateway (`PUT /api/connections/dropbox`
+— user-held; I never touch the credential). Then, per table: probe at the
+pack's exact inputs and declared bounds; diff real row keys against
+mapped columns both directions; force real multi-page pagination with a
+small `limit`; confirm every mapped column extracts a non-NULL value
+somewhere; confirm termination on the real final page; scan end to end
+through skardi-server against LIVE discovery. This step also answers Q1
+(`path` + `cursor` together on `list_shared_links`), Q2 (cursor
+lifetime), and the `orderBy` stability note; fixtures re-derived as
+redacted captures; any wire-vs-declared contradiction recorded with the
+pinned provider API version.
+
+### Step 6 — Self-review and submission
+
+Work through `references/review-checklist.md` against the actual diff;
+`cargo fmt` + `cargo clippy` clean; full `cargo test -p skardi --lib`;
+test counts via the documented commands
+(`cargo test -p skardi --lib sources::providers::open_connector` and the
+`packs::dropbox` filter) matched everywhere they're stated; `/code-review`
+on the diff with every finding fixed or rebutted with evidence. Then
+update PR #216's body with the verification section and per-table live
+evidence, and flip it from Draft — after step 5 has run, not before.
+
+### Sequencing
+
+Three commits on this branch, one PR (#216), per the 5.1/5.2 precedent of
+engine extensions shipping inside the pack PR that needs them:
+
+1. `feat(sources): cursor continuation pagination — split-action page 2+`
+2. `feat(sources): Dropbox source pack — files, shared_links, file_search`
+3. `docs(sources): Dropbox pack docs + milestone 5.5 entry`
+
+Steps 1, 3, 4 are executable now, in order, with placeholder pins.
+Steps 2 and 5 are blocked on the two user-provided prerequisites; the
+PR stays Draft until step 5 completes.

--- a/docs/superpowers/specs/2026-08-16-dropbox-source-pack-design.md
+++ b/docs/superpowers/specs/2026-08-16-dropbox-source-pack-design.md
@@ -1,0 +1,358 @@
+# Dropbox Source Pack (milestone 5.5)
+
+**Status:** Draft for review — no implementation started
+**Date:** 2026-08-16
+**Branch:** `feature/open-connector-dropbox-pack`
+**Gateway reconciled against:** oomol-lab/open-connector **v1.3.5** (source
+read; live probe still outstanding — see [Open questions](#open-questions))
+
+## Summary
+
+A Dropbox source pack exposing three read-only tables — `dropbox.files`,
+`dropbox.shared_links`, `dropbox.file_search` — over Open Connector's
+Dropbox provider, plus one backward-compatible **engine extension**
+(`pagination.continuation`) without which two of the three tables cannot
+pass the admission gate at all.
+
+The headline finding of phase-1 reconciliation: **Dropbox's list actions
+paginate through a *different action ID* than the one that starts the
+listing.** `dropbox.list_folder` begins a listing; pages 2..N come from
+`dropbox.list_folder_continue`, whose input schema accepts *only* a
+cursor. Skardi's scan engine issues every page against a single
+`action_id` and injects the cursor into the same input map, so today it
+cannot page Dropbox at all — and because `list_folder`'s input schema is
+`additionalProperties: false`, the attempt would be a hard HTTP 400 on
+page 2 rather than a quiet truncation.
+
+The second finding: `list_folder` returns a **non-empty cursor on the
+final page** (the executor's `requireString(payload.cursor)` makes the
+field mandatory). Cursor-spelling termination would refetch and fail as
+`PaginationLoop`. The engine already has the fix — `has_more_path`, added
+for Feishu's wiki spaces in 5.4 — so this one costs a declaration, not
+code.
+
+## Reconciliation evidence (phase 1)
+
+Read from the v1.3.5 checkout, which the skill designates the row-shape
+authority: `src/providers/dropbox/{actions,executors,definition,scopes}.ts`.
+
+### Rows are normalized, not passthrough
+
+Every list executor maps rows through `mapDropboxMetadata` (executors.ts
+:797), which rebuilds each entry into a **fixed camelCase shape** with
+every key present:
+
+```
+tag, name, id, pathDisplay, pathLower, clientModified, serverModified,
+rev, sizeBytes, isDownloadable, contentHash, url, expiresAt,
+sharingInfo, linkPermissions
+```
+
+This is Slack-style normalization, and it matters: `dropboxMetadataSchema`
+is declared with `s.object` (→ `additionalProperties: false`, json-schema.ts
+:72) and lists all fifteen keys as `required`. So unlike GitHub/Notion/
+Feishu passthrough rows, **every mapped column here sits inside the
+fingerprint gate**. The coverage-gap pin should come back empty, and
+phase 4's column risk drops from "the declared contract is not column
+truth" to "which columns are structurally always-NULL for this action".
+
+Mapping Dropbox's raw snake_case (`path_display`, `client_modified`,
+`size`) would have produced all-NULL columns — the exact 5.2 failure mode.
+
+### Pagination, per action
+
+| Action | Continuation | Cursor on final page | Terminates on |
+|---|---|---|---|
+| `list_folder` | **separate action** `list_folder_continue` (cursor-only input) | non-empty (`requireString`) | `hasMore: false` only |
+| `search_files` | **separate action** `search_files_continue` (cursor-only input) | `?? null` | `hasMore: false`, cursor also nulls |
+| `list_shared_links` | same action, `cursor` input | `?? null` | `hasMore: false`, cursor also nulls |
+| `list_revisions` | none — manual `beforeRev` paging | n/a | `hasMore` with nothing to follow |
+
+`hasMore` is `readBoolean(payload.has_more) ?? false` in every one, so the
+signal is always a present boolean — safe to declare as authoritative.
+
+### Errors and rate limits
+
+`dropboxRpcRequest` (executors.ts:702) throws `normalizeDropboxHttpError`
+on any non-2xx, so Dropbox's in-band `error_summary` envelope and its
+`429` rate-limit responses both surface as **gateway failure envelopes**,
+never as HTTP 200 rows. Every table therefore declares `error_path: None`,
+matching the Slack/Notion/Feishu precedent, and an e2e test pins that a
+Dropbox error code surfaces through the gateway-failure path.
+
+### Auth and scopes
+
+OAuth2 only (definition.ts), `token_access_type: offline`. The pack needs
+exactly two of the six declared scopes:
+
+- `files.metadata.read` — `files`, `file_search`
+- `sharing.read` — `shared_links`
+
+No content scopes (`files.content.*`) and no write scopes are required by
+any shipped table. That is a documentable authz boundary: a connection
+scoped read-only still serves the whole pack.
+
+## Engine extension: `pagination.continuation`
+
+Required for `files` and `file_search`. Backward-compatible: absent →
+today's behavior, byte for byte.
+
+```yaml
+pagination:
+  strategy: cursor
+  cursor_input: cursor
+  next_cursor_path: "$.cursor"
+  page_size_input: limit
+  page_size: 2000
+  has_more_path: "$.hasMore"
+  continuation:                                  # NEW, optional
+    action: dropbox.list_folder_continue         # default: the table's own action
+    fingerprint: <blake3-hex>                    # required when `action` is set
+    inputs: cursor_only                          # cursor_only | full (default: full)
+```
+
+Semantics:
+
+- **Page 1** — unchanged: the table's `action`, with resources + fixed
+  inputs + pushed filters + page-size input.
+- **Pages 2..N** — issued against `continuation.action` (defaulting to the
+  table's own action). With `inputs: cursor_only` the request body is
+  *exactly* `{<cursor_input>: <token>}`: no resources, no fixed inputs, no
+  pushed filters, no page size. This is not a preference — the continue
+  actions' schemas are strict and declare `cursor` as their only property,
+  so anything else is a 400.
+- Loop detection, `max_pages`, the scan deadline, LIMIT pushdown and
+  `has_more_path` are untouched. `page_size` still doubles as the
+  limit-pushdown ceiling; Dropbox sizes continuation pages from the
+  original request, so the ceiling stays honest.
+
+Code shape (three touch points, all small):
+
+1. `PaginationStrategy::Cursor` gains `continuation: Option<Continuation>`;
+   `validate()` rejects `inputs: cursor_only` combined with a `PageNumber`
+   strategy and validates the action-ID spelling.
+2. `Pagination` exposes `continuation() -> Option<(&str action, &str
+   cursor_param, &str token)>` when past page 1; `exec.rs::next_page`
+   branches on it to choose the action ID and to build a cursor-only input
+   instead of the assembled map.
+3. Registration fingerprints **both** actions. A continue action serving
+   pages 2..N is exactly as exposed to contract drift as the first — gating
+   only the primary would leave most of a large scan unguarded — so
+   `continuation.fingerprint` is mandatory whenever `continuation.action`
+   is set, and a drift-refusal e2e covers it.
+
+The `inputs` knob is deliberately separate from `action` rather than
+implied by it: `list_shared_links` continues through the *same* action and
+may still need cursor-only bodies (see [Open questions](#open-questions)),
+and a future provider may continue through a separate action that wants
+its filters repeated.
+
+### Alternatives rejected
+
+- **Defer `files` and `file_search`, ship only `shared_links`.** Gate-clean
+  and zero engine risk, but a Dropbox pack that cannot list a folder is not
+  a Dropbox integration. Kept as the fallback if the extension is refused.
+- **Upstream: teach `dropbox.list_folder` to accept a `cursor`.** Precedent
+  exists (oomol-lab/open-connector#228 added `pageInfo.fetched` for the
+  GitHub pack), and it would erase the extension entirely. Rejected as the
+  *primary* path because it blocks this milestone on an upstream merge —
+  but worth filing as a follow-up regardless, since it would benefit every
+  Open Connector consumer. Note it does not fully subsume the extension:
+  `search_files_continue` has the same split shape.
+
+## Tables
+
+### `dropbox.files`
+
+| | |
+|---|---|
+| Action | `dropbox.list_folder` → `dropbox.list_folder_continue` |
+| Row path | `$.entries` |
+| Pagination | cursor, `has_more_path: $.hasMore`, `page_size: 2000` (schema max), `continuation` cursor-only |
+| Optional resource | `path` (folder to list; omitted → account root) |
+| Fixed inputs | `recursive: true`, `includeMountedFolders: true`, `includeDeleted: false` |
+| Filters | none pushed (see below) |
+
+Columns (12): `tag` (utf8, **not null**), `name` (utf8, **not null**),
+`id`, `path_display`, `path_lower`, `rev`, `content_hash` (utf8, nullable);
+`client_modified`, `server_modified` (`timestamp_ms_utc` — the executor
+emits ISO 8601 strings); `size_bytes` (int64); `is_downloadable`
+(boolean); `sharing_info` (json).
+
+Decisions to record in the module doc:
+
+- **`tag` and `name` are non-null** because the executor guarantees them
+  (`resolveDropboxMetadataTag` always returns a string; `name` is
+  `?? ""`). A null arriving there is drift and should fail the scan, not
+  produce a quiet NULL.
+- **`recursive: true` is pinned** — this is the `state=all` move from 5.1.
+  A SQL table named `files` that returns one directory level is a
+  surprising contract; pinned recursion makes `dropbox.files` mean "every
+  file under `path`". Cost: a scan of a large account is genuinely large,
+  bounded by `max_pages` and the scan deadline like every other pack.
+- **`includeMountedFolders: true` is pinned** for the same completeness
+  reason (Dropbox's own default, pinned so it cannot drift).
+- **`includeDeleted: false` is pinned** — deleted tombstones carry a
+  `deleted` tag and null everything else; admitting them would populate
+  the table with rows that fail no test and inform no query. Documented as
+  out of scope rather than silently defaulted.
+- **`url`, `expires_at`, `link_permissions` are deliberately omitted.**
+  They exist in `mapDropboxMetadata` but are sourced from
+  `record.url` / `record.expires` / `record.link_permissions`, which
+  `files/list_folder` never returns — mapping them would ship three
+  structurally always-NULL columns. Negative-space guard test pins their
+  absence from the schema.
+- **No pushed filters.** `list_folder`'s remaining inputs (`recursive`,
+  `includeDeleted`, `includeMountedFolders`, `limit`) are scan-shape
+  controls, not column predicates; `path` is a resource, not an equality
+  on `path_lower` (it selects the listing root, and a `path_lower = '/a/b'`
+  predicate means something different from "list under `/a/b`"). Guard
+  test proves no filter key ever reaches the wire.
+
+### `dropbox.shared_links`
+
+| | |
+|---|---|
+| Action | `dropbox.list_shared_links` (same action continues) |
+| Row path | `$.links` |
+| Pagination | cursor, `next_cursor_path: $.cursor`, `has_more_path: $.hasMore`, no page-size input |
+| Optional resources | `path`, `directOnly` |
+| Fixed inputs | none |
+| Filters | none pushed |
+
+Columns (15): the full `mapDropboxMetadata` set — the shared-link-only
+fields (`url`, `expires_at`, `link_permissions`) populate here, which is
+precisely why they belong to this table and not to `files`.
+
+`url` is mapped **nullable** even though it is the natural identity: the
+executor spells it `optionalString(record.url) ?? null`, so a non-null
+declaration would fail scans on a row the gateway considers legal.
+Documented rather than "fixed" by tightening.
+
+`path` stays an optional resource rather than an `eq` push onto
+`path_lower`: the input accepts paths, file IDs *and* rev IDs, so the
+mapping would be unfaithful across most of its value domain — an `Exact`
+claim would be wrong and an `Inexact` one would still push a rev ID as if
+it were a path. Guard test pins that no `path` key is derived from a
+predicate.
+
+**This table needs no engine extension** and is the fallback pack if the
+extension is refused.
+
+### `dropbox.file_search`
+
+| | |
+|---|---|
+| Action | `dropbox.search_files` → `dropbox.search_files_continue` |
+| Row path | `$.matches` |
+| Pagination | cursor, `has_more_path: $.hasMore`, `page_size_input: maxResults`, `page_size: 1000` (schema max), `continuation` cursor-only |
+| Required resource | `query` |
+| Optional resource | `path` |
+| Fixed inputs | `fileStatus: active` |
+| Filters | none pushed |
+
+Columns (13): `match_type` (utf8, **not null** — the executor's
+`?? "unknown"`), then the metadata block at nested paths
+`metadata.tag`, `metadata.name`, `metadata.id`, `metadata.pathDisplay`,
+`metadata.pathLower`, `metadata.clientModified`, `metadata.serverModified`,
+`metadata.rev`, `metadata.sizeBytes`, `metadata.isDownloadable`,
+`metadata.contentHash`, `metadata.sharingInfo`.
+
+- **`query` is a required resource**, the GitHub `owner`/`repo` precedent:
+  a search table without a query is not a table. Required-resource
+  enforcement must fail before any HTTP.
+- **`fileStatus: active` is pinned** for the same reason `includeDeleted`
+  is pinned off on `files`.
+- **`highlight_spans` is not mapped and `includeHighlights` is never
+  sent.** Two reasons: the field only populates when highlights are
+  requested, and the declared schema (`s.nullable(s.array(...))`)
+  contradicts the executor (`readObjectArray(...)`, which returns `[]`,
+  never null) — a declared-vs-wire contradiction worth recording but not
+  worth a column. Negative-space guard on the input key.
+- **`orderBy` is left unpinned.** Feishu pinned `ByCreateTimeAsc` because
+  its default ordering reshuffles mid-scan; Dropbox's `search/continue_v2`
+  pages a server-side snapshot taken at the first call, so relevance order
+  is stable within one scan. To be confirmed live.
+
+## Deferred, with reasons
+
+Recorded in the module doc and the pack doc as *absent by decision*, per
+the admission gate:
+
+- **`list_revisions`** — pages by passing a `beforeRev` from the previous
+  page's rows and answers `hasMore` with no cursor to follow. No pack-side
+  strategy can complete it, and `limit` caps at 100. This is the 5.2 Slack
+  message-history deferral repeated.
+- **`get_current_account`** — returns one object; `RowPath::rows` requires
+  an array (row_path.rs:105). A single-row table would need a different
+  engine concept.
+- **`get_tags`** — its input is an array of paths (resources are scalars)
+  and it declares no pagination.
+- **All write actions** (`upload_file`, `create_folder`, `move`, `copy`,
+  `delete`, `create_shared_link`, `modify_shared_link`,
+  `revoke_shared_link`, `save_url`, `restore`) — outside the read-only
+  allowlist.
+- **Content actions** (`download_file`, `get_temporary_link`,
+  `get_shared_link_file`) — base64 payloads and single objects, not rows.
+
+## Verification plan
+
+**Phase 3 (implementation).** Six fixture categories per table including
+schema-mismatch; `expected_fingerprint` per table plus
+`continuation.fingerprint` for the two split-action tables, each locked to
+its captured contract by a sync test; mock discovery serving the captured
+contracts; a drift-refusal e2e per table *and* one for a continue action;
+a `fingerprint_uncovered_columns` pin (expected empty, given the strict
+normalized schema — a non-empty result is itself a finding). E2e set:
+multi-page scan per table, every termination spelling,
+`PaginationHasMoreInvalid` / `PaginationCursorInvalid` failure modes,
+LIMIT early-stop, empty collection, fixed-input pins asserted on the
+request body, required-resource enforcement before HTTP, negative-space
+guards for every deliberate absence above, gateway-failure surfacing, and
+UDTF parity for one table. Plus, new here: an e2e asserting the
+continuation request body is **exactly** `{"cursor": …}` — the assertion
+that would have caught the 400 this whole extension exists to avoid.
+
+**Phase 4 (live).** Needs from you: a Node runtime on this box (none
+installed — `node`/`npm` are absent, which is why phase 1 stopped at
+source) and a free Dropbox account with an OAuth app carrying
+`files.metadata.read` + `sharing.read`. Then: probe each action at the
+pack's exact inputs and at its declared bounds, diff real row keys against
+mapped columns in both directions, force multi-page pagination with a
+small `limit`, confirm every mapped column extracts a non-NULL value
+somewhere, confirm termination on the real final page, and re-derive the
+fixtures as redacted live captures.
+
+**Phase 5.** `cargo fmt`, `cargo clippy`, the full `cargo test -p skardi
+--lib` (the engine change ripples beyond the pack), counted tests matching
+the docs, and a `/code-review` pass on the diff.
+
+## Open questions
+
+1. **`list_shared_links` with both `path` and `cursor`.** The executor
+   `compactObject`s them together, but Dropbox may reject the combination.
+   If it does, this table needs `continuation: {inputs: cursor_only}` as
+   well — which the proposed design already spells without a code change.
+   Resolvable only on the live wire.
+2. **`list_folder` cursor lifetime.** Dropbox cursors can expire or be
+   invalidated mid-listing; a long recursive scan may hit it. Behavior and
+   whether it warrants a documented bound is a phase-4 observation.
+3. **Whether `recursive: true` is the right pin** — the alternative is
+   pinning it off and making the subtree the user's choice via a second
+   table. Flagging because it is the single most consequential contract
+   decision in this pack.
+4. **Engine-extension appetite.** If `pagination.continuation` is not
+   wanted in this milestone, the honest fallback is a one-table pack
+   (`shared_links`) with `files` and `file_search` deferred as
+   gate-failing — worse, but not misleading.
+
+## Scope of this milestone
+
+- `crates/skardi/src/sources/providers/open_connector/pagination.rs`,
+  `exec.rs`, `packs/loader.rs`, `source_pack.rs` — the continuation
+  extension and its registration gating.
+- `packs/dropbox.yaml`, `packs/dropbox.rs`, `packs/mod.rs`,
+  `packs/fixtures/dropbox/**`.
+- `docs/open-connector-dropbox.md`, the 5.5 entry in
+  `2026-07-11-open-connector-integration-tasks.md`, and the supported-pack
+  list in `docs/open-connector.md`.

--- a/docs/superpowers/specs/2026-08-16-dropbox-source-pack-design.md
+++ b/docs/superpowers/specs/2026-08-16-dropbox-source-pack-design.md
@@ -1,15 +1,16 @@
 # Dropbox Source Pack (milestone 5.5)
 
-**Status:** Steps 1, 3, 4 landed (engine extension, pack, docs). Steps 2
-(contract capture) and 5 (live verification) remain BLOCKED on a Node
-runtime and a Dropbox account — so every fingerprint in the shipped pack
-is source-derived and will fail the contract gate against a real gateway
-until re-pinned. Runbook for the blocked steps:
+**Status:** ALL SIX STEPS LANDED. Steps 1, 3, 4 (engine extension, pack,
+docs) shipped first; steps 2 and 5 (contract capture, live verification)
+were unblocked once a Node runtime and a Dropbox account became
+available, and RAN on 2026-08-18 — every fingerprint in the shipped pack
+is now a hash of a live capture, and registration passed the contract
+gate unchanged. Run record:
 [2026-08-18-dropbox-live-evaluation.md](../plans/2026-08-18-dropbox-live-evaluation.md).
-**Date:** 2026-08-16 (status updated 2026-08-18)
+**Date:** 2026-08-16 (status updated 2026-08-19)
 **Branch:** `feature/open-connector-dropbox-pack`
 **Gateway reconciled against:** oomol-lab/open-connector **v1.3.5** (source
-read; live probe still outstanding — see [Open questions](#open-questions)
+read, then probed live at commit `a3efa99` — see [Open questions](#open-questions)
 and the [live-evaluation runbook](../plans/2026-08-18-dropbox-live-evaluation.md))
 
 ## Summary
@@ -335,24 +336,23 @@ the docs, and a `/code-review` pass on the diff.
 
 ## Open questions
 
-1. **`list_shared_links` with both `path` and `cursor`.** STILL OPEN. The
-   shipped pack declares no `continuation` for this table, i.e. it ships
-   the inference that the combination is accepted; the yaml and module doc
-   label it as an inference rather than an observation. The executor
-   `compactObject`s them together, but Dropbox may reject the combination.
-   If it does, this table needs `continuation: {inputs: cursor_only}` as
-   well — which the proposed design already spells without a code change.
-   Resolvable only on the live wire.
-2. **`list_folder` cursor lifetime.** Dropbox cursors can expire or be
-   invalidated mid-listing; a long recursive scan may hit it. Behavior and
-   whether it warrants a documented bound is a phase-4 observation.
-3. **Can `matches[].metadata` be null?** NEW, found in self-review. The
-   derived contract declares it a required non-nullable object, and
-   `file_search` maps `tag`/`name` as `nullable: false` on that basis — so
-   a real null-metadata match would fail the scan rather than yield NULLs.
-   `file_search_null_parent.json` is labelled synthetic and pins the
-   converter's behavior if it ever happens. If the wire can null it, those
-   two columns become nullable and the fixture graduates to a capture.
+1. **`list_shared_links` with both `path` and `cursor`.** ANSWERED YES
+   on the wire, 2026-08-18. Dropbox accepts the combination, so this table
+   correctly ships with no `continuation` block and needs no
+   `inputs: cursor_only`. The yaml and module doc now record it as an
+   observation rather than an inference.
+2. **`list_folder` cursor lifetime.** ANSWERED as a lower bound only,
+   2026-08-18: a cursor replayed ~40 minutes later — after files and
+   shared links had been added to the listed tree — still returned rows.
+   No upper bound was established, so this is documented in
+   `docs/open-connector-dropbox.md` as a lower bound and not as a
+   guarantee. No pack change warranted.
+3. **Can `matches[].metadata` be null?** ANSWERED NO, 2026-08-18: the
+   executor always returns a full metadata object, so
+   `file_search.tag`/`name` stay `nullable: false` and the mapping stands.
+   `file_search_null_parent.json` therefore stays SYNTHETIC permanently —
+   it pins the converter's behavior against a shape the contract forbids,
+   which is its purpose, not a placeholder awaiting a capture.
 4. **Whether `recursive: true` is the right pin** — the alternative is
    pinning it off and making the subtree the user's choice via a second
    table. Flagging because it is the single most consequential contract
@@ -438,10 +438,12 @@ UDTF-path equivalent.
 **Gate:** full `cargo test -p skardi --lib` green before any pack work —
 this step touches the engine every pack rides on.
 
-### Step 2 — Contract capture (blocked: needs Node)
+### Step 2 — Contract capture — DONE (2026-08-18)
 
-Prerequisite: a Node runtime (none installed — `node`/`npm` absent).
-Then, from the open-connector v1.3.5 checkout: start the gateway, capture
+All five contracts captured from a live gateway at commit `a3efa99` and
+committed to `packs/fixtures/dropbox/contracts/`; each came back
+byte-identical to the source-derived schema it replaced, so no pin
+changed. What the step called for, as executed: from the open-connector v1.3.5 checkout: start the gateway, capture
 `data.outputSchema` for all five actions (`list_folder`,
 `list_folder_continue`, `list_shared_links`, `search_files`,
 `search_files_continue`) into `packs/fixtures/dropbox/contracts/`,
@@ -498,9 +500,20 @@ tasks-spec entry per A3 — left unticked until step 5 passes, since the
 entry's verification blurb must state live status honestly; the
 supported-packs paragraph in `docs/open-connector.md`.
 
-### Step 5 — Live verification (blocked: needs Node + a Dropbox account)
+### Step 5 — Live verification — DONE (2026-08-18)
 
-Needs from the user: the Node runtime (step 2's) and a free Dropbox
+Ran against a self-hosted gateway at commit `a3efa99` and a real
+free-tier Dropbox account. The outcome in full is recorded in the
+module-doc provenance banner in `packs/dropbox.rs` and in the run record;
+in short: all five fingerprints matched live discovery unchanged, all
+three tables scanned real rows, page sizes were probed at the boundary,
+real multi-page pagination ran through `list_folder_continue`, and the
+pass DROPPED four `shared_links` columns it found could never populate.
+Two claims stayed unobserved rather than confirmed
+(`shared_links.expires_at`, `file_search.match_type = 'content'`), and
+one gateway defect was filed upstream
+(oomol-lab/open-connector#358). What the step called for, as executed: a
+free Dropbox
 account with an OAuth app carrying `files.metadata.read` +
 `sharing.read`, configured in the gateway (`PUT /api/connections/dropbox`
 — user-held; I never touch the credential). Then, per table: probe at the
@@ -534,6 +547,8 @@ engine extensions shipping inside the pack PR that needs them:
 2. `feat(sources): Dropbox source pack — files, shared_links, file_search`
 3. `docs(sources): Dropbox pack docs + milestone 5.5 entry`
 
-Steps 1, 3, 4 are executable now, in order, with placeholder pins.
-Steps 2 and 5 are blocked on the two user-provided prerequisites; the
-PR stays Draft until step 5 completes.
+Steps 1, 3, 4 landed first, in order, with placeholder pins. Steps 2 and
+5 were blocked at authoring time on two user-provided prerequisites; both
+arrived, both steps ran on 2026-08-18, and the placeholder pins were
+replaced by live captures in the same pass (they turned out identical, so
+no pin text changed).


### PR DESCRIPTION
Milestone 5.10: a Dropbox source pack — `dropbox.files`, `dropbox.shared_links`, `dropbox.file_search` — plus the backward-compatible engine extension two of those three tables cannot pass the admission gate without.

Fourteen commits: the design spec and its execution plan, the engine extension, the pack, a self-review pass, the live-verification pass, a second review round, a fix-up that reconciles this branch with the `Keyset` / `single_page` strategies the Discord pack (5.6) landed meanwhile, the milestone renumber the rebases forced, a third review round, a test fix-up for a CI failure that round introduced (see **CI fix-up** below), and a fourth review round.

> **✅ Live-verified 2026-08-18** against a self-hosted Open Connector gateway at commit `a3efa99` and a real free-tier Dropbox account, following [the live-evaluation runbook](docs/superpowers/plans/2026-08-18-dropbox-live-evaluation.md).
>
> The earlier revision of this description warned that **registration was expected to fail the contract gate until the pins were re-captured**. That was wrong, and pleasantly so: all five committed contracts came back **byte-identical** to the live captures, so every fingerprint matched live discovery unchanged and registration passed on the first try. Nothing needed re-pinning. The opener/continuation schema identity — previously flagged as suspicious because each `*_continue.json` was byte-identical to its opener — turns out to be a fact about the wire, not an artifact of how the files were derived.
>
> The pass did find one real defect, in the one place a contract-level check cannot look. See **What the live pass changed**.

## What the wire confirmed

Every claim the pack had labelled as an inference off the provider source:

| Claim | Live result |
|---|---|
| Cursor fed to the *opening* action is a hard 400 | Confirmed — rejected bare and alongside the full input |
| `cursor_only`: the continue action takes the cursor and nothing else | Confirmed — any extra input is refused; its real input schema declares `cursor` as its only property, `required`, `additionalProperties: false`. Committed as `fixtures/dropbox/contracts/inputs/*.json` and checked against the declaring table by a test, so a re-capture that grows a `required` key fails CI |
| `list_folder`'s final page carries `hasMore: false` beside a **non-empty** cursor | Confirmed — 259-char cursor on the last page; following it returns an empty page, so cursor-spelling termination really would refetch and trip the loop guard. `has_more_path` is load-bearing, not decorative |
| `limit: 2000` / `maxResults: 1000` are the wire's maxima | Confirmed at the boundary — both return rows; 2001 and 1001 are refused |
| The root path defaults when no `path` key is sent | Confirmed — `path` is correctly an *optional* resource |
| Row keys are exactly the 15 normalized keys | Exact match, both directions — nothing mapped-but-absent, nothing on-wire-but-unmapped |
| In-band Dropbox errors surface as gateway *failure* envelopes, never 200 rows | Confirmed via a refused shared-link expiry (`settings_error/not_authorized`, `errorCode: invalid_input`) |
| `LIMIT` pushdown stops the scan before the continuation request | Confirmed — `pages=1 rows=1` against `pages=2 rows=378` unbounded |
| `directOnly` reaches the strict schema as a JSON boolean | Confirmed — accepted, returns rows |
| `highlightSpans` is `[]` and never null when highlights aren't requested | Confirmed — the module doc's wire-vs-contract note is accurate |

**Both design-spec open questions are answered.** Q1: `list_shared_links` **does** accept `path` and `cursor` in one request, so `shared_links` needs no `cursor_only` continuation — the shipped inference was right. Q3: `matches[].metadata` can **never** be null, because `normalizeSearchResult` always maps through `mapDropboxMetadata` (`tag` → `"unknown"`, `name` → `""`), so `file_search.tag`/`name` stay non-nullable and `file_search_null_parent.json` is correctly labelled synthetic. Q2 (cursor lifetime): a cursor replayed ~40 minutes later, after the listed tree had been mutated, still returned rows — a lower bound, no upper bound established.

**The engine extension works live.** `files` scanned `pages=2 rows=378` through `dropbox.list_folder_continue`.

## What the live pass changed

**`shared_links` shipped four columns that can never carry a value.** `sharing/list_shared_links` returns `SharedLinkMetadata`, which carries `path_lower` but has **no** `path_display`, `is_downloadable`, `content_hash` or `sharing_info` field at all. The shared normalizer reads those four off keys the payload never has. Measured **0/5 non-NULL** across 3 file links and 2 folder links, then settled decisively by pointing both endpoints at one file: **a file whose `files` row carries all four returns all four NULL on its own `shared_links` row** — same file, same normalizer, different endpoint.

This is the mirror image of the reasoning the pack already applied correctly when it deliberately omitted `url` / `expires_at` / `link_permissions` from `files`. It just was never applied in the other direction. **Removed: 15 → 11 columns**, pinned by a negative-space guard test, with the fixture corrected to the live shape (it had claimed three of the four populated).

Worth being precise about why no gate caught it, because it qualifies a claim this PR previously made with some pride. All five list actions publish the **same** normalized 15-key schema, so a fingerprint match says nothing about whether a given key is populated for a given *action*. "Every mapped column sits inside the fingerprint gate and the coverage-gap pin is empty" was true and still insufficient. **Real rows remain the only column truth**, normalized executor or not — the Notion 5.3 lesson, arriving by a different route.

Per-column coverage after the trim:

| Table | Rows | Coverage |
|---|---|---|
| `files` | 378 (299 files / 79 folders) | **12/12** non-NULL |
| `shared_links` | 6 | **11/11** bar the labelled `expires_at` |
| `file_search` | 2 seeded + 19 ad-hoc | **13/13** (`sharing_info` 15/19 via a shared-folder hit) |

Value-level checks beyond non-NULLness: `recursive: true` really recurses (a depth-3 file came back), a folder nulls the file-only columns while a 0-byte file reads `size_bytes = 0` distinguishable from NULL, and timestamps parse from the real ISO 8601 `…Z` spelling.

**Two claims remain unobserved rather than confirmed**, both environmental and neither a defect — labelled at every point a reader meets them: `shared_links.expires_at` needs paid-tier link expiry (a free account is refused), and `file_search.match_type = 'content'` needs Dropbox content indexing, which never landed during the pass. Both columns stay mapped because both are structurally reachable.

**Also corrected: the scope claim.** Two read scopes cover every *action* (confirmed in the live gateway's per-action `requiredScopes`), but the gateway's dropbox provider requests the union of all six at authorize time — including `files.content.write` and `sharing.write` — so a connection created through its OAuth flow carries write access this pack never exercises. The docs now say that instead of implying an operator can provision read-only.

**Row fixtures are still authored shapes, not redacted live captures**, because the verified account holds personal files. Recorded per file in `packs/fixtures/dropbox/README.md`, next to the files themselves: `contracts/*.json` are live captures (output schemas — that is all a `fingerprint:` covers), `contracts/inputs/*.json` are transcriptions of the input shape the pass observed rather than byte-exact captures (the probe wrote them to `/tmp`; only the shape was carried into the repo, and the runbook now writes them straight into the directory), the six row fixtures are authored, and two of those six are deliberately *impossible* — they encode shapes the captured contract forbids, so they will never graduate to captures.

## Gateway defect — filed upstream, resolved there; no prerequisite on a current gateway

At the checkout the live pass used (`a3efa99`, 2026-07-07) the gateway's `GET /v1/actions/<id>` — the endpoint `discover_action` reads — does not serialize the `execution` block, so Skardi's default-deny action registry refuses **every action from every source pack** on that checkout. This is not this pack's bug: it reproduces identically for the merged `github` pack (`github.list_repository_issues does not declare whether it is locally executable`).

Filed as [oomol-lab/open-connector#358](https://github.com/oomol-lab/open-connector/issues/358), closed as **completed**: upstream `1607633` (#149, 2026-07-19) had already added the block to that route, so the checkout simply predated the fix and a gateway at or after that commit needs nothing. **Skardi's gate is correct and is left untouched** — deliberately no compatibility fallback that reads the classification from another route. Live verification here ran against a locally patched gateway, which is behaviorally what the upstream fix produces.

## The engine extension: `pagination.continuation`

**Dropbox continues a listing through a different action ID than the one that starts it.** `dropbox.list_folder` begins a folder listing; pages 2..N come from `dropbox.list_folder_continue`, whose input schema declares `cursor` as its only property. Skardi's exec loop issued every page against a single `action_id` and injected the cursor into the same input map — and since `list_folder` is `additionalProperties: false` and does not declare `cursor`, that is a hard **400 on page 2**, not a quiet truncation. Both halves of that sentence are now confirmed on the wire. `dropbox.search_files` splits the same way.

Opt-in, nested under the cursor strategy, `None` for every pre-existing pack — absent, behavior is byte-for-byte what it was:

```yaml
continuation:
  action: dropbox.list_folder_continue   # default: the table's own action
  fingerprint: <blake3-hex>              # required whenever the block is present
  inputs: cursor_only                    # cursor_only | full (default: full)
```

Page 1 always uses the table's own action with the full input. `cursor_only` makes pages 2..N carry the cursor and nothing else — no resources, no fixed inputs, no page size — because the listing's shape was committed by the request that opened it.

**Both actions are gated, and the two gates cover different things.** A contract fingerprint hashes the **output** schema, so the continuation pin guards the row shape of pages 2..N. It does *not* cover `cursor_only`, which is a claim about **inputs** — and where an opener and its continuation publish the same output schema (the Dropbox case, now confirmed), the continuation pin cannot even fail alone. So the **input** side is checked separately, at registration, against the continuation action's discovered input schema — in **both** directions of `inputs:`, since a wrong claim either way is a hard 400 on page two of a live scan:

- **`cursor_only`** — the cursor input must be a declared property, and no other input may be `required`.
- **`full`** (the default) targeting a *different* action — every input the table sends on **every** request must satisfy that action's `required`, and under `additionalProperties: false` every input the table *can* send must be a declared property. Optional resources and pushed filters count toward the second but not the first: a binding may omit them, so they cannot satisfy a mandatory field. When the continuation names the table's own action the check is skipped, and the skip is sound by construction — one action, one input schema, and page one already satisfied it.

An action publishing no input schema at all is refused rather than trusted — the same default-deny posture `open_connector_scan` takes toward a missing read/write classification — as is a `required` list that is present but is not an array of strings, since a gate that cannot read its input has verified nothing. A schema that is *present but shapeless* gets its own diagnostic rather than being reported as absent, so an operator is not sent to debug the wrong layer of their gateway.

**One gate, one call site per entry point.** An earlier revision of this description claimed the two entry points could not disagree because "both gate call sites run the same helpers". The helpers were shared, but that was two public checks with two call sites each, and review round 3 demonstrated that three of the four could be deleted with the suite still green. `check_continuation_inputs` now dispatches on `inputs:` internally and both arms are private, so YAML registration and `open_connector_query` each make exactly one call — held in place by a YAML test and a UDTF test respectively. The UDTF path also now genuinely crosses a page boundary in tests (it previously answered `hasMore: false` on page one, which left the whole continuation loop unexercised through that entry point), and has twins for the discovery, fingerprint and input gates.

Remaining gap, stated rather than implied closed: the `full` arm is exercised only by direct unit call, because no pack declares `inputs: full` against a different action, so the shape does not exist in any registered pack.

Not checked, deliberately: whether the cursor is the action's *only* property. An upstream release adding an optional input alongside it does not break a cursor-only request, and refusing to start over it would be a false alarm.

**Four authoring invariants are enforced by the loader** with targeted errors:

1. a `continuation` on a `page_number` table is a `deny_unknown_fields` parse error;
2. a table pinning its continuation's fingerprint must pin its own action's too (half a gate reads as gated while verifying only pages 2..N);
3. a same-action continuation may not pin a fingerprint *different* from the table's own — one action has one contract, so no gateway can satisfy both, and the UDTF path (which looks the expectation up by action id) could only ever check one of the two;
4. `inputs: cursor_only` may not be paired with an **`Exact`**-fidelity filter. Exact pushdown deletes the `Filter` node from the plan, so page one would apply the predicate as an action input while pages 2..N could not, with no node left to re-apply it — silently returning rows the query excluded. `Inexact` stays legal and is pinned as such: the `Filter` node survives, so the rows are right. Not free, though, and the comment and docs now say so — pages 2..N fetch the *unfiltered* collection and the scan bounds count what the gateway returned, so a selective `Inexact` filter wants `max_rows`/`max_pages` headroom sized for the whole collection, or a query that works today becomes a hard `ScanBoundsExceeded` rather than a slower one.

## The tables

| Table | Action(s) | Row path | Required | Optional | Columns |
|---|---|---|---|---|---|
| `files` | `list_folder` → `list_folder_continue` | `$.entries` | — | `path` | 12 |
| `shared_links` | `list_shared_links` (continues on itself) | `$.links` | — | `path`, `directOnly` | 11 |
| `file_search` | `search_files` → `search_files_continue` | `$.matches` | `query` | `path` | 13 |

No table pushes a filter: Dropbox's remaining list inputs are scan-shape controls, not column predicates, and `path` selects the listing *root* on `files` while accepting paths, file IDs **and** rev IDs on `shared_links` — no fidelity level would be honest across that value domain. Guard tests pin that no filter key ever reaches the wire.

`files` pins `recursive: true` / `includeMountedFolders: true` / `includeDeleted: false`; `file_search` pins `fileStatus: active`. `url` / `expires_at` / `link_permissions` are deliberately absent from `files` (structurally always-NULL there) and mapped on `shared_links`, where they populate — pinned by a negative-space test, which now also pins the four absences in the other direction.

Deferred with reasons recorded: `list_revisions` (`beforeRev` paging cannot be completed — the 5.2 Slack message-history deferral repeated), `get_current_account` (single object; a row path requires an array), `get_tags`, every write action, and the base64 content actions.

## Verification

Local `cargo` counts are omitted rather than restated stale — the previously published figures predated four commits and the rebase onto three new packs, so **CI on this branch is the source of truth for the suite**.

`cargo fmt --all -- --check` is clean. The full library suite was run green on the rebased tree, with only documentation and one commit message changed since. The rebase surfaced exactly one compile error — the `exclusive_resources` struct-literal field described under **Rebased onto main** — which is fixed.

Plus the live pass above: registration against live discovery, per-column non-NULL sweeps per table, forced multi-page pagination, and `LIMIT` early-stop read off the server's own scan-completion events rather than inferred.

The engine extension's own regression test is the one this whole change exists to prevent: an e2e asserting page 2 hits `/v1/actions/<continue-action>` with a body that is **exactly** `{"cursor": …}`, parsed structurally rather than substring-matched.

## Rebased onto main

Rebased onto `main` at `78bf3d8`. Three more packs landed while this branch was open — **5.7** Outlook, **5.8** OneDrive (#223) and **5.9** Google Drive (#226) — so Dropbox is renumbered **5.10** in the tasks spec and its "Current PR" note, the design-spec title, and the two runbook cross-references. (The design spec's planned-commit list keeps its historical "milestone 5.5 entry" wording: that records what was planned when the spec was written, not the current number.)

**Nothing about the pack or the engine extension changed in this rebase.** Five conflicts, all in places where the two branches' rosters or milestone numbering overlapped:

| Conflict | Resolution |
|---|---|
| `source_pack.rs` — `impl SourcePackTable` | Union of two disjoint method sets. Main added `conflicting_resources` (OneDrive's exclusive-resource gate); this branch added `actions` / `gated_actions`. Both kept; all four call sites verified to resolve. |
| `source_pack.rs` — `packs_iterates_every_builtin_in_name_order` | Sorted union of the roster pin: `dropbox` alongside main's `google_drive` and `one_drive`. |
| `README.md` | Main rewrote the README wholesale (#205, #215, #228), so the branch's old-structure version was discarded and only its one-line addition re-applied — Dropbox appended to the Open Connector source row. |
| `docs/open-connector.md` | Main's OneDrive + Google Drive status entries kept; Dropbox's appended, carrying the *later* commits' live-verified wording rather than the earlier "not yet live-verified" text the first review round wrote. |
| `docs/…-integration-tasks.md` (×2) | The milestone entry and the "Current PR" note, renumbered to 5.10 and updated to say 5.1–5.9 are merged. |

**One conflict the merge could not surface, caught by compiling.** OneDrive (5.8) added a required `exclusive_resources` field to `SourcePackTable`. The Dropbox pack itself is YAML-loaded, so it defaults cleanly — but this branch's `exec.rs` test helper `split_action_table()` builds a `SourcePackTable` by struct literal, and a struct literal must name every field. `cargo test` failed with `E0063: missing field exclusive_resources`; the field was added as `&[]` and squashed into the commit that introduced the helper, so history stays bisectable.

An earlier rebase (commit 8 above) reconciled this branch with the two engine additions the Discord pack (5.6) brought:

- **`PaginationStrategy::Keyset` and a YAML-reachable `single_page`.** This branch's `cursor_only` input gate reads the pagination inputs a table guarantees on every request, so `pagination_input_keys` now covers all four strategies — keyset injects a cursor and a page-size input; `single_page` gained a `next_cursor_path` field, so its pattern is braced. The loader's "pagination input collides with a declared resource" gate (added in review round 2) consequently now covers keyset tables too, which is a strict widening.
- **`Paginator::advance` takes a third `last_row` argument** (keyset reads its cursor off the previous page's last row); the `cursor_only` test follows.

One assertion also moved: main renders a conversion-kind mismatch as `found a string`, not `found string`, so the Dropbox error-identity test matches the current wording.

## CI fix-up

Review round 3 split the unverifiable-`cursor_only` diagnostic into two arms — an **absent** `inputSchema` ("no input schema") and one that is **present but shapeless** ("no input properties") — precisely so an operator hunting a missing schema is not sent looking for one that is in fact present and empty. Two Dropbox tests document the absent arm and assert on its wording, but their mock gateway published `"inputSchema":{}`, which is the *other* arm, so `a_continue_action_without_an_input_schema_is_refused` failed on CI.

`input_schema` is an `Option<Value>`, so `null` is the absent case; both mocks now send `null` and land on the arm they describe. No production code changed. The present-but-shapeless arm keeps its direct coverage in `source_pack`'s two `..._reject_every_way_the_claim_can_break` tables, so holding these two integration tests on the absent-schema path costs no coverage.

## Still open for review

1. **Is `recursive: true` the right pin on `dropbox.files`?** The single most consequential contract decision here. Pinned, the table means "every file under `path`" (the `state=all` move from 5.1); unpinned it returns one directory level, a surprising contract for a table called `files`. The live pass confirmed it recurses and that the pin is honored; whether it is the right *default* is still a judgment call.
2. **Should `expires_at` stay mapped while unobservable on a free tier?** It is structurally reachable and cheap to keep, but no run on a free account will ever prove it populates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







