### PR TITLE
feat(server): require an authenticated session on every /jobs/* endpoint

### DIFF
--- a/crates/server/src/auth/layer.rs
+++ b/crates/server/src/auth/layer.rs
@@ -120,6 +120,7 @@ impl AuthLayer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::auth::test_env;
 
     fn unique_test_db_path() -> String {
         ":memory:".to_string()
@@ -142,6 +143,7 @@ mod tests {
 
     #[tokio::test]
     async fn build_better_auth_missing_secret_errors() {
+        let _env = test_env::lock().await;
         unsafe {
             std::env::remove_var("AUTH_SECRET");
             std::env::set_var("AUTH_DB_PATH", unique_test_db_path());
@@ -158,6 +160,7 @@ mod tests {
 
     #[tokio::test]
     async fn build_better_auth_success() {
+        let _env = test_env::lock().await;
         unsafe {
             std::env::set_var("AUTH_SECRET", "test-secret-that-is-at-least-32-characters!");
             std::env::set_var("AUTH_DB_PATH", unique_test_db_path());
@@ -179,6 +182,7 @@ mod tests {
 
     #[tokio::test]
     async fn build_better_auth_respects_auth_base_url() {
+        let _env = test_env::lock().await;
         unsafe {
             std::env::set_var("AUTH_SECRET", "test-secret-that-is-at-least-32-characters!");
             std::env::set_var("AUTH_DB_PATH", unique_test_db_path());
@@ -200,6 +204,7 @@ mod tests {
 
     #[tokio::test]
     async fn clone_better_auth_shares_arc() {
+        let _env = test_env::lock().await;
         unsafe {
             std::env::set_var("AUTH_SECRET", "test-secret-that-is-at-least-32-characters!");
             std::env::set_var("AUTH_DB_PATH", unique_test_db_path());

--- a/crates/server/src/auth/mod.rs
+++ b/crates/server/src/auth/mod.rs
@@ -3,3 +3,31 @@ pub mod layer;
 pub mod mode;
 pub mod routes;
 pub mod types;
+
+#[cfg(test)]
+pub(crate) mod test_env {
+    use tokio::sync::{Mutex, MutexGuard};
+
+    /// Serializes tests that mutate `AUTH_SECRET` / `AUTH_DB_PATH` /
+    /// `AUTH_BASE_URL`.
+    ///
+    /// Environment variables are process-global, and `layer.rs` and
+    /// `routes.rs` tests share one test binary that libtest runs in parallel.
+    /// `build_better_auth_missing_secret_errors` removes `AUTH_SECRET` and
+    /// asserts the build fails; every other auth test sets it. Without
+    /// serialization those two race, and the removal test intermittently sees
+    /// a secret another test just set and fails with "expected Err when
+    /// AUTH_SECRET is unset".
+    ///
+    /// A `tokio::sync::Mutex` rather than `std::sync::Mutex` because the
+    /// guard must be held across `AuthLayer::build(..).await` — locking only
+    /// around the mutation would still let another test set the variable
+    /// between the mutation and the build that reads it.
+    static ENV_LOCK: Mutex<()> = Mutex::const_new(());
+
+    /// Hold the returned guard for as long as the process environment must
+    /// stay as this test left it — i.e. through the `build` that reads it.
+    pub(crate) async fn lock() -> MutexGuard<'static, ()> {
+        ENV_LOCK.lock().await
+    }
+}

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -407,6 +407,10 @@ mod tests {
     }
 
     async fn make_better_auth_state() -> AppState {
+        // Held only across the env mutation + `build` below: once the layer
+        // exists it no longer reads the environment, so callers need not
+        // keep the guard.
+        let _env = crate::auth::test_env::lock().await;
         use crate::auth::layer::AuthLayer;
         use crate::config::{CliArgs, ServerConfig};
         use crate::semantics::SemanticsRegistry;

--- a/crates/server/src/jobs_handlers.rs
+++ b/crates/server/src/jobs_handlers.rs
@@ -21,6 +21,7 @@ use serde_json::Value;
 use skardi::jobs::{JobRun, JobSubmitError};
 use std::collections::HashMap;
 
+use crate::auth::routes::require_session;
 use crate::query_audit::{QueryAuditStatus, QueryAuditStore};
 use crate::server::AppState;
 use crate::session_header::{SESSION_ID_HEADER, session_id_from_headers};
@@ -59,6 +60,26 @@ fn error_json(msg: &str, kind: &str, details: Option<Value>) -> Json<JobErrorRes
         details,
         timestamp: chrono::Utc::now().to_rfc3339(),
     })
+}
+
+/// Reject the request unless it carries a valid session.
+///
+/// `require_session` reports through the shared `ErrorResponse` shape; the
+/// jobs endpoints answer in `JobErrorResponse`. Rather than let one endpoint
+/// family answer in two shapes, the status is kept and the body re-rendered —
+/// `unauthorized` is already this crate's `error_type` for the condition, so
+/// the only thing a client sees differ from `/query` is the envelope it
+/// already expects from `/jobs/*`.
+///
+/// A no-auth server short-circuits inside `verify_session`, so this is a
+/// no-op for deployments that never configured auth.
+async fn require_job_session(
+    app_state: &AppState,
+    headers: &HeaderMap,
+) -> Result<(), (StatusCode, Json<JobErrorResponse>)> {
+    require_session(app_state, headers)
+        .await
+        .map_err(|(status, body)| (status, error_json(&body.error, "unauthorized", None)))
 }
 
 fn submit_error_status(err: &JobSubmitError) -> StatusCode {
@@ -124,6 +145,13 @@ pub async fn submit_job_run(
     Path(name): Path<String>,
     Json(req): Json<SubmitRunRequest>,
 ) -> Result<Json<SubmitRunResponse>, (StatusCode, Json<JobErrorResponse>)> {
+    // First statement, ahead of the jobs-disabled probe and the job-existence
+    // lookup, matching `execute_pipeline_by_name` and `/query`. Deliberately
+    // *outside* the status-precedence ladder those two checks establish: an
+    // unauthenticated caller learns neither whether jobs are enabled on this
+    // server nor which job names exist.
+    require_job_session(&app_state, &headers).await?;
+
     let Some(executor) = app_state.jobs.clone() else {
         return Err((
             StatusCode::SERVICE_UNAVAILABLE,
@@ -277,8 +305,10 @@ pub async fn submit_job_run(
 /// `GET /jobs/runs/:run_id`
 pub async fn get_job_run(
     State(app_state): State<AppState>,
+    headers: HeaderMap,
     Path(run_id): Path<String>,
 ) -> Result<Json<Value>, (StatusCode, Json<JobErrorResponse>)> {
+    require_job_session(&app_state, &headers).await?;
     let Some(executor) = app_state.jobs.clone() else {
         return Err((
             StatusCode::SERVICE_UNAVAILABLE,
@@ -307,8 +337,10 @@ pub struct ListRunsQuery {
 /// `GET /jobs/runs?job=...&limit=...`
 pub async fn list_job_runs(
     State(app_state): State<AppState>,
+    headers: HeaderMap,
     Query(q): Query<ListRunsQuery>,
 ) -> Result<Json<Value>, (StatusCode, Json<JobErrorResponse>)> {
+    require_job_session(&app_state, &headers).await?;
     let Some(executor) = app_state.jobs.clone() else {
         return Err((
             StatusCode::SERVICE_UNAVAILABLE,
@@ -337,8 +369,10 @@ pub async fn list_job_runs(
 /// the executor.
 pub async fn cancel_job_run(
     State(app_state): State<AppState>,
+    headers: HeaderMap,
     Path(run_id): Path<String>,
 ) -> Result<Json<Value>, (StatusCode, Json<JobErrorResponse>)> {
+    require_job_session(&app_state, &headers).await?;
     let Some(executor) = app_state.jobs.clone() else {
         return Err((
             StatusCode::SERVICE_UNAVAILABLE,
@@ -362,7 +396,9 @@ pub async fn cancel_job_run(
 /// for CLI discovery.
 pub async fn list_jobs(
     State(app_state): State<AppState>,
+    headers: HeaderMap,
 ) -> Result<Json<Value>, (StatusCode, Json<JobErrorResponse>)> {
+    require_job_session(&app_state, &headers).await?;
     let Some(executor) = app_state.jobs.clone() else {
         return Err((
             StatusCode::SERVICE_UNAVAILABLE,

--- a/crates/server/src/jobs_handlers.rs
+++ b/crates/server/src/jobs_handlers.rs
@@ -66,10 +66,15 @@ fn error_json(msg: &str, kind: &str, details: Option<Value>) -> Json<JobErrorRes
 ///
 /// `require_session` reports through the shared `ErrorResponse` shape; the
 /// jobs endpoints answer in `JobErrorResponse`. Rather than let one endpoint
-/// family answer in two shapes, the status is kept and the body re-rendered —
-/// `unauthorized` is already this crate's `error_type` for the condition, so
-/// the only thing a client sees differ from `/query` is the envelope it
-/// already expects from `/jobs/*`.
+/// family answer in two shapes, the status is kept and the body re-rendered
+/// into this crate's envelope — so the only thing a client sees differ from
+/// `/query` is the wrapper it already expects from `/jobs/*`.
+///
+/// `error_type` is propagated rather than pinned to `unauthorized`, which is
+/// all `require_session` classifies today: `verify_session` already
+/// distinguishes "Authentication required" from "Invalid or expired session"
+/// internally, so a second classification growing upstream would otherwise
+/// change the message while silently leaving the type behind.
 ///
 /// A no-auth server short-circuits inside `verify_session`, so this is a
 /// no-op for deployments that never configured auth.
@@ -79,7 +84,7 @@ async fn require_job_session(
 ) -> Result<(), (StatusCode, Json<JobErrorResponse>)> {
     require_session(app_state, headers)
         .await
-        .map_err(|(status, body)| (status, error_json(&body.error, "unauthorized", None)))
+        .map_err(|(status, body)| (status, error_json(&body.error, &body.error_type, None)))
 }
 
 fn submit_error_status(err: &JobSubmitError) -> StatusCode {
@@ -145,11 +150,17 @@ pub async fn submit_job_run(
     Path(name): Path<String>,
     Json(req): Json<SubmitRunRequest>,
 ) -> Result<Json<SubmitRunResponse>, (StatusCode, Json<JobErrorResponse>)> {
-    // First statement, ahead of the jobs-disabled probe and the job-existence
-    // lookup, matching `execute_pipeline_by_name` and `/query`. Deliberately
-    // *outside* the status-precedence ladder those two checks establish: an
-    // unauthenticated caller learns neither whether jobs are enabled on this
-    // server nor which job names exist.
+    // First statement in the handler, ahead of the jobs-disabled probe and the
+    // job-existence lookup, matching `execute_pipeline_by_name` and `/query`.
+    // Deliberately *outside* the status-precedence ladder those two checks
+    // establish, so an unauthenticated caller cannot read either off the
+    // status code.
+    //
+    // "First" is about the handler body: axum runs extractors ahead of it, so
+    // a malformed `Query`/`Json` still answers 400/422 pre-gate. That leak is
+    // schema-shaped rather than data-shaped, identical on `/query` and the
+    // pipeline endpoints, and does not reach the audit writes this gate exists
+    // to protect — those all live below.
     require_job_session(&app_state, &headers).await?;
 
     let Some(executor) = app_state.jobs.clone() else {

--- a/crates/server/tests/jobs_auth_http.rs
+++ b/crates/server/tests/jobs_auth_http.rs
@@ -136,7 +136,24 @@ spec:
     (state, tmp)
 }
 
+/// Serializes the `AUTH_*` mutations below.
+///
+/// Environment variables are process-global and libtest runs this binary's
+/// tests on parallel threads, so concurrent `set_var` calls are a data race —
+/// which is why edition 2024 makes `set_var` `unsafe`. Identical values do not
+/// rescue it, and the file would become order-dependently flaky the moment one
+/// test wanted a different `AUTH_DB_PATH`.
+///
+/// A `tokio::sync::Mutex` rather than `std::sync::Mutex` because the guard has
+/// to be held across `AuthLayer::build(..).await`: `build` is what reads these
+/// variables, so releasing after the mutation would still let another test
+/// overwrite them before the read. Mirrors `auth::test_env::lock`, which
+/// cannot be reused here — it is `#[cfg(test)]` on the lib and so invisible to
+/// an integration-test binary.
+static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 async fn better_auth_layer() -> AuthLayer {
+    let _env = ENV_LOCK.lock().await;
     unsafe {
         std::env::set_var("AUTH_SECRET", "test-secret-that-is-at-least-32-characters!");
         std::env::set_var("AUTH_DB_PATH", ":memory:");

--- a/crates/server/tests/jobs_auth_http.rs
+++ b/crates/server/tests/jobs_auth_http.rs
@@ -1,0 +1,249 @@
+//! HTTP integration tests for authentication on the `/jobs/*` endpoints.
+//!
+//! Until this change the jobs handlers performed no auth check at all, while
+//! `/query` and `POST /:pipeline/execute` both called `require_session` as
+//! their first statement. That gap became load-bearing once job submissions
+//! started writing into the query-audit ledger (#219): it made
+//! `POST /jobs/:name/run` the ledger's only unauthenticated write path, so an
+//! unauthenticated caller could mint `session_id` values into rows the Learn
+//! stage stitches on.
+//!
+//! These tests pin both halves: every endpoint 401s without a session when
+//! auth is configured, and every endpoint is unaffected when it is not.
+
+use arrow::array::Int64Array;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use datafusion::datasource::MemTable;
+use datafusion::prelude::SessionContext;
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use skardi::jobs::{JobDefinition, JobExecutor, JobStore, SqliteJobStore};
+use skardi::sources::DataSourceType;
+use std::collections::HashMap;
+use std::io::Write;
+use std::sync::Arc;
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+use skardi_server::auth::layer::AuthLayer;
+use skardi_server::auth::mode::AuthMode;
+use skardi_server::config::{CliArgs, ServerConfig};
+use skardi_server::semantics::SemanticsRegistry;
+use skardi_server::server::{AppState, configure_routes};
+
+const TEST_JOB_NAME: &str = "ingest-all";
+
+/// Every route under `/jobs`, as (method, uri). Kept as one list so a route
+/// added to `configure_routes` without an auth gate shows up as a missing
+/// entry here rather than as silently uncovered surface.
+fn all_job_routes() -> Vec<(&'static str, String)> {
+    vec![
+        ("GET", "/jobs".to_string()),
+        ("POST", format!("/jobs/{TEST_JOB_NAME}/run")),
+        ("GET", "/jobs/runs".to_string()),
+        ("GET", "/jobs/runs/some-run-id".to_string()),
+        ("POST", "/jobs/runs/some-run-id/cancel".to_string()),
+    ]
+}
+
+fn write_yaml(path: &std::path::Path, content: &str) {
+    let mut f = std::fs::File::create(path).unwrap();
+    f.write_all(content.as_bytes()).unwrap();
+}
+
+fn sample_batch() -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+    RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(vec![1i64, 2, 3]))]).unwrap()
+}
+
+/// `AppState` with a working jobs executor and the given auth layer.
+async fn make_app_state(auth_layer: AuthLayer) -> (AppState, TempDir) {
+    let tmp = TempDir::new().unwrap();
+    let ctx = Arc::new(SessionContext::new());
+    ctx.register_batch("src", sample_batch()).unwrap();
+
+    let dest_schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+    let dest = MemTable::try_new(
+        dest_schema.clone(),
+        vec![vec![RecordBatch::new_empty(dest_schema)]],
+    )
+    .unwrap();
+    ctx.register_table("dest", Arc::new(dest)).unwrap();
+
+    let yaml_path = tmp.path().join("j.yaml");
+    write_yaml(
+        &yaml_path,
+        r#"
+kind: job
+metadata:
+  name: "ingest-all"
+  version: "1.0.0"
+spec:
+  query: |
+    SELECT id FROM src
+  destination:
+    table: "dest"
+    mode: append
+"#,
+    );
+    let job = JobDefinition::load_from_file(&yaml_path, Arc::clone(&ctx))
+        .await
+        .unwrap()
+        .unwrap();
+    let mut jobs_map = HashMap::new();
+    jobs_map.insert(job.name().to_string(), job);
+
+    let store = Arc::new(SqliteJobStore::open_in_memory().await.unwrap());
+    let executor = Some(Arc::new(JobExecutor::new(
+        jobs_map.clone(),
+        store as Arc<dyn JobStore>,
+        Arc::clone(&ctx),
+        HashMap::<String, DataSourceType>::new(),
+        HashMap::new(),
+    )));
+
+    let engine = Arc::new(skardi::engine::datafusion::DataFusionEngine::new_with_arc(
+        Arc::clone(&ctx),
+    ));
+    let config = ServerConfig {
+        pipelines: HashMap::new(),
+        jobs: jobs_map,
+        data_sources: vec![],
+        semantics: SemanticsRegistry::default(),
+        args: CliArgs {
+            pipeline_path: None,
+            jobs_path: None,
+            jobs_db_path: None,
+            ctx_file: None,
+            semantics_path: None,
+            port: 0,
+            query_audit_db: None,
+            query_audit_retention_days: None,
+        },
+    };
+    let state = AppState::new(
+        config,
+        engine,
+        Arc::clone(&ctx),
+        auth_layer,
+        executor,
+        None,
+        Default::default(),
+    );
+    (state, tmp)
+}
+
+async fn better_auth_layer() -> AuthLayer {
+    unsafe {
+        std::env::set_var("AUTH_SECRET", "test-secret-that-is-at-least-32-characters!");
+        std::env::set_var("AUTH_DB_PATH", ":memory:");
+        std::env::remove_var("AUTH_BASE_URL");
+    }
+    AuthLayer::build(&AuthMode::BetterAuthDieselSqlite)
+        .await
+        .unwrap()
+}
+
+async fn body_to_json(resp: axum::response::Response) -> Value {
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+async fn call(
+    state: &AppState,
+    method: &str,
+    uri: &str,
+    headers: &[(&str, &str)],
+) -> axum::response::Response {
+    let app = configure_routes(state.clone());
+    let mut builder = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json");
+    for (name, value) in headers {
+        builder = builder.header(*name, *value);
+    }
+    app.oneshot(builder.body(Body::from(json!({}).to_string())).unwrap())
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn every_jobs_route_401s_without_a_session() {
+    let (state, _tmp) = make_app_state(better_auth_layer().await).await;
+    for (method, uri) in all_job_routes() {
+        let resp = call(&state, method, &uri, &[]).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "{method} {uri} was not gated"
+        );
+        let body = body_to_json(resp).await;
+        // The jobs endpoint family answers in one envelope, so the auth
+        // rejection must not arrive in `/query`'s shape.
+        assert_eq!(body["error_type"], json!("unauthorized"), "{method} {uri}");
+        assert_eq!(body["success"], json!(false), "{method} {uri}");
+        assert!(body["timestamp"].is_string(), "{method} {uri}");
+    }
+}
+
+#[tokio::test]
+async fn every_jobs_route_401s_with_an_invalid_bearer_token() {
+    let (state, _tmp) = make_app_state(better_auth_layer().await).await;
+    for (method, uri) in all_job_routes() {
+        let resp = call(&state, method, &uri, &[("authorization", "Bearer bogus")]).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "{method} {uri} accepted a bogus token"
+        );
+    }
+}
+
+#[tokio::test]
+async fn auth_precedes_job_existence_and_subsystem_checks() {
+    // An unauthenticated caller must not be able to distinguish "this job
+    // exists" (404 vs 200) or "jobs are enabled here" (503) by reading the
+    // status code — so the gate sits ahead of both checks rather than inside
+    // the precedence ladder they form.
+    let (state, _tmp) = make_app_state(better_auth_layer().await).await;
+
+    let resp = call(&state, "POST", "/jobs/no-such-job/run", &[]).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "unknown-job 404 leaked ahead of the auth gate"
+    );
+
+    let (mut jobless, _tmp2) = make_app_state(better_auth_layer().await).await;
+    jobless.jobs = None;
+    let resp = call(&jobless, "POST", &format!("/jobs/{TEST_JOB_NAME}/run"), &[]).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "jobs-disabled 503 leaked ahead of the auth gate"
+    );
+}
+
+#[tokio::test]
+async fn no_auth_server_is_unaffected() {
+    // `verify_session` short-circuits when no auth layer is configured, so
+    // adding the gate must not change behaviour for deployments that never
+    // enabled auth — the large majority today.
+    let (state, _tmp) = make_app_state(AuthLayer::None).await;
+
+    let resp = call(&state, "GET", "/jobs", &[]).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let resp = call(&state, "POST", &format!("/jobs/{TEST_JOB_NAME}/run"), &[]).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_to_json(resp).await;
+    assert!(body["run_id"].is_string(), "no run was created: {body}");
+
+    // A read path too, so the gate is not merely absent from the write one.
+    let resp = call(&state, "GET", "/jobs/runs", &[]).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+}

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -175,8 +175,30 @@ On startup the server:
 | `/jobs/runs/:run_id` | GET | Current state of one run |
 | `/jobs/runs/:run_id/cancel` | POST | Flag a run for cancellation |
 
-When the server was started without `--jobs`, every endpoint above
-returns `503 Service Unavailable` with `error_type: jobs_disabled`.
+For an authenticated caller, a server started without `--jobs` returns
+`503 Service Unavailable` with `error_type: jobs_disabled` from every
+endpoint above. An unauthenticated caller sees the `401` below instead and
+never learns whether jobs are enabled.
+
+### Authentication
+
+Every `/jobs/*` route requires a valid session when the server is started
+with authentication configured. The check is the first thing each handler
+does, so it **precedes** both the `jobs_disabled` 503 and the unknown-job
+404 — deliberately, so an unauthenticated caller cannot read either fact off
+the status code. The rejection is `401 Unauthorized` with
+`error_type: unauthorized`, in the same error envelope as every other jobs
+response.
+
+Servers with no auth layer configured are unaffected: the check
+short-circuits, and all five endpoints behave exactly as before.
+
+Note this is separate from the `X-Skardi-Session-Id` header below.
+Authentication answers *may this caller use the endpoint at all*; the
+session header answers *which agent session should this submission be
+attributed to*, and stays self-reported. Passing the header does not
+authenticate a request, and authenticating does not make the header
+trustworthy.
 
 ### Session attribution
 
@@ -236,6 +258,14 @@ and falls back to a plain string otherwise.
 Jobs run **only inside the server** — there is no in-process fallback
 and no `--ctx` flag on the CLI-side job commands. If the server isn't
 running you'll get a connection-refused error.
+
+Against an auth-enabled server every `skardi job` subcommand needs a token,
+since all five endpoints are gated (see
+[Authentication](#authentication)). Supply it with `--token`,
+`$SKARDI_API_TOKEN`, or `~/.skardi/config.yaml`; the CLI attaches it as
+`Authorization: Bearer <token>` on every request. Without one the symptom is
+a `401 unauthorized` from a command that needed no token before the gate
+existed.
 
 ---
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -328,34 +328,15 @@ ad-hoc queries, pipeline calls, and job submissions in one ordered read.
 
 Two properties of this seam an operator should know before relying on it:
 
-- **It is the ledger's only unauthenticated write path, and that costs
-  availability, not just attribution.** `/query` and
-  `POST /:pipeline/execute` both call `require_session` before writing
-  anything; the jobs handlers perform no auth check at all. Two distinct
-  consequences, the second the more serious:
-
-  1. *Forged attribution.* The header is self-reported on every endpoint — it
-     never attests to origin — but on the other two the caller is at least
-     authenticated. Here neither is true, so anyone who can reach
-     `POST /jobs/:name/run` can mint arbitrary `session_id` values into
-     `query_audit`, including ones belonging to real sessions. A forged row
-     lands inside a legitimate session's `list_by_session` read and is
-     indistinguishable from a real submission.
-
-  2. *Denial of service against the other two endpoints.* Every submission —
-     including ones the executor will reject — issues writes on the ledger's
-     **single serialized writer thread**, shared with every audited request.
-     `/query` and `POST /:pipeline/execute` are fail-closed on that thread:
-     when work on it exceeds the write timeout, they return `503` by design.
-     Before job auditing existed, `POST /jobs/:name/run` did not touch that
-     thread at all. It now does, unrate-limited and unauthenticated — so an
-     anonymous caller can stall writes that two *authenticated* endpoints
-     block on, plus grow a ledger whose retention is off by default.
-
-  Weigh the second one when deciding where to enable `--query-audit-db`: if
-  the deployment is behind auth, this seam is not gated and the exposure is
-  to the availability of the endpoints that are. Backfilling the check is
-  tracked separately.
+- **Attribution is authenticated but still self-reported.** Every `/jobs/*`
+  endpoint calls `require_session` first, so the ledger has no
+  unauthenticated write path — an anonymous caller can no longer mint
+  `session_id` values into `query_audit`, nor queue writes onto its single
+  serialized writer thread. The header itself is unchanged: it names a
+  session, it does not prove one, exactly as on `/query` and
+  `POST /:pipeline/execute`. An authenticated caller can still stamp its
+  submissions with another session's id. Read `session_id` as a correlation
+  key, never as evidence of who ran what.
 
 - **The `job_run_id` bridge is best-effort and one-directional.** It is
   stamped after `executor.submit` returns, so if that write fails, times out,

--- a/docs/superpowers/specs/2026-08-18-jobs-audit-design.md
+++ b/docs/superpowers/specs/2026-08-18-jobs-audit-design.md
@@ -138,18 +138,10 @@ owned by the server.
 - `GET /jobs/*` reads, run polling, cancellation — reads and control-plane
   operations, not data-touching submissions. (Cancel arguably mutates; it
   acts on a run already attributed at submission.)
-- Backfilling `require_session` onto jobs handlers: they perform **no auth
-  check at all** today, unlike `/query` and pipelines. Pre-existing as a
-  *submission* concern, but this change gives it a second edge worth stating
-  plainly: `POST /jobs/:name/run` becomes the audit ledger's only
-  unauthenticated write path. An unauthenticated caller can therefore mint
-  arbitrary `session_id` values into `query_audit` — including ones belonging
-  to real agent sessions, which the Learn stage stitches on and cannot
-  distinguish — and can queue unrate-limited work onto the store's single
-  serialized writer thread, whose stalls 503 every concurrent `/query` and
-  pipeline execute. Called out in `docs/server.md`'s ledger section so an
-  operator enabling `--query-audit-db` behind auth knows one seam is not
-  gated; the fix is a scope of its own.
+- Backfilling `require_session` onto jobs handlers. **Done as a follow-up**
+  (`2026-08-19-jobs-auth-design.md`), because this change is what made the
+  gap load-bearing: it turned `POST /jobs/:name/run` into the audit ledger's
+  only unauthenticated write path.
 - **Guaranteeing** the `job_run_id` correlation. The column exists because
   name + timestamp is ambiguous under concurrent submissions of the same
   job, and it removes that ambiguity on the happy path — but the stamp is

--- a/docs/superpowers/specs/2026-08-19-jobs-auth-design.md
+++ b/docs/superpowers/specs/2026-08-19-jobs-auth-design.md
@@ -1,0 +1,83 @@
+# Jobs endpoints: require an authenticated session
+
+**Date:** 2026-08-19
+**Scope:** `crates/server` (jobs handlers), docs. Stacked on the jobs-audit
+change (#219); closes the non-goal that change recorded rather than fixed.
+
+## Why now
+
+The jobs handlers have never performed an auth check, while `/query` and
+`POST /:pipeline/execute` both call `require_session` as their first
+statement. On its own that is a submission-authorization gap and arguably
+pre-existing. #219 changed what it costs:
+
+- **Attribution forgery.** Job submissions now write `session_id` into
+  `query_audit` from the `X-Skardi-Session-Id` header. That made
+  `POST /jobs/:name/run` the ledger's *only* unauthenticated write path, so
+  anyone who could reach it could mint rows carrying a real agent session's
+  id. The Learn stage stitches intentions on exactly that key, and a forged
+  row lands inside a legitimate session's `list_by_session` read
+  indistinguishable from a real one.
+- **Cross-endpoint availability coupling.** Every submission — including ones
+  the executor will reject — issues writes on `QueryAuditStore`'s single
+  serialized writer thread, shared with every audited `/query` and pipeline
+  execution. Work exceeding `AUDIT_WRITE_TIMEOUT` there 503s those other
+  requests. The endpoint handed an unauthenticated actor an unrate-limited
+  way to queue onto it.
+
+Authentication does not make the header trustworthy — it is self-reported on
+every endpoint, by design — but it bounds *who* can self-report to callers
+the operator has admitted.
+
+## What
+
+`require_session` on all five `/jobs/*` handlers, not only the write path:
+`GET /jobs` exposes job definitions and parameter names, and
+`GET /jobs/runs` returns `job_runs.parameters` — raw parameter *values*,
+which is exactly what `query_audit` refuses to store. Gating submissions
+while leaving those readable would close the smaller hole.
+
+**Placement: first statement, ahead of the jobs-disabled 503 and the
+job-existence 404.** #219 established a precedence ladder among those
+checks; the auth gate deliberately sits outside it rather than inside. An
+unauthenticated caller learns neither whether jobs are enabled on this
+server nor which job names exist — both are otherwise readable straight off
+the status code.
+
+**Response shape.** `require_session` reports through the shared
+`ErrorResponse`; the jobs endpoints answer in `JobErrorResponse`. A thin
+`require_job_session` adapter keeps the status and re-renders the body, so
+one endpoint family does not answer in two envelopes. `unauthorized` is
+already the crate's `error_type` for the condition.
+
+**No behaviour change without auth.** `verify_session` returns `Ok` when
+`auth_layer.as_better_auth()` is `None`, so servers that never configured
+auth are unaffected — pinned by a test rather than left to inspection.
+
+## Non-goals
+
+- Authorization beyond "has a valid session" — no per-job ACLs, no
+  distinction between submitting and cancelling. Every authenticated caller
+  can do everything, as on `/query` and pipelines today.
+- Making the session header attestable. It remains self-reported; see the
+  ledger section of `docs/server.md`.
+- `job_runs.parameters` storing raw parameter values. Gating the read
+  narrows the exposure but does not resolve the threat-model question #219
+  flagged alongside #217.
+
+## Testing
+
+`crates/server/tests/jobs_auth_http.rs`:
+
+- Every route in one table-driven list 401s without a session, and 401s with
+  a bogus bearer token. Driving the list rather than five separate tests
+  means a route added to `configure_routes` without a gate shows up as a
+  missing entry rather than as silently uncovered surface.
+- The rejection arrives in `JobErrorResponse`'s envelope
+  (`success`/`error_type`/`timestamp`), not `/query`'s.
+- Auth precedes both the unknown-job 404 and the jobs-disabled 503.
+- A no-auth server still serves `GET /jobs`, `POST /jobs/:name/run` (with a
+  real run created) and `GET /jobs/runs`.
+
+Mutation-checked: removing the gate from any single handler fails the
+table-driven tests.

--- a/docs/superpowers/specs/2026-08-19-jobs-auth-design.md
+++ b/docs/superpowers/specs/2026-08-19-jobs-auth-design.md
@@ -31,24 +31,42 @@ the operator has admitted.
 
 ## What
 
-`require_session` on all five `/jobs/*` handlers, not only the write path:
-`GET /jobs` exposes job definitions and parameter names, and
-`GET /jobs/runs` returns `job_runs.parameters` — raw parameter *values*,
-which is exactly what `query_audit` refuses to store. Gating submissions
-while leaving those readable would close the smaller hole.
+`require_session` on all five `/jobs/*` handlers, not only the write path.
+The load-bearing reason is the run history: `GET /jobs/runs` and
+`GET /jobs/runs/:run_id` return `job_runs.parameters` — raw parameter
+*values*, which is exactly what `query_audit` refuses to store, and which
+nothing else on the server exposes. Gating submissions while leaving those
+readable would close the smaller hole.
+
+`GET /jobs` is gated for consistency across the family rather than for
+confidentiality: job names, versions, destinations, parameter names and
+example request bodies are all rendered by the ungated dashboard at `GET /`
+(`gui.rs::render_job_card`), so gating this route alone does not make them
+non-public. See the non-goals.
 
 **Placement: first statement, ahead of the jobs-disabled 503 and the
 job-existence 404.** #219 established a precedence ladder among those
-checks; the auth gate deliberately sits outside it rather than inside. An
-unauthenticated caller learns neither whether jobs are enabled on this
-server nor which job names exist — both are otherwise readable straight off
-the status code.
+checks; the auth gate deliberately sits outside it rather than inside, so
+neither "jobs are enabled here" nor "this job name exists" is readable off
+the status code — both otherwise are.
+
+"First statement" is about the handler body. Axum runs extractors ahead of
+it, so a malformed `?limit=` or a non-object JSON body still answers
+400/422 before the gate is reached. The residue is schema-shaped rather
+than data-shaped, is identical on `/query` and `POST /:pipeline/execute`,
+and is bounded by axum's 2 MB default body cap; the audit writes this gate
+exists to protect all sit below it. Making the invariant hold literally
+would mean a middleware gate on the `/jobs` subtree — out of scope here.
 
 **Response shape.** `require_session` reports through the shared
 `ErrorResponse`; the jobs endpoints answer in `JobErrorResponse`. A thin
 `require_job_session` adapter keeps the status and re-renders the body, so
-one endpoint family does not answer in two envelopes. `unauthorized` is
-already the crate's `error_type` for the condition.
+one endpoint family does not answer in two envelopes. Both `error` and
+`error_type` are propagated rather than the type being pinned to
+`unauthorized` — the only classification `require_session` produces today,
+but `verify_session` already distinguishes "Authentication required" from
+"Invalid or expired session" internally, and a constant would let the
+message diverge from the type if that ever surfaced.
 
 **No behaviour change without auth.** `verify_session` returns `Ok` when
 `auth_layer.as_better_auth()` is `None`, so servers that never configured
@@ -64,6 +82,12 @@ auth are unaffected — pinned by a test rather than left to inspection.
 - `job_runs.parameters` storing raw parameter values. Gating the read
   narrows the exposure but does not resolve the threat-model question #219
   flagged alongside #217.
+- Gating the dashboard at `GET /`. It renders every job's name, version,
+  destination, parameter list and an example request body, so job names are
+  effectively public whatever this change does. Gating it is a UX decision
+  about the dashboard, not a ledger-integrity one, and deserves its own
+  change; the write-attribution and audit-thread fixes here do not depend on
+  it.
 
 ## Testing
 


### PR DESCRIPTION
> **Stacked on #219** (`worktree-jobs-audit`). Review that one first — this branch contains only its own 2 commits. Retarget to `main` once #219 lands.
>
> Rebased after #219 was rebased onto #206 (the ledger-crate extraction). No content change here — the only knock-on was `session_id_from_headers` moving to `crates/server/src/session_header.rs`, since the extracted ledger crate depends on neither `axum` nor `skardi`. Full workspace on this tip: **1471 passed, 0 failed.**

Closes the non-goal #219 recorded rather than fixed, raised in [review](https://github.com/SkardiLabs/skardi/pull/219#discussion_r3802536379).

## Why

The jobs handlers have never called `require_session`, while `/query` ([query_handlers.rs:134](https://github.com/SkardiLabs/skardi/blob/main/crates/server/src/query_handlers.rs#L134)) and `POST /:pipeline/execute` ([pipeline_handlers.rs:879](https://github.com/SkardiLabs/skardi/blob/main/crates/server/src/pipeline_handlers.rs#L879)) both call it as their first statement. On its own that is a submission-authorization gap, and arguably pre-existing. **#219 changed what it costs**, in two ways:

1. **Attribution forgery.** Job submissions now write `session_id` into `query_audit` from `X-Skardi-Session-Id`, which made `POST /jobs/:name/run` the ledger's *only* unauthenticated write path. Anyone who could reach it could mint rows carrying a real agent session's id — and the Learn stage stitches intentions on exactly that key, so a forged row lands inside a legitimate session's `list_by_session` read indistinguishable from a real submission.
2. **Cross-endpoint availability coupling.** Every submission — including ones the executor rejects — issues writes on `QueryAuditStore`'s single serialized writer thread, shared with every audited request. Work exceeding `AUDIT_WRITE_TIMEOUT` there 503s *other* concurrent `/query` and pipeline executions. The endpoint handed an unauthenticated actor an unrate-limited way to queue onto it.

Authentication does not make the header trustworthy — it stays self-reported by design, here as on the other two endpoints. It bounds *who* can self-report to callers the operator admitted.

## What

**All five handlers, not only the write path.** `GET /jobs` exposes job definitions and parameter names; `GET /jobs/runs` returns `job_runs.parameters` — raw parameter *values*, exactly what `query_audit` refuses to store. Gating submissions alone would close the smaller hole.

**First statement, ahead of the jobs-disabled 503 and the unknown-job 404** — deliberately outside the precedence ladder #219 established among those checks. An unauthenticated caller learns neither whether jobs are enabled on this server nor which job names exist; both are otherwise readable straight off the status code.

**One envelope.** `require_session` reports in the shared `ErrorResponse` shape while the jobs endpoints answer in `JobErrorResponse`. A thin `require_job_session` adapter keeps the status and re-renders the body, so one endpoint family does not answer in two shapes. `unauthorized` is already the crate's `error_type` for the condition.

**No behaviour change without auth.** `verify_session` returns `Ok` when `auth_layer.as_better_auth()` is `None`, so servers that never configured auth are unaffected — pinned by a test rather than left to inspection.

## Tests

New `crates/server/tests/jobs_auth_http.rs`, 4 tests. The 401 cases are **table-driven over the route list**, so a route added to `configure_routes` without a gate shows up as a missing entry rather than as silently uncovered surface — that seemed worth more than five near-identical tests, given the failure mode this PR exists to fix.

- every route 401s with no session, and with a bogus bearer token
- the rejection arrives in `JobErrorResponse`'s envelope, not `/query`'s
- auth precedes both the unknown-job 404 and the jobs-disabled 503
- a no-auth server still serves `GET /jobs`, `POST /jobs/:name/run` (real run created) and `GET /jobs/runs`

Mutation-checked: removing the gate from any single handler fails the table-driven tests.

## Also here: a pre-existing test flake, split into its own commit

`auth::layer::tests::build_better_auth_missing_secret_errors` removes `AUTH_SECRET` and asserts the build fails; four sibling tests set it. They share one test binary that libtest runs in parallel, and env vars are process-global — so the removal test intermittently sees a secret another test just set. It reproduces under `cargo test --workspace` (concurrent test binaries change the interleaving) and **not** under `cargo test -p skardi-server --lib` alone, which is why it has read as random.

Unrelated to the auth gate; separated as `72ee9b3` so this change is not blamed for it. Serialized with a `tokio::sync::Mutex` rather than `std::sync::Mutex` because the guard must be held across `AuthLayer::build(..).await` — locking only the mutation would still let another test set the variable before the build reads it.

## Not fixed here

`crates/server/tests/pipeline_audit_http.rs`'s `unknown_pipeline_request_is_logged` is also flaky under full-workspace load (thread-local `tracing` dispatcher). Pre-existing on `main`, in a file neither this PR nor #219 touches — flagging rather than folding in.

## Non-goals

- Authorization beyond "has a valid session" — no per-job ACLs, no submit/cancel distinction. Same posture as `/query` and pipelines today.
- Making the session header attestable. It stays self-reported; see the ledger section of `docs/server.md`.
- `job_runs.parameters` storing raw values. Gating the read narrows exposure but does not resolve the threat-model question #219 flagged alongside #217.

Design notes in `docs/superpowers/specs/2026-08-19-jobs-auth-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
