### PR TITLE
feat(server): audit job submissions — session attribution + run_id bridge to the jobs ledger

### DIFF
--- a/crates/cli/src/commands/jobs.rs
+++ b/crates/cli/src/commands/jobs.rs
@@ -7,6 +7,7 @@
 
 use crate::client::{ApiClient, encode_component};
 use crate::params::build_body;
+use crate::session::validate_session_id;
 use anyhow::Result;
 use clap::Subcommand;
 use serde::Deserialize;
@@ -25,6 +26,10 @@ pub enum JobCmd {
         /// back to a plain string otherwise.
         #[arg(short = 'p', long = "param", value_name = "NAME=VALUE")]
         params: Vec<String>,
+        /// Session id recorded with this run in the server's audit ledger
+        /// (sent as the X-Skardi-Session-Id header).
+        #[arg(long)]
+        session_id: Option<String>,
     },
     /// Print the current status of one run.
     Status {
@@ -60,10 +65,29 @@ struct RunIdResponse {
 /// Run `skardi job <cmd>` against `client`.
 pub async fn run(client: &ApiClient, cmd: JobCmd) -> Result<()> {
     match cmd {
-        JobCmd::Run { job, params } => {
+        JobCmd::Run {
+            job,
+            params,
+            session_id,
+        } => {
+            if let Some(sid) = &session_id {
+                validate_session_id(sid)?;
+            }
+
             let body = build_body(None, &params)?;
             let path = format!("/jobs/{}/run", encode_component(&job));
-            let response = client.post(&path, &Value::Object(body)).await?;
+            let response = match &session_id {
+                Some(sid) => {
+                    client
+                        .post_with_headers(
+                            &path,
+                            &Value::Object(body),
+                            &[("x-skardi-session-id", sid)],
+                        )
+                        .await?
+                }
+                None => client.post(&path, &Value::Object(body)).await?,
+            };
             let resp: RunIdResponse = serde_json::from_value(response)?;
             println!(
                 "submitted: {} ({})",
@@ -130,10 +154,10 @@ fn print_run_list(resp: &Value) {
 #[cfg(test)]
 mod tests {
     use super::{JobCmd, run};
-    use crate::client::ApiClient;
+    use crate::client::{ApiClient, ApiError};
     use crate::config::ClientConfig;
     use serde_json::json;
-    use wiremock::matchers::{body_json, method, path, query_param};
+    use wiremock::matchers::{body_json, header, method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn test_config(server: &str) -> ClientConfig {
@@ -166,11 +190,82 @@ mod tests {
             JobCmd::Run {
                 job: "nightly_sync".to_string(),
                 params: vec!["day=2026-07-23".to_string(), "batch=500".to_string()],
+                session_id: None,
             },
         )
         .await;
 
         assert!(result.is_ok(), "expected Ok, got {result:?}");
+    }
+
+    // -- 1b. `job run --session-id` sends x-skardi-session-id header --------
+
+    #[tokio::test]
+    async fn job_run_with_session_id_sets_header() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/jobs/nightly_sync/run"))
+            .and(header("x-skardi-session-id", "sess-9"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({"run_id": "r-1", "status": "pending"})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(&test_config(&server.uri())).unwrap();
+        let result = run(
+            &client,
+            JobCmd::Run {
+                job: "nightly_sync".to_string(),
+                params: vec![],
+                session_id: Some("sess-9".to_string()),
+            },
+        )
+        .await;
+
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+    }
+
+    // -- 1c. invalid `--session-id` errors before any request is sent -------
+
+    #[tokio::test]
+    async fn job_run_with_invalid_session_id_errors_without_request() {
+        let server = MockServer::start().await;
+        // expect(0): the whole point is that no request is ever sent — a
+        // deferred header error would surface as ApiError::Connect and be
+        // misread as "server unreachable".
+        Mock::given(method("POST"))
+            .and(path("/jobs/nightly_sync/run"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({"run_id": "r-1", "status": "pending"})),
+            )
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(&test_config(&server.uri())).unwrap();
+        let result = run(
+            &client,
+            JobCmd::Run {
+                job: "nightly_sync".to_string(),
+                params: vec![],
+                session_id: Some("bad,id".to_string()),
+            },
+        )
+        .await;
+
+        let err = result.expect_err("expected validation error");
+        assert!(
+            err.to_string().contains("--session-id"),
+            "expected a --session-id validation message, got: {err}"
+        );
+        assert!(
+            err.downcast_ref::<ApiError>().is_none(),
+            "must not be an ApiError (would map to a connection exit code)"
+        );
     }
 
     // -- 2. `job list` with a filter sends both limit and job query params --

--- a/crates/cli/src/commands/jobs.rs
+++ b/crates/cli/src/commands/jobs.rs
@@ -26,8 +26,8 @@ pub enum JobCmd {
         /// back to a plain string otherwise.
         #[arg(short = 'p', long = "param", value_name = "NAME=VALUE")]
         params: Vec<String>,
-        /// Session id recorded with this run in the server's audit ledger
-        /// (sent as the X-Skardi-Session-Id header).
+        /// Session id recorded with this submission in the server's audit
+        /// ledger (sent as the X-Skardi-Session-Id header).
         #[arg(long)]
         session_id: Option<String>,
     },

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -4,15 +4,9 @@
 use crate::client::{ApiClient, ApiError, encode_component};
 use crate::output::print_result;
 use crate::params::build_body;
+use crate::session::validate_session_id;
 use anyhow::{Result, anyhow};
 use serde_json::Value;
-
-/// Maximum session-id length, in characters. Restates the server's
-/// `query_audit::MAX_SESSION_ID_CHARS` under the same name — `skardi-cli`
-/// does not depend on the server crate, so this cannot be a shared item, but
-/// an identical name keeps `grep MAX_SESSION_ID_CHARS` finding every site
-/// that must move together.
-const MAX_SESSION_ID_CHARS: usize = 200;
 
 /// Run `skardi run <name>`: build the request body from `-d`/`-p`, `POST` it
 /// to `/{name}/execute`, and hand the response envelope to [`print_result`].
@@ -33,33 +27,8 @@ pub async fn run(
     table: bool,
     session_id: Option<String>,
 ) -> Result<()> {
-    // Validate before building the request: reqwest defers an invalid header
-    // value to `send()`, whose errors are all mapped to `ApiError::Connect` —
-    // so without this check a bad `--session-id` prints a connection error
-    // naming a server that was never contacted, and exits with the
-    // "server unreachable" code. The rules are now an EXACT mirror of the
-    // server's `session_id_from_headers` — visible ASCII graphic characters,
-    // no comma, no space — with no trimming semantics to reason about on
-    // either side: previously this check let space through, but the server
-    // sees whatever `httparse` hands it after stripping leading/trailing
-    // whitespace per RFC 9110 §5.5 (interior whitespace untouched). That gap
-    // meant `--session-id "  sess-1  "` passed here and got silently
-    // recorded server-side under the different key `sess-1` (breaking the
-    // session stitching this field exists for), while `--session-id "   "`
-    // passed here and then 400ed server-side — the exact fail-late round
-    // trip this client-side check exists to prevent. A grouping key has no
-    // legitimate use for spaces, so both sides now reject them outright
-    // instead of defining trimming semantics.
-    let invalid_session_id = session_id.as_deref().is_some_and(|sid| {
-        sid.is_empty()
-            || sid.chars().count() > MAX_SESSION_ID_CHARS
-            || !sid.chars().all(|c| c.is_ascii_graphic() && c != ',')
-    });
-    if invalid_session_id {
-        return Err(anyhow!(
-            "--session-id must be non-empty, at most {MAX_SESSION_ID_CHARS} \
-             characters, and contain only visible ASCII with no spaces and no commas"
-        ));
+    if let Some(sid) = &session_id {
+        validate_session_id(sid)?;
     }
 
     let body = build_body(data, param_flags)?;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -19,6 +19,7 @@ mod commands;
 mod config;
 mod output;
 mod params;
+mod session;
 
 /// Command-line interface for interacting with a skardi-server instance.
 #[derive(Parser, Debug)]

--- a/crates/cli/src/session.rs
+++ b/crates/cli/src/session.rs
@@ -1,0 +1,47 @@
+//! Shared `--session-id` validation for commands that record an execution
+//! against a session in the server's audit ledger (`skardi run`,
+//! `skardi job run`). Both send the same `x-skardi-session-id` header on a
+//! successful validation, so the rules live here once instead of being
+//! duplicated per command.
+
+use anyhow::{Result, anyhow};
+
+/// Maximum session-id length, in characters. Restates the server's
+/// `query_audit::MAX_SESSION_ID_CHARS` under the same name — `skardi-cli`
+/// does not depend on the server crate, so this cannot be a shared item, but
+/// an identical name keeps `grep MAX_SESSION_ID_CHARS` finding every site
+/// that must move together.
+pub(crate) const MAX_SESSION_ID_CHARS: usize = 200;
+
+/// Validate a `--session-id` flag value before it is sent as the
+/// `x-skardi-session-id` header.
+///
+/// Callers must validate before building the request: reqwest defers an
+/// invalid header value to `send()`, whose errors are all mapped to
+/// `ApiError::Connect` — so without this check a bad `--session-id` prints a
+/// connection error naming a server that was never contacted, and exits
+/// with the "server unreachable" code.
+///
+/// The rules are an EXACT mirror of the server's `session_id_from_headers`:
+/// visible ASCII graphic characters, no comma, no space, plus the length cap
+/// above — and no trimming semantics on either side. Space is rejected
+/// rather than trimmed because the server sees whatever `httparse` hands it
+/// after stripping leading/trailing whitespace (RFC 9110 §5.5): if space
+/// were tolerated here, `--session-id "  sess-1  "` would be recorded
+/// server-side under the different key `sess-1`, silently breaking the
+/// session stitching this field exists for, while `--session-id "   "` would
+/// pass here and 400 there — the exact fail-late round trip this check
+/// exists to prevent. Commas are rejected because proxies may merge repeated
+/// header lines into one comma-separated value (RFC 9110 §5.3).
+pub(crate) fn validate_session_id(sid: &str) -> Result<()> {
+    let invalid = sid.is_empty()
+        || sid.chars().count() > MAX_SESSION_ID_CHARS
+        || !sid.chars().all(|c| c.is_ascii_graphic() && c != ',');
+    if invalid {
+        return Err(anyhow!(
+            "--session-id must be non-empty, at most {MAX_SESSION_ID_CHARS} \
+             characters, and contain only visible ASCII with no spaces and no commas"
+        ));
+    }
+    Ok(())
+}

--- a/crates/query-audit/src/lib.rs
+++ b/crates/query-audit/src/lib.rs
@@ -12,8 +12,9 @@
 //! template lives on disk; parameter values are never recorded — the version
 //! is what keeps "what ran" answerable after the promotion loop edits a
 //! template, since rows are kept forever by default). Ad-hoc rows carry
-//! `statement_kind` values from `StatementKind`'s `Debug` form — `Query` /
-//! `Other` — not SQL verbs like `select`.
+//! `statement_kind` values naming the server's statement *classification* —
+//! `query` / `other` (see [`QUERY_STATEMENT_KIND`]) — not SQL verbs like
+//! `select`.
 //!
 //! Design notes:
 //!
@@ -202,6 +203,30 @@ const IDENTITY_COLUMNS: [&str; 5] = ["request_id", "org_id", "workspace_id", "us
 /// own run — one column, one meaning.
 const BRIDGE_COLUMNS: [&str; 1] = ["job_run_id"];
 
+/// Index over the `job_run_id` bridge, applied after [`ensure_added_columns`]
+/// has guaranteed the column exists — so it cannot live in
+/// [`INIT_SCHEMA_SQL`], which also runs against pre-column databases, where
+/// indexing a missing column would fail.
+///
+/// The forward direction — session to its rows — is served by
+/// `idx_query_audit_session_created`. This covers the reverse: given a run id
+/// from `GET /jobs/runs`, which session submitted it. Partial, because
+/// `job_run_id` is NULL on every non-job row, so the index stays proportional
+/// to job submissions rather than to a ledger that is append-only and has
+/// retention off by default.
+const JOB_RUN_ID_INDEX_SQL: &str = "CREATE INDEX IF NOT EXISTS idx_query_audit_job_run_id
+    ON query_audit (job_run_id) WHERE job_run_id IS NOT NULL;";
+
+/// True for the `duplicate column name` error SQLite raises when an
+/// `ALTER TABLE ... ADD COLUMN` loses a race with another connection that
+/// already added it.
+///
+/// Matched on message text because `rusqlite` surfaces it as a generic
+/// `SqliteFailure` with `SQLITE_ERROR`, carrying no distinguishing code.
+fn is_duplicate_column(e: &rusqlite::Error) -> bool {
+    e.to_string().contains("duplicate column name")
+}
+
 /// Add any of `columns` the live table is missing, as nullable `TEXT`.
 fn ensure_added_columns(conn: &rusqlite::Connection, columns: &[&str]) -> SqlResult<()> {
     let mut stmt = conn.prepare("PRAGMA table_info(query_audit)")?;
@@ -210,19 +235,32 @@ fn ensure_added_columns(conn: &rusqlite::Connection, columns: &[&str]) -> SqlRes
         .collect::<std::result::Result<_, _>>()?;
     for col in columns {
         if !existing.contains(*col) {
-            conn.execute(
+            // The read above is not atomic with this ALTER: two processes
+            // opening the same file concurrently (a rolling restart, an
+            // operator tool, a second server pointed at the same path) can
+            // both observe the column missing and both issue it. The loser
+            // gets `duplicate column name` — which is exactly the
+            // post-condition this step wanted, so it counts as success rather
+            // than aborting startup over a benign race.
+            match conn.execute(
                 &format!("ALTER TABLE query_audit ADD COLUMN {col} TEXT"),
                 [],
-            )?;
+            ) {
+                Ok(_) => {}
+                Err(e) if is_duplicate_column(&e) => {}
+                Err(e) => return Err(e),
+            }
         }
     }
     Ok(())
 }
 
-/// Every column added to `query_audit` after its original DDL.
+/// Every column added to `query_audit` after its original DDL, plus the
+/// indexes that can only be built once those columns exist.
 fn ensure_schema_additions(conn: &rusqlite::Connection) -> SqlResult<()> {
     ensure_added_columns(conn, &IDENTITY_COLUMNS)?;
     ensure_added_columns(conn, &BRIDGE_COLUMNS)?;
+    conn.execute_batch(JOB_RUN_ID_INDEX_SQL)?;
     Ok(())
 }
 
@@ -582,6 +620,18 @@ impl QueryAuditStore {
     /// Distinct from the identity envelope's `run_id` ([`QueryIdentity`]),
     /// which names the *caller's* run rather than the job run this submission
     /// produced. One column, one meaning.
+    ///
+    /// Only applies to a row still in `started`, the same guard (and the same
+    /// reasoning) as [`Self::spawn_timeout_correction`]: the write is
+    /// monotonic, so a row that already reached a terminal state stays there.
+    /// Within one process the transition is unreachable — the 503 path returns
+    /// before any outcome stamp — but the ledger is a *file*, and nothing stops
+    /// two servers being pointed at one `--query-audit-db`. In that
+    /// configuration server B's startup [`Self::reconcile_orphaned`] can stamp
+    /// A's in-flight submission `unknown` before A's outcome write lands;
+    /// without this guard that late write would resurrect a terminal row and
+    /// defeat reconciliation. 0 rows updated is therefore not an error: it
+    /// means something else already settled the row.
     pub async fn record_job_outcome(
         &self,
         id: &str,
@@ -599,8 +649,15 @@ impl QueryAuditStore {
                 conn.execute(
                     "UPDATE query_audit
                         SET status = ?2, finished_at = ?3, job_run_id = ?4, error = ?5
-                      WHERE id = ?1",
-                    params![id, status, finished_at, job_run_id, error],
+                      WHERE id = ?1 AND status = ?6",
+                    params![
+                        id,
+                        status,
+                        finished_at,
+                        job_run_id,
+                        error,
+                        QueryAuditStatus::Started.as_str(),
+                    ],
                 )?;
                 Ok(())
             }),
@@ -612,6 +669,9 @@ impl QueryAuditStore {
     }
 
     /// Update a record with its terminal outcome.
+    ///
+    /// Shares [`Self::record_job_outcome`]'s `started`-only guard, for the
+    /// same reason.
     pub async fn record_outcome(
         &self,
         id: &str,
@@ -630,8 +690,15 @@ impl QueryAuditStore {
                 conn.execute(
                     "UPDATE query_audit
                         SET status = ?2, finished_at = ?3, row_count = ?4, error = ?5
-                      WHERE id = ?1",
-                    params![id, status, finished_at, row_count, error],
+                      WHERE id = ?1 AND status = ?6",
+                    params![
+                        id,
+                        status,
+                        finished_at,
+                        row_count,
+                        error,
+                        QueryAuditStatus::Started.as_str(),
+                    ],
                 )?;
                 Ok(())
             }),
@@ -912,6 +979,24 @@ fn restrict_permissions(path: &Path) -> Result<()> {
 /// Statement-kind marker distinguishing pipeline rows from ad-hoc SQL rows.
 const PIPELINE_STATEMENT_KIND: &str = "pipeline";
 
+/// Statement-kind markers for the two ad-hoc row kinds.
+///
+/// `pub` and named rather than derived from the server's statement-classifier
+/// `Debug` form. The ledger's `statement_kind` vocabulary is a consumer-facing
+/// contract ("consumers filtering the ledger must match these exact strings"),
+/// and leaking `Debug` both bound that contract to a type in another crate
+/// whose variant names could be renamed freely, and mixed `PascalCase` ad-hoc
+/// values with the `lowercase` `pipeline` / `job` markers. All four values now
+/// live here, in one casing.
+///
+/// The classifier itself stays in the server — this crate deliberately does
+/// not depend on `skardi` (#206) — so the mapping from its variants onto these
+/// constants lives in `server::query_handlers::adhoc_statement_kind`. The
+/// vocabulary is owned here; only the translation is over there.
+pub const QUERY_STATEMENT_KIND: &str = "query";
+/// See [`QUERY_STATEMENT_KIND`].
+pub const OTHER_STATEMENT_KIND: &str = "other";
+
 /// Statement-kind marker for job-submission rows. Nothing outside this
 /// module reads it directly (Task 2 goes through `record_job_submitted`),
 /// so it stays private, mirroring `PIPELINE_STATEMENT_KIND`'s narrowing.
@@ -1040,7 +1125,7 @@ mod tests {
                 "SELECT * FROM t WHERE ssn = '123-45-6789'",
                 Some(&ctx),
                 100,
-                "Query",
+                "query",
             )
             .await
             .unwrap();
@@ -1053,7 +1138,7 @@ mod tests {
         assert_eq!(record["ai_context"]["purpose"], json!("kyc"));
         assert_eq!(record["session_id"], json!("sess-1"));
         assert_eq!(record["max_rows"], json!(100));
-        assert_eq!(record["statement_kind"], json!("Query"));
+        assert_eq!(record["statement_kind"], json!("query"));
         assert_eq!(record["status"], json!("started"));
         assert!(record["finished_at"].is_null());
 
@@ -1071,7 +1156,7 @@ mod tests {
     async fn failed_outcome_carries_the_error() {
         let store = QueryAuditStore::open_in_memory().await.unwrap();
         let id = store
-            .record_started("SELECT 1", None, 1, "Query")
+            .record_started("SELECT 1", None, 1, "query")
             .await
             .unwrap();
         store
@@ -1089,15 +1174,15 @@ mod tests {
         let ctx = json!({"purpose": "audit", "session_id": "sess-42"});
         let other = json!({"purpose": "audit", "session_id": "sess-other"});
         store
-            .record_started("SELECT 1", Some(&ctx), 1, "Query")
+            .record_started("SELECT 1", Some(&ctx), 1, "query")
             .await
             .unwrap();
         store
-            .record_started("SELECT 2", Some(&other), 1, "Query")
+            .record_started("SELECT 2", Some(&other), 1, "query")
             .await
             .unwrap();
         store
-            .record_started("SELECT 3", Some(&ctx), 1, "Query")
+            .record_started("SELECT 3", Some(&ctx), 1, "query")
             .await
             .unwrap();
 
@@ -1111,11 +1196,11 @@ mod tests {
     async fn reconcile_marks_orphans_unknown() {
         let store = QueryAuditStore::open_in_memory().await.unwrap();
         let orphan = store
-            .record_started("SELECT 1", None, 1, "Query")
+            .record_started("SELECT 1", None, 1, "query")
             .await
             .unwrap();
         let done = store
-            .record_started("SELECT 2", None, 1, "Query")
+            .record_started("SELECT 2", None, 1, "query")
             .await
             .unwrap();
         store
@@ -1141,7 +1226,7 @@ mod tests {
     async fn prune_deletes_only_older_records() {
         let store = QueryAuditStore::open_in_memory().await.unwrap();
         store
-            .record_started("SELECT 1", None, 1, "Query")
+            .record_started("SELECT 1", None, 1, "query")
             .await
             .unwrap();
         assert_eq!(store.count().await.unwrap(), 1);
@@ -1170,7 +1255,7 @@ mod tests {
         let total_rows = (PRUNE_BATCH_SIZE * 2) + 500;
         for _ in 0..total_rows {
             store
-                .record_started("SELECT 1", None, 1, "Query")
+                .record_started("SELECT 1", None, 1, "query")
                 .await
                 .unwrap();
         }
@@ -1280,7 +1365,7 @@ mod tests {
         let path = dir.path().join("nested").join("audit.db");
         let store = QueryAuditStore::open(&path).await.unwrap();
         store
-            .record_started("SELECT 1", None, 1, "Query")
+            .record_started("SELECT 1", None, 1, "query")
             .await
             .unwrap();
 
@@ -1311,7 +1396,7 @@ mod tests {
         let id = {
             let store = QueryAuditStore::open(&path).await.unwrap();
             store
-                .record_started("SELECT 'durable'", None, 1, "Query")
+                .record_started("SELECT 'durable'", None, 1, "query")
                 .await
                 .unwrap()
         };
@@ -1357,7 +1442,7 @@ mod tests {
         let store = QueryAuditStore::open_in_memory().await.unwrap();
         let ctx = serde_json::json!({"purpose": "p", "session_id": "sess-mix"});
         store
-            .record_started("SELECT 1", Some(&ctx), 10, "Query")
+            .record_started("SELECT 1", Some(&ctx), 10, "query")
             .await
             .unwrap();
         store
@@ -1369,7 +1454,7 @@ mod tests {
         // The promised property is the *ordering* (insertion order via
         // created_at with id as tie-break), plus the sql-column overload —
         // a bare count passes with ORDER BY dropped or reversed.
-        assert_eq!(rows[0]["statement_kind"], json!("Query"));
+        assert_eq!(rows[0]["statement_kind"], json!("query"));
         assert_eq!(rows[0]["sql"], json!("SELECT 1"));
         assert_eq!(rows[1]["statement_kind"], json!("pipeline"));
         assert_eq!(rows[1]["sql"], json!("weekly-churn@1.0.0"));
@@ -1435,7 +1520,7 @@ mod tests {
         let store = QueryAuditStore::open_in_memory().await.unwrap();
         let ctx = serde_json::json!({"purpose": "p", "session_id": "sess-all"});
         store
-            .record_started("SELECT 1", Some(&ctx), 10, "Query")
+            .record_started("SELECT 1", Some(&ctx), 10, "query")
             .await
             .unwrap();
         store
@@ -1448,7 +1533,7 @@ mod tests {
             .unwrap();
         let rows = store.list_by_session("sess-all").await.unwrap();
         assert_eq!(rows.len(), 3);
-        assert_eq!(rows[0]["statement_kind"], json!("Query"));
+        assert_eq!(rows[0]["statement_kind"], json!("query"));
         assert_eq!(rows[1]["statement_kind"], json!("pipeline"));
         assert_eq!(rows[2]["statement_kind"], json!("job"));
         assert_eq!(rows[2]["sql"], json!("nightly-backfill@2.1.0"));
@@ -1497,5 +1582,126 @@ mod tests {
         let row = store.get(&id).await.unwrap().unwrap();
         assert_eq!(row["statement_kind"], json!("job"));
         assert!(row["job_run_id"].is_null());
+    }
+
+    #[tokio::test]
+    async fn open_creates_job_run_id_index_on_migrated_and_fresh_databases() {
+        // The index cannot live in INIT_SCHEMA_SQL — that batch also runs
+        // against pre-column databases, where indexing job_run_id would fail
+        // — so it is applied in `ensure_schema_additions`, after the column is
+        // guaranteed. Pin that it lands on both a fresh database and a
+        // migrated one.
+        async fn index_exists(store: &QueryAuditStore) -> bool {
+            store
+                .conn
+                .call(|conn| -> SqlResult<bool> {
+                    conn.prepare(
+                        "SELECT 1 FROM sqlite_master
+                          WHERE type = 'index' AND name = 'idx_query_audit_job_run_id'",
+                    )?
+                    .exists([])
+                })
+                .await
+                .unwrap()
+        }
+
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        let fresh = QueryAuditStore::open(tmp.path().join("fresh.db"))
+            .await
+            .unwrap();
+        assert!(
+            index_exists(&fresh).await,
+            "fresh database is missing the job_run_id index"
+        );
+
+        let old_path = tmp.path().join("old.db");
+        {
+            let conn = rusqlite::Connection::open(&old_path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE query_audit (
+                    id TEXT PRIMARY KEY, created_at TEXT NOT NULL,
+                    finished_at TEXT, sql TEXT NOT NULL, ai_context TEXT,
+                    session_id TEXT, max_rows INTEGER NOT NULL,
+                    statement_kind TEXT NOT NULL, status TEXT NOT NULL,
+                    row_count INTEGER, error TEXT);",
+            )
+            .unwrap();
+        }
+        let migrated = QueryAuditStore::open(&old_path).await.unwrap();
+        assert!(
+            index_exists(&migrated).await,
+            "migrated database is missing the job_run_id index"
+        );
+    }
+
+    #[test]
+    fn duplicate_column_error_is_recognised() {
+        // The migration's check-then-ALTER is not atomic, so a second process
+        // can win the race and leave this connection's ALTER failing with
+        // `duplicate column name`. That is the post-condition the step wanted,
+        // so `open()` treats it as success — but only if it can tell that
+        // error apart from a real one. rusqlite reports it as a generic
+        // SQLITE_ERROR with no distinguishing code, hence the text match;
+        // this test is what keeps the match honest against a rusqlite bump.
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE query_audit (id TEXT PRIMARY KEY);")
+            .unwrap();
+        conn.execute("ALTER TABLE query_audit ADD COLUMN job_run_id TEXT", [])
+            .unwrap();
+        let err = conn
+            .execute("ALTER TABLE query_audit ADD COLUMN job_run_id TEXT", [])
+            .expect_err("adding an existing column must fail");
+        assert!(is_duplicate_column(&err), "unrecognised: {err}");
+
+        // A genuinely different failure must not be swallowed.
+        let other = conn
+            .execute("ALTER TABLE nonexistent ADD COLUMN run_id TEXT", [])
+            .expect_err("altering a missing table must fail");
+        assert!(!is_duplicate_column(&other), "over-matched: {other}");
+    }
+
+    #[tokio::test]
+    async fn job_outcome_does_not_resurrect_a_reconciled_row() {
+        // Two servers sharing one --query-audit-db file: B's startup
+        // reconciliation settles A's in-flight submission to `unknown`, then
+        // A's outcome write lands. Without the started-only guard that late
+        // write would flip a terminal row back to `succeeded` and defeat
+        // reconciliation.
+        let store = QueryAuditStore::open_in_memory().await.unwrap();
+        let id = store
+            .record_job_submitted("nightly-backfill", "2.1.0", Some("sess-j"))
+            .await
+            .unwrap();
+        store.reconcile_orphaned("server B restart").await.unwrap();
+
+        // Not an error: 0 rows updated means something else already settled it.
+        store
+            .record_job_outcome(&id, Some("run-late"), QueryAuditStatus::Succeeded, None)
+            .await
+            .unwrap();
+
+        let row = store.get(&id).await.unwrap().unwrap();
+        assert_eq!(row["status"], json!("unknown"));
+        assert!(row["run_id"].is_null(), "terminal row was resurrected");
+    }
+
+    #[tokio::test]
+    async fn query_outcome_does_not_resurrect_a_reconciled_row() {
+        let store = QueryAuditStore::open_in_memory().await.unwrap();
+        let id = store
+            .record_started("SELECT 1", None, 10, "query")
+            .await
+            .unwrap();
+        store.reconcile_orphaned("server B restart").await.unwrap();
+
+        store
+            .record_outcome(&id, QueryAuditStatus::Succeeded, Some(7), None)
+            .await
+            .unwrap();
+
+        let row = store.get(&id).await.unwrap().unwrap();
+        assert_eq!(row["status"], json!("unknown"));
+        assert!(row["row_count"].is_null(), "terminal row was resurrected");
     }
 }

--- a/crates/query-audit/src/lib.rs
+++ b/crates/query-audit/src/lib.rs
@@ -35,7 +35,6 @@
 //! forever, and pruning/rotation is the operator's call.
 
 use anyhow::{Context, Result, anyhow};
-use axum::http::HeaderMap;
 use serde_json::Value;
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -64,77 +63,18 @@ pub(crate) const AUDIT_WRITE_TIMEOUT: Duration = Duration::from_secs(5);
 /// Maximum length of a session id, in characters — shared by `/query`'s
 /// `ai_context.session_id` and the `x-skardi-session-id` header consumed by
 /// both the pipeline execute endpoint and the jobs submit endpoint (see
-/// `query_handlers::validate_ai_context` and [`session_id_from_headers`]),
+/// `query_handlers::validate_ai_context` and
+/// `session_header::session_id_from_headers` in the server crate),
 /// so all three paths can't drift apart. It is an opaque grouping key, not a
 /// payload.
 ///
-/// `skardi-cli` restates this cap under the same name (`run.rs`) because the
-/// CLI crate does not depend on this one; keep them in sync.
+/// `skardi-cli` restates this cap under the same name
+/// (`crates/cli/src/session.rs`) because the CLI crate does not depend on this
+/// one; keep them in sync.
 /// `pub` because the handlers that enforce this bound now live in a
 /// different crate: `pub(crate)` was the right scope while this module was
 /// inside the server, and the extraction is what widened it.
 pub const MAX_SESSION_ID_CHARS: usize = 200;
-
-/// Optional caller-supplied session header. A header (not a body field)
-/// because the pipeline-execute body IS the flattened parameter map — a
-/// reserved key could collide with a legitimate SQL parameter of the same
-/// name. The jobs submit endpoint shares the header for the same reason:
-/// its body is the job's parameter map.
-///
-/// Not an auth credential: unrelated to `require_session`. The value is
-/// caller-asserted, so ledger session attribution is self-reported rather
-/// than derived from an authenticated principal — the same property as
-/// `/query`'s `ai_context.session_id`.
-pub(crate) const SESSION_ID_HEADER: &str = "x-skardi-session-id";
-
-/// Extract and validate the session header. `Ok(None)` when absent; `Err`
-/// when present but malformed — silently dropping a malformed value would
-/// corrupt session stitching, the one job this field has.
-///
-/// Allowed characters are visible ASCII graphic characters, excluding comma —
-/// no space, no tab, no other whitespace or control character. Space is
-/// rejected (not just trimmed) because `httparse` strips leading/trailing
-/// whitespace per RFC 9110 §5.5 before this code ever sees the value: if
-/// spaces were merely tolerated, `"  sess-1  "` would be recorded under the
-/// different key `sess-1` (silently breaking the session stitching this
-/// field exists for) while `"   "` would 400 here — the exact fail-late
-/// round trip a client-side check exists to prevent. A grouping key has no
-/// legitimate use for spaces, so this rejects them outright instead of
-/// defining trimming semantics. Commas are rejected because RFC 9110 §5.3
-/// lets any intermediary merge repeated header lines into one comma-joined
-/// value, which would otherwise slip a duplicate past the check below as a
-/// single merged `"id1, id2"`. This predicate is mirrored exactly by the
-/// CLI's own check in `crates/cli/src/session.rs`.
-pub(crate) fn session_id_from_headers(headers: &HeaderMap) -> Result<Option<String>, String> {
-    let mut values = headers.get_all(SESSION_ID_HEADER).iter();
-    let Some(value) = values.next() else {
-        return Ok(None);
-    };
-    if values.next().is_some() {
-        return Err(format!(
-            "{SESSION_ID_HEADER} must not be sent more than once"
-        ));
-    }
-    let s = value
-        .to_str()
-        .map_err(|_| format!("{SESSION_ID_HEADER} must contain only visible ASCII characters"))?;
-    if !s.chars().all(|c| c.is_ascii_graphic() && c != ',') {
-        return Err(format!(
-            "{SESSION_ID_HEADER} must contain only visible ASCII characters, \
-             with no spaces and no commas (proxies may merge repeated header \
-             lines into one comma-separated value)"
-        ));
-    }
-    if s.is_empty() {
-        return Err(format!("{SESSION_ID_HEADER} must not be empty"));
-    }
-    if s.chars().count() > MAX_SESSION_ID_CHARS {
-        return Err(format!(
-            "{SESSION_ID_HEADER} must be at most {MAX_SESSION_ID_CHARS} characters"
-        ));
-    }
-    Ok(Some(s.to_string()))
-}
 
 /// Error from [`bounded`] that keeps "the write timed out" distinguishable
 /// from "the write ran and failed" (e.g. `ConnectionClosed`). Only the

--- a/crates/query-audit/src/lib.rs
+++ b/crates/query-audit/src/lib.rs
@@ -35,6 +35,7 @@
 //! forever, and pruning/rotation is the operator's call.
 
 use anyhow::{Context, Result, anyhow};
+use axum::http::HeaderMap;
 use serde_json::Value;
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -61,10 +62,11 @@ use tokio_rusqlite::{Connection, params, rusqlite};
 pub(crate) const AUDIT_WRITE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Maximum length of a session id, in characters — shared by `/query`'s
-/// `ai_context.session_id` and the pipeline execute endpoint's
-/// `x-skardi-session-id` header (see `query_handlers::validate_ai_context`
-/// and `pipeline_handlers::session_id_from_headers`), so the two paths can't
-/// drift apart. It is an opaque grouping key, not a payload.
+/// `ai_context.session_id` and the `x-skardi-session-id` header consumed by
+/// both the pipeline execute endpoint and the jobs submit endpoint (see
+/// `query_handlers::validate_ai_context` and [`session_id_from_headers`]),
+/// so all three paths can't drift apart. It is an opaque grouping key, not a
+/// payload.
 ///
 /// `skardi-cli` restates this cap under the same name (`run.rs`) because the
 /// CLI crate does not depend on this one; keep them in sync.
@@ -72,6 +74,67 @@ pub(crate) const AUDIT_WRITE_TIMEOUT: Duration = Duration::from_secs(5);
 /// different crate: `pub(crate)` was the right scope while this module was
 /// inside the server, and the extraction is what widened it.
 pub const MAX_SESSION_ID_CHARS: usize = 200;
+
+/// Optional caller-supplied session header. A header (not a body field)
+/// because the pipeline-execute body IS the flattened parameter map — a
+/// reserved key could collide with a legitimate SQL parameter of the same
+/// name. The jobs submit endpoint shares the header for the same reason:
+/// its body is the job's parameter map.
+///
+/// Not an auth credential: unrelated to `require_session`. The value is
+/// caller-asserted, so ledger session attribution is self-reported rather
+/// than derived from an authenticated principal — the same property as
+/// `/query`'s `ai_context.session_id`.
+pub(crate) const SESSION_ID_HEADER: &str = "x-skardi-session-id";
+
+/// Extract and validate the session header. `Ok(None)` when absent; `Err`
+/// when present but malformed — silently dropping a malformed value would
+/// corrupt session stitching, the one job this field has.
+///
+/// Allowed characters are visible ASCII graphic characters, excluding comma —
+/// no space, no tab, no other whitespace or control character. Space is
+/// rejected (not just trimmed) because `httparse` strips leading/trailing
+/// whitespace per RFC 9110 §5.5 before this code ever sees the value: if
+/// spaces were merely tolerated, `"  sess-1  "` would be recorded under the
+/// different key `sess-1` (silently breaking the session stitching this
+/// field exists for) while `"   "` would 400 here — the exact fail-late
+/// round trip a client-side check exists to prevent. A grouping key has no
+/// legitimate use for spaces, so this rejects them outright instead of
+/// defining trimming semantics. Commas are rejected because RFC 9110 §5.3
+/// lets any intermediary merge repeated header lines into one comma-joined
+/// value, which would otherwise slip a duplicate past the check below as a
+/// single merged `"id1, id2"`. This predicate is mirrored exactly by the
+/// CLI's own check in `crates/cli/src/session.rs`.
+pub(crate) fn session_id_from_headers(headers: &HeaderMap) -> Result<Option<String>, String> {
+    let mut values = headers.get_all(SESSION_ID_HEADER).iter();
+    let Some(value) = values.next() else {
+        return Ok(None);
+    };
+    if values.next().is_some() {
+        return Err(format!(
+            "{SESSION_ID_HEADER} must not be sent more than once"
+        ));
+    }
+    let s = value
+        .to_str()
+        .map_err(|_| format!("{SESSION_ID_HEADER} must contain only visible ASCII characters"))?;
+    if !s.chars().all(|c| c.is_ascii_graphic() && c != ',') {
+        return Err(format!(
+            "{SESSION_ID_HEADER} must contain only visible ASCII characters, \
+             with no spaces and no commas (proxies may merge repeated header \
+             lines into one comma-separated value)"
+        ));
+    }
+    if s.is_empty() {
+        return Err(format!("{SESSION_ID_HEADER} must not be empty"));
+    }
+    if s.chars().count() > MAX_SESSION_ID_CHARS {
+        return Err(format!(
+            "{SESSION_ID_HEADER} must be at most {MAX_SESSION_ID_CHARS} characters"
+        ));
+    }
+    Ok(Some(s.to_string()))
+}
 
 /// Error from [`bounded`] that keeps "the write timed out" distinguishable
 /// from "the write ran and failed" (e.g. `ConnectionClosed`). Only the
@@ -532,7 +595,7 @@ impl QueryAuditStore {
         let session_id = session_id.map(str::to_string);
         let row_id = id.clone();
 
-        bounded(
+        match bounded(
             self.conn.call(move |conn| -> SqlResult<()> {
                 conn.execute(
                     "INSERT INTO query_audit
@@ -554,9 +617,21 @@ impl QueryAuditStore {
             "Failed to write pre-execution job-audit record",
             self.write_timeout,
         )
-        .await?;
-
-        Ok(id)
+        .await
+        {
+            Ok(()) => Ok(id),
+            Err(e) => {
+                // Same reasoning as `record_pipeline_started`: this is a
+                // pre-execution write, so a timeout means the caller has
+                // already been told "503, the job was not submitted" — a
+                // fact worth recording precisely instead of letting startup
+                // reconcile the abandoned row to the ambiguous `unknown`.
+                if e.is_timeout() {
+                    self.spawn_timeout_correction(id);
+                }
+                Err(e.into())
+            }
+        }
     }
 
     /// Update a job-submission record with its terminal outcome, stamping the

--- a/crates/query-audit/src/lib.rs
+++ b/crates/query-audit/src/lib.rs
@@ -171,7 +171,8 @@ const INIT_SCHEMA_SQL: &str = "CREATE TABLE IF NOT EXISTS query_audit (
     org_id         TEXT,
     workspace_id   TEXT,
     user_id        TEXT,
-    run_id         TEXT
+    run_id         TEXT,
+    job_run_id     TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_query_audit_session_created
     ON query_audit (session_id, created_at DESC);
@@ -183,24 +184,42 @@ CREATE INDEX IF NOT EXISTS idx_query_audit_statement_kind
     ON query_audit (statement_kind);";
 
 /// The five identity columns, in order. `CREATE TABLE IF NOT EXISTS` cannot
-/// retrofit an existing table, so [`ensure_identity_columns`] reconciles the
+/// retrofit an existing table, so [`ensure_added_columns`] reconciles the
 /// live schema on every open — additive, idempotent, and a no-op on fresh
 /// databases.
 const IDENTITY_COLUMNS: [&str; 5] = ["request_id", "org_id", "workspace_id", "user_id", "run_id"];
 
-fn ensure_identity_columns(conn: &rusqlite::Connection) -> SqlResult<()> {
+/// Columns bridging a ledger row to another ledger's record of the same work.
+/// Reconciled by the same mechanism as [`IDENTITY_COLUMNS`], but kept a
+/// separate list because they answer a different question: identity is *who
+/// asked*, a bridge is *what the work became*.
+///
+/// `job_run_id` holds `job_runs.id` for `statement_kind = 'job'` rows.
+/// Deliberately not the identity envelope's `run_id`, which names the caller's
+/// own run — one column, one meaning.
+const BRIDGE_COLUMNS: [&str; 1] = ["job_run_id"];
+
+/// Add any of `columns` the live table is missing, as nullable `TEXT`.
+fn ensure_added_columns(conn: &rusqlite::Connection, columns: &[&str]) -> SqlResult<()> {
     let mut stmt = conn.prepare("PRAGMA table_info(query_audit)")?;
     let existing: std::collections::HashSet<String> = stmt
         .query_map([], |row| row.get::<_, String>(1))?
         .collect::<std::result::Result<_, _>>()?;
-    for col in IDENTITY_COLUMNS {
-        if !existing.contains(col) {
+    for col in columns {
+        if !existing.contains(*col) {
             conn.execute(
                 &format!("ALTER TABLE query_audit ADD COLUMN {col} TEXT"),
                 [],
             )?;
         }
     }
+    Ok(())
+}
+
+/// Every column added to `query_audit` after its original DDL.
+fn ensure_schema_additions(conn: &rusqlite::Connection) -> SqlResult<()> {
+    ensure_added_columns(conn, &IDENTITY_COLUMNS)?;
+    ensure_added_columns(conn, &BRIDGE_COLUMNS)?;
     Ok(())
 }
 
@@ -292,7 +311,7 @@ impl QueryAuditStore {
             conn.pragma_update(None, "journal_mode", "WAL")?;
             conn.pragma_update(None, "synchronous", "FULL")?;
             conn.execute_batch(INIT_SCHEMA_SQL)?;
-            ensure_identity_columns(conn)?;
+            ensure_schema_additions(conn)?;
             Ok(())
         })
         .await
@@ -324,7 +343,7 @@ impl QueryAuditStore {
             .context("Failed to open in-memory query-audit db")?;
         conn.call(|conn| -> SqlResult<()> {
             conn.execute_batch(INIT_SCHEMA_SQL)?;
-            ensure_identity_columns(conn)?;
+            ensure_schema_additions(conn)?;
             Ok(())
         })
         .await
@@ -492,6 +511,89 @@ impl QueryAuditStore {
                 Err(e.into())
             }
         }
+    }
+
+    /// Insert a `started` row for a job *submission*.
+    ///
+    /// The row's lifecycle is the submission's, not the run's: `succeeded`
+    /// means "accepted and enqueued" (stamped with the `job_run_id` that
+    /// bridges to the jobs ledger, the authority on the run itself), `failed` means
+    /// the executor rejected it. Stores `name@version`; parameter values are
+    /// never recorded here — `job_runs.parameters` is a separate concern.
+    pub async fn record_job_submitted(
+        &self,
+        job_name: &str,
+        version: &str,
+        session_id: Option<&str>,
+    ) -> Result<String> {
+        let id = new_id();
+        let created_at = chrono::Utc::now().to_rfc3339();
+        let name_at_version = format!("{job_name}@{version}");
+        let session_id = session_id.map(str::to_string);
+        let row_id = id.clone();
+
+        bounded(
+            self.conn.call(move |conn| -> SqlResult<()> {
+                conn.execute(
+                    "INSERT INTO query_audit
+                        (id, created_at, sql, ai_context, session_id, max_rows,
+                         statement_kind, status)
+                     VALUES (?1, ?2, ?3, NULL, ?4, ?5, ?6, ?7)",
+                    params![
+                        row_id,
+                        created_at,
+                        name_at_version,
+                        session_id,
+                        PIPELINE_MAX_ROWS_SENTINEL,
+                        JOB_STATEMENT_KIND,
+                        QueryAuditStatus::Started.as_str(),
+                    ],
+                )?;
+                Ok(())
+            }),
+            "Failed to write pre-execution job-audit record",
+            self.write_timeout,
+        )
+        .await?;
+
+        Ok(id)
+    }
+
+    /// Update a job-submission record with its terminal outcome, stamping the
+    /// `job_run_id` that bridges this row to the jobs ledger's authoritative
+    /// record of the run itself. `job_run_id` is `None` when the submission was
+    /// rejected before a run was ever created.
+    ///
+    /// Distinct from the identity envelope's `run_id` ([`QueryIdentity`]),
+    /// which names the *caller's* run rather than the job run this submission
+    /// produced. One column, one meaning.
+    pub async fn record_job_outcome(
+        &self,
+        id: &str,
+        job_run_id: Option<&str>,
+        status: QueryAuditStatus,
+        error: Option<&str>,
+    ) -> Result<()> {
+        let id = id.to_string();
+        let finished_at = chrono::Utc::now().to_rfc3339();
+        let status = status.as_str();
+        let job_run_id = job_run_id.map(str::to_string);
+        let error = error.map(str::to_string);
+        bounded(
+            self.conn.call(move |conn| -> SqlResult<()> {
+                conn.execute(
+                    "UPDATE query_audit
+                        SET status = ?2, finished_at = ?3, job_run_id = ?4, error = ?5
+                      WHERE id = ?1",
+                    params![id, status, finished_at, job_run_id, error],
+                )?;
+                Ok(())
+            }),
+            "Failed to update job-audit record",
+            self.write_timeout,
+        )
+        .await?;
+        Ok(())
     }
 
     /// Update a record with its terminal outcome.
@@ -668,7 +770,8 @@ impl QueryAuditStore {
                 let mut stmt = conn.prepare(
                     "SELECT id, created_at, finished_at, sql, ai_context, session_id,
                             max_rows, statement_kind, status, row_count, error,
-                            request_id, org_id, workspace_id, user_id, run_id
+                            request_id, org_id, workspace_id, user_id, run_id,
+                            job_run_id
                        FROM query_audit WHERE id = ?1",
                 )?;
                 let row = stmt
@@ -691,6 +794,7 @@ impl QueryAuditStore {
                             "workspace_id": row.get::<_, Option<String>>(13)?,
                             "user_id": row.get::<_, Option<String>>(14)?,
                             "run_id": row.get::<_, Option<String>>(15)?,
+                            "job_run_id": row.get::<_, Option<String>>(16)?,
                         }))
                     })
                     .ok();
@@ -793,8 +897,14 @@ fn restrict_permissions(path: &Path) -> Result<()> {
 /// Statement-kind marker distinguishing pipeline rows from ad-hoc SQL rows.
 const PIPELINE_STATEMENT_KIND: &str = "pipeline";
 
+/// Statement-kind marker for job-submission rows. Nothing outside this
+/// module reads it directly (Task 2 goes through `record_job_submitted`),
+/// so it stays private, mirroring `PIPELINE_STATEMENT_KIND`'s narrowing.
+const JOB_STATEMENT_KIND: &str = "job";
+
 /// `max_rows` does not apply to pipeline executions, but the column is NOT
-/// NULL; pipeline rows store this sentinel.
+/// NULL; pipeline rows store this sentinel. Job-submission rows share it for
+/// the same reason — `max_rows` has no meaning for a job run either.
 ///
 /// The sentinel is unambiguous only because `/query` rejects
 /// `max_rows: Some(0)` up front (the `Some(0)` arm in
@@ -1261,5 +1371,116 @@ mod tests {
         assert_eq!(n, 1);
         let row = store.get(&id).await.unwrap().unwrap();
         assert_eq!(row["status"], json!("unknown"));
+    }
+
+    #[tokio::test]
+    async fn job_row_round_trips_with_job_run_id() {
+        let store = QueryAuditStore::open_in_memory().await.unwrap();
+        let id = store
+            .record_job_submitted("nightly-backfill", "2.1.0", Some("sess-j"))
+            .await
+            .unwrap();
+        store
+            .record_job_outcome(&id, Some("run-abc123"), QueryAuditStatus::Succeeded, None)
+            .await
+            .unwrap();
+        let row = store.get(&id).await.unwrap().unwrap();
+        assert_eq!(row["sql"], json!("nightly-backfill@2.1.0"));
+        assert_eq!(row["statement_kind"], json!("job"));
+        assert_eq!(row["session_id"], json!("sess-j"));
+        assert_eq!(row["status"], json!("succeeded"));
+        assert_eq!(row["job_run_id"], json!("run-abc123"));
+        // The identity envelope's `run_id` is a different column with a
+        // different meaning and must stay untouched by the bridge stamp.
+        assert!(row["run_id"].is_null());
+        assert_eq!(row["max_rows"], json!(0));
+        assert!(row["ai_context"].is_null());
+        assert!(row["row_count"].is_null());
+    }
+
+    #[tokio::test]
+    async fn rejected_job_submission_records_fixed_kind_and_null_job_run_id() {
+        let store = QueryAuditStore::open_in_memory().await.unwrap();
+        let id = store
+            .record_job_submitted("nightly-backfill", "2.1.0", None)
+            .await
+            .unwrap();
+        store
+            .record_job_outcome(&id, None, QueryAuditStatus::Failed, Some("schema_mismatch"))
+            .await
+            .unwrap();
+        let row = store.get(&id).await.unwrap().unwrap();
+        assert_eq!(row["status"], json!("failed"));
+        assert_eq!(row["error"], json!("schema_mismatch"));
+        assert!(row["job_run_id"].is_null());
+    }
+
+    #[tokio::test]
+    async fn list_by_session_interleaves_all_three_kinds_in_order() {
+        let store = QueryAuditStore::open_in_memory().await.unwrap();
+        let ctx = serde_json::json!({"purpose": "p", "session_id": "sess-all"});
+        store
+            .record_started("SELECT 1", Some(&ctx), 10, "Query")
+            .await
+            .unwrap();
+        store
+            .record_pipeline_started("weekly-churn", "1.0.0", Some("sess-all"))
+            .await
+            .unwrap();
+        store
+            .record_job_submitted("nightly-backfill", "2.1.0", Some("sess-all"))
+            .await
+            .unwrap();
+        let rows = store.list_by_session("sess-all").await.unwrap();
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0]["statement_kind"], json!("Query"));
+        assert_eq!(rows[1]["statement_kind"], json!("pipeline"));
+        assert_eq!(rows[2]["statement_kind"], json!("job"));
+        assert_eq!(rows[2]["sql"], json!("nightly-backfill@2.1.0"));
+    }
+
+    #[tokio::test]
+    async fn orphaned_job_rows_reconcile_to_unknown() {
+        let store = QueryAuditStore::open_in_memory().await.unwrap();
+        let id = store
+            .record_job_submitted("nightly-backfill", "2.1.0", None)
+            .await
+            .unwrap();
+        let n = store.reconcile_orphaned("test restart").await.unwrap();
+        assert_eq!(n, 1);
+        let row = store.get(&id).await.unwrap().unwrap();
+        assert_eq!(row["status"], json!("unknown"));
+    }
+
+    #[tokio::test]
+    async fn open_migrates_old_schema_without_job_run_id_column() {
+        // A database created before job_run_id existed must open and serve job
+        // rows after migration. Covers the bridge column specifically: #206's
+        // identity columns have their own old-schema fixture, and both are
+        // reconciled by the same `ensure_schema_additions` step.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("old.db");
+        {
+            // Original DDL: INIT_SCHEMA_SQL before either the identity
+            // columns or the bridge column existed.
+            let conn = rusqlite::Connection::open(&path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE query_audit (
+                    id TEXT PRIMARY KEY, created_at TEXT NOT NULL,
+                    finished_at TEXT, sql TEXT NOT NULL, ai_context TEXT,
+                    session_id TEXT, max_rows INTEGER NOT NULL,
+                    statement_kind TEXT NOT NULL, status TEXT NOT NULL,
+                    row_count INTEGER, error TEXT);",
+            )
+            .unwrap();
+        }
+        let store = QueryAuditStore::open(&path).await.unwrap();
+        let id = store
+            .record_job_submitted("nightly-backfill", "2.1.0", None)
+            .await
+            .unwrap();
+        let row = store.get(&id).await.unwrap().unwrap();
+        assert_eq!(row["statement_kind"], json!("job"));
+        assert!(row["job_run_id"].is_null());
     }
 }

--- a/crates/query-audit/src/lib.rs
+++ b/crates/query-audit/src/lib.rs
@@ -255,12 +255,44 @@ fn ensure_added_columns(conn: &rusqlite::Connection, columns: &[&str]) -> SqlRes
     Ok(())
 }
 
-/// Every column added to `query_audit` after its original DDL, plus the
-/// indexes that can only be built once those columns exist.
+/// Normalise the pre-#219 `statement_kind` casing on rows already on disk.
+///
+/// Ad-hoc rows used to record the `Debug` form of `StatementKind` — `Query`
+/// and `Other`. They now record [`QUERY_STATEMENT_KIND`] /
+/// [`OTHER_STATEMENT_KIND`], so without this a ledger written before the
+/// change holds both casings for one concept: `WHERE statement_kind =
+/// 'query'` (the filter `docs/server.md` documents) silently returns only
+/// post-upgrade rows, and `= 'Query'` silently loses everything after.
+/// `idx_query_audit_statement_kind` makes both look fast, so the only symptom
+/// is wrong counts. The ledger is append-only with retention off by default,
+/// so those rows never age out on their own.
+///
+/// Idempotent and a no-op on fresh databases, like the column reconcile it
+/// sits beside. `statement_kind` carries no `COLLATE NOCASE`, so the match is
+/// case-sensitive and normalised rows cannot be rewritten again. `pipeline`
+/// and `job` were lowercase from the start and are untouched.
+fn normalise_statement_kind_casing(conn: &rusqlite::Connection) -> SqlResult<()> {
+    for (legacy, current) in [
+        ("Query", QUERY_STATEMENT_KIND),
+        ("Other", OTHER_STATEMENT_KIND),
+    ] {
+        conn.execute(
+            "UPDATE query_audit SET statement_kind = ?1 WHERE statement_kind = ?2",
+            params![current, legacy],
+        )?;
+    }
+    Ok(())
+}
+
+/// Every column added to `query_audit` after its original DDL, the indexes
+/// that can only be built once those columns exist, and the one-shot data
+/// normalisations that keep an existing file consistent with what the current
+/// code writes.
 fn ensure_schema_additions(conn: &rusqlite::Connection) -> SqlResult<()> {
     ensure_added_columns(conn, &IDENTITY_COLUMNS)?;
     ensure_added_columns(conn, &BRIDGE_COLUMNS)?;
     conn.execute_batch(JOB_RUN_ID_INDEX_SQL)?;
+    normalise_statement_kind_casing(conn)?;
     Ok(())
 }
 
@@ -351,6 +383,20 @@ impl QueryAuditStore {
             // engine.
             conn.pragma_update(None, "journal_mode", "WAL")?;
             conn.pragma_update(None, "synchronous", "FULL")?;
+            // SQLite installs no busy handler by default: a write that finds
+            // the lock held returns `SQLITE_BUSY` immediately. Two servers
+            // pointed at one `--query-audit-db` — the case
+            // `ensure_added_columns` and the `started`-only guard are written
+            // for — would then fail on the lock before ever reaching the
+            // races being guarded: B's `ALTER TABLE` during A's INSERT aborts
+            // B's startup with `database is locked`, and an audited request
+            // that loses the lock 503s under a fail-closed policy that was
+            // meant for real write failures. Bounded by the same
+            // `AUDIT_WRITE_TIMEOUT` the callers already wait out, so waiting
+            // for the lock cannot outlast the request bound. Matches the
+            // sqlite source provider, which defaults `busy_timeout_ms` to
+            // 5000 rather than taking SQLite's default.
+            conn.busy_timeout(AUDIT_WRITE_TIMEOUT)?;
             conn.execute_batch(INIT_SCHEMA_SQL)?;
             ensure_schema_additions(conn)?;
             Ok(())
@@ -1585,6 +1631,80 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn open_normalises_legacy_statement_kind_casing() {
+        // A ledger written before the casing change holds `Query` / `Other`
+        // (the leaked `Debug` form). After upgrading, the documented filter
+        // `WHERE statement_kind = 'query'` must see those rows too — otherwise
+        // every pre-upgrade ad-hoc statement is silently invisible to the
+        // intention-mining consumer the ledger exists for.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("legacy-casing.db");
+        {
+            let conn = rusqlite::Connection::open(&path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE query_audit (
+                    id TEXT PRIMARY KEY, created_at TEXT NOT NULL,
+                    finished_at TEXT, sql TEXT NOT NULL, ai_context TEXT,
+                    session_id TEXT, max_rows INTEGER NOT NULL,
+                    statement_kind TEXT NOT NULL, status TEXT NOT NULL,
+                    row_count INTEGER, error TEXT);",
+            )
+            .unwrap();
+            for (id, kind) in [
+                ("old-q", "Query"),
+                ("old-o", "Other"),
+                ("old-p", "pipeline"),
+            ] {
+                conn.execute(
+                    "INSERT INTO query_audit
+                        (id, created_at, sql, max_rows, statement_kind, status, session_id)
+                     VALUES (?1, '2026-08-01T00:00:00Z', 'SELECT 1', 10, ?2, 'succeeded', 'sess-legacy')",
+                    params![id, kind],
+                )
+                .unwrap();
+            }
+        }
+
+        let store = QueryAuditStore::open(&path).await.unwrap();
+        store
+            .record_started(
+                "SELECT 2",
+                Some(&json!({ "session_id": "sess-legacy" })),
+                10,
+                QUERY_STATEMENT_KIND,
+            )
+            .await
+            .unwrap();
+
+        let rows = store.list_by_session("sess-legacy").await.unwrap();
+        let kinds: Vec<&str> = rows
+            .iter()
+            .map(|r| r["statement_kind"].as_str().unwrap())
+            .collect();
+        // Both pre-upgrade ad-hoc rows now answer to the documented filter,
+        // alongside the post-upgrade one. `pipeline` was already lowercase.
+        assert_eq!(kinds.iter().filter(|k| **k == "query").count(), 2);
+        assert_eq!(kinds.iter().filter(|k| **k == "other").count(), 1);
+        assert_eq!(kinds.iter().filter(|k| **k == "pipeline").count(), 1);
+        assert!(
+            !kinds.iter().any(|k| *k == "Query" || *k == "Other"),
+            "legacy casing survived the migration: {kinds:?}"
+        );
+
+        // Idempotent: a second open must not disturb the normalised rows.
+        drop(store);
+        let store = QueryAuditStore::open(&path).await.unwrap();
+        let rows = store.list_by_session("sess-legacy").await.unwrap();
+        assert_eq!(rows.len(), 4);
+        assert!(
+            rows.iter()
+                .all(|r| r["statement_kind"] != json!("Query")
+                    && r["statement_kind"] != json!("Other")),
+            "second open reintroduced legacy casing"
+        );
+    }
+
+    #[tokio::test]
     async fn open_creates_job_run_id_index_on_migrated_and_fresh_databases() {
         // The index cannot live in INIT_SCHEMA_SQL — that batch also runs
         // against pre-column databases, where indexing job_run_id would fail
@@ -1683,7 +1803,11 @@ mod tests {
 
         let row = store.get(&id).await.unwrap().unwrap();
         assert_eq!(row["status"], json!("unknown"));
-        assert!(row["run_id"].is_null(), "terminal row was resurrected");
+        // `job_run_id`, not `run_id`: the bridge stamp is the only column
+        // `record_job_outcome` writes, so it is the only one whose absence
+        // proves the guard blocked the late write. `run_id` is #206's
+        // identity envelope — always NULL here regardless of the guard.
+        assert!(row["job_run_id"].is_null(), "terminal row was resurrected");
     }
 
     #[tokio::test]

--- a/crates/server/src/jobs_handlers.rs
+++ b/crates/server/src/jobs_handlers.rs
@@ -14,13 +14,14 @@
 use axum::{
     Json,
     extract::{Path, Query, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use skardi::jobs::{JobRun, JobSubmitError};
 use std::collections::HashMap;
 
+use crate::query_audit::{QueryAuditStatus, QueryAuditStore, session_id_from_headers};
 use crate::server::AppState;
 
 #[derive(Debug, Deserialize)]
@@ -74,6 +75,29 @@ fn submit_error_status(err: &JobSubmitError) -> StatusCode {
     }
 }
 
+/// Stamp the terminal outcome onto a job-submission audit record.
+///
+/// Mirrors `query_audit::finish_audit`'s policy: a failure (or timeout) here
+/// cannot un-submit a job that already reached the executor, so it is logged
+/// rather than surfaced — the row simply stays `started` and the next
+/// startup reconciles it to `unknown`. No-op when auditing is off or when
+/// the pre-submit write itself failed (no `audit_id`, which fails the
+/// request closed before this point is ever reached).
+async fn finish_job_audit(
+    store: Option<&QueryAuditStore>,
+    audit_id: Option<&str>,
+    run_id: Option<&str>,
+    status: QueryAuditStatus,
+    error: Option<&str>,
+) {
+    let (Some(store), Some(id)) = (store, audit_id) else {
+        return;
+    };
+    if let Err(e) = store.record_job_outcome(id, run_id, status, error).await {
+        tracing::error!("Failed to record job-audit outcome for {id}: {e}");
+    }
+}
+
 fn job_run_to_json(run: &JobRun) -> Value {
     serde_json::json!({
         "run_id": run.id,
@@ -92,6 +116,7 @@ fn job_run_to_json(run: &JobRun) -> Value {
 /// `POST /jobs/:name/run`
 pub async fn submit_job_run(
     State(app_state): State<AppState>,
+    headers: HeaderMap,
     Path(name): Path<String>,
     Json(req): Json<SubmitRunRequest>,
 ) -> Result<Json<SubmitRunResponse>, (StatusCode, Json<JobErrorResponse>)> {
@@ -106,11 +131,85 @@ pub async fn submit_job_run(
         ));
     };
 
+    // Existence + version pre-check, ahead of header validation: the reject
+    // below would otherwise label a metric/log line with an arbitrary
+    // caller-supplied URL segment (the metric-cardinality / status-precedence
+    // lesson from #213 round 3, mirrored from `execute_pipeline_by_name`).
+    // Post-lookup, `name` is bounded to configured jobs, and an unknown job
+    // correctly 404s regardless of header shape. This races benignly with
+    // `executor.submit`'s own name resolution a few lines down — both sides
+    // read the same `RwLock`-guarded config, so a job removed between the
+    // two lookups just becomes a 404 either way.
+    let version = {
+        let config = app_state.config.read().unwrap_or_else(|p| p.into_inner());
+        match config.jobs.get(&name) {
+            Some(def) => def.version().to_string(),
+            None => {
+                return Err((
+                    StatusCode::NOT_FOUND,
+                    error_json(
+                        &format!("Job '{name}' not found"),
+                        "unknown_job",
+                        Some(serde_json::json!({ "job": name })),
+                    ),
+                ));
+            }
+        }
+    };
+
+    let session_id = session_id_from_headers(&headers).map_err(|msg| {
+        (
+            StatusCode::BAD_REQUEST,
+            error_json(&msg, "parameter_validation_error", None),
+        )
+    })?;
+
+    tracing::info!(
+        session_id = session_id.as_deref().unwrap_or_default(),
+        "Received submit request for job '{}'",
+        name
+    );
+
+    // Record-before-submit, fail-closed: a write failure here means the job
+    // is never handed to the executor. An audited server must not run
+    // anything it cannot account for.
+    let audit_id = match &app_state.query_audit {
+        Some(store) => match store
+            .record_job_submitted(&name, &version, session_id.as_deref())
+            .await
+        {
+            Ok(id) => Some(id),
+            Err(e) => {
+                tracing::error!("Job audit write failed; refusing to submit: {e}");
+                return Err((
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    error_json(
+                        "Query auditing is enabled but the audit record could not be \
+                         written; the job was not submitted",
+                        "query_audit_error",
+                        None,
+                    ),
+                ));
+            }
+        },
+        None => None,
+    };
+
     match executor.submit(&name, req.parameters).await {
-        Ok(run_id) => Ok(Json(SubmitRunResponse {
-            run_id,
-            status: "pending".to_string(),
-        })),
+        Ok(run_id) => {
+            finish_job_audit(
+                app_state.query_audit.as_deref(),
+                audit_id.as_deref(),
+                Some(&run_id),
+                QueryAuditStatus::Succeeded,
+                None,
+            )
+            .await;
+            Ok(Json(SubmitRunResponse {
+                run_id,
+                status: "pending".to_string(),
+            }))
+        }
         Err(err) => {
             let status = submit_error_status(&err);
             let kind = err.category().to_string();
@@ -123,6 +222,14 @@ pub async fn submit_job_run(
                 JobSubmitError::UnknownJob(job) => Some(serde_json::json!({ "job": job })),
                 _ => None,
             };
+            finish_job_audit(
+                app_state.query_audit.as_deref(),
+                audit_id.as_deref(),
+                None,
+                QueryAuditStatus::Failed,
+                Some(&kind),
+            )
+            .await;
             Err((status, error_json(&msg, &kind, details)))
         }
     }

--- a/crates/server/src/jobs_handlers.rs
+++ b/crates/server/src/jobs_handlers.rs
@@ -156,6 +156,15 @@ pub async fn submit_job_run(
     // divergence is that future feature's problem to solve, not something
     // this handler guards against today.
     let version = {
+        // Recover from poisoning rather than 500, per the repo's error-handling
+        // policy for `std::sync` locks. `execute_pipeline_by_name` maps the
+        // same lock's poison to `500 internal_error`
+        // (`pipeline_handlers.rs`); the divergence is deliberate, not an
+        // oversight. `ServerConfig` is a startup snapshot that nothing mutates
+        // in production (the only `config.write()` in the tree is test-only),
+        // so a poisoned guard carries no torn state and the read below is
+        // still sound — failing the request would trade a correct answer for
+        // an outage.
         let config = app_state.config.read().unwrap_or_else(|p| p.into_inner());
         match config.jobs.get(&name) {
             Some(def) => def.version().to_string(),
@@ -179,8 +188,13 @@ pub async fn submit_job_run(
         )
     })?;
 
+    // Recorded as an `Option`, not `unwrap_or_default()`: the empty string is
+    // the one value `session_id_from_headers` rejects outright, so rendering
+    // "absent" as `""` would collide with a shape the validator calls
+    // malformed. `None` keeps "no header sent" distinguishable in log-based
+    // analysis — the same distinction NULL-vs-value preserves in the ledger.
     tracing::info!(
-        session_id = session_id.as_deref().unwrap_or_default(),
+        session_id = ?session_id,
         "Received submit request for job '{}'",
         name
     );

--- a/crates/server/src/jobs_handlers.rs
+++ b/crates/server/src/jobs_handlers.rs
@@ -21,8 +21,9 @@ use serde_json::Value;
 use skardi::jobs::{JobRun, JobSubmitError};
 use std::collections::HashMap;
 
-use crate::query_audit::{QueryAuditStatus, QueryAuditStore, session_id_from_headers};
+use crate::query_audit::{QueryAuditStatus, QueryAuditStore};
 use crate::server::AppState;
+use crate::session_header::session_id_from_headers;
 
 #[derive(Debug, Deserialize)]
 pub struct SubmitRunRequest {
@@ -86,14 +87,17 @@ fn submit_error_status(err: &JobSubmitError) -> StatusCode {
 async fn finish_job_audit(
     store: Option<&QueryAuditStore>,
     audit_id: Option<&str>,
-    run_id: Option<&str>,
+    job_run_id: Option<&str>,
     status: QueryAuditStatus,
     error: Option<&str>,
 ) {
     let (Some(store), Some(id)) = (store, audit_id) else {
         return;
     };
-    if let Err(e) = store.record_job_outcome(id, run_id, status, error).await {
+    if let Err(e) = store
+        .record_job_outcome(id, job_run_id, status, error)
+        .await
+    {
         tracing::error!("Failed to record job-audit outcome for {id}: {e}");
     }
 }
@@ -136,10 +140,21 @@ pub async fn submit_job_run(
     // caller-supplied URL segment (the metric-cardinality / status-precedence
     // lesson from #213 round 3, mirrored from `execute_pipeline_by_name`).
     // Post-lookup, `name` is bounded to configured jobs, and an unknown job
-    // correctly 404s regardless of header shape. This races benignly with
-    // `executor.submit`'s own name resolution a few lines down — both sides
-    // read the same `RwLock`-guarded config, so a job removed between the
-    // two lookups just becomes a 404 either way.
+    // correctly 404s regardless of header shape. This check and
+    // `executor.submit`'s own name resolution a few lines down read two
+    // *different* maps: this one is `app_state.config` (a
+    // `std::sync::RwLock<ServerConfig>`), the executor's is its own
+    // `Arc<tokio::sync::RwLock<HashMap<String, JobDefinition>>>` built from
+    // `config.jobs.clone()` at construction (see
+    // `crates/skardi/src/jobs/executor.rs`). Both are startup snapshots of
+    // the same job set, and today nothing writes to either map after
+    // startup, so the two lookups can never actually disagree. If a future
+    // hot-reload updates one map without the other, this pre-check and
+    // `executor.submit` could resolve different versions of the same job —
+    // the ledger might record a version the run didn't use, or this could
+    // 404 a job the executor would still accept (or vice versa). That
+    // divergence is that future feature's problem to solve, not something
+    // this handler guards against today.
     let version = {
         let config = app_state.config.read().unwrap_or_else(|p| p.into_inner());
         match config.jobs.get(&name) {

--- a/crates/server/src/jobs_handlers.rs
+++ b/crates/server/src/jobs_handlers.rs
@@ -23,7 +23,7 @@ use std::collections::HashMap;
 
 use crate::query_audit::{QueryAuditStatus, QueryAuditStore};
 use crate::server::AppState;
-use crate::session_header::session_id_from_headers;
+use crate::session_header::{SESSION_ID_HEADER, session_id_from_headers};
 
 #[derive(Debug, Deserialize)]
 pub struct SubmitRunRequest {
@@ -184,7 +184,17 @@ pub async fn submit_job_run(
     let session_id = session_id_from_headers(&headers).map_err(|msg| {
         (
             StatusCode::BAD_REQUEST,
-            error_json(&msg, "parameter_validation_error", None),
+            // `details.header` matches what `execute_pipeline_by_name` returns
+            // for the identical rejection. `error_type` alone cannot
+            // discriminate here: this endpoint also returns
+            // `parameter_validation_error` for genuine job-parameter
+            // rejections, so the header field is the only machine-readable
+            // way for a client to tell the two apart.
+            error_json(
+                &msg,
+                "parameter_validation_error",
+                Some(serde_json::json!({ "header": SESSION_ID_HEADER })),
+            ),
         )
     })?;
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -15,6 +15,7 @@ pub mod query_handlers;
 pub mod remote_storage;
 pub mod response;
 pub mod server;
+pub mod session_header;
 pub mod telemetry;
 
 // Re-export `skardi::semantics` so server code can use `crate::semantics::...`.

--- a/crates/server/src/pipeline_handlers.rs
+++ b/crates/server/src/pipeline_handlers.rs
@@ -27,14 +27,13 @@ use std::time::Instant;
 
 use crate::auth::routes::require_session;
 use crate::config::{DataSourceType, HierarchyLevel};
-use crate::query_audit::{
-    QueryAuditStatus, SESSION_ID_HEADER, finish_audit, session_id_from_headers,
-};
+use crate::query_audit::{QueryAuditStatus, finish_audit};
 use crate::response::{
     ErrorResponse, create_error_response, create_success_response, record_batch_to_json,
 };
 use crate::semantics::SemanticsRegistry;
 use crate::server::AppState;
+use crate::session_header::{SESSION_ID_HEADER, session_id_from_headers};
 
 /// Request structure for pipeline execution
 #[derive(Debug, Deserialize)]

--- a/crates/server/src/pipeline_handlers.rs
+++ b/crates/server/src/pipeline_handlers.rs
@@ -27,74 +27,14 @@ use std::time::Instant;
 
 use crate::auth::routes::require_session;
 use crate::config::{DataSourceType, HierarchyLevel};
-use crate::query_audit::{MAX_SESSION_ID_CHARS, QueryAuditStatus, finish_audit};
+use crate::query_audit::{
+    QueryAuditStatus, SESSION_ID_HEADER, finish_audit, session_id_from_headers,
+};
 use crate::response::{
     ErrorResponse, create_error_response, create_success_response, record_batch_to_json,
 };
 use crate::semantics::SemanticsRegistry;
 use crate::server::AppState;
-
-/// Optional caller-supplied session header. A header (not a body field)
-/// because the execute body IS the flattened parameter map — a reserved key
-/// could collide with a legitimate SQL parameter of the same name.
-///
-/// Not an auth credential: unrelated to [`require_session`] on the line
-/// above its extraction. The value is caller-asserted, so ledger session
-/// attribution is self-reported rather than derived from an authenticated
-/// principal — the same property as `/query`'s `ai_context.session_id`.
-const SESSION_ID_HEADER: &str = "x-skardi-session-id";
-
-/// Extract and validate the session header. `Ok(None)` when absent; `Err`
-/// when present but malformed — silently dropping a malformed value would
-/// corrupt session stitching, the one job this field has.
-///
-/// Allowed characters are visible ASCII graphic characters, excluding comma —
-/// no space, no tab, no other whitespace or control character. Space is
-/// rejected (not just trimmed) because `httparse` strips leading/trailing
-/// whitespace per RFC 9110 §5.5 before this code ever sees the value: if
-/// interior/exterior spaces were merely tolerated, `"  sess-1  "` would be
-/// recorded under the different key `sess-1` (silently breaking the session
-/// stitching this field exists for) while `"   "` would 400 here — the exact
-/// fail-late round trip a client-side check exists to prevent. A grouping
-/// key has no legitimate use for spaces, so this rejects them outright
-/// instead of defining trimming semantics. This predicate is mirrored
-/// exactly by the CLI's own check in `crates/cli/src/commands/run.rs`.
-fn session_id_from_headers(headers: &HeaderMap) -> Result<Option<String>, String> {
-    let mut values = headers.get_all(SESSION_ID_HEADER).iter();
-    let Some(value) = values.next() else {
-        return Ok(None);
-    };
-    if values.next().is_some() {
-        return Err(format!(
-            "{SESSION_ID_HEADER} must not be sent more than once"
-        ));
-    }
-    let s = value
-        .to_str()
-        .map_err(|_| format!("{SESSION_ID_HEADER} must contain only visible ASCII characters"))?;
-    // Commas are rejected because RFC 9110 §5.3 lets any intermediary merge
-    // repeated header lines into one comma-joined value — without this, a
-    // duplicate sent through such a proxy would slip past the duplicate
-    // check above as a single merged "id1, id2". Spaces (and every other
-    // non-graphic character, including tab) are rejected for the trimming
-    // reason above.
-    if !s.chars().all(|c| c.is_ascii_graphic() && c != ',') {
-        return Err(format!(
-            "{SESSION_ID_HEADER} must contain only visible ASCII characters, \
-             with no spaces and no commas (proxies may merge repeated header \
-             lines into one comma-separated value)"
-        ));
-    }
-    if s.is_empty() {
-        return Err(format!("{SESSION_ID_HEADER} must not be empty"));
-    }
-    if s.chars().count() > MAX_SESSION_ID_CHARS {
-        return Err(format!(
-            "{SESSION_ID_HEADER} must be at most {MAX_SESSION_ID_CHARS} characters"
-        ));
-    }
-    Ok(Some(s.to_string()))
-}
 
 /// Request structure for pipeline execution
 #[derive(Debug, Deserialize)]
@@ -932,7 +872,7 @@ pub fn substitute_sql_params(
 /// Execute pipeline endpoint - POST /:name/execute
 pub async fn execute_pipeline_by_name(
     State(app_state): State<AppState>,
-    headers: axum::http::HeaderMap,
+    headers: HeaderMap,
     Path(pipeline_name): Path<String>,
     Json(request): Json<ExecuteRequest>,
 ) -> Result<Json<Value>, (StatusCode, Json<ErrorResponse>)> {
@@ -1446,7 +1386,7 @@ spec:
         // Execute the pipeline by name
         let result = execute_pipeline_by_name(
             axum::extract::State(app_state),
-            axum::http::HeaderMap::new(),
+            HeaderMap::new(),
             Path(pipeline_name),
             Json(request),
         )
@@ -1495,7 +1435,7 @@ spec:
 
         let result = execute_pipeline_by_name(
             axum::extract::State(app_state),
-            axum::http::HeaderMap::new(),
+            HeaderMap::new(),
             Path("test-pipeline".to_string()),
             Json(request),
         )
@@ -1524,7 +1464,7 @@ spec:
 
         let result = execute_pipeline_by_name(
             axum::extract::State(app_state),
-            axum::http::HeaderMap::new(),
+            HeaderMap::new(),
             Path("test-pipeline".to_string()),
             Json(request),
         )
@@ -1545,7 +1485,7 @@ spec:
 
         let result = execute_pipeline_by_name(
             axum::extract::State(app_state),
-            axum::http::HeaderMap::new(),
+            HeaderMap::new(),
             Path("nonexistent-pipeline".to_string()),
             Json(request),
         )
@@ -1580,7 +1520,7 @@ spec:
         // by checking it gets to the SQL execution phase (not parameter validation error)
         let result = execute_pipeline_by_name(
             axum::extract::State(app_state),
-            axum::http::HeaderMap::new(),
+            HeaderMap::new(),
             Path("test-pipeline".to_string()),
             Json(request),
         )

--- a/crates/server/src/query_handlers.rs
+++ b/crates/server/src/query_handlers.rs
@@ -16,7 +16,10 @@ use skardi::sources::sql_validator::{SqlValidationError, StatementKind, validate
 use std::time::Instant;
 
 use crate::auth::routes::require_session;
-use crate::query_audit::{MAX_SESSION_ID_CHARS, QueryAuditStatus, finish_audit};
+use crate::query_audit::{
+    MAX_SESSION_ID_CHARS, OTHER_STATEMENT_KIND, QUERY_STATEMENT_KIND, QueryAuditStatus,
+    finish_audit,
+};
 use crate::response::{
     ErrorResponse, create_error_response, create_success_response, record_batch_to_json,
 };
@@ -126,6 +129,21 @@ fn validate_context_string(
 // is the ledger's, not `/query`'s, and it is shared with `pipeline_handlers`.
 
 /// Execute ad-hoc SQL endpoint - POST /query
+/// The ledger's `statement_kind` marker for an ad-hoc statement of the given
+/// kind.
+///
+/// Lives here rather than in `skardi-query-audit` because [`StatementKind`]
+/// comes from `skardi`, which that crate deliberately does not depend on
+/// (#206). The marker *strings* are still owned by the ledger — this only
+/// translates the classifier onto them, so the two cannot drift into two
+/// vocabularies.
+fn adhoc_statement_kind(kind: StatementKind) -> &'static str {
+    match kind {
+        StatementKind::Query => QUERY_STATEMENT_KIND,
+        StatementKind::Other => OTHER_STATEMENT_KIND,
+    }
+}
+
 pub async fn execute_query(
     State(app_state): State<AppState>,
     headers: axum::http::HeaderMap,
@@ -232,9 +250,9 @@ pub async fn execute_query(
     // anything it cannot account for.
     let audit_id = match &app_state.query_audit {
         Some(store) => {
-            let kind = format!("{statement_kind:?}");
+            let kind = adhoc_statement_kind(statement_kind);
             match store
-                .record_started(&request.sql, request.ai_context.as_ref(), max_rows, &kind)
+                .record_started(&request.sql, request.ai_context.as_ref(), max_rows, kind)
                 .await
             {
                 Ok(id) => Some(id),

--- a/crates/server/src/query_handlers.rs
+++ b/crates/server/src/query_handlers.rs
@@ -128,7 +128,6 @@ fn validate_context_string(
 // off; a failed outcome write leaves the row `started` for startup reconcile)
 // is the ledger's, not `/query`'s, and it is shared with `pipeline_handlers`.
 
-/// Execute ad-hoc SQL endpoint - POST /query
 /// The ledger's `statement_kind` marker for an ad-hoc statement of the given
 /// kind.
 ///
@@ -144,6 +143,7 @@ fn adhoc_statement_kind(kind: StatementKind) -> &'static str {
     }
 }
 
+/// Execute ad-hoc SQL endpoint - POST /query
 pub async fn execute_query(
     State(app_state): State<AppState>,
     headers: axum::http::HeaderMap,

--- a/crates/server/src/session_header.rs
+++ b/crates/server/src/session_header.rs
@@ -1,0 +1,76 @@
+//! The shared `X-Skardi-Session-Id` request header.
+//!
+//! Lives in the server rather than beside the ledger it feeds: the header is
+//! an HTTP concern (`axum::http::HeaderMap`), and `skardi-query-audit` was
+//! extracted precisely so downstream distributions could adopt the ledger
+//! without inheriting this crate's dependency tree (#206). The cap it
+//! validates against, `MAX_SESSION_ID_CHARS`, still comes from the ledger —
+//! that is the value all three attribution paths must agree on.
+//!
+//! Three consumers: the pipeline execute endpoint, the jobs submit endpoint,
+//! and — for the cap only — `/query`'s `ai_context.session_id`.
+
+use axum::http::HeaderMap;
+
+use crate::query_audit::MAX_SESSION_ID_CHARS;
+
+/// Optional caller-supplied session header. A header (not a body field)
+/// because the pipeline-execute body IS the flattened parameter map — a
+/// reserved key could collide with a legitimate SQL parameter of the same
+/// name. The jobs submit endpoint shares the header for the same reason:
+/// its body is the job's parameter map.
+///
+/// Not an auth credential: unrelated to `require_session`. The value is
+/// caller-asserted, so ledger session attribution is self-reported rather
+/// than derived from an authenticated principal — the same property as
+/// `/query`'s `ai_context.session_id`.
+pub const SESSION_ID_HEADER: &str = "x-skardi-session-id";
+
+/// Extract and validate the session header. `Ok(None)` when absent; `Err`
+/// when present but malformed — silently dropping a malformed value would
+/// corrupt session stitching, the one job this field has.
+///
+/// Allowed characters are visible ASCII graphic characters, excluding comma —
+/// no space, no tab, no other whitespace or control character. Space is
+/// rejected (not just trimmed) because `httparse` strips leading/trailing
+/// whitespace per RFC 9110 §5.5 before this code ever sees the value: if
+/// spaces were merely tolerated, `"  sess-1  "` would be recorded under the
+/// different key `sess-1` (silently breaking the session stitching this
+/// field exists for) while `"   "` would 400 here — the exact fail-late
+/// round trip a client-side check exists to prevent. A grouping key has no
+/// legitimate use for spaces, so this rejects them outright instead of
+/// defining trimming semantics. Commas are rejected because RFC 9110 §5.3
+/// lets any intermediary merge repeated header lines into one comma-joined
+/// value, which would otherwise slip a duplicate past the check below as a
+/// single merged `"id1, id2"`. This predicate is mirrored exactly by the
+/// CLI's own check in `crates/cli/src/session.rs`.
+pub fn session_id_from_headers(headers: &HeaderMap) -> Result<Option<String>, String> {
+    let mut values = headers.get_all(SESSION_ID_HEADER).iter();
+    let Some(value) = values.next() else {
+        return Ok(None);
+    };
+    if values.next().is_some() {
+        return Err(format!(
+            "{SESSION_ID_HEADER} must not be sent more than once"
+        ));
+    }
+    let s = value
+        .to_str()
+        .map_err(|_| format!("{SESSION_ID_HEADER} must contain only visible ASCII characters"))?;
+    if !s.chars().all(|c| c.is_ascii_graphic() && c != ',') {
+        return Err(format!(
+            "{SESSION_ID_HEADER} must contain only visible ASCII characters, \
+             with no spaces and no commas (proxies may merge repeated header \
+             lines into one comma-separated value)"
+        ));
+    }
+    if s.is_empty() {
+        return Err(format!("{SESSION_ID_HEADER} must not be empty"));
+    }
+    if s.chars().count() > MAX_SESSION_ID_CHARS {
+        return Err(format!(
+            "{SESSION_ID_HEADER} must be at most {MAX_SESSION_ID_CHARS} characters"
+        ));
+    }
+    Ok(Some(s.to_string()))
+}

--- a/crates/server/tests/jobs_audit_http.rs
+++ b/crates/server/tests/jobs_audit_http.rs
@@ -1,7 +1,7 @@
 //! HTTP integration tests for job-submission auditing (`POST
 //! /jobs/:name/run`) — mirrors `pipeline_audit_http.rs`'s coverage of the
 //! pipeline path, but exercises the jobs path: record-before-submit, the
-//! shared `x-skardi-session-id` header, the run_id stamp on success, and
+//! shared `x-skardi-session-id` header, the job_run_id stamp on success, and
 //! value-free recording (only `name@version` is ever written, never
 //! parameter values).
 
@@ -163,6 +163,7 @@ spec:
         AuthLayer::None,
         executor,
         query_audit,
+        Default::default(),
     );
     (state, tmp)
 }
@@ -230,7 +231,7 @@ async fn wait_for_terminal(state: &AppState, run_id: &str) -> Value {
 }
 
 #[tokio::test]
-async fn submission_is_audited_with_session_and_run_id() {
+async fn submission_is_audited_with_session_and_job_run_id() {
     let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
     let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
     let resp = submit_with_headers(&state, &[("x-skardi-session-id", "sess-j")], json!({})).await;
@@ -246,7 +247,10 @@ async fn submission_is_audited_with_session_and_run_id() {
     assert_eq!(row["statement_kind"], json!("job"));
     assert_eq!(row["sql"], format!("{TEST_JOB_NAME}@{TEST_JOB_VERSION}"));
     assert_eq!(row["status"], json!("succeeded"));
-    assert_eq!(row["run_id"], json!(run_id));
+    assert_eq!(row["job_run_id"], json!(run_id));
+    // #206's identity envelope owns `run_id` — the caller's own run, not the
+    // job run this submission produced. The bridge stamp must not touch it.
+    assert!(row["run_id"].is_null());
     assert!(row["ai_context"].is_null());
     assert!(row["row_count"].is_null());
 }
@@ -309,6 +313,29 @@ async fn malformed_header_on_real_job_is_400_and_records_nothing() {
         "expected the session-header reject, got {body}"
     );
     assert_eq!(store.count().await.unwrap(), 0);
+}
+
+/// The docs promise the header is validated whether or not auditing is
+/// enabled; this pins the audit-off half of that promise (mirrors
+/// `pipeline_audit_http.rs`'s `session_header_is_validated_even_with_auditing_off`).
+#[tokio::test]
+async fn session_header_is_validated_even_with_auditing_off() {
+    let (state, _tmp) = make_app_state(None).await;
+    let resp = submit_with_headers(
+        &state,
+        &[("x-skardi-session-id", "x".repeat(201).as_str())],
+        json!({}),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = body_to_json(resp).await;
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap()
+            .contains("x-skardi-session-id"),
+        "expected the session-header reject, got {body}"
+    );
 }
 
 #[tokio::test]
@@ -385,7 +412,7 @@ async fn parameter_values_never_reach_the_audit_row() {
 /// (`JobSubmitError::MissingParameters`, since `ingest-filtered` requires
 /// `min_id` and this submits none). Pins that the ledger row still gets a
 /// terminal stamp — `failed`, the fixed `category()` string (not the
-/// human-readable message), and a null `run_id` because no run was ever
+/// human-readable message), and a null `job_run_id` because no run was ever
 /// created — and that the HTTP response keeps the endpoint's existing
 /// rejection contract (400, `missing_parameters`) unchanged.
 #[tokio::test]
@@ -412,7 +439,7 @@ async fn submit_rejection_after_audit_write_is_recorded_failed() {
     );
     assert_eq!(row["status"], json!("failed"));
     assert_eq!(row["error"], json!("missing_parameters"));
-    assert!(row["run_id"].is_null());
+    assert!(row["job_run_id"].is_null());
 
     // Confirms the executor never created a run for the rejected submission
     // — the same "not submitted" observability the audit-write-failure test

--- a/crates/server/tests/jobs_audit_http.rs
+++ b/crates/server/tests/jobs_audit_http.rs
@@ -312,6 +312,12 @@ async fn malformed_header_on_real_job_is_400_and_records_nothing() {
             .contains("x-skardi-session-id"),
         "expected the session-header reject, got {body}"
     );
+    // Same discriminator the pipeline path supplies. `error_type` is shared
+    // with genuine job-parameter rejections on this endpoint, so
+    // `details.header` is the only machine-readable way a client can tell a
+    // bad session header from a bad job parameter.
+    assert_eq!(body["error_type"], json!("parameter_validation_error"));
+    assert_eq!(body["details"]["header"], json!("x-skardi-session-id"));
     assert_eq!(store.count().await.unwrap(), 0);
 }
 

--- a/crates/server/tests/jobs_audit_http.rs
+++ b/crates/server/tests/jobs_audit_http.rs
@@ -37,6 +37,18 @@ const TEST_JOB_NAME: &str = "ingest-all";
 /// `sql = "<name>@<version>"`.
 const TEST_JOB_VERSION: &str = "1.0.0";
 
+/// Name of the second fixture job registered by `make_app_state`: its SQL
+/// requires a `min_id` parameter that the submit-time param-validation step
+/// checks for *inside* `executor.submit` — i.e. strictly after the
+/// existence pre-check, header validation, and audit write the handler does
+/// itself. Submitting with no parameters is therefore a deterministic,
+/// post-audit-write rejection (`JobSubmitError::MissingParameters`),
+/// exercising the `Err` arm of the outcome-stamp contract.
+const REJECTING_JOB_NAME: &str = "ingest-filtered";
+
+/// Version set in the rejecting fixture job's `metadata.version`.
+const REJECTING_JOB_VERSION: &str = "1.0.0";
+
 fn write_yaml(path: &std::path::Path, content: &str) {
     let mut f = std::fs::File::create(path).unwrap();
     f.write_all(content.as_bytes()).unwrap();
@@ -88,6 +100,33 @@ spec:
     let mut jobs_map = HashMap::new();
     jobs_map.insert(job.name().to_string(), job);
 
+    // A second job whose SQL requires a parameter (`min_id`) that the
+    // caller never supplies in the rejection tests below — `executor.submit`
+    // rejects it with `JobSubmitError::MissingParameters` *after* the
+    // handler's own existence/header/audit-write steps have already run,
+    // giving a deterministic post-audit-write failure to assert on.
+    let rejecting_yaml_path = tmp.path().join("j2.yaml");
+    write_yaml(
+        &rejecting_yaml_path,
+        r#"
+kind: job
+metadata:
+  name: "ingest-filtered"
+  version: "1.0.0"
+spec:
+  query: |
+    SELECT id FROM src WHERE id >= {min_id}
+  destination:
+    table: "dest"
+    mode: append
+"#,
+    );
+    let rejecting_job = JobDefinition::load_from_file(&rejecting_yaml_path, Arc::clone(&ctx))
+        .await
+        .unwrap()
+        .unwrap();
+    jobs_map.insert(rejecting_job.name().to_string(), rejecting_job);
+
     let store = Arc::new(SqliteJobStore::open_in_memory().await.unwrap());
     let data_source_types: HashMap<String, DataSourceType> = HashMap::new();
     let executor = Some(Arc::new(JobExecutor::new(
@@ -133,17 +172,17 @@ async fn body_to_json(resp: axum::response::Response) -> Value {
     serde_json::from_slice(&bytes).unwrap()
 }
 
-/// POST `body` to `/jobs/{TEST_JOB_NAME}/run`, attaching the given extra
-/// headers.
-async fn submit_with_headers(
+/// POST `body` to `/jobs/{job_name}/run`, attaching the given extra headers.
+async fn submit_job_with_headers(
     state: &AppState,
+    job_name: &str,
     headers: &[(&str, &str)],
     body: Value,
 ) -> axum::response::Response {
     let app = configure_routes(state.clone());
     let mut builder = Request::builder()
         .method("POST")
-        .uri(format!("/jobs/{TEST_JOB_NAME}/run"))
+        .uri(format!("/jobs/{job_name}/run"))
         .header("content-type", "application/json");
     for (name, value) in headers {
         builder = builder.header(*name, *value);
@@ -151,6 +190,16 @@ async fn submit_with_headers(
     app.oneshot(builder.body(Body::from(body.to_string())).unwrap())
         .await
         .unwrap()
+}
+
+/// POST `body` to `/jobs/{TEST_JOB_NAME}/run`, attaching the given extra
+/// headers.
+async fn submit_with_headers(
+    state: &AppState,
+    headers: &[(&str, &str)],
+    body: Value,
+) -> axum::response::Response {
+    submit_job_with_headers(state, TEST_JOB_NAME, headers, body).await
 }
 
 /// Poll `/jobs/runs/:run_id` until it reaches a terminal state, so
@@ -327,5 +376,51 @@ async fn parameter_values_never_reach_the_audit_row() {
         !rows[0].to_string().contains("PII-CANARY-77"),
         "a parameter value reached the audit ledger: {}",
         rows[0]
+    );
+}
+
+/// The `Err` half of "outcome stamped on both arms": a submission that
+/// clears the handler's own existence pre-check, header validation, and
+/// audit write, then gets rejected by `executor.submit` itself
+/// (`JobSubmitError::MissingParameters`, since `ingest-filtered` requires
+/// `min_id` and this submits none). Pins that the ledger row still gets a
+/// terminal stamp — `failed`, the fixed `category()` string (not the
+/// human-readable message), and a null `run_id` because no run was ever
+/// created — and that the HTTP response keeps the endpoint's existing
+/// rejection contract (400, `missing_parameters`) unchanged.
+#[tokio::test]
+async fn submit_rejection_after_audit_write_is_recorded_failed() {
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    let resp = submit_job_with_headers(
+        &state,
+        REJECTING_JOB_NAME,
+        &[("x-skardi-session-id", "sess-reject")],
+        json!({}),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = body_to_json(resp).await;
+    assert_eq!(body["error_type"], json!("missing_parameters"));
+
+    let rows = store.list_by_session("sess-reject").await.unwrap();
+    assert_eq!(rows.len(), 1);
+    let row = &rows[0];
+    assert_eq!(
+        row["sql"],
+        format!("{REJECTING_JOB_NAME}@{REJECTING_JOB_VERSION}")
+    );
+    assert_eq!(row["status"], json!("failed"));
+    assert_eq!(row["error"], json!("missing_parameters"));
+    assert!(row["run_id"].is_null());
+
+    // Confirms the executor never created a run for the rejected submission
+    // — the same "not submitted" observability the audit-write-failure test
+    // above uses.
+    let executor = state.jobs.clone().unwrap();
+    let runs = executor.store().list_runs(None, 10).await.unwrap();
+    assert!(
+        runs.is_empty(),
+        "a run was created despite the rejection: {runs:?}"
     );
 }

--- a/crates/server/tests/jobs_audit_http.rs
+++ b/crates/server/tests/jobs_audit_http.rs
@@ -1,0 +1,331 @@
+//! HTTP integration tests for job-submission auditing (`POST
+//! /jobs/:name/run`) — mirrors `pipeline_audit_http.rs`'s coverage of the
+//! pipeline path, but exercises the jobs path: record-before-submit, the
+//! shared `x-skardi-session-id` header, the run_id stamp on success, and
+//! value-free recording (only `name@version` is ever written, never
+//! parameter values).
+
+use arrow::array::Int64Array;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use axum::body::Body;
+use axum::http::{HeaderValue, Request, StatusCode};
+use datafusion::datasource::MemTable;
+use datafusion::prelude::SessionContext;
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use skardi::jobs::{JobDefinition, JobExecutor, JobStore, SqliteJobStore};
+use skardi::sources::DataSourceType;
+use std::collections::HashMap;
+use std::io::Write;
+use std::sync::Arc;
+use std::time::Duration;
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+use skardi_server::auth::layer::AuthLayer;
+use skardi_server::config::{CliArgs, ServerConfig};
+use skardi_server::query_audit::QueryAuditStore;
+use skardi_server::semantics::SemanticsRegistry;
+use skardi_server::server::{AppState, configure_routes};
+
+/// Name of the job registered by `make_app_state`. Bound as a `const` so
+/// assertions and the YAML fixture below stay in sync.
+const TEST_JOB_NAME: &str = "ingest-all";
+
+/// Version set in the fixture job's `metadata.version`; ledger rows store
+/// `sql = "<name>@<version>"`.
+const TEST_JOB_VERSION: &str = "1.0.0";
+
+fn write_yaml(path: &std::path::Path, content: &str) {
+    let mut f = std::fs::File::create(path).unwrap();
+    f.write_all(content.as_bytes()).unwrap();
+}
+
+fn sample_batch() -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+    RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(vec![1i64, 2, 3]))]).unwrap()
+}
+
+/// Build an `AppState` with a working jobs executor + destination fixture
+/// (cribbed from `jobs_http.rs`), and — when requested — an operator audit
+/// ledger wired in (cribbed from `pipeline_audit_http.rs`'s `make_app_state`
+/// param shape).
+async fn make_app_state(query_audit: Option<Arc<QueryAuditStore>>) -> (AppState, TempDir) {
+    let tmp = TempDir::new().unwrap();
+    let ctx = Arc::new(SessionContext::new());
+    ctx.register_batch("src", sample_batch()).unwrap();
+
+    // Destination MemTable — DataFusion handles INSERT INTO for this.
+    let dest_schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+    let dest = MemTable::try_new(
+        dest_schema.clone(),
+        vec![vec![RecordBatch::new_empty(dest_schema)]],
+    )
+    .unwrap();
+    ctx.register_table("dest", Arc::new(dest)).unwrap();
+
+    let yaml_path = tmp.path().join("j.yaml");
+    write_yaml(
+        &yaml_path,
+        r#"
+kind: job
+metadata:
+  name: "ingest-all"
+  version: "1.0.0"
+spec:
+  query: |
+    SELECT id FROM src
+  destination:
+    table: "dest"
+    mode: append
+"#,
+    );
+    let job = JobDefinition::load_from_file(&yaml_path, Arc::clone(&ctx))
+        .await
+        .unwrap()
+        .unwrap();
+    let mut jobs_map = HashMap::new();
+    jobs_map.insert(job.name().to_string(), job);
+
+    let store = Arc::new(SqliteJobStore::open_in_memory().await.unwrap());
+    let data_source_types: HashMap<String, DataSourceType> = HashMap::new();
+    let executor = Some(Arc::new(JobExecutor::new(
+        jobs_map.clone(),
+        store as Arc<dyn JobStore>,
+        Arc::clone(&ctx),
+        data_source_types,
+        HashMap::new(),
+    )));
+
+    let engine = Arc::new(skardi::engine::datafusion::DataFusionEngine::new_with_arc(
+        Arc::clone(&ctx),
+    ));
+    let config = ServerConfig {
+        pipelines: HashMap::new(),
+        jobs: jobs_map,
+        data_sources: vec![],
+        semantics: SemanticsRegistry::default(),
+        args: CliArgs {
+            pipeline_path: None,
+            jobs_path: None,
+            jobs_db_path: None,
+            ctx_file: None,
+            semantics_path: None,
+            port: 0,
+            query_audit_db: None,
+            query_audit_retention_days: None,
+        },
+    };
+    let state = AppState::new(
+        config,
+        engine,
+        Arc::clone(&ctx),
+        AuthLayer::None,
+        executor,
+        query_audit,
+    );
+    (state, tmp)
+}
+
+async fn body_to_json(resp: axum::response::Response) -> Value {
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+/// POST `body` to `/jobs/{TEST_JOB_NAME}/run`, attaching the given extra
+/// headers.
+async fn submit_with_headers(
+    state: &AppState,
+    headers: &[(&str, &str)],
+    body: Value,
+) -> axum::response::Response {
+    let app = configure_routes(state.clone());
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri(format!("/jobs/{TEST_JOB_NAME}/run"))
+        .header("content-type", "application/json");
+    for (name, value) in headers {
+        builder = builder.header(*name, *value);
+    }
+    app.oneshot(builder.body(Body::from(body.to_string())).unwrap())
+        .await
+        .unwrap()
+}
+
+/// Poll `/jobs/runs/:run_id` until it reaches a terminal state, so
+/// `record_job_outcome`'s async write has actually landed before assertions
+/// read the ledger.
+async fn wait_for_terminal(state: &AppState, run_id: &str) -> Value {
+    let app = configure_routes(state.clone());
+    for _ in 0..200 {
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(format!("/jobs/runs/{run_id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = body_to_json(resp).await;
+        let status = body.get("status").unwrap().as_str().unwrap();
+        if matches!(status, "succeeded" | "failed" | "cancelled") {
+            return body;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("run never reached terminal state");
+}
+
+#[tokio::test]
+async fn submission_is_audited_with_session_and_run_id() {
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    let resp = submit_with_headers(&state, &[("x-skardi-session-id", "sess-j")], json!({})).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_to_json(resp).await;
+    let run_id = body.get("run_id").unwrap().as_str().unwrap().to_string();
+
+    wait_for_terminal(&state, &run_id).await;
+
+    let rows = store.list_by_session("sess-j").await.unwrap();
+    assert_eq!(rows.len(), 1);
+    let row = &rows[0];
+    assert_eq!(row["statement_kind"], json!("job"));
+    assert_eq!(row["sql"], format!("{TEST_JOB_NAME}@{TEST_JOB_VERSION}"));
+    assert_eq!(row["status"], json!("succeeded"));
+    assert_eq!(row["run_id"], json!(run_id));
+    assert!(row["ai_context"].is_null());
+    assert!(row["row_count"].is_null());
+}
+
+#[tokio::test]
+async fn submission_without_header_audits_null_session() {
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    let resp = submit_with_headers(&state, &[], json!({})).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_to_json(resp).await;
+    let run_id = body.get("run_id").unwrap().as_str().unwrap().to_string();
+    wait_for_terminal(&state, &run_id).await;
+
+    assert_eq!(store.count().await.unwrap(), 1);
+    assert!(store.list_by_session("").await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn no_store_configured_still_submits() {
+    let (state, _tmp) = make_app_state(None).await;
+    let resp = submit_with_headers(&state, &[], json!({})).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn unknown_job_with_malformed_header_is_404_and_records_nothing() {
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    let app = configure_routes(state.clone());
+    let request = Request::builder()
+        .method("POST")
+        .uri("/jobs/no-such-job/run")
+        .header("content-type", "application/json")
+        .header("x-skardi-session-id", "")
+        .body(Body::from(json!({}).to_string()))
+        .unwrap();
+    let resp = app.oneshot(request).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    assert_eq!(store.count().await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn malformed_header_on_real_job_is_400_and_records_nothing() {
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    let resp = submit_with_headers(
+        &state,
+        &[("x-skardi-session-id", "x".repeat(201).as_str())],
+        json!({}),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = body_to_json(resp).await;
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap()
+            .contains("x-skardi-session-id"),
+        "expected the session-header reject, got {body}"
+    );
+    assert_eq!(store.count().await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn non_visible_ascii_session_header_on_real_job_is_400() {
+    // Cannot be built through `submit_with_headers` — `Request::builder`
+    // refuses the bytes client-side — so this constructs the `HeaderValue`
+    // directly, mirroring `pipeline_audit_http.rs`'s equivalent test.
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    let app = configure_routes(state.clone());
+    let request = Request::builder()
+        .method("POST")
+        .uri(format!("/jobs/{TEST_JOB_NAME}/run"))
+        .header("content-type", "application/json")
+        .header(
+            "x-skardi-session-id",
+            HeaderValue::from_bytes(&[0xff]).unwrap(),
+        )
+        .body(Body::from(json!({}).to_string()))
+        .unwrap();
+    let resp = app.oneshot(request).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(store.count().await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn audit_write_failure_is_503_and_job_is_not_submitted() {
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    store.close_for_test().await;
+
+    let resp = submit_with_headers(&state, &[], json!({})).await;
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let body = body_to_json(resp).await;
+    assert_eq!(body["error_type"], json!("query_audit_error"));
+
+    // The "not submitted" half is directly observable: the jobs ledger has
+    // no new run.
+    let executor = state.jobs.clone().unwrap();
+    let runs = executor.store().list_runs(None, 10).await.unwrap();
+    assert!(
+        runs.is_empty(),
+        "job was submitted despite the audit-write failure: {runs:?}"
+    );
+}
+
+#[tokio::test]
+async fn parameter_values_never_reach_the_audit_row() {
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    let resp = submit_with_headers(
+        &state,
+        &[("x-skardi-session-id", "sess-pii")],
+        json!({"canary": "PII-CANARY-77"}),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_to_json(resp).await;
+    let run_id = body.get("run_id").unwrap().as_str().unwrap().to_string();
+    wait_for_terminal(&state, &run_id).await;
+
+    let rows = store.list_by_session("sess-pii").await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert!(
+        !rows[0].to_string().contains("PII-CANARY-77"),
+        "a parameter value reached the audit ledger: {}",
+        rows[0]
+    );
+}

--- a/crates/server/tests/query_http.rs
+++ b/crates/server/tests/query_http.rs
@@ -575,7 +575,7 @@ async fn audit_records_raw_sql_ai_context_and_success() {
     );
     assert_eq!(record["ai_context"]["purpose"], json!("brand audit"));
     assert_eq!(record["session_id"], json!("sess-42"));
-    assert_eq!(record["statement_kind"], json!("Query"));
+    assert_eq!(record["statement_kind"], json!("query"));
     assert_eq!(record["status"], json!("succeeded"));
     assert_eq!(record["row_count"], json!(3));
     assert!(!record["finished_at"].is_null(), "{record:?}");

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -198,6 +198,15 @@ skardi job cancel <run_id>
 skardi job show
 ```
 
+`--session-id <ID>` — sent as `X-Skardi-Session-Id`; groups this job
+submission with an agent session in the server's query audit ledger. The
+value is validated client-side before any request is sent (non-empty,
+≤ 200 characters, visible ASCII, no commas — the same rules the server
+enforces), so a bad value fails fast instead of surfacing as a connection
+error. When the server has auditing enabled, a `503` with `error_type
+"query_audit_error"` means the job **was not submitted** and the call is
+safe to retry.
+
 ## Exit codes
 
 | Code | Meaning |

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -178,6 +178,19 @@ On startup the server:
 When the server was started without `--jobs`, every endpoint above
 returns `503 Service Unavailable` with `error_type: jobs_disabled`.
 
+### Session attribution
+
+`POST /jobs/:name/run` accepts an optional `X-Skardi-Session-Id` request
+header (non-empty, ≤ 200 characters) that attributes the submission to an
+agent session in the query audit ledger. A malformed header is rejected
+with `400 parameter_validation_error` — the header is always validated once
+the job exists, regardless of audit configuration. When `--query-audit-db`
+is configured, the submission is recorded as a `job` row with the session
+id and `name@version` in the ledger, with the submission's outcome
+(`succeeded` or `failed`) and any bridge `run_id`. When the server has
+auditing enabled, a `503` with `error_type: query_audit_error` means the
+job **was not submitted** and the call is safe to retry.
+
 ---
 
 ## Submitting a run from the CLI

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -187,7 +187,7 @@ with `400 parameter_validation_error` — the header is always validated once
 the job exists, regardless of audit configuration. When `--query-audit-db`
 is configured, the submission is recorded as a `job` row with the session
 id and `name@version` in the ledger, with the submission's outcome
-(`succeeded` or `failed`) and any bridge `run_id`. When the server has
+(`succeeded` or `failed`) and the `job_run_id` bridge to the run. When the server has
 auditing enabled, a `503` with `error_type: query_audit_error` means the
 job **was not submitted** and the call is safe to retry.
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -179,7 +179,8 @@ execution and updated with its outcome afterwards:
 | `ai_context` | the caller's object, verbatim JSON |
 | `session_id` | denormalised from `ai_context` for indexed session lookup |
 | `max_rows` | requested row cap (`0` on pipeline rows — not applicable) |
-| `statement_kind` | `Query` or `Other` for ad-hoc rows (the `Debug` form of the server's statement classifier — not SQL verbs like `select`/`dml`), `pipeline` for pipeline rows. Consumers filtering the ledger must match these exact strings. |
+| `run_id` | job_runs.id bridge, job rows only |
+| `statement_kind` | `Query` or `Other` for ad-hoc rows (the `Debug` form of the server's statement classifier — not SQL verbs like `select`/`dml`), `pipeline` for pipeline rows, `job` for job rows. Consumers filtering the ledger must match these exact strings. |
 | `status` | `started` → `succeeded` / `failed`, or `unknown` after a crash |
 | `row_count`, `error` | outcome detail |
 
@@ -303,6 +304,23 @@ requires both halves, and today only `skardi run --session-id` exists —
 ([#218](https://github.com/SkardiLabs/skardi/issues/218)), so the ad-hoc
 half of a CLI session lands unattributed until then. Direct HTTP callers
 get the full interleaving today.
+
+#### Job submissions in the ledger
+
+`POST /jobs/:name/run` is audited as a *submission event*: the row's
+lifecycle is the submission's, not the run's. `statement_kind` is `job`,
+`sql` holds `name@version`, and on acceptance the row is stamped
+`succeeded` with the `run_id` that bridges to the jobs ledger — which
+remains the authority on the run itself (parameters, progress, outcome).
+A rejected submission is stamped `failed` with the executor's fixed error
+category, never its message text. Unlike pipelines, a job's parameter
+validation happens inside the executor — after the audit write — so a
+parameter rejection leaves a `failed` row rather than recording nothing.
+Record-before-submit and the fail-closed `503 query_audit_error` behave
+exactly as for pipelines: a job the ledger cannot account for is not
+submitted. The same `X-Skardi-Session-Id` header (same validation)
+attributes the submission, so `list_by_session` returns an agent session's
+ad-hoc queries, pipeline calls, and job submissions in one ordered read.
 
 ---
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -178,7 +178,7 @@ execution and updated with its outcome afterwards:
 | `sql` | raw statement text |
 | `ai_context` | the caller's object, verbatim JSON |
 | `session_id` | denormalised from `ai_context` for indexed session lookup |
-| `max_rows` | requested row cap (`0` on pipeline rows — not applicable) |
+| `max_rows` | requested row cap (`0` on pipeline and job rows — not applicable) |
 | `run_id` | job_runs.id bridge, job rows only |
 | `statement_kind` | `Query` or `Other` for ad-hoc rows (the `Debug` form of the server's statement classifier — not SQL verbs like `select`/`dml`), `pipeline` for pipeline rows, `job` for job rows. Consumers filtering the ledger must match these exact strings. |
 | `status` | `started` → `succeeded` / `failed`, or `unknown` after a crash |

--- a/docs/server.md
+++ b/docs/server.md
@@ -179,14 +179,18 @@ execution and updated with its outcome afterwards:
 | `ai_context` | the caller's object, verbatim JSON |
 | `session_id` | denormalised from `ai_context` for indexed session lookup |
 | `max_rows` | requested row cap (`0` on pipeline and job rows — not applicable) |
-| `run_id` | job_runs.id bridge, job rows only |
-| `statement_kind` | `Query` or `Other` for ad-hoc rows (the `Debug` form of the server's statement classifier — not SQL verbs like `select`/`dml`), `pipeline` for pipeline rows, `job` for job rows. Consumers filtering the ledger must match these exact strings. |
+| `job_run_id` | `job_runs.id` bridge, job rows only. Distinct from the identity envelope's `run_id`, which names the *caller's* run — one column, one meaning. |
+| `request_id`, `org_id`, `workspace_id`, `user_id`, `run_id` | caller-identity envelope; all NULL on this server, filled by distributions that authenticate their callers |
+| `statement_kind` | `query` or `other` for ad-hoc rows (the server's statement *classification* — not SQL verbs like `select`/`dml`), `pipeline` for pipeline rows, `job` for job rows. Consumers filtering the ledger must match these exact strings. |
 | `status` | `started` → `succeeded` / `failed`, or `unknown` after a crash |
 | `row_count`, `error` | outcome detail |
 
 Indexed on `(session_id, created_at)`, `created_at`, `status` and
 `statement_kind`, so an agent session can be reconstructed — and a single row
-kind selected — with plain SQL.
+kind selected — with plain SQL. `job_run_id` carries its own partial index
+(`WHERE job_run_id IS NOT NULL`) so the reverse lookup — given a run id from
+`GET /jobs/runs`, which session submitted it — does not scan a table that is
+append-only and has retention off by default.
 
 What is **not** here: job runs. `POST /jobs/:name/run` executes its own SQL
 through the same engine but is recorded in the separate jobs run ledger (see
@@ -310,7 +314,7 @@ get the full interleaving today.
 `POST /jobs/:name/run` is audited as a *submission event*: the row's
 lifecycle is the submission's, not the run's. `statement_kind` is `job`,
 `sql` holds `name@version`, and on acceptance the row is stamped
-`succeeded` with the `run_id` that bridges to the jobs ledger — which
+`succeeded` with the `job_run_id` that bridges to the jobs ledger — which
 remains the authority on the run itself (parameters, progress, outcome).
 A rejected submission is stamped `failed` with the executor's fixed error
 category, never its message text. Unlike pipelines, a job's parameter
@@ -321,6 +325,30 @@ exactly as for pipelines: a job the ledger cannot account for is not
 submitted. The same `X-Skardi-Session-Id` header (same validation)
 attributes the submission, so `list_by_session` returns an agent session's
 ad-hoc queries, pipeline calls, and job submissions in one ordered read.
+
+Two properties of this seam an operator should know before relying on it:
+
+- **It is the ledger's only unauthenticated write path.** `/query` and
+  `POST /:pipeline/execute` both call `require_session` before writing
+  anything; the jobs handlers perform no auth check at all. The header is
+  self-reported on every endpoint — it never attests to origin — but on the
+  other two the caller is at least authenticated. Here neither is true, so
+  anyone who can reach `POST /jobs/:name/run` can mint arbitrary
+  `session_id` values into `query_audit`, including ones belonging to real
+  sessions, and can queue writes onto the ledger's single serialized writer
+  thread (shared with every audited request). If you enable
+  `--query-audit-db` behind auth, note that this one seam is not gated.
+  Backfilling the check is tracked separately.
+
+- **The `job_run_id` bridge is best-effort and one-directional.** It is
+  stamped after `executor.submit` returns, so if that write fails, times out,
+  or the process dies in the window, the run exists in `job_runs` but the row
+  keeps `job_run_id = NULL` (and reconciles to `unknown` on restart). `job_runs`
+  carries no `session_id` and no audit-row id, so there is no reverse pointer
+  to rebuild the correlation from — it is lost, not merely delayed. Exact
+  correlation is the column's purpose, so treat it as *usually* exact rather
+  than guaranteed; making it reconstructable needs a durable half in the
+  jobs ledger, which is out of scope here.
 
 ---
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -328,17 +328,34 @@ ad-hoc queries, pipeline calls, and job submissions in one ordered read.
 
 Two properties of this seam an operator should know before relying on it:
 
-- **It is the ledger's only unauthenticated write path.** `/query` and
+- **It is the ledger's only unauthenticated write path, and that costs
+  availability, not just attribution.** `/query` and
   `POST /:pipeline/execute` both call `require_session` before writing
-  anything; the jobs handlers perform no auth check at all. The header is
-  self-reported on every endpoint — it never attests to origin — but on the
-  other two the caller is at least authenticated. Here neither is true, so
-  anyone who can reach `POST /jobs/:name/run` can mint arbitrary
-  `session_id` values into `query_audit`, including ones belonging to real
-  sessions, and can queue writes onto the ledger's single serialized writer
-  thread (shared with every audited request). If you enable
-  `--query-audit-db` behind auth, note that this one seam is not gated.
-  Backfilling the check is tracked separately.
+  anything; the jobs handlers perform no auth check at all. Two distinct
+  consequences, the second the more serious:
+
+  1. *Forged attribution.* The header is self-reported on every endpoint — it
+     never attests to origin — but on the other two the caller is at least
+     authenticated. Here neither is true, so anyone who can reach
+     `POST /jobs/:name/run` can mint arbitrary `session_id` values into
+     `query_audit`, including ones belonging to real sessions. A forged row
+     lands inside a legitimate session's `list_by_session` read and is
+     indistinguishable from a real submission.
+
+  2. *Denial of service against the other two endpoints.* Every submission —
+     including ones the executor will reject — issues writes on the ledger's
+     **single serialized writer thread**, shared with every audited request.
+     `/query` and `POST /:pipeline/execute` are fail-closed on that thread:
+     when work on it exceeds the write timeout, they return `503` by design.
+     Before job auditing existed, `POST /jobs/:name/run` did not touch that
+     thread at all. It now does, unrate-limited and unauthenticated — so an
+     anonymous caller can stall writes that two *authenticated* endpoints
+     block on, plus grow a ledger whose retention is off by default.
+
+  Weigh the second one when deciding where to enable `--query-audit-db`: if
+  the deployment is behind auth, this seam is not gated and the exposure is
+  to the availability of the endpoints that are. Backfilling the check is
+  tracked separately.
 
 - **The `job_run_id` bridge is best-effort and one-directional.** It is
   stamped after `executor.submit` returns, so if that write fails, times out,

--- a/docs/superpowers/plans/2026-08-18-jobs-audit.md
+++ b/docs/superpowers/plans/2026-08-18-jobs-audit.md
@@ -2,6 +2,20 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+> **Superseded in four places by the rebase onto #206 and review round 1.** This plan was
+> written before the ledger-crate extraction landed and records what was
+> planned, not what shipped. Where the two disagree, the authority is
+> `docs/superpowers/specs/2026-08-18-jobs-audit-design.md` under *Rebase
+> decisions*, and the code. The divergences, all of which recur throughout
+> the steps and snippets below:
+>
+> | this plan says | what shipped | why |
+> | --- | --- | --- |
+> | the bridge column is `run_id` | `job_run_id` | #206's identity envelope already claims `run_id`, meaning the *caller's* run — one column cannot carry two meanings |
+> | its own guarded `ALTER TABLE` migration | `ensure_added_columns` in `crates/query-audit` | #206 shipped the same mechanism for its five identity columns; sharing it spread the duplicate-column race fix across all six |
+> | `session_id_from_headers` moves to `query_audit` | `crates/server/src/session_header.rs` | it needs `axum::http::HeaderMap`, and `skardi-query-audit` depends on neither `axum` nor `skardi` — the point of the extraction |
+> | ad-hoc rows assert `statement_kind == "Query"` | `"query"` | review round 1: all four values share one casing |
+
 **Goal:** Record every job submission in the `query_audit` ledger with session attribution and a `run_id` bridge to the jobs ledger, so agent-submitted jobs join session mining.
 
 **Architecture:** `POST /jobs/:name/run` writes a `started` row (statement_kind=`job`, `name@version`, optional session header) before `executor.submit`, fail-closed like #213; the outcome stamp carries `run_id` on success or a fixed error kind on rejection. Run detail stays in `job_runs`. One new nullable ledger column (`run_id`) via a guarded migration. `session_id_from_headers` moves to `query_audit` (third consumer). CLI gains `skardi job run --session-id` with the validation extracted to a shared module.

--- a/docs/superpowers/plans/2026-08-18-jobs-audit.md
+++ b/docs/superpowers/plans/2026-08-18-jobs-audit.md
@@ -1,0 +1,439 @@
+# Job-Submission Attribution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Record every job submission in the `query_audit` ledger with session attribution and a `run_id` bridge to the jobs ledger, so agent-submitted jobs join session mining.
+
+**Architecture:** `POST /jobs/:name/run` writes a `started` row (statement_kind=`job`, `name@version`, optional session header) before `executor.submit`, fail-closed like #213; the outcome stamp carries `run_id` on success or a fixed error kind on rejection. Run detail stays in `job_runs`. One new nullable ledger column (`run_id`) via a guarded migration. `session_id_from_headers` moves to `query_audit` (third consumer). CLI gains `skardi job run --session-id` with the validation extracted to a shared module.
+
+**Tech Stack:** Rust, Axum, tokio-rusqlite, wiremock. Branch is stacked on `worktree-pipeline-audit` (#213) and uses its `bounded`/`AUDIT_WRITE_TIMEOUT`/`finish_audit` machinery.
+
+**Spec:** `docs/superpowers/specs/2026-08-18-jobs-audit-design.md`
+
+## Global Constraints
+
+- Imports via `use` at the top; never full crate paths inline in function bodies (CLAUDE.md).
+- No raw `.unwrap()` outside `crates/cli/` and test code (CLAUDE.md rules for `.expect`/lock poisoning apply).
+- Parameter values NEVER reach the `query_audit` ledger, its logs, or traces. (`job_runs.parameters` legitimately holds them — out of scope.)
+- Session cap and header rules come from `query_audit::MAX_SESSION_ID_CHARS` and the shared `session_id_from_headers` — nothing re-hardcoded. The CLI restates the cap only inside the new shared `crates/cli/src/session.rs`.
+- Precedence on `POST /jobs/:name/run`: jobs-disabled 503 → unknown job 404 → malformed header 400 → audit-write 503 → submit. A test pins 404-before-400.
+- Every task ends with `cargo fmt --all` and its named test command green before commit. Commit with `git -c commit.gpgsign=false commit` and trailer `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+---
+
+### Task 1: Store — `run_id` migration, `record_job_submitted`, `record_job_outcome`
+
+**Files:**
+- Modify: `crates/server/src/query_audit.rs`
+
+**Interfaces:**
+- Consumes: existing `bounded`, `new_id`, `QueryAuditStatus`, `PIPELINE_MAX_ROWS_SENTINEL` (reused for job rows — rename NOT wanted; add a doc line that job rows share it).
+- Produces (Task 2 calls these exactly):
+  - `pub const JOB_STATEMENT_KIND: &str = "job";` — private if nothing outside the module ends up using it (mirror the `PIPELINE_STATEMENT_KIND` narrowing from #213's final round).
+  - `pub async fn record_job_submitted(&self, job_name: &str, version: &str, session_id: Option<&str>) -> Result<String>`
+  - `pub async fn record_job_outcome(&self, id: &str, run_id: Option<&str>, status: QueryAuditStatus, error: Option<&str>) -> Result<()>`
+
+- [ ] **Step 1: Write the failing tests** (in the existing tests module; match its style)
+
+```rust
+#[tokio::test]
+async fn job_row_round_trips_with_run_id() {
+    let store = QueryAuditStore::open_in_memory().await.unwrap();
+    let id = store
+        .record_job_submitted("nightly-backfill", "2.1.0", Some("sess-j"))
+        .await
+        .unwrap();
+    store
+        .record_job_outcome(&id, Some("run-abc123"), QueryAuditStatus::Succeeded, None)
+        .await
+        .unwrap();
+    let row = store.get(&id).await.unwrap().unwrap();
+    assert_eq!(row["sql"], json!("nightly-backfill@2.1.0"));
+    assert_eq!(row["statement_kind"], json!("job"));
+    assert_eq!(row["session_id"], json!("sess-j"));
+    assert_eq!(row["status"], json!("succeeded"));
+    assert_eq!(row["run_id"], json!("run-abc123"));
+    assert_eq!(row["max_rows"], json!(0));
+    assert!(row["ai_context"].is_null());
+    assert!(row["row_count"].is_null());
+}
+
+#[tokio::test]
+async fn rejected_job_submission_records_fixed_kind_and_null_run_id() {
+    let store = QueryAuditStore::open_in_memory().await.unwrap();
+    let id = store
+        .record_job_submitted("nightly-backfill", "2.1.0", None)
+        .await
+        .unwrap();
+    store
+        .record_job_outcome(&id, None, QueryAuditStatus::Failed, Some("schema_mismatch"))
+        .await
+        .unwrap();
+    let row = store.get(&id).await.unwrap().unwrap();
+    assert_eq!(row["status"], json!("failed"));
+    assert_eq!(row["error"], json!("schema_mismatch"));
+    assert!(row["run_id"].is_null());
+}
+
+#[tokio::test]
+async fn list_by_session_interleaves_all_three_kinds_in_order() {
+    let store = QueryAuditStore::open_in_memory().await.unwrap();
+    let ctx = serde_json::json!({"purpose": "p", "session_id": "sess-all"});
+    store
+        .record_started("SELECT 1", Some(&ctx), 10, "Query")
+        .await
+        .unwrap();
+    store
+        .record_pipeline_started("weekly-churn", "1.0.0", Some("sess-all"))
+        .await
+        .unwrap();
+    store
+        .record_job_submitted("nightly-backfill", "2.1.0", Some("sess-all"))
+        .await
+        .unwrap();
+    let rows = store.list_by_session("sess-all").await.unwrap();
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0]["statement_kind"], json!("Query"));
+    assert_eq!(rows[1]["statement_kind"], json!("pipeline"));
+    assert_eq!(rows[2]["statement_kind"], json!("job"));
+    assert_eq!(rows[2]["sql"], json!("nightly-backfill@2.1.0"));
+}
+
+#[tokio::test]
+async fn orphaned_job_rows_reconcile_to_unknown() {
+    let store = QueryAuditStore::open_in_memory().await.unwrap();
+    let id = store
+        .record_job_submitted("nightly-backfill", "2.1.0", None)
+        .await
+        .unwrap();
+    let n = store.reconcile_orphaned("test restart").await.unwrap();
+    assert_eq!(n, 1);
+    let row = store.get(&id).await.unwrap().unwrap();
+    assert_eq!(row["status"], json!("unknown"));
+}
+
+#[tokio::test]
+async fn open_migrates_old_schema_without_run_id_column() {
+    // A database created before the run_id column existed must open and
+    // serve job rows after migration.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let path = tmp.path().join("old.db");
+    {
+        // Pre-#218-era DDL: the INIT_SCHEMA_SQL minus the run_id column.
+        let conn = rusqlite::Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE query_audit (
+                id TEXT PRIMARY KEY, created_at TEXT NOT NULL,
+                finished_at TEXT, sql TEXT NOT NULL, ai_context TEXT,
+                session_id TEXT, max_rows INTEGER NOT NULL,
+                statement_kind TEXT NOT NULL, status TEXT NOT NULL,
+                row_count INTEGER, error TEXT);",
+        )
+        .unwrap();
+    }
+    let store = QueryAuditStore::open(&path).await.unwrap();
+    let id = store
+        .record_job_submitted("nightly-backfill", "2.1.0", None)
+        .await
+        .unwrap();
+    let row = store.get(&id).await.unwrap().unwrap();
+    assert_eq!(row["statement_kind"], json!("job"));
+    assert!(row["run_id"].is_null());
+}
+```
+
+(Direct `rusqlite` use inside the test: import whatever `query_audit.rs` already re-exports — `tokio_rusqlite::rusqlite` is in scope via the existing `use`.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test -p skardi-server --lib query_audit 2>&1 | tail -5`
+Expected: compile error — `record_job_submitted` not found.
+
+- [ ] **Step 3: Implement**
+
+1. Schema: add `run_id TEXT` to `INIT_SCHEMA_SQL`'s CREATE TABLE, and in `open()` (after the schema batch) run the guarded migration:
+
+```rust
+// Databases created before the run_id column (pre-#218 dev builds) lack
+// it, and CREATE TABLE IF NOT EXISTS will not add columns. Idempotent:
+// checked against pragma table_info on every open.
+conn.call(|conn| -> SqlResult<()> {
+    let has_run_id = conn
+        .prepare("SELECT 1 FROM pragma_table_info('query_audit') WHERE name = 'run_id'")?
+        .exists([])?;
+    if !has_run_id {
+        conn.execute("ALTER TABLE query_audit ADD COLUMN run_id TEXT", [])?;
+    }
+    Ok(())
+})
+.await
+.context("Failed to migrate query-audit schema (run_id column)")?;
+```
+
+2. Add `run_id` to the SELECT lists in `get()` and `list_by_session`'s row loader, and to the JSON row construction (nullable → `Value::Null`).
+3. `const JOB_STATEMENT_KIND: &str = "job";` next to `PIPELINE_STATEMENT_KIND`; extend the sentinel's doc comment to say job rows share `PIPELINE_MAX_ROWS_SENTINEL` (do not rename it in this stacked PR — churn against #213's diff).
+4. `record_job_submitted` — clone of `record_pipeline_started` with `JOB_STATEMENT_KIND` and its own doc:
+
+```rust
+/// Insert a `started` row for a job *submission*.
+///
+/// The row's lifecycle is the submission's, not the run's: `succeeded`
+/// means "accepted and enqueued" (stamped with the `run_id` that bridges
+/// to the jobs ledger, the authority on the run itself), `failed` means
+/// the executor rejected it. Stores `name@version`; parameter values are
+/// never recorded here — `job_runs.parameters` is a separate concern.
+pub async fn record_job_submitted(
+    &self,
+    job_name: &str,
+    version: &str,
+    session_id: Option<&str>,
+) -> Result<String> { /* mirror record_pipeline_started; kind = JOB_STATEMENT_KIND */ }
+```
+
+5. `record_job_outcome` — UPDATE setting `status`, `finished_at`, `run_id`, `error` by id, through `bounded`:
+
+```rust
+pub async fn record_job_outcome(
+    &self,
+    id: &str,
+    run_id: Option<&str>,
+    status: QueryAuditStatus,
+    error: Option<&str>,
+) -> Result<()> {
+    let id = id.to_string();
+    let finished_at = chrono::Utc::now().to_rfc3339();
+    let status = status.as_str();
+    let run_id = run_id.map(str::to_string);
+    let error = error.map(str::to_string);
+    bounded(
+        self.conn.call(move |conn| -> SqlResult<()> {
+            conn.execute(
+                "UPDATE query_audit
+                    SET status = ?2, finished_at = ?3, run_id = ?4, error = ?5
+                  WHERE id = ?1",
+                params![id, status, finished_at, run_id, error],
+            )?;
+            Ok(())
+        }),
+        "Failed to update job-audit record",
+    )
+    .await?;
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test -p skardi-server --lib query_audit 2>&1 | tail -5`
+Expected: all pass including the 5 new tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/server/src/query_audit.rs
+git commit -m "feat(server): job-submission rows in the query-audit ledger — run_id bridge, guarded migration"
+```
+
+---
+
+### Task 2: Handler — audit `POST /jobs/:name/run`; move `session_id_from_headers` to `query_audit`
+
+**Files:**
+- Modify: `crates/server/src/jobs_handlers.rs` (`submit_job_run`, ~line 93)
+- Modify: `crates/server/src/query_audit.rs` (receive `session_id_from_headers` + `SESSION_ID_HEADER`)
+- Modify: `crates/server/src/pipeline_handlers.rs` (import them from `query_audit`; delete local copies)
+- Create: `crates/server/tests/jobs_audit_http.rs`
+
+**Interfaces:**
+- Consumes: Task 1's `record_job_submitted` / `record_job_outcome`; `session_id_from_headers(&HeaderMap) -> Result<Option<String>, String>` (unchanged semantics, new home); `JobSubmitError::category()`.
+- Produces: the endpoint contract — precedence `jobs_disabled 503 → unknown job 404 → malformed header 400 → audit 503 → submit`; audit rows per spec. Task 3 relies on the header name only.
+
+- [ ] **Step 1: Move the helper.** Cut `SESSION_ID_HEADER` + `session_id_from_headers` (with doc comments intact) from `pipeline_handlers.rs` into `query_audit.rs` as `pub(crate)`; `pipeline_handlers.rs` imports them. `query_audit.rs` needs `use axum::http::HeaderMap;`. Run `cargo test -p skardi-server --test pipeline_audit_http` — all green before proceeding (pure move).
+
+- [ ] **Step 2: Write the failing integration tests.** Create `crates/server/tests/jobs_audit_http.rs`. Crib the app-state harness from `crates/server/tests/jobs_http.rs` (it builds a working jobs executor + destination fixtures) and add the `query_audit: Option<Arc<QueryAuditStore>>` parameter exactly as `pipeline_audit_http.rs`'s `make_app_state` does. Reuse `jobs_http.rs`'s job fixture; bind `TEST_JOB_NAME` and `TEST_JOB_VERSION` consts matching its YAML. Tests:
+
+```rust
+#[tokio::test]
+async fn submission_is_audited_with_session_and_run_id() {
+    // POST with x-skardi-session-id: sess-j and a valid body.
+    // Assert 200/202 per existing contract; parse run_id from response.
+    // Ledger: one row for sess-j; statement_kind "job";
+    // sql == format!("{TEST_JOB_NAME}@{TEST_JOB_VERSION}");
+    // status "succeeded"; row["run_id"] == response run_id;
+    // ai_context null; row_count null.
+}
+
+#[tokio::test]
+async fn submission_without_header_audits_null_session() {
+    // No header → 1 row recorded, count()==1, list_by_session("") empty.
+}
+
+#[tokio::test]
+async fn no_store_configured_still_submits() {
+    // query_audit: None → submission succeeds exactly as today.
+}
+
+#[tokio::test]
+async fn unknown_job_with_malformed_header_is_404_and_records_nothing() {
+    // POST /jobs/no-such-job/run with x-skardi-session-id: "" →
+    // 404 (existing unknown-job error shape), store.count() == 0.
+    // Pins 404-before-400 precedence.
+}
+
+#[tokio::test]
+async fn malformed_header_on_real_job_is_400_and_records_nothing() {
+    // Oversize header on TEST_JOB_NAME → 400, error mentions
+    // "x-skardi-session-id", store.count() == 0.
+}
+
+#[tokio::test]
+async fn audit_write_failure_is_503_and_job_is_not_submitted() {
+    // close_for_test() → POST valid submission → 503 query_audit_error,
+    // AND the jobs ledger has no new run:
+    // executor.store().list_runs(None, 10) is empty (the "not submitted"
+    // half is directly observable — assert it).
+}
+
+#[tokio::test]
+async fn parameter_values_never_reach_the_audit_row() {
+    // Submit with a param value "PII-CANARY-77"; on success fetch the
+    // audit row via list_by_session and assert
+    // !row.to_string().contains("PII-CANARY-77").
+    // (job_runs.parameters legitimately contains it — do not grep that.)
+}
+```
+
+Match `jobs_http.rs`'s request-building style; the exact fixture/body comes from that file. Every assertion above is fixed; the scaffolding follows the neighbors.
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `cargo test -p skardi-server --test jobs_audit_http 2>&1 | tail -8`
+Expected: the audit-asserting tests FAIL (nothing recorded yet); `no_store_configured_still_submits` may already pass.
+
+- [ ] **Step 4: Implement in `submit_job_run`.** After the existing jobs-disabled guard:
+
+1. Existence + version pre-check (read lock on `app_state.config`, mirroring the pipeline lookup block): unknown name → the endpoint's existing 404 unknown-job error shape (`error_json`, kind `unknown_job`). Extract `version` from `config.jobs.get(&name)`. Note in a comment: this pre-check exists so 404 wins over header validation (metric-cardinality/status-precedence lesson from #213 round 3) and races benignly with `executor.submit`'s own resolution.
+2. `session_id_from_headers(&headers)` → on Err, `400` with the endpoint's error shape and kind `parameter_validation_error`. (Handler signature gains `headers: HeaderMap`.)
+3. Record-before-submit, fail-closed:
+
+```rust
+let audit_id = match &app_state.query_audit {
+    Some(store) => match store
+        .record_job_submitted(&name, &version, session_id.as_deref())
+        .await
+    {
+        Ok(id) => Some(id),
+        Err(e) => {
+            tracing::error!("Job audit write failed; refusing to submit: {e}");
+            return Err((
+                StatusCode::SERVICE_UNAVAILABLE,
+                error_json(
+                    "Query auditing is enabled but the audit record could not be \
+                     written; the job was not submitted",
+                    "query_audit_error",
+                    None,
+                ),
+            ));
+        }
+    },
+    None => None,
+};
+```
+
+4. Stamp outcomes on both arms of the existing `match executor.submit(...)`:
+   - `Ok(run_id)` → `record_job_outcome(id, Some(&run_id), Succeeded, None)` (log-only on failure, like `finish_audit`; a small local helper or inline `if let Some(id) = &audit_id { if let Err(e) = ... { tracing::error!(...) } }`).
+   - `Err(err)` → `record_job_outcome(id, None, Failed, Some(err.category()))` — the category string only; the HTTP response keeps the full message as today.
+5. INFO marker: add `session_id = session_id.as_deref().unwrap_or_default()` to whatever INFO line exists (or add one mirroring the pipeline marker) — placed after validation.
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `cargo test -p skardi-server --test jobs_audit_http --test jobs_http --test jobs_e2e --test pipeline_audit_http 2>&1 | tail -8`
+Expected: all green (jobs + pipeline regressions included).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/server/src/jobs_handlers.rs crates/server/src/query_audit.rs crates/server/src/pipeline_handlers.rs crates/server/tests/jobs_audit_http.rs
+git commit -m "feat(server): audit job submissions — record-before-submit, session header, run_id stamp"
+```
+
+---
+
+### Task 3: CLI — `skardi job run --session-id` + shared session validation
+
+**Files:**
+- Create: `crates/cli/src/session.rs`
+- Modify: `crates/cli/src/lib.rs` or `main.rs` (module registration — match how other modules are declared)
+- Modify: `crates/cli/src/commands/run.rs` (use the shared helper; delete the local const + predicate)
+- Modify: `crates/cli/src/commands/jobs.rs` (flag + header)
+- Modify: `crates/cli/src/main.rs` (clap arg on the job-run variant; find it via the `JobCmd` enum)
+
+**Interfaces:**
+- Consumes: `Client::post_with_headers` (exists), header name `x-skardi-session-id`.
+- Produces: `pub(crate) fn validate_session_id(sid: &str) -> anyhow::Result<()>` and `pub(crate) const MAX_SESSION_ID_CHARS: usize = 200;` in `session.rs` (move the doc comment about mirroring the server from `run.rs`).
+
+- [ ] **Step 1: Write the failing tests.** In `jobs.rs`'s tests (match its wiremock style — if it has none, crib `run.rs`'s): `job_run_with_session_id_sets_header` (mock matches `header("x-skardi-session-id", "sess-9")`, `.expect(1)`); `job_run_with_invalid_session_id_errors_without_request` (`.expect(0)`, err mentions `--session-id`, not an `ApiError`). In `run.rs`'s tests: existing cases keep passing unchanged (they now route through `session.rs`).
+
+- [ ] **Step 2: Run to verify failure** — `cargo test -p skardi-cli 2>&1 | tail -4`. Expected: compile error (no `session_id` param / module).
+
+- [ ] **Step 3: Implement.** `session.rs` holds the const + `validate_session_id` returning the exact error message currently in `run.rs` (parameterized by flag name if trivial — otherwise keep the `--session-id` text; both commands use the same flag name). `run.rs` calls it. `jobs.rs`'s run arm mirrors `run.rs`: validate, then `post_with_headers` when `Some`, plain `post` when `None`. Wire the clap arg.
+
+- [ ] **Step 4: Verify** — `cargo test -p skardi-cli 2>&1 | tail -4`, all green; `cargo clippy --all-targets -p skardi-cli` no new warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cli/src/session.rs crates/cli/src/commands/run.rs crates/cli/src/commands/jobs.rs crates/cli/src/main.rs crates/cli/src/lib.rs
+git commit -m "feat(cli): skardi job run --session-id; shared session-id validation"
+```
+
+---
+
+### Task 4: Docs + QA sweep
+
+**Files:**
+- Modify: `docs/server.md`, `docs/jobs.md`, `docs/cli.md`, `docs/superpowers/specs/2026-08-14-pipeline-audit-design.md`
+
+**Interfaces:** prose only.
+
+- [ ] **Step 1: `docs/server.md`.** In the ledger section: `statement_kind` value set gains `job` (update the column-table row); new short subsection after the pipeline one:
+
+```markdown
+#### Job submissions in the ledger
+
+`POST /jobs/:name/run` is audited as a *submission event*: the row's
+lifecycle is the submission's, not the run's. `statement_kind` is `job`,
+`sql` holds `name@version`, and on acceptance the row is stamped
+`succeeded` with the `run_id` that bridges to the jobs ledger — which
+remains the authority on the run itself (parameters, progress, outcome).
+A rejected submission is stamped `failed` with the executor's fixed error
+category, never its message text. Record-before-submit and the fail-closed
+`503 query_audit_error` behave exactly as for pipelines: a job the ledger
+cannot account for is not submitted. The same `X-Skardi-Session-Id` header
+(same validation) attributes the submission, so `list_by_session` returns
+an agent session's ad-hoc queries, pipeline calls, and job submissions in
+one ordered read.
+```
+
+  Also update the earlier "run_id" mention in the column table (new row: `run_id` — `job_runs.id` bridge, job rows only).
+
+- [ ] **Step 2: `docs/jobs.md`.** Session-attribution paragraph (mirror `docs/pipelines.md`'s, including the always-validated wording and the retryable `503 query_audit_error` meaning "the job was not submitted, retry later").
+
+- [ ] **Step 3: `docs/cli.md`.** `--session-id` on `skardi job run`, referencing the same client-side validation.
+
+- [ ] **Step 4: Supersede the old non-goal.** In `2026-08-14-pipeline-audit-design.md`'s jobs non-goal bullet, append: "Superseded by `2026-08-18-jobs-audit-design.md`, which adds submission-event attribution while leaving run records in the jobs ledger."
+
+- [ ] **Step 5: QA sweep.**
+
+```bash
+cargo fmt --all
+cargo test -p skardi-server -p skardi-cli 2>&1 | grep -E "^test result" | sort | uniq -c
+cargo clippy --all-targets -p skardi-server -p skardi-cli 2>&1 | grep -E "^\s+-->"   # no findings in files this branch touches (gui.rs et al. pre-existing)
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/server.md docs/jobs.md docs/cli.md docs/superpowers/specs/2026-08-14-pipeline-audit-design.md
+git commit -m "docs: job submissions in the audit ledger — run_id bridge, session attribution, retryable 503"
+```

--- a/docs/superpowers/specs/2026-08-14-pipeline-audit-design.md
+++ b/docs/superpowers/specs/2026-08-14-pipeline-audit-design.md
@@ -99,7 +99,9 @@ already-noted gap — out of scope here.)
   SQLite jobs store), so unlike pipelines they were never unobserved; what
   they lack is `ai_context`/session attribution in the *query* ledger.
   Unifying the two ledgers is real future work — best coordinated with the
-  identity-column work in #206 rather than bolted on here.
+  identity-column work in #206 rather than bolted on here. Superseded by
+  `2026-08-18-jobs-audit-design.md`, which adds submission-event
+  attribution while leaving run records in the jobs ledger.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-08-14-pipeline-audit-design.md
+++ b/docs/superpowers/specs/2026-08-14-pipeline-audit-design.md
@@ -23,7 +23,7 @@ ad-hoc SQL or a named pipeline call.
 
 | column | value for a pipeline row |
 | --- | --- |
-| `statement_kind` | `"pipeline"` (ad-hoc rows keep `Query` / `Other` — the `Debug` form of the server's `StatementKind` classifier, not SQL verbs; correction from review, the original draft wrongly said `select` / `dml`) |
+| `statement_kind` | `"pipeline"` (ad-hoc rows keep `Query` / `Other` — the `Debug` form of the server's `StatementKind` classifier, not SQL verbs; correction from review, the original draft wrongly said `select` / `dml`). **Superseded** by `2026-08-18-jobs-audit-design.md`: ad-hoc rows are now `query` / `other`, mapped explicitly, so all four values share one casing. |
 | `sql` | **`name@version`** (from `metadata.version`; revised in review — originally the bare name, but rows outlive template revisions since retention is off by default, so the name alone stops answering *what SQL ran*) — the versioned template lives on disk with no secrets and `metadata.description` carries the purpose (written at promotion time) |
 | `session_id` | from the optional `X-Skardi-Session-Id` request header |
 | `ai_context` | NULL — purpose lives in the pipeline description; a synthetic object would masquerade as caller-sent data |

--- a/docs/superpowers/specs/2026-08-18-jobs-audit-design.md
+++ b/docs/superpowers/specs/2026-08-18-jobs-audit-design.md
@@ -1,0 +1,137 @@
+# Job-submission attribution: the loop's last unattributed surface
+
+**Date:** 2026-08-18
+**Scope:** `crates/server` (jobs handler + audit store), `crates/cli` (`skardi job run --session-id`), docs. Stacked on #213 (`worktree-pipeline-audit`); supersedes the jobs non-goal in `2026-08-14-pipeline-audit-design.md`.
+
+## Problem
+
+Job *runs* are fully observed — the jobs ledger (`job_runs`) records
+parameters, status, timestamps, and run id. What they lack is
+*attribution*: no `session_id`, no link to the agent session that submitted
+them. So the one thing the Learn stage cannot do is stitch "this session ran
+four ad-hoc queries, called two pipelines, then submitted a backfill job"
+into a single intention — and an agent that manually submits the same job
+on a cadence (a promotion signal: it wants to be a routine) is invisible to
+mining. Meanwhile scheduler-style callers carry no intention signal at all.
+Conveniently, skardi has no built-in cron: every submission arrives through
+`POST /jobs/:name/run`, so attribution has exactly one seam, and "no
+session header = not agent behavior" falls out naturally.
+
+## Design
+
+**Record the submission event, not the run.** One new row kind in
+`query_audit`; run detail stays in `job_runs`, bridged by `run_id`. No
+double-logging: the audit row's lifecycle is the *submission's*, and the
+jobs ledger remains the authority on the run.
+
+### The job row
+
+| column | value |
+| --- | --- |
+| `statement_kind` | `"job"` |
+| `sql` | `name@version` (from `JobDefinition::version()`), same convention as pipeline rows |
+| `session_id` | from the optional `X-Skardi-Session-Id` header — same validation, same shared cap |
+| `ai_context` | NULL (same rationale as pipeline rows) |
+| `max_rows` | 0 sentinel (same invariant note) |
+| `run_id` | **new nullable column** — `job_runs.id` once the submission is accepted; NULL on non-job rows and on rejected submissions |
+| `status` | submission-scoped: `started` before submit → `succeeded` + `run_id` once enqueued → `failed` + fixed error kind if the executor rejects it. For job rows, `succeeded` means "submission accepted", documented on the method; run outcome lives in `job_runs`. (Alternative considered: a new `submitted` terminal status — rejected to keep the status enum and every existing consumer's filter unchanged.) |
+| `error` on rejection | `JobSubmitError::category()` — static per-variant strings (`unknown_job`, `schema_mismatch`, …), value-free by construction; the HTTP response keeps the full message |
+
+### Schema change: `run_id`
+
+First actual schema change to the ledger. `--query-audit-db` remains
+unreleased, but dev databases exist, so `open()` gains an idempotent guarded
+migration: `ALTER TABLE query_audit ADD COLUMN run_id TEXT` when
+`pragma table_info` lacks it. `get()`/`list_by_session` include the column.
+Exact-correlation is the point: name + timestamp correlation is ambiguous
+under concurrent submissions of the same job.
+
+### Handler semantics (mirroring #213's lessons)
+
+1. **Jobs subsystem disabled** → existing `503 jobs_disabled`, before
+   anything else (unchanged).
+2. **Job existence checked before header validation** (via `config.jobs`,
+   the same read-lock pattern as the pipeline lookup): unknown job → 404
+   regardless of header shape. This is round 3's metric-cardinality /
+   status-precedence lesson applied from the start — even though jobs
+   handlers currently record no metrics, the 404-wins precedence is the
+   contract. The existence pre-check races with `executor.submit`'s own
+   resolution (config can change between them); a TOCTOU loser gets a
+   `failed` audit row with `unknown_job`, which is accurate.
+3. **Header validated** with the same `session_id_from_headers`, which
+   **moves from `pipeline_handlers` to `query_audit`** alongside
+   `SESSION_ID_HEADER` — third consumer, same boundary argument that moved
+   `finish_audit` (this is ledger-attribution plumbing, not
+   pipeline-endpoint logic).
+4. **Record-before-submit, fail-closed**: `record_job_submitted` commits the
+   `started` row before `executor.submit`; a failed/timed-out write → `503
+   query_audit_error` and the job is **not submitted** (nothing may run
+   unaccounted — the run is what must not start). All writes inherit
+   `AUDIT_WRITE_TIMEOUT` via `bounded`.
+5. **Outcome**: submit `Ok(run_id)` → `record_job_outcome(id,
+   Some(run_id), Succeeded, None)`; submit `Err` → `record_job_outcome(id,
+   None, Failed, Some(err.category()))`, response unchanged.
+6. **No store configured** → today's behavior exactly.
+
+### CLI
+
+`skardi job run <name> --session-id <ID>`, sent as the header. The
+client-side validation (non-empty, ≤ 200 chars, visible ASCII, no comma/tab)
+moves from `run.rs` into a shared `crates/cli/src/session.rs`
+(`MAX_SESSION_ID_CHARS` + `validate_session_id`) consumed by both commands —
+the same rule must not be maintained twice inside one crate.
+
+### Store API
+
+- `record_job_submitted(&self, job_name: &str, version: &str, session_id: Option<&str>) -> Result<String>`
+- `record_job_outcome(&self, id: &str, run_id: Option<&str>, status: QueryAuditStatus, error: Option<&str>) -> Result<()>`
+  (dedicated method rather than widening `record_outcome`: existing callers
+  keep their signature, and the `run_id` stamp is job-specific)
+
+## Non-goals
+
+- Auditing run *outcomes* in `query_audit` (the jobs ledger owns them;
+  `run_id` bridges).
+- `GET /jobs/*` reads, run polling, cancellation — reads and control-plane
+  operations, not data-touching submissions. (Cancel arguably mutates; it
+  acts on a run already attributed at submission.)
+- Backfilling `require_session` onto jobs handlers: they perform **no auth
+  check at all** today, unlike `/query` and pipelines. Pre-existing,
+  surfaced to maintainers as an observation — a scope of its own.
+- Reconciling the jobs ledger's raw-parameter storage with the query
+  ledger's never-store-values stance. Flagged: `job_runs.parameters` holds
+  exactly what `query_audit` refuses to hold, and deserves the same
+  threat-model review — but changing what the jobs ledger records is a
+  behavior change for existing consumers of `GET /jobs/runs`.
+
+## Testing
+
+- **Store unit tests**: job row round-trip incl. `run_id` stamp;
+  `list_by_session` interleaves all three kinds in insertion order;
+  orphaned job rows reconcile; migration adds `run_id` to a pre-existing
+  old-schema database file (open twice: once with the old DDL, once
+  through `open()`).
+- **HTTP integration** (`tests/jobs_audit_http.rs`, harness cribbed from
+  `jobs_http.rs` + `pipeline_audit_http.rs`): submission audited with
+  session and `run_id` equal to the response's; absent header → NULL
+  session; no store → no-op; unknown job + malformed header → 404,
+  nothing recorded; malformed header on a real job → 400, nothing
+  recorded; fail-closed 503 → **no run row in the jobs ledger** (the
+  "not submitted" half is observable, unlike #213's engine); rejected
+  submission → `failed` row, fixed kind, `run_id` NULL; params canary —
+  a planted parameter value appears nowhere in the serialized audit row
+  (it *will* legitimately be in `job_runs.parameters`; the canary greps
+  only the audit row).
+- **CLI**: `--session-id` header present/absent; invalid value fails fast
+  with no request (shared helper, both commands).
+
+## Docs
+
+- `docs/server.md`: extend the ledger section — job rows, `run_id`
+  bridge, submission-vs-run semantics, the `statement_kind` value set
+  gains `job`.
+- `docs/jobs.md`: session attribution on submit; the retryable
+  `503 query_audit_error` (same contract as pipelines).
+- `docs/cli.md`: `skardi job run --session-id`.
+- `2026-08-14-pipeline-audit-design.md`: non-goals note updated to point
+  here (superseded).

--- a/docs/superpowers/specs/2026-08-18-jobs-audit-design.md
+++ b/docs/superpowers/specs/2026-08-18-jobs-audit-design.md
@@ -46,8 +46,9 @@ jobs ledger remains the authority on the run.
 
 First actual schema change to the ledger. `--query-audit-db` remains
 unreleased, but dev databases exist, so `open()` gains an idempotent guarded
-migration: `ALTER TABLE query_audit ADD COLUMN run_id TEXT` when
-`pragma table_info` lacks it. `get()`/`list_by_session` include the column.
+migration: `ALTER TABLE query_audit ADD COLUMN job_run_id TEXT` when
+`pragma table_info` lacks it. (The column is `job_run_id`, not `run_id` —
+see *Rebase decisions* below for why the two names are not interchangeable.) `get()`/`list_by_session` include the column.
 Exact-correlation is the point: name + timestamp correlation is ambiguous
 under concurrent submissions of the same job.
 

--- a/docs/superpowers/specs/2026-08-18-jobs-audit-design.md
+++ b/docs/superpowers/specs/2026-08-18-jobs-audit-design.md
@@ -1,7 +1,12 @@
 # Job-submission attribution: the loop's last unattributed surface
 
 **Date:** 2026-08-18
-**Scope:** `crates/server` (jobs handler + audit store), `crates/cli` (`skardi job run --session-id`), docs. Stacked on #213 (`worktree-pipeline-audit`); supersedes the jobs non-goal in `2026-08-14-pipeline-audit-design.md`.
+**Scope:** `crates/server` (jobs handler + audit store), `crates/cli` (`skardi job run --session-id`), docs. Stacked on #213 (`worktree-pipeline-audit`); rebased onto #206's ledger-crate extraction (see *Rebase decisions* below);
+supersedes the jobs non-goal in `2026-08-14-pipeline-audit-design.md`, and
+its `statement_kind` row: ad-hoc rows now record `query` / `other`, mapped
+explicitly rather than leaked from `StatementKind`'s `Debug` form, so the
+ledger's four-value vocabulary shares one casing while `--query-audit-db`
+is still unreleased and the change is free.
 
 ## Problem
 
@@ -20,7 +25,7 @@ session header = not agent behavior" falls out naturally.
 ## Design
 
 **Record the submission event, not the run.** One new row kind in
-`query_audit`; run detail stays in `job_runs`, bridged by `run_id`. No
+`query_audit`; run detail stays in `job_runs`, bridged by `job_run_id`. No
 double-logging: the audit row's lifecycle is the *submission's*, and the
 jobs ledger remains the authority on the run.
 
@@ -33,11 +38,11 @@ jobs ledger remains the authority on the run.
 | `session_id` | from the optional `X-Skardi-Session-Id` header — same validation, same shared cap |
 | `ai_context` | NULL (same rationale as pipeline rows) |
 | `max_rows` | 0 sentinel (same invariant note) |
-| `run_id` | **new nullable column** — `job_runs.id` once the submission is accepted; NULL on non-job rows and on rejected submissions |
-| `status` | submission-scoped: `started` before submit → `succeeded` + `run_id` once enqueued → `failed` + fixed error kind if the executor rejects it. For job rows, `succeeded` means "submission accepted", documented on the method; run outcome lives in `job_runs`. (Alternative considered: a new `submitted` terminal status — rejected to keep the status enum and every existing consumer's filter unchanged.) |
+| `job_run_id` | **new nullable column** — `job_runs.id` once the submission is accepted; NULL on non-job rows and on rejected submissions |
+| `status` | submission-scoped: `started` before submit → `succeeded` + `job_run_id` once enqueued → `failed` + fixed error kind if the executor rejects it. For job rows, `succeeded` means "submission accepted", documented on the method; run outcome lives in `job_runs`. (Alternative considered: a new `submitted` terminal status — rejected to keep the status enum and every existing consumer's filter unchanged.) |
 | `error` on rejection | `JobSubmitError::category()` — static per-variant strings (`unknown_job`, `schema_mismatch`, …), value-free by construction; the HTTP response keeps the full message |
 
-### Schema change: `run_id`
+### Schema change: `job_run_id`
 
 First actual schema change to the ledger. `--query-audit-db` remains
 unreleased, but dev databases exist, so `open()` gains an idempotent guarded
@@ -86,18 +91,80 @@ the same rule must not be maintained twice inside one crate.
 - `record_job_submitted(&self, job_name: &str, version: &str, session_id: Option<&str>) -> Result<String>`
 - `record_job_outcome(&self, id: &str, run_id: Option<&str>, status: QueryAuditStatus, error: Option<&str>) -> Result<()>`
   (dedicated method rather than widening `record_outcome`: existing callers
-  keep their signature, and the `run_id` stamp is job-specific)
+  keep their signature, and the `job_run_id` stamp is job-specific)
+
+## Rebase decisions (#206 landed first)
+
+#206 extracted the ledger into `crates/query-audit` (`skardi-query-audit`,
+re-exported at the old path) and added five nullable identity columns. Three
+consequences for this change, resolved as follows.
+
+**The bridge column is `job_run_id`, not `run_id`.** #206's identity envelope
+already claims `run_id`, meaning *which of the caller's runs issued this
+statement* — filled at insert time by a distribution that authenticates its
+callers. This change's column means *which job run this submission produced*,
+stamped at outcome time. Same name, two meanings, distinguishable only by
+`statement_kind`: exactly the overloading review pushed back on for
+`statement_kind`'s own casing. Renaming ours was the only option that did not
+redefine a just-merged field the cloud engine adopts wholesale. A test asserts
+the bridge stamp leaves the identity `run_id` NULL.
+
+**One additive-column mechanism, not two.** #206's `ensure_identity_columns`
+already reconciles the live schema against a column list on every open, which
+is what this change's standalone guarded `ALTER` was doing for one column.
+Generalised to `ensure_added_columns(conn, columns)` and called with two named
+lists — `IDENTITY_COLUMNS` (who asked) and `BRIDGE_COLUMNS` (what the work
+became) — kept separate because they answer different questions. The
+duplicate-column tolerance review asked for now covers all six columns rather
+than only ours: #206 introduced the same check-then-ACT race five times over.
+
+**`session_id_from_headers` moves to the server, not the ledger.** This change
+originally relocated it into `query_audit` as its third consumer. That is no
+longer possible: the helper needs `axum::http::HeaderMap`, and
+`skardi-query-audit` depends on neither `axum` nor `skardi` — which is the
+entire point of the extraction. It now lives in
+`crates/server/src/session_header.rs`, shared by the pipeline and jobs
+handlers, still validating against the ledger's `MAX_SESSION_ID_CHARS` so the
+three attribution paths cannot drift. For the same reason the
+`StatementKind` → marker mapping sits in `query_handlers` while the marker
+strings stay `pub` in the ledger: vocabulary owned by the ledger, translation
+owned by the server.
 
 ## Non-goals
 
 - Auditing run *outcomes* in `query_audit` (the jobs ledger owns them;
-  `run_id` bridges).
+  `job_run_id` bridges).
 - `GET /jobs/*` reads, run polling, cancellation — reads and control-plane
   operations, not data-touching submissions. (Cancel arguably mutates; it
   acts on a run already attributed at submission.)
 - Backfilling `require_session` onto jobs handlers: they perform **no auth
-  check at all** today, unlike `/query` and pipelines. Pre-existing,
-  surfaced to maintainers as an observation — a scope of its own.
+  check at all** today, unlike `/query` and pipelines. Pre-existing as a
+  *submission* concern, but this change gives it a second edge worth stating
+  plainly: `POST /jobs/:name/run` becomes the audit ledger's only
+  unauthenticated write path. An unauthenticated caller can therefore mint
+  arbitrary `session_id` values into `query_audit` — including ones belonging
+  to real agent sessions, which the Learn stage stitches on and cannot
+  distinguish — and can queue unrate-limited work onto the store's single
+  serialized writer thread, whose stalls 503 every concurrent `/query` and
+  pipeline execute. Called out in `docs/server.md`'s ledger section so an
+  operator enabling `--query-audit-db` behind auth knows one seam is not
+  gated; the fix is a scope of its own.
+- **Guaranteeing** the `job_run_id` correlation. The column exists because
+  name + timestamp is ambiguous under concurrent submissions of the same
+  job, and it removes that ambiguity on the happy path — but the stamp is
+  written after `executor.submit` has already created the run, best-effort.
+  If it fails, times out, or the process dies first, the run exists in
+  `job_runs` while the audit row keeps `run_id = NULL` and reconciles to
+  `unknown`. Because `job_runs` carries neither `session_id` nor an
+  audit-row id, there is no reverse pointer: the correlation is
+  unrecoverable, not merely delayed, and `unknown` on a job row means
+  "definitely submitted, linkage lost" rather than the "may have run after a
+  crash" it means on a query row. Closing this needs a durable half in the
+  jobs ledger — an `audit_id` (or `session_id`) column on `job_runs`, plumbed
+  through `executor.submit` — which puts a server-layer audit concern into
+  the core `skardi` crate's jobs subsystem, a layering decision this change
+  does not make. Stated in `docs/server.md` so consumers read `job_run_id` as
+  usually-exact rather than guaranteed.
 - Reconciling the jobs ledger's raw-parameter storage with the query
   ledger's never-store-values stance. Flagged: `job_runs.parameters` holds
   exactly what `query_audit` refuses to hold, and deserves the same
@@ -106,19 +173,19 @@ the same rule must not be maintained twice inside one crate.
 
 ## Testing
 
-- **Store unit tests**: job row round-trip incl. `run_id` stamp;
+- **Store unit tests**: job row round-trip incl. `job_run_id` stamp;
   `list_by_session` interleaves all three kinds in insertion order;
-  orphaned job rows reconcile; migration adds `run_id` to a pre-existing
+  orphaned job rows reconcile; migration adds `job_run_id` to a pre-existing
   old-schema database file (open twice: once with the old DDL, once
   through `open()`).
 - **HTTP integration** (`tests/jobs_audit_http.rs`, harness cribbed from
   `jobs_http.rs` + `pipeline_audit_http.rs`): submission audited with
-  session and `run_id` equal to the response's; absent header → NULL
+  session and `job_run_id` equal to the response's; absent header → NULL
   session; no store → no-op; unknown job + malformed header → 404,
   nothing recorded; malformed header on a real job → 400, nothing
   recorded; fail-closed 503 → **no run row in the jobs ledger** (the
   "not submitted" half is observable, unlike #213's engine); rejected
-  submission → `failed` row, fixed kind, `run_id` NULL; params canary —
+  submission → `failed` row, fixed kind, `job_run_id` NULL; params canary —
   a planted parameter value appears nowhere in the serialized audit row
   (it *will* legitimately be in `job_runs.parameters`; the canary greps
   only the audit row).
@@ -127,7 +194,7 @@ the same rule must not be maintained twice inside one crate.
 
 ## Docs
 
-- `docs/server.md`: extend the ledger section — job rows, `run_id`
+- `docs/server.md`: extend the ledger section — job rows, `job_run_id`
   bridge, submission-vs-run semantics, the `statement_kind` value set
   gains `job`.
 - `docs/jobs.md`: session attribution on submit; the retryable


### PR DESCRIPTION
> **Targets `main` directly**, rebased onto #206 (the ledger-crate extraction), which merged as 095d124. Carries its own 7 commits. Review round 1 is addressed — see *Review round 1* and *Rebasing onto #206* below.
>
> Two follow-ups are stacked on this branch: #221 (auth) and #222 (bridge reconstruction), each closing a non-goal this PR records.

## Why

Job *runs* were never the blind spot pipelines were — the jobs ledger records parameters, status, and run ids. What they lacked is **attribution**: no session linkage, so the Learn stage can't stitch "this session ran four ad-hoc queries, called two pipelines, then submitted a backfill" into one intention, and an agent that manually submits the same job on a cadence (a promotion signal — it wants to be a routine) is invisible to mining. Skardi has no built-in cron, so every submission arrives through `POST /jobs/:name/run`: attribution has exactly one seam, and "no session header = not agent behavior" falls out naturally. Design discussion in `docs/superpowers/specs/2026-08-18-jobs-audit-design.md`; supersedes the jobs non-goal in #213's spec.

## What

**Record the submission event, not the run.** One new row kind in `query_audit`; run detail stays in `job_runs`, bridged by a new nullable `run_id` column. No double-logging: the audit row's lifecycle is the submission's, and the jobs ledger remains the authority on the run.

| | job row |
|---|---|
| `statement_kind` | `job` (value set is now `Query` / `Other` / `pipeline` / `job`) |
| `sql` | `name@version`, same convention as pipeline rows |
| `session_id` | from the shared `X-Skardi-Session-Id` header — same validation, same cap |
| `job_run_id` | **new nullable column** = `job_runs.id` once accepted; NULL on rejection and on all non-job rows. Added through #206's additive-column reconciler, now generalized and duplicate-column tolerant (pre-column DBs open and migrate — tests pin both fresh and migrated files) |
| `status` | submission-scoped: `started` → `succeeded` + `run_id` (accepted/enqueued) or `failed` + the executor's **static error category** (`missing_parameters`, `schema_mismatch`, …) — never message text |

- **Precedence, each step test-pinned**: jobs-disabled 503 → unknown job 404 (existence pre-check *before* header validation — #213 round-3's 404-wins/bounded-label lesson applied from the start) → malformed header 400 → audit-write 503 (`query_audit_error`, and the test proves the job was **not submitted** by asserting the jobs ledger is empty) → submit.
- **One honest asymmetry, documented**: job parameter validation happens *inside* `executor.submit` — after the audit write — so a parameter rejection leaves a `failed` row, unlike pipelines where param rejects record nothing. Structural (the server can't pre-validate job params), stated explicitly in `docs/server.md`.
- **`session_id_from_headers` moved to `query_audit`** (third consumer) — ledger-attribution plumbing now lives with the ledger, shrinking the #206 collision surface further.
- **CLI**: `skardi job run --session-id`, with the client-side validation extracted to a shared `cli/src/session.rs` used by both commands (fail-fast, no `ApiError::Connect` misattribution).
- `list_by_session` now returns an agent session's ad-hoc queries, pipeline calls, and job submissions in one totally-ordered read — the shape intention-mining skills consume.

## Tests

5 new store unit tests (job row round-trip with `run_id`, rejected-submission shape, three-kind interleaving in order, orphan reconcile, old-schema migration) and 10 integration tests in `tests/jobs_audit_http.rs` — including the fail-closed not-submitted proof, the post-audit rejection path (mutation-checked: removing the `Err`-arm stamp fails it), a param-value canary against the audit row, 404-before-400 precedence, and audit-off header validation. CLI: header present/absent + fail-fast tests over the shared validator. Full workspace suite: 1332 passed, 0 failed.

## Out of scope (deliberate)

- Auditing run *outcomes* in `query_audit` — the jobs ledger owns them; `run_id` bridges.
- Jobs handlers perform **no auth check at all** today (unlike `/query` and pipelines, which call `require_session`) — pre-existing, surfaced here as an observation; its own scope.
- `job_runs.parameters` stores raw parameter values — exactly what `query_audit` refuses to store. Flagged in the spec for the same threat-model review as #217; changing it would alter `GET /jobs/runs` behavior.

Refs: #213 (merged — this extends its ledger), #206 (ledger crate extraction — the helper moves here reduce the conflict), #217 (param egress), #218 (`skardi query` passthrough).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round 1 — addressed

All eight comments, in `fab5857` plus the rebase below. Replies are in each thread.

| | change |
|---|---|
| Migration race | check-then-`ALTER` was not atomic; the loser's `duplicate column name` aborted startup over a condition that already held. Now counted as success, and because the reconciler is shared it covers **all six** added columns — #206 introduced the same race five more times |
| Missing index | partial `idx_query_audit_job_run_id ... WHERE job_run_id IS NOT NULL`. It cannot go in `INIT_SCHEMA_SQL` at all — that batch runs *before* the column exists, against pre-column DBs — so it lives in the reconcile step; a test pins it on fresh **and** migrated files |
| Outcome-write guard | `WHERE status = 'started'` on `record_job_outcome` *and* `record_outcome`, so a late write cannot resurrect a row reconciliation already settled. Both tests fail with the guard removed |
| `statement_kind` casing | normalized — ad-hoc rows record `query` / `other` from named `pub` constants instead of a leaked `Debug` form, so all four values share one casing |
| Unauthenticated ledger write path | documented in `docs/server.md` and the spec non-goals with the two concrete consequences; **fixed in #221** |
| One-directional `job_run_id` bridge | stated as a non-goal with the reason it is structural; **fixed in #222** via a durable reverse pointer |
| Lock-poisoning divergence | kept the recovery, commented why. `.claude/CLAUDE.md` mandates `unwrap_or_else(\|p\| p.into_inner())` for `std::sync` poisoning, so this handler follows policy and `pipeline_handlers.rs` is the outlier |
| `session_id` log field | recorded as an `Option`; `unwrap_or_default()` rendered "absent" as `""`, the one value the validator rejects |

## Rebasing onto #206

#206 moved the ledger into `crates/query-audit` and added five nullable identity columns. That produced one semantic conflict and two structural ones.

**The bridge column is now `job_run_id`.** #206's identity envelope already claims `run_id`, meaning *which of the caller's runs issued this statement* — written at insert time by a distribution that authenticates its callers. Ours means *which job run this submission produced*, stamped at outcome time. Same name, two meanings, distinguishable only by `statement_kind` — exactly the overloading review pushed back on for `statement_kind` itself. Renaming ours was the only resolution that does not redefine a just-merged field the cloud engine adopts wholesale. A test asserts the bridge stamp leaves the identity `run_id` NULL.

**One additive-column mechanism, not two.** #206's `ensure_identity_columns` already reconciles the live schema against a column list on every open — which is what this PR's standalone guarded `ALTER` was doing for one column. Generalized to `ensure_added_columns(conn, columns)`, called with two named lists: `IDENTITY_COLUMNS` (who asked) and `BRIDGE_COLUMNS` (what the work became). Kept separate because they answer different questions; sharing the mechanism is what spreads the duplicate-column fix across all six.

**`session_id_from_headers` lands in the server, not the ledger.** This PR originally relocated it into `query_audit` as its third consumer. No longer possible: it needs `axum::http::HeaderMap`, and `skardi-query-audit` depends on neither `axum` nor `skardi` — the whole point of the extraction. It now lives in `crates/server/src/session_header.rs`, shared by both handlers, still validating against the ledger's `MAX_SESSION_ID_CHARS` so the three attribution paths cannot drift. Same reasoning splits `statement_kind`: the marker strings stay `pub` in the ledger, the `StatementKind` → marker mapping sits in `query_handlers`. Vocabulary owned by the ledger, translation owned by the server.

Full workspace after the rebase: **1467 passed, 0 failed.** Clippy clean on every touched file.
