### PR TITLE
feat(jobs): durable reverse pointer so a lost run_id stamp cannot lose the correlation

### DIFF
--- a/crates/query-audit/src/lib.rs
+++ b/crates/query-audit/src/lib.rs
@@ -845,6 +845,73 @@ impl QueryAuditStore {
         Ok(updated)
     }
 
+    /// Job rows whose forward pointer was lost: `status = unknown` with no
+    /// `job_run_id`. Returns their ids, oldest first.
+    ///
+    /// Exactly the rows [`Self::record_job_outcome`] can no longer repair — its
+    /// `WHERE status = 'started'` guard means once `reconcile_orphaned` has
+    /// rewritten a row to `unknown`, no later well-behaved write can ever stamp
+    /// it. Without a pass like this, "the correlation is recoverable" is only
+    /// true for an operator with `sqlite3` and both ledger files open; the row
+    /// an auditor actually reads still says `unknown, NULL`, which for a job
+    /// row means "definitely submitted, linkage lost" while reading identically
+    /// to a query row's "may have run after a crash".
+    ///
+    /// The repair itself lives in the server, which is the only layer holding
+    /// both ledgers: `job_runs.submission_id` carries this id, so each of these
+    /// resolves through `JobStore::get_run_by_submission_id`.
+    pub async fn job_rows_missing_run_id(&self) -> Result<Vec<String>> {
+        let ids = self
+            .conn
+            .call(move |conn| -> SqlResult<Vec<String>> {
+                let mut stmt = conn.prepare(
+                    "SELECT id FROM query_audit
+                      WHERE statement_kind = ?1
+                        AND status = ?2
+                        AND job_run_id IS NULL
+                      ORDER BY created_at ASC",
+                )?;
+                let rows = stmt.query_map(
+                    params![JOB_STATEMENT_KIND, QueryAuditStatus::Unknown.as_str()],
+                    |row| row.get::<_, String>(0),
+                )?;
+                rows.collect()
+            })
+            .await
+            .context("Failed to list job rows missing job_run_id")?;
+        Ok(ids)
+    }
+
+    /// Stamp `job_run_id` onto a row whose forward pointer was lost. Returns
+    /// whether a row was updated.
+    ///
+    /// Deliberately not reusing [`Self::record_job_outcome`]: that guards on
+    /// `status = 'started'`, which is precisely the state these rows are no
+    /// longer in. The guard here is the mirror image — `unknown` with the
+    /// column still NULL — so a repair can neither overwrite a pointer that was
+    /// written correctly nor touch a row that is still live. `status` is left
+    /// as `unknown`, which stays the truth: the outcome was never observed, only
+    /// the linkage is recovered.
+    pub async fn backfill_job_run_id(&self, id: &str, job_run_id: &str) -> Result<bool> {
+        let id = id.to_string();
+        let job_run_id = job_run_id.to_string();
+        let updated = self
+            .conn
+            .call(move |conn| -> SqlResult<usize> {
+                conn.execute(
+                    "UPDATE query_audit
+                        SET job_run_id = ?2
+                      WHERE id = ?1
+                        AND job_run_id IS NULL
+                        AND status = ?3",
+                    params![id, job_run_id, QueryAuditStatus::Unknown.as_str()],
+                )
+            })
+            .await
+            .context("Failed to backfill job_run_id")?;
+        Ok(updated > 0)
+    }
+
     /// Delete records created before `cutoff` (RFC 3339). Returns the total
     /// row count deleted.
     ///
@@ -1516,6 +1583,105 @@ mod tests {
         let n = store.reconcile_orphaned("test restart").await.unwrap();
         assert_eq!(n, 1);
         let row = store.get(&id).await.unwrap().unwrap();
+        assert_eq!(row["status"], json!("unknown"));
+    }
+
+    #[tokio::test]
+    async fn only_unknown_job_rows_with_a_null_pointer_are_repair_candidates() {
+        let store = QueryAuditStore::open_in_memory().await.unwrap();
+
+        // A row whose stamp was lost: reconciled to `unknown`, pointer NULL.
+        let lost = store
+            .record_job_submitted("nightly", "1.0.0", None)
+            .await
+            .unwrap();
+        // A row that recorded its outcome normally.
+        let stamped = store
+            .record_job_submitted("nightly", "1.0.0", None)
+            .await
+            .unwrap();
+        store
+            .record_job_outcome(&stamped, Some("run-ok"), QueryAuditStatus::Succeeded, None)
+            .await
+            .unwrap();
+        // A non-job row, also reconciled — must never be a candidate.
+        let query_row = store
+            .record_started("SELECT 1", None, 10, "Query")
+            .await
+            .unwrap();
+
+        store.reconcile_orphaned("crash").await.unwrap();
+
+        let candidates = store.job_rows_missing_run_id().await.unwrap();
+        assert_eq!(candidates, vec![lost.clone()]);
+        assert!(!candidates.contains(&stamped), "a stamped row is not lost");
+        assert!(!candidates.contains(&query_row), "query rows are not jobs");
+    }
+
+    #[tokio::test]
+    async fn backfill_restores_a_lost_pointer_and_refuses_every_other_row() {
+        let store = QueryAuditStore::open_in_memory().await.unwrap();
+        let lost = store
+            .record_job_submitted("nightly", "1.0.0", Some("sess-x"))
+            .await
+            .unwrap();
+        store.reconcile_orphaned("crash").await.unwrap();
+
+        assert!(
+            store.backfill_job_run_id(&lost, "run-found").await.unwrap(),
+            "a lost row must be repairable"
+        );
+        let row = store.get(&lost).await.unwrap().unwrap();
+        assert_eq!(row["job_run_id"], json!("run-found"));
+        // The outcome was never observed; only the linkage is recovered.
+        assert_eq!(row["status"], json!("unknown"));
+        assert_eq!(row["session_id"], json!("sess-x"));
+
+        // Idempotent: a second pass finds nothing to do and cannot overwrite.
+        assert!(
+            !store.backfill_job_run_id(&lost, "run-other").await.unwrap(),
+            "a repaired row must not be rewritten"
+        );
+        assert_eq!(
+            store.get(&lost).await.unwrap().unwrap()["job_run_id"],
+            json!("run-found")
+        );
+        assert!(store.job_rows_missing_run_id().await.unwrap().is_empty());
+
+        // A row still `started` is live, not lost — the guard must decline it,
+        // so a repair pass can never race a submission in flight.
+        let live = store
+            .record_job_submitted("nightly", "1.0.0", None)
+            .await
+            .unwrap();
+        assert!(
+            !store.backfill_job_run_id(&live, "run-live").await.unwrap(),
+            "a started row must be left to record_job_outcome"
+        );
+        assert!(store.get(&live).await.unwrap().unwrap()["job_run_id"].is_null());
+    }
+
+    #[tokio::test]
+    async fn record_job_outcome_cannot_repair_what_reconcile_already_touched() {
+        // The premise the repair pass exists for: once a row is `unknown`, the
+        // `status = 'started'` guard means no later well-behaved write can ever
+        // stamp it. If this ever stops being true, the pass is redundant.
+        let store = QueryAuditStore::open_in_memory().await.unwrap();
+        let id = store
+            .record_job_submitted("nightly", "1.0.0", None)
+            .await
+            .unwrap();
+        store.reconcile_orphaned("crash").await.unwrap();
+
+        store
+            .record_job_outcome(&id, Some("run-late"), QueryAuditStatus::Succeeded, None)
+            .await
+            .unwrap();
+        let row = store.get(&id).await.unwrap().unwrap();
+        assert!(
+            row["job_run_id"].is_null(),
+            "record_job_outcome stamped a reconciled row; the repair pass is now dead code"
+        );
         assert_eq!(row["status"], json!("unknown"));
     }
 

--- a/crates/server/src/jobs_handlers.rs
+++ b/crates/server/src/jobs_handlers.rs
@@ -140,7 +140,6 @@ fn job_run_to_json(run: &JobRun) -> Value {
         "rows_written": run.rows_written,
         "snapshot_id": run.snapshot_id,
         "error": run.error,
-        "submission_id": run.submission_id,
     })
 }
 
@@ -351,6 +350,13 @@ pub async fn get_job_run(
 pub struct ListRunsQuery {
     pub job: Option<String>,
     pub limit: Option<usize>,
+    /// Resolve the single run carrying this correlation token.
+    ///
+    /// The recovery direction of the audit bridge: an operator holding a
+    /// `query_audit` row id whose `job_run_id` was lost asks for it here. A
+    /// filter on the way in rather than the token on the way out — see
+    /// [`job_run_to_json`], which deliberately does not emit it.
+    pub submission_id: Option<String>,
 }
 
 /// `GET /jobs/runs?job=...&limit=...`
@@ -366,6 +372,27 @@ pub async fn list_job_runs(
             error_json("Jobs subsystem is not enabled", "jobs_disabled", None),
         ));
     };
+    // An exact-token lookup, not a filter over the recent window: the run an
+    // operator needs during an incident is the one that has already fallen off
+    // it, which is exactly when concurrent submissions made `job_run_id` worth
+    // having. `job` and `limit` are ignored — one token names at most one run.
+    if let Some(token) = q.submission_id.as_deref() {
+        return match executor.store().get_run_by_submission_id(token).await {
+            Ok(run) => {
+                let body: Vec<Value> = run.iter().map(job_run_to_json).collect();
+                Ok(Json(serde_json::json!({
+                    "success": true,
+                    "runs": body,
+                    "count": body.len(),
+                })))
+            }
+            Err(e) => Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                error_json(&e.to_string(), "internal_error", None),
+            )),
+        };
+    }
+
     let limit = q.limit.unwrap_or(50).clamp(1, 500);
     match executor.store().list_runs(q.job.as_deref(), limit).await {
         Ok(runs) => {

--- a/crates/server/src/jobs_handlers.rs
+++ b/crates/server/src/jobs_handlers.rs
@@ -140,6 +140,7 @@ fn job_run_to_json(run: &JobRun) -> Value {
         "rows_written": run.rows_written,
         "snapshot_id": run.snapshot_id,
         "error": run.error,
+        "submission_id": run.submission_id,
     })
 }
 
@@ -273,7 +274,14 @@ pub async fn submit_job_run(
         None => None,
     };
 
-    match executor.submit(&name, req.parameters).await {
+    // The audit row id doubles as the run's submission token, so the two
+    // ledgers point at each other. This half is durable at run-creation time;
+    // the `run_id` stamp below is best-effort, and if it is lost the
+    // correlation is still recoverable through `get_run_by_submission_id`.
+    match executor
+        .submit(&name, req.parameters, audit_id.as_deref())
+        .await
+    {
         Ok(run_id) => {
             finish_job_audit(
                 app_state.query_audit.as_deref(),

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -289,6 +289,26 @@ pub async fn setup_app_state(config: ServerConfig) -> Result<AppState> {
         None => None,
     };
 
+    // Both ledgers are open and both have reconciled their own orphans, which
+    // is the only point in startup where the correlation between them can be
+    // rebuilt. Runs after the audit `reconcile_orphaned` above deliberately:
+    // that pass is what moves a lost row to `unknown`, so repairing first would
+    // miss the rows this crash just created.
+    if let (Some(audit), Some(jobs)) = (query_audit.as_ref(), jobs_bundle.as_ref()) {
+        match repair_lost_job_correlations(audit, jobs.store().as_ref()).await {
+            Ok(0) => {}
+            Ok(n) => tracing::warn!(
+                "Recovered the audit correlation for {n} job submission(s) whose \
+                 job_run_id stamp was lost to a crash or a write failure",
+            ),
+            // A ledger that cannot be repaired is not a ledger that must not
+            // serve: the rows stay exactly as they were, recoverable by hand
+            // and by the next boot. Failing startup here would take a server
+            // down over history rather than over anything it is about to do.
+            Err(e) => tracing::error!("Job-correlation repair pass failed: {e}"),
+        }
+    }
+
     // Create shared application state with RwLock for runtime updates
     let app_state = AppState::new(
         config,
@@ -305,6 +325,57 @@ pub async fn setup_app_state(config: ServerConfig) -> Result<AppState> {
     tracing::info!("Application state setup completed successfully");
 
     Ok(app_state)
+}
+
+/// Re-link job submissions whose forward pointer was lost, using the durable
+/// reverse one.
+///
+/// `query_audit.job_run_id` is stamped *after* `executor.submit` returns, so a
+/// crash or a write failure in that window leaves a row that is `unknown` with
+/// no run id — while the run itself exists and really did execute.
+/// `job_runs.submission_id` carries the audit row's id, written in the same
+/// INSERT that created the run, so the linkage is still on disk in the other
+/// file. This is the pass that puts it back into the row an auditor reads,
+/// rather than leaving it to an operator with `sqlite3`.
+///
+/// Idempotent and safely re-runnable: `backfill_job_run_id` only writes rows
+/// still `unknown` with a NULL pointer, so a repaired row is skipped on the
+/// next boot, and a row whose pointer was written correctly is never touched.
+/// A candidate with no matching run is left alone — with no pruning on
+/// `job_runs`, that is positive evidence `submit` never created a run, which is
+/// a different fact worth preserving rather than papering over.
+///
+/// Returns how many rows were re-linked.
+///
+/// `pub` so the acceptance suite can drive the same function startup calls,
+/// rather than a re-implementation of it.
+pub async fn repair_lost_job_correlations(
+    audit: &QueryAuditStore,
+    jobs: &dyn skardi::jobs::JobStore,
+) -> anyhow::Result<usize> {
+    let candidates = audit.job_rows_missing_run_id().await?;
+    if candidates.is_empty() {
+        return Ok(0);
+    }
+    tracing::debug!(
+        "Job-correlation repair: {} audit row(s) with a lost job_run_id",
+        candidates.len()
+    );
+    let mut repaired = 0;
+    for audit_id in candidates {
+        match jobs.get_run_by_submission_id(&audit_id).await {
+            Ok(Some(run)) => {
+                if audit.backfill_job_run_id(&audit_id, &run.id).await? {
+                    repaired += 1;
+                }
+            }
+            // No run carries this token: the submission never got as far as
+            // creating one. The row's `unknown` is already the right answer.
+            Ok(None) => {}
+            Err(e) => tracing::warn!("Job-correlation repair: lookup for {audit_id} failed: {e}"),
+        }
+    }
+    Ok(repaired)
 }
 
 /// Prune audit records older than `retention_days` now, then hourly for the

--- a/crates/server/tests/jobs_audit_http.rs
+++ b/crates/server/tests/jobs_audit_http.rs
@@ -27,7 +27,7 @@ use skardi_server::auth::layer::AuthLayer;
 use skardi_server::config::{CliArgs, ServerConfig};
 use skardi_server::query_audit::QueryAuditStore;
 use skardi_server::semantics::SemanticsRegistry;
-use skardi_server::server::{AppState, configure_routes};
+use skardi_server::server::{AppState, configure_routes, repair_lost_job_correlations};
 
 /// Name of the job registered by `make_app_state`. Bound as a `const` so
 /// assertions and the YAML fixture below stay in sync.
@@ -541,6 +541,123 @@ async fn correlation_survives_a_lost_forward_stamp() {
 }
 
 #[tokio::test]
+async fn the_startup_repair_pass_relinks_the_row_an_auditor_reads() {
+    // `correlation_survives_a_lost_forward_stamp` proves the linkage is still
+    // *on disk*. This proves something stronger and is the point of the whole
+    // change: the row an auditor actually reads gets fixed, without an operator
+    // holding both SQLite files open.
+    //
+    // `record_job_outcome` cannot do it — its `WHERE status = 'started'` guard
+    // means that once `reconcile_orphaned` has rewritten the row to `unknown`,
+    // no later well-behaved write can ever stamp it.
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    let executor = state.jobs.clone().unwrap();
+
+    let audit_id = store
+        .record_job_submitted(TEST_JOB_NAME, TEST_JOB_VERSION, Some("sess-repair"))
+        .await
+        .unwrap();
+    let run_id = executor
+        .submit(TEST_JOB_NAME, HashMap::new(), Some(&audit_id))
+        .await
+        .unwrap();
+
+    // The crash: no outcome recorded, then a restart reconciles the orphan.
+    store.reconcile_orphaned("simulated crash").await.unwrap();
+    let before = store.get(&audit_id).await.unwrap().unwrap();
+    assert_eq!(before["status"], json!("unknown"));
+    assert!(
+        before["job_run_id"].is_null(),
+        "precondition: the forward stamp must be missing"
+    );
+
+    // The next boot.
+    let repaired = repair_lost_job_correlations(&store, executor.store().as_ref())
+        .await
+        .unwrap();
+    assert_eq!(repaired, 1);
+
+    let after = store.get(&audit_id).await.unwrap().unwrap();
+    assert_eq!(
+        after["job_run_id"],
+        json!(run_id),
+        "the ledger row was not re-linked: {after}"
+    );
+    // The outcome genuinely was never observed, so `unknown` stays the truth;
+    // only the linkage is recovered.
+    assert_eq!(after["status"], json!("unknown"));
+    assert_eq!(after["session_id"], json!("sess-repair"));
+
+    // Idempotent: a second boot finds nothing left to do.
+    assert_eq!(
+        repair_lost_job_correlations(&store, executor.store().as_ref())
+            .await
+            .unwrap(),
+        0
+    );
+}
+
+#[tokio::test]
+async fn the_repair_pass_leaves_a_submission_that_never_created_a_run_alone() {
+    // A candidate row with no matching run means `submit` failed before
+    // `create_run`. `job_runs` is never pruned, so the miss is positive
+    // evidence of "never ran" — a different fact from "ran, linkage lost", and
+    // the pass must not blur them.
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    let executor = state.jobs.clone().unwrap();
+
+    let audit_id = store
+        .record_job_submitted(TEST_JOB_NAME, TEST_JOB_VERSION, None)
+        .await
+        .unwrap();
+    store.reconcile_orphaned("simulated crash").await.unwrap();
+
+    assert_eq!(
+        repair_lost_job_correlations(&store, executor.store().as_ref())
+            .await
+            .unwrap(),
+        0
+    );
+    let row = store.get(&audit_id).await.unwrap().unwrap();
+    assert!(row["job_run_id"].is_null());
+    assert_eq!(row["status"], json!("unknown"));
+}
+
+#[tokio::test]
+async fn the_repair_pass_cannot_touch_a_submission_still_in_flight() {
+    // The pass runs at startup, but nothing stops an operator-triggered or
+    // future periodic call, so it must not race a live submission: a `started`
+    // row is `record_job_outcome`'s to settle, not the repair's.
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    let executor = state.jobs.clone().unwrap();
+
+    let audit_id = store
+        .record_job_submitted(TEST_JOB_NAME, TEST_JOB_VERSION, None)
+        .await
+        .unwrap();
+    executor
+        .submit(TEST_JOB_NAME, HashMap::new(), Some(&audit_id))
+        .await
+        .unwrap();
+
+    // No `reconcile_orphaned`: the row is still `started`.
+    assert_eq!(
+        repair_lost_job_correlations(&store, executor.store().as_ref())
+            .await
+            .unwrap(),
+        0,
+        "a live submission was treated as a lost one"
+    );
+    assert_eq!(
+        store.get(&audit_id).await.unwrap().unwrap()["status"],
+        json!("started")
+    );
+}
+
+#[tokio::test]
 async fn unaudited_server_leaves_submission_id_null() {
     // No ledger means no token to carry; the column must stay NULL rather
     // than pick up some stand-in that would collide in the reverse lookup.
@@ -555,10 +672,32 @@ async fn unaudited_server_leaves_submission_id_null() {
     assert!(run.submission_id.is_none());
 }
 
+/// GET `uri` and return the parsed body.
+async fn get_json(state: &AppState, uri: &str) -> Value {
+    let app = configure_routes(state.clone());
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(uri)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "GET {uri}");
+    body_to_json(resp).await
+}
+
 #[tokio::test]
-async fn run_detail_exposes_the_submission_id() {
-    // The reverse pointer is only useful to an operator if it is readable
-    // from the runs API, not just from the ledger file.
+async fn the_token_resolves_a_run_on_the_way_in_and_is_never_returned() {
+    // The reverse pointer has to be reachable over HTTP, or the operator
+    // procedure is "open the SQLite file". It is reachable as a filter, not as
+    // a field: `submission_id` is a `query_audit` primary key, and the ledger
+    // is a deliberately access-restricted artifact (0600 on its file), while
+    // `GET /jobs/runs` returns every run to any authenticated session — jobs
+    // auth is authentication, not authorization. Emitting the token would
+    // publish one caller's audit-row id to every other caller.
     let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
     let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
 
@@ -568,7 +707,82 @@ async fn run_detail_exposes_the_submission_id() {
         .unwrap()
         .to_string();
     let detail = wait_for_terminal(&state, &run_id).await;
+    let audit_id = store.list_by_session("sess-api").await.unwrap()[0]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
 
-    let rows = store.list_by_session("sess-api").await.unwrap();
-    assert_eq!(detail["submission_id"], rows[0]["id"]);
+    // Not on the way out — neither from the detail route nor the list route.
+    assert!(
+        detail.get("submission_id").is_none(),
+        "run detail leaked the audit row id: {detail}"
+    );
+    let listed = get_json(&state, "/jobs/runs").await;
+    assert!(
+        listed["runs"][0].get("submission_id").is_none(),
+        "the runs list leaked the audit row id: {listed}"
+    );
+
+    // On the way in: an exact-token lookup resolving the one matching run.
+    let found = get_json(&state, &format!("/jobs/runs?submission_id={audit_id}")).await;
+    assert_eq!(found["count"], json!(1), "{found}");
+    assert_eq!(found["runs"][0]["run_id"], json!(run_id));
+}
+
+#[tokio::test]
+async fn an_unmatched_token_is_an_empty_result_not_an_error() {
+    // With no pruning on `job_runs`, a miss is positive evidence that `submit`
+    // never created a run — a fact worth returning cleanly rather than as a
+    // 404 an operator has to disambiguate from a bad route.
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+
+    let found = get_json(&state, "/jobs/runs?submission_id=audit-never-existed").await;
+    assert_eq!(found["count"], json!(0));
+    assert_eq!(found["runs"], json!([]));
+    assert_eq!(found["success"], json!(true));
+}
+
+#[tokio::test]
+async fn the_token_lookup_finds_a_run_that_has_fallen_off_the_recent_window() {
+    // The case the filter exists for. `list_job_runs` clamps to 500 with no
+    // offset, so on a server busy enough for the concurrent-submission
+    // ambiguity `job_run_id` was introduced to remove, the run an operator
+    // needs during an incident is exactly the one no longer in the window.
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    let executor = state.jobs.clone().unwrap();
+    let jobs = executor.store();
+
+    let audit_id = store
+        .record_job_submitted(TEST_JOB_NAME, TEST_JOB_VERSION, None)
+        .await
+        .unwrap();
+    let wanted = executor
+        .submit(TEST_JOB_NAME, HashMap::new(), Some(&audit_id))
+        .await
+        .unwrap();
+
+    // Bury it under more runs than the list route will ever return.
+    for _ in 0..3 {
+        executor
+            .submit(TEST_JOB_NAME, HashMap::new(), None)
+            .await
+            .unwrap();
+    }
+    let listed = get_json(&state, "/jobs/runs?limit=2").await;
+    assert_eq!(listed["count"], json!(2), "precondition: a bounded window");
+
+    let found = get_json(&state, &format!("/jobs/runs?submission_id={audit_id}")).await;
+    assert_eq!(found["count"], json!(1));
+    assert_eq!(found["runs"][0]["run_id"], json!(wanted));
+    // `job` and `limit` cannot narrow a token lookup away — one token names at
+    // most one run.
+    let found = get_json(
+        &state,
+        &format!("/jobs/runs?submission_id={audit_id}&limit=1&job=nope"),
+    )
+    .await;
+    assert_eq!(found["runs"][0]["run_id"], json!(wanted));
+    drop(jobs);
 }

--- a/crates/server/tests/jobs_audit_http.rs
+++ b/crates/server/tests/jobs_audit_http.rs
@@ -457,3 +457,118 @@ async fn submit_rejection_after_audit_write_is_recorded_failed() {
         "a run was created despite the rejection: {runs:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// The submission bridge: durable in `job_runs`, best-effort in `query_audit`
+
+#[tokio::test]
+async fn submission_bridge_points_both_ways() {
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+
+    let resp =
+        submit_with_headers(&state, &[("x-skardi-session-id", "sess-bridge")], json!({})).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let run_id = body_to_json(resp).await["run_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    wait_for_terminal(&state, &run_id).await;
+
+    let rows = store.list_by_session("sess-bridge").await.unwrap();
+    assert_eq!(rows.len(), 1);
+    let audit_id = rows[0]["id"].as_str().unwrap();
+
+    // Forward: audit row -> run. Stamped after `executor.submit` returned,
+    // so this half is best-effort.
+    assert_eq!(rows[0]["job_run_id"], json!(run_id));
+
+    // Reverse: run -> audit row. Written in the INSERT that created the run,
+    // so this half is durable the moment the run exists.
+    let executor = state.jobs.clone().unwrap();
+    let run = executor.store().get_run(&run_id).await.unwrap().unwrap();
+    assert_eq!(
+        run.submission_id.as_deref(),
+        Some(audit_id),
+        "the run does not point back at its audit row"
+    );
+}
+
+#[tokio::test]
+async fn correlation_survives_a_lost_forward_stamp() {
+    // The failure this whole change exists for: `record_job_outcome` fails,
+    // times out, or the process dies before it lands, so the audit row keeps
+    // `job_run_id = NULL` and reconciles to `unknown`. Before the reverse pointer
+    // that lost the correlation permanently — `job_runs` carried neither a
+    // session id nor an audit-row id to rebuild from.
+    //
+    // Reproduced at the executor seam rather than over HTTP, because the
+    // point is precisely that no forward stamp is ever written: the handler
+    // would race to write one.
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+    let executor = state.jobs.clone().unwrap();
+
+    let audit_id = store
+        .record_job_submitted(TEST_JOB_NAME, TEST_JOB_VERSION, Some("sess-lost"))
+        .await
+        .unwrap();
+    let run_id = executor
+        .submit(TEST_JOB_NAME, HashMap::new(), Some(&audit_id))
+        .await
+        .unwrap();
+
+    // No `record_job_outcome` call — then a restart reconciles the orphan.
+    store.reconcile_orphaned("simulated crash").await.unwrap();
+
+    let rows = store.list_by_session("sess-lost").await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["status"], json!("unknown"));
+    assert!(
+        rows[0]["job_run_id"].is_null(),
+        "precondition: the forward stamp must be missing"
+    );
+
+    // Recoverable anyway, from the half that was durable.
+    let recovered = executor
+        .store()
+        .get_run_by_submission_id(rows[0]["id"].as_str().unwrap())
+        .await
+        .unwrap()
+        .expect("the correlation was lost");
+    assert_eq!(recovered.id, run_id);
+    assert_eq!(recovered.job_name, TEST_JOB_NAME);
+}
+
+#[tokio::test]
+async fn unaudited_server_leaves_submission_id_null() {
+    // No ledger means no token to carry; the column must stay NULL rather
+    // than pick up some stand-in that would collide in the reverse lookup.
+    let (state, _tmp) = make_app_state(None).await;
+    let resp = submit_with_headers(&state, &[], json!({})).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_to_json(resp).await;
+    let run_id = body["run_id"].as_str().unwrap().to_string();
+
+    let executor = state.jobs.clone().unwrap();
+    let run = executor.store().get_run(&run_id).await.unwrap().unwrap();
+    assert!(run.submission_id.is_none());
+}
+
+#[tokio::test]
+async fn run_detail_exposes_the_submission_id() {
+    // The reverse pointer is only useful to an operator if it is readable
+    // from the runs API, not just from the ledger file.
+    let store = Arc::new(QueryAuditStore::open_in_memory().await.unwrap());
+    let (state, _tmp) = make_app_state(Some(Arc::clone(&store))).await;
+
+    let resp = submit_with_headers(&state, &[("x-skardi-session-id", "sess-api")], json!({})).await;
+    let run_id = body_to_json(resp).await["run_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let detail = wait_for_terminal(&state, &run_id).await;
+
+    let rows = store.list_by_session("sess-api").await.unwrap();
+    assert_eq!(detail["submission_id"], rows[0]["id"]);
+}

--- a/crates/server/tests/jobs_bridge_startup.rs
+++ b/crates/server/tests/jobs_bridge_startup.rs
@@ -1,0 +1,173 @@
+//! The startup half of the audit bridge: that `setup_app_state` actually runs
+//! the correlation repair, on the real on-disk ledgers, in the right order.
+//!
+//! `jobs_audit_http.rs` drives `repair_lost_job_correlations` directly, which
+//! pins what the pass *does*. It cannot catch the call site going missing —
+//! and a repair pass nothing calls leaves the ledger exactly as broken as no
+//! pass at all. This boots twice over the same two files instead.
+
+use skardi::jobs::{JobRun, JobRunStatus};
+use skardi_server::config::{CliArgs, load_server_config};
+use skardi_server::query_audit::{QueryAuditStatus, QueryAuditStore};
+use skardi_server::server::{AppState, setup_app_state};
+use std::path::{Path, PathBuf};
+
+const JOB_YAML: &str = r#"
+kind: job
+metadata:
+  name: "nightly"
+  version: "1.0.0"
+spec:
+  query: |
+    SELECT 1 AS id
+  destination:
+    table: "dest"
+    mode: append
+"#;
+
+fn args(jobs_path: PathBuf, jobs_db: PathBuf, audit_db: PathBuf) -> CliArgs {
+    CliArgs {
+        pipeline_path: None,
+        jobs_path: Some(jobs_path),
+        jobs_db_path: Some(jobs_db),
+        ctx_file: None,
+        semantics_path: None,
+        port: 8080,
+        query_audit_db: Some(audit_db),
+        query_audit_retention_days: None,
+    }
+}
+
+async fn boot(jobs_path: &Path, jobs_db: &Path, audit_db: &Path) -> AppState {
+    let config = load_server_config(args(
+        jobs_path.to_path_buf(),
+        jobs_db.to_path_buf(),
+        audit_db.to_path_buf(),
+    ))
+    .await
+    .expect("config loads");
+    setup_app_state(config).await.expect("startup")
+}
+
+#[tokio::test]
+async fn a_restart_repairs_a_correlation_lost_before_the_previous_shutdown() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let jobs_yaml = dir.path().join("nightly.yaml");
+    std::fs::write(&jobs_yaml, JOB_YAML).unwrap();
+    let jobs_db = dir.path().join("jobs.db");
+    let audit_db = dir.path().join("audit.db");
+
+    // ---- first boot: plant exactly the state a crash in the stamp window
+    // leaves behind — a real run carrying the token, and an audit row that
+    // never got its forward pointer.
+    let audit_id = {
+        let state = boot(&jobs_yaml, &jobs_db, &audit_db).await;
+        let audit = state.query_audit.clone().expect("audit ledger configured");
+        let jobs = state.jobs.clone().expect("jobs enabled").store();
+
+        let audit_id = audit
+            .record_job_submitted("nightly", "1.0.0", Some("sess-crash"))
+            .await
+            .unwrap();
+        jobs.create_run(&JobRun {
+            id: "run-crashed".to_string(),
+            job_name: "nightly".to_string(),
+            parameters: "{}".to_string(),
+            status: JobRunStatus::Succeeded,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            started_at: None,
+            finished_at: None,
+            rows_written: Some(1),
+            snapshot_id: None,
+            error: None,
+            submission_id: Some(audit_id.clone()),
+        })
+        .await
+        .unwrap();
+
+        // No `record_job_outcome`: the process "dies" here.
+        audit_id
+    };
+
+    // The row is still `started` on disk — the reconcile that turns it into a
+    // repair candidate is itself part of the next startup.
+    {
+        let audit = QueryAuditStore::open(&audit_db).await.unwrap();
+        let row = audit.get(&audit_id).await.unwrap().unwrap();
+        assert_eq!(row["status"], serde_json::json!("started"));
+        assert!(row["job_run_id"].is_null());
+    }
+
+    // ---- second boot: reconcile, then repair, both wired into startup.
+    let state = boot(&jobs_yaml, &jobs_db, &audit_db).await;
+    let audit = state.query_audit.clone().unwrap();
+    let row = audit.get(&audit_id).await.unwrap().unwrap();
+
+    assert_eq!(
+        row["job_run_id"],
+        serde_json::json!("run-crashed"),
+        "startup did not repair the correlation: {row}"
+    );
+    // The outcome was never observed, so `unknown` stays the truth; the repair
+    // recovers the linkage only.
+    assert_eq!(
+        row["status"],
+        serde_json::json!(QueryAuditStatus::Unknown.as_str())
+    );
+    assert_eq!(row["session_id"], serde_json::json!("sess-crash"));
+}
+
+#[tokio::test]
+async fn a_clean_restart_repairs_nothing_and_leaves_stamped_rows_alone() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let jobs_yaml = dir.path().join("nightly.yaml");
+    std::fs::write(&jobs_yaml, JOB_YAML).unwrap();
+    let jobs_db = dir.path().join("jobs.db");
+    let audit_db = dir.path().join("audit.db");
+
+    let audit_id = {
+        let state = boot(&jobs_yaml, &jobs_db, &audit_db).await;
+        let audit = state.query_audit.clone().unwrap();
+        let jobs = state.jobs.clone().unwrap().store();
+
+        let audit_id = audit
+            .record_job_submitted("nightly", "1.0.0", None)
+            .await
+            .unwrap();
+        jobs.create_run(&JobRun {
+            id: "run-ok".to_string(),
+            job_name: "nightly".to_string(),
+            parameters: "{}".to_string(),
+            status: JobRunStatus::Succeeded,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            started_at: None,
+            finished_at: None,
+            rows_written: Some(1),
+            snapshot_id: None,
+            error: None,
+            submission_id: Some(audit_id.clone()),
+        })
+        .await
+        .unwrap();
+        // This time the outcome *is* recorded, as it is on the happy path.
+        audit
+            .record_job_outcome(&audit_id, Some("run-ok"), QueryAuditStatus::Succeeded, None)
+            .await
+            .unwrap();
+        audit_id
+    };
+
+    let state = boot(&jobs_yaml, &jobs_db, &audit_db).await;
+    let row = state
+        .query_audit
+        .clone()
+        .unwrap()
+        .get(&audit_id)
+        .await
+        .unwrap()
+        .unwrap();
+    // A correctly stamped, terminal row must survive a restart untouched — the
+    // repair's guards are what keep it out of the candidate set.
+    assert_eq!(row["job_run_id"], serde_json::json!("run-ok"));
+    assert_eq!(row["status"], serde_json::json!("succeeded"));
+}

--- a/crates/server/tests/jobs_e2e.rs
+++ b/crates/server/tests/jobs_e2e.rs
@@ -129,7 +129,10 @@ spec:
         "min_id".to_string(),
         serde_json::Value::Number(serde_json::Number::from(0)),
     );
-    let run_id = exec.submit("ingest-lake", params.clone()).await.unwrap();
+    let run_id = exec
+        .submit("ingest-lake", params.clone(), None)
+        .await
+        .unwrap();
     let run = wait_for_terminal(&exec, &run_id).await;
     assert_eq!(
         run.status,
@@ -141,7 +144,7 @@ spec:
     assert!(lance_dataset_exists(lake_path.to_str().unwrap()));
 
     // Submit #2 — append mode should double the row count.
-    let run_id = exec.submit("ingest-lake", params).await.unwrap();
+    let run_id = exec.submit("ingest-lake", params, None).await.unwrap();
     let run = wait_for_terminal(&exec, &run_id).await;
     assert_eq!(
         run.status,
@@ -263,7 +266,10 @@ spec:
         lake_path.to_str().unwrap(),
     )
     .await;
-    let err = exec.submit("mismatch", HashMap::new()).await.unwrap_err();
+    let err = exec
+        .submit("mismatch", HashMap::new(), None)
+        .await
+        .unwrap_err();
     let err_str = err.to_string();
     assert!(
         err_str.contains("schema mismatch") || err_str.contains("Destination schema mismatch"),
@@ -326,7 +332,10 @@ spec:
         HashMap::new(),
     );
 
-    let err = exec.submit("db-ingest", HashMap::new()).await.unwrap_err();
+    let err = exec
+        .submit("db-ingest", HashMap::new(), None)
+        .await
+        .unwrap_err();
     assert!(
         matches!(
             err,
@@ -371,7 +380,10 @@ spec:
 
     let exec =
         build_executor_for_lance(Arc::clone(&ctx), job, "lake", lake_path.to_str().unwrap()).await;
-    let err = exec.submit("strict", HashMap::new()).await.unwrap_err();
+    let err = exec
+        .submit("strict", HashMap::new(), None)
+        .await
+        .unwrap_err();
     assert!(
         matches!(
             err,
@@ -404,6 +416,7 @@ async fn restart_reconciles_orphaned_running_row_to_failed() {
             rows_written: None,
             snapshot_id: None,
             error: None,
+            submission_id: None,
         };
         store.create_run(&run).await.unwrap();
     }
@@ -474,7 +487,7 @@ spec:
         "min_id".to_string(),
         serde_json::Value::Number(serde_json::Number::from(2)),
     );
-    let run_id = exec.submit("db-ingest", params).await.unwrap();
+    let run_id = exec.submit("db-ingest", params, None).await.unwrap();
     let run = wait_for_terminal(&exec, &run_id).await;
     assert_eq!(
         run.status,
@@ -547,7 +560,10 @@ spec:
         HashMap::new(),
     );
 
-    let err = exec.submit("nontx", HashMap::new()).await.unwrap_err();
+    let err = exec
+        .submit("nontx", HashMap::new(), None)
+        .await
+        .unwrap_err();
     assert!(
         matches!(
             err,

--- a/crates/skardi/src/jobs/executor.rs
+++ b/crates/skardi/src/jobs/executor.rs
@@ -189,10 +189,18 @@ impl JobExecutor {
 
     /// Submit a run. Validates params + destination up front, persists a
     /// `pending` row, and spawns the background task. Returns the run id.
+    ///
+    /// `submission_id` is an opaque token stored verbatim on the run and
+    /// never interpreted here — see [`JobRun::submission_id`]. The server
+    /// passes its query-audit row id so the two ledgers point at each other;
+    /// callers with no such ledger pass `None`. It is a required argument
+    /// rather than a defaulted one precisely because it is an attribution
+    /// seam: a new call site has to decide, not inherit a silent `None`.
     pub async fn submit(
         &self,
         job_name: &str,
         params: HashMap<String, Value>,
+        submission_id: Option<&str>,
     ) -> Result<String, JobSubmitError> {
         let job = {
             let jobs = self.jobs.read().await;
@@ -260,6 +268,10 @@ impl JobExecutor {
             rows_written: None,
             snapshot_id: None,
             error: None,
+            // Written in the same INSERT that creates the run: the reverse
+            // pointer is durable the moment the run exists, so it survives
+            // the submitter failing to record its own forward pointer.
+            submission_id: submission_id.map(str::to_string),
         };
         self.store
             .create_run(&run)
@@ -789,7 +801,7 @@ spec:
     async fn submit_unknown_job_rejected() {
         let (exec, _tmp) = setup_executor_with_memtable_dest().await;
         let err = exec
-            .submit("does-not-exist", HashMap::new())
+            .submit("does-not-exist", HashMap::new(), None)
             .await
             .unwrap_err();
         assert!(matches!(err, JobSubmitError::UnknownJob(_)));
@@ -798,7 +810,10 @@ spec:
     #[tokio::test]
     async fn submit_missing_param_rejected() {
         let (exec, _tmp) = setup_executor_with_memtable_dest().await;
-        let err = exec.submit("ingest", HashMap::new()).await.unwrap_err();
+        let err = exec
+            .submit("ingest", HashMap::new(), None)
+            .await
+            .unwrap_err();
         assert!(
             matches!(err, JobSubmitError::MissingParameters(_)),
             "got {err}"
@@ -813,7 +828,7 @@ spec:
             "min_id".to_string(),
             Value::Number(serde_json::Number::from(1)),
         );
-        let run_id = exec.submit("ingest", params).await.unwrap();
+        let run_id = exec.submit("ingest", params, None).await.unwrap();
 
         // Spin until terminal. `submit` returns synchronously after
         // spawning, so the row exists but the task may still be running.
@@ -872,7 +887,10 @@ spec:
         let exec = JobExecutor::new(map, store, ctx, HashMap::new(), HashMap::new());
 
         // A non-Lance destination that doesn't exist should be rejected.
-        let err = exec.submit("ingest", HashMap::new()).await.unwrap_err();
+        let err = exec
+            .submit("ingest", HashMap::new(), None)
+            .await
+            .unwrap_err();
         assert!(
             matches!(err, JobSubmitError::DbDestinationMissing { .. }),
             "got {err}"
@@ -923,7 +941,10 @@ spec:
         types.insert("cpu".to_string(), source_type);
         let exec = JobExecutor::new(map, store, ctx, types, HashMap::new());
 
-        let err = exec.submit("ingest", HashMap::new()).await.unwrap_err();
+        let err = exec
+            .submit("ingest", HashMap::new(), None)
+            .await
+            .unwrap_err();
         assert!(
             matches!(err, JobSubmitError::NonTransactionalDestination { .. }),
             "got {err}"

--- a/crates/skardi/src/jobs/store.rs
+++ b/crates/skardi/src/jobs/store.rs
@@ -30,12 +30,31 @@ const INIT_SCHEMA_SQL: &str = "CREATE TABLE IF NOT EXISTS job_runs (
     finished_at   TEXT,
     rows_written  INTEGER,
     snapshot_id   TEXT,
-    error         TEXT
+    error         TEXT,
+    submission_id TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_job_runs_name_created
     ON job_runs (job_name, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_job_runs_status
     ON job_runs (status);";
+
+/// Index over [`JobRun::submission_id`], applied after the migration below has
+/// guaranteed the column exists — so it cannot live in [`INIT_SCHEMA_SQL`],
+/// which also runs against pre-column ledgers.
+///
+/// Partial, because the column is NULL for every run not submitted through an
+/// audited server, and because the only query against it is an equality
+/// lookup for one submission.
+const SUBMISSION_ID_INDEX_SQL: &str = "CREATE INDEX IF NOT EXISTS idx_job_runs_submission_id
+    ON job_runs (submission_id) WHERE submission_id IS NOT NULL;";
+
+/// True for the `duplicate column name` error SQLite raises when an
+/// `ALTER TABLE ... ADD COLUMN` loses a race with another connection that
+/// already added it. Matched on message text because `rusqlite` reports it as
+/// a generic `SqliteFailure` with no distinguishing code.
+fn is_duplicate_column(e: &rusqlite::Error) -> bool {
+    e.to_string().contains("duplicate column name")
+}
 
 /// Lifecycle status of a single job run.
 ///
@@ -102,6 +121,16 @@ pub struct JobRun {
     /// string). For DB destinations this is typically null.
     pub snapshot_id: Option<String>,
     pub error: Option<String>,
+    /// Opaque correlation token supplied by whoever submitted the run, stored
+    /// verbatim and never interpreted here.
+    ///
+    /// The jobs subsystem has no notion of the query-audit ledger; this is the
+    /// seam that lets a caller which *does* — the server — make the
+    /// correlation reconstructable from either side. It writes its audit row
+    /// id here in the same INSERT that creates the run, so the pointer is
+    /// durable at run-creation time rather than stamped afterwards. See the
+    /// ledger section of `docs/server.md`.
+    pub submission_id: Option<String>,
 }
 
 /// Trait over the run ledger. All methods are async because the default
@@ -110,6 +139,16 @@ pub struct JobRun {
 pub trait JobStore: Send + Sync {
     async fn create_run(&self, run: &JobRun) -> Result<()>;
     async fn get_run(&self, run_id: &str) -> Result<Option<JobRun>>;
+    /// Look a run up by the opaque token its submitter stored on it.
+    ///
+    /// This is the direction that makes the correlation *reconstructable*:
+    /// the submitter already knows its own token, so it can recover the run
+    /// even when its own forward pointer was never written.
+    ///
+    /// Returns the most recently created match. Duplicate tokens are a
+    /// caller error rather than something this ledger enforces — nothing
+    /// here can know whether a given token is meant to be unique.
+    async fn get_run_by_submission_id(&self, submission_id: &str) -> Result<Option<JobRun>>;
     async fn list_runs(&self, job_name: Option<&str>, limit: usize) -> Result<Vec<JobRun>>;
     async fn update_status(
         &self,
@@ -187,6 +226,38 @@ impl SqliteJobStore {
             })
             .await
             .map_err(|e| anyhow::anyhow!("Failed to initialize jobs.db schema: {e}"))?;
+
+        // `CREATE TABLE IF NOT EXISTS` above no-ops on an existing ledger and
+        // will not add columns, so ledgers written before `submission_id`
+        // need the column bolted on. Idempotent: re-checked against
+        // pragma table_info on every open.
+        self.conn
+            .call(|conn| -> std::result::Result<(), rusqlite::Error> {
+                let has_column = conn
+                    .prepare(
+                        "SELECT 1 FROM pragma_table_info('job_runs') \
+                         WHERE name = 'submission_id'",
+                    )?
+                    .exists([])?;
+                if !has_column {
+                    // The check is not atomic with the ALTER, so a second
+                    // process opening the same file can win the race. Its
+                    // `duplicate column name` is exactly the post-condition
+                    // wanted here — treat it as success rather than failing
+                    // startup over a benign race.
+                    match conn.execute("ALTER TABLE job_runs ADD COLUMN submission_id TEXT", []) {
+                        Ok(_) => {}
+                        Err(e) if is_duplicate_column(&e) => {}
+                        Err(e) => return Err(e),
+                    }
+                }
+                conn.execute_batch(SUBMISSION_ID_INDEX_SQL)?;
+                Ok(())
+            })
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!("Failed to migrate jobs.db schema (submission_id): {e}")
+            })?;
         Ok(())
     }
 }
@@ -211,6 +282,7 @@ fn row_to_job_run(row: &Row<'_>) -> rusqlite::Result<JobRun> {
         rows_written: row.get::<_, Option<i64>>("rows_written")?.map(|v| v as u64),
         snapshot_id: row.get("snapshot_id")?,
         error: row.get("error")?,
+        submission_id: row.get("submission_id")?,
     })
 }
 
@@ -223,8 +295,8 @@ impl JobStore for SqliteJobStore {
                 conn.execute(
                     "INSERT INTO job_runs
                          (id, job_name, parameters, status, created_at, started_at,
-                          finished_at, rows_written, snapshot_id, error)
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                          finished_at, rows_written, snapshot_id, error, submission_id)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
                     rusqlite::params![
                         run.id,
                         run.job_name,
@@ -236,6 +308,7 @@ impl JobStore for SqliteJobStore {
                         run.rows_written.map(|v| v as i64),
                         run.snapshot_id,
                         run.error,
+                        run.submission_id,
                     ],
                 )?;
                 Ok(())
@@ -253,7 +326,7 @@ impl JobStore for SqliteJobStore {
                 move |conn| -> std::result::Result<Option<JobRun>, rusqlite::Error> {
                     let mut stmt = conn.prepare(
                         "SELECT id, job_name, parameters, status, created_at, started_at,
-                            finished_at, rows_written, snapshot_id, error
+                            finished_at, rows_written, snapshot_id, error, submission_id
                      FROM job_runs
                      WHERE id = ?1",
                     )?;
@@ -269,6 +342,32 @@ impl JobStore for SqliteJobStore {
         Ok(row)
     }
 
+    async fn get_run_by_submission_id(&self, submission_id: &str) -> Result<Option<JobRun>> {
+        let submission_id = submission_id.to_string();
+        let row = self
+            .conn
+            .call(
+                move |conn| -> std::result::Result<Option<JobRun>, rusqlite::Error> {
+                    let mut stmt = conn.prepare(
+                        "SELECT id, job_name, parameters, status, created_at, started_at,
+                            finished_at, rows_written, snapshot_id, error, submission_id
+                     FROM job_runs
+                     WHERE submission_id = ?1
+                     ORDER BY created_at DESC
+                     LIMIT 1",
+                    )?;
+                    let mut rows = stmt.query(rusqlite::params![submission_id])?;
+                    match rows.next()? {
+                        Some(row) => Ok(Some(row_to_job_run(row)?)),
+                        None => Ok(None),
+                    }
+                },
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!("get_run_by_submission_id failed: {e}"))?;
+        Ok(row)
+    }
+
     async fn list_runs(&self, job_name: Option<&str>, limit: usize) -> Result<Vec<JobRun>> {
         let job_name = job_name.map(|s| s.to_string());
         let limit = limit as i64;
@@ -279,7 +378,7 @@ impl JobStore for SqliteJobStore {
                     let (sql, params): (&str, Vec<rusqlite::types::Value>) = match &job_name {
                         Some(name) => (
                             "SELECT id, job_name, parameters, status, created_at, started_at,
-                                    finished_at, rows_written, snapshot_id, error
+                                    finished_at, rows_written, snapshot_id, error, submission_id
                              FROM job_runs
                              WHERE job_name = ?1
                              ORDER BY created_at DESC
@@ -291,7 +390,7 @@ impl JobStore for SqliteJobStore {
                         ),
                         None => (
                             "SELECT id, job_name, parameters, status, created_at, started_at,
-                                    finished_at, rows_written, snapshot_id, error
+                                    finished_at, rows_written, snapshot_id, error, submission_id
                              FROM job_runs
                              ORDER BY created_at DESC
                              LIMIT ?1",
@@ -379,6 +478,10 @@ mod tests {
     use super::*;
 
     fn sample_run(id: &str, job_name: &str) -> JobRun {
+        sample_run_with_submission(id, job_name, None)
+    }
+
+    fn sample_run_with_submission(id: &str, job_name: &str, submission_id: Option<&str>) -> JobRun {
         JobRun {
             id: id.to_string(),
             job_name: job_name.to_string(),
@@ -390,6 +493,7 @@ mod tests {
             rows_written: None,
             snapshot_id: None,
             error: None,
+            submission_id: submission_id.map(str::to_string),
         }
     }
 
@@ -516,5 +620,138 @@ mod tests {
             let got = s.get_run("rX").await.unwrap().unwrap();
             assert_eq!(got.job_name, "ingest");
         }
+    }
+
+    #[tokio::test]
+    async fn submission_id_round_trips_and_looks_up_in_reverse() {
+        let s = SqliteJobStore::open_in_memory().await.unwrap();
+        s.create_run(&sample_run_with_submission(
+            "r1",
+            "ingest",
+            Some("audit-abc"),
+        ))
+        .await
+        .unwrap();
+
+        assert_eq!(
+            s.get_run("r1").await.unwrap().unwrap().submission_id,
+            Some("audit-abc".to_string())
+        );
+        let found = s
+            .get_run_by_submission_id("audit-abc")
+            .await
+            .unwrap()
+            .expect("submission token did not resolve to its run");
+        assert_eq!(found.id, "r1");
+        assert!(
+            s.get_run_by_submission_id("audit-nope")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn unattributed_runs_keep_a_null_submission_id() {
+        // Runs submitted through an unaudited server carry no token, and must
+        // not collide with each other in the reverse lookup.
+        let s = SqliteJobStore::open_in_memory().await.unwrap();
+        s.create_run(&sample_run("r1", "ingest")).await.unwrap();
+        s.create_run(&sample_run("r2", "ingest")).await.unwrap();
+        assert!(
+            s.get_run("r1")
+                .await
+                .unwrap()
+                .unwrap()
+                .submission_id
+                .is_none()
+        );
+        assert!(s.list_runs(None, 10).await.unwrap().len() == 2);
+    }
+
+    #[tokio::test]
+    async fn open_migrates_a_ledger_written_before_submission_id() {
+        // `CREATE TABLE IF NOT EXISTS` no-ops on an existing ledger and will
+        // not add columns, so a jobs.db from before this change has to be
+        // migrated on open — and must stay readable and writable after.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        drop(tmp);
+        {
+            let conn = rusqlite::Connection::open(&path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE job_runs (
+                    id TEXT PRIMARY KEY, job_name TEXT NOT NULL,
+                    parameters TEXT NOT NULL, status TEXT NOT NULL,
+                    created_at TEXT NOT NULL, started_at TEXT, finished_at TEXT,
+                    rows_written INTEGER, snapshot_id TEXT, error TEXT);
+                 INSERT INTO job_runs (id, job_name, parameters, status, created_at)
+                 VALUES ('old-run', 'ingest', '{}', 'succeeded', '2026-01-01T00:00:00Z');",
+            )
+            .unwrap();
+        }
+
+        let s = SqliteJobStore::open(&path).await.unwrap();
+
+        // The pre-migration row survives, with the new column NULL.
+        let old = s.get_run("old-run").await.unwrap().unwrap();
+        assert_eq!(old.job_name, "ingest");
+        assert!(old.submission_id.is_none());
+
+        // And the migrated ledger accepts attributed writes.
+        s.create_run(&sample_run_with_submission(
+            "new-run",
+            "ingest",
+            Some("audit-1"),
+        ))
+        .await
+        .unwrap();
+        assert_eq!(
+            s.get_run_by_submission_id("audit-1")
+                .await
+                .unwrap()
+                .unwrap()
+                .id,
+            "new-run"
+        );
+
+        // The partial index is applied in the same guarded step as the ALTER,
+        // so a migrated ledger must not be left without it.
+        let has_index = s
+            .conn
+            .call(|conn| -> std::result::Result<bool, rusqlite::Error> {
+                conn.prepare(
+                    "SELECT 1 FROM sqlite_master
+                      WHERE type = 'index' AND name = 'idx_job_runs_submission_id'",
+                )?
+                .exists([])
+            })
+            .await
+            .unwrap();
+        assert!(
+            has_index,
+            "migrated ledger is missing the submission_id index"
+        );
+    }
+
+    #[test]
+    fn duplicate_column_error_is_recognised() {
+        // The migration's check-then-ALTER is not atomic, so a second process
+        // can win the race. Treating its error as success is only safe if it
+        // can be told apart from a real failure.
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE job_runs (id TEXT PRIMARY KEY);")
+            .unwrap();
+        conn.execute("ALTER TABLE job_runs ADD COLUMN submission_id TEXT", [])
+            .unwrap();
+        let err = conn
+            .execute("ALTER TABLE job_runs ADD COLUMN submission_id TEXT", [])
+            .expect_err("adding an existing column must fail");
+        assert!(is_duplicate_column(&err), "unrecognised: {err}");
+
+        let other = conn
+            .execute("ALTER TABLE nonexistent ADD COLUMN submission_id TEXT", [])
+            .expect_err("altering a missing table must fail");
+        assert!(!is_duplicate_column(&other), "over-matched: {other}");
     }
 }

--- a/crates/skardi/src/jobs/store.rs
+++ b/crates/skardi/src/jobs/store.rs
@@ -12,8 +12,10 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio_rusqlite::{Connection, Row, rusqlite};
 
 /// DDL for the run ledger. Idempotent — run on every `open` via
@@ -45,15 +47,135 @@ CREATE INDEX IF NOT EXISTS idx_job_runs_status
 /// Partial, because the column is NULL for every run not submitted through an
 /// audited server, and because the only query against it is an equality
 /// lookup for one submission.
-const SUBMISSION_ID_INDEX_SQL: &str = "CREATE INDEX IF NOT EXISTS idx_job_runs_submission_id
+///
+/// **Unique**, which is the difference between a duplicate token being caught
+/// and a duplicate token being hidden. `get_run_by_submission_id` resolves
+/// `ORDER BY created_at DESC LIMIT 1`, so without the constraint a second run
+/// carrying an existing token makes the lookup return a *confidently wrong*
+/// run — no error, no signal, the same shape as a correct answer, for a column
+/// whose entire purpose is saying which run a submission produced. The
+/// constraint moves that from a wrong answer during an incident to a
+/// `create_run` failure at the moment the mistake is made. It constrains
+/// nothing that exists today: the one production writer mints a fresh audit id
+/// per submission. NULLs stay unconstrained, so unattributed runs are
+/// unaffected.
+///
+/// The `DROP` is not vestigial. `CREATE UNIQUE INDEX IF NOT EXISTS` matches on
+/// *name*, so it would silently no-op against the non-unique index of the same
+/// name that earlier builds of this branch created — leaving a ledger that
+/// looks constrained and is not. Dropping first makes the outcome the same
+/// whichever build wrote the file.
+const SUBMISSION_ID_INDEX_SQL: &str = "DROP INDEX IF EXISTS idx_job_runs_submission_id;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_job_runs_submission_id_unique
     ON job_runs (submission_id) WHERE submission_id IS NOT NULL;";
+
+/// Columns that `CREATE TABLE IF NOT EXISTS` cannot retrofit onto a ledger
+/// written before they existed, reconciled by [`ensure_added_columns`] on
+/// every open.
+const ADDED_COLUMNS: [&str; 1] = ["submission_id"];
+
+/// How long a write waits for another connection's lock before giving up.
+///
+/// SQLite installs no busy handler by default — a write that finds the lock
+/// held returns `SQLITE_BUSY` immediately. See the pragmas in
+/// [`SqliteJobStore::open`] for why that default is wrong here.
+const JOBS_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// True for the `duplicate column name` error SQLite raises when an
 /// `ALTER TABLE ... ADD COLUMN` loses a race with another connection that
 /// already added it. Matched on message text because `rusqlite` reports it as
 /// a generic `SqliteFailure` with no distinguishing code.
+///
+/// Byte-for-byte the predicate at `crates/query-audit/src/lib.rs`
+/// (`is_duplicate_column`), duplicated because `crates/skardi` must not depend
+/// on `skardi-query-audit` for a two-line string match. Kept in sync by hand:
+/// a future SQLite rewording of this message breaks both, silently, in
+/// different crates — so change them together.
 fn is_duplicate_column(e: &rusqlite::Error) -> bool {
     e.to_string().contains("duplicate column name")
+}
+
+/// Add any of `columns` the live `job_runs` table is missing, as nullable
+/// `TEXT`. Idempotent and additive; a no-op on a fresh ledger, where
+/// [`INIT_SCHEMA_SQL`] already declared them.
+///
+/// Mirrors `ensure_added_columns` in `crates/query-audit/src/lib.rs`. Written
+/// as a loop over a column list rather than inline for the single column that
+/// needs it today, so the next column on `job_runs` is a list entry instead of
+/// a fourth copy of this block.
+fn ensure_added_columns(conn: &rusqlite::Connection, columns: &[&str]) -> rusqlite::Result<()> {
+    let mut stmt = conn.prepare("PRAGMA table_info(job_runs)")?;
+    let existing: HashSet<String> = stmt
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<std::result::Result<_, _>>()?;
+    for col in columns {
+        if existing.contains(*col) {
+            continue;
+        }
+        // The read above is not atomic with this ALTER, so a second process
+        // opening the same file can win the race. Its `duplicate column name`
+        // is exactly the post-condition wanted here — treat it as success
+        // rather than failing startup over a benign race. The busy timeout set
+        // in `open` is what keeps the *other* interleaving (the winner still
+        // mid-write when this ALTER fires) from surfacing as `database is
+        // locked` instead of as this tolerated error.
+        match conn.execute(&format!("ALTER TABLE job_runs ADD COLUMN {col} TEXT"), []) {
+            Ok(_) => {}
+            Err(e) if is_duplicate_column(&e) => {}
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(())
+}
+
+/// Create `path` owner-only so it is never briefly world-readable: SQLite
+/// would otherwise create it through the process umask (typically 0644).
+///
+/// `jobs.db` holds `job_runs.parameters` — the raw submit-time parameter
+/// *values* that the query-audit ledger deliberately refuses to store — and
+/// since [`JobRun::submission_id`] it also links each run to a row in that
+/// ledger, which is chmod 0600. Mirrors `create_private_file` in
+/// `crates/query-audit/src/lib.rs`; duplicated for the same
+/// no-dependency reason as [`is_duplicate_column`].
+fn create_private_file(path: &Path) -> Result<()> {
+    if path.exists() {
+        return Ok(());
+    }
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    match options.open(path) {
+        Ok(_) => Ok(()),
+        // Lost a race with another process; permissions get fixed below.
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+        Err(e) => {
+            Err(e).with_context(|| format!("Failed to create jobs.db file: {}", path.display()))
+        }
+    }
+}
+
+/// Force owner-only permissions on a ledger file. No-op off Unix, where the
+/// permission model does not map.
+fn restrict_permissions(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).with_context(
+            || {
+                format!(
+                    "Failed to restrict jobs.db file permissions: {}",
+                    path.display()
+                )
+            },
+        )?;
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+    Ok(())
 }
 
 /// Lifecycle status of a single job run.
@@ -190,14 +312,51 @@ impl SqliteJobStore {
             std::fs::create_dir_all(parent)
                 .with_context(|| format!("Failed to create jobs.db parent dir: {parent:?}"))?;
         }
+        // Create the file ourselves so it is never briefly world-readable.
+        create_private_file(&path)?;
+
         let conn = Connection::open(&path)
             .await
             .with_context(|| format!("Failed to open jobs.db: {path:?}"))?;
+
+        conn.call(|conn| -> std::result::Result<(), rusqlite::Error> {
+            // WAL so a reader (a `GET /jobs/runs`, a CLI poll) does not block
+            // the background task's status writes.
+            conn.pragma_update(None, "journal_mode", "WAL")?;
+            // SQLite's default busy handler is "fail immediately". Without a
+            // timeout, two processes opening the same `jobs.db` — a rolling
+            // restart, an operator tool, a second server on the same path —
+            // turn the benign migration race `ensure_added_columns` tolerates
+            // into a startup failure: the loser's `ALTER TABLE` lands while the
+            // winner is still mid-write and gets `database is locked`, which is
+            // not a `duplicate column name` and so is not tolerated. Every
+            // other `job_runs` write is exposed to the same default. Matches
+            // the query-audit ledger, which sets both pragmas before its own
+            // column reconciliation for exactly this reason.
+            conn.busy_timeout(JOBS_BUSY_TIMEOUT)?;
+            Ok(())
+        })
+        .await
+        .with_context(|| format!("Failed to configure jobs.db: {}", path.display()))?;
+
         let store = Self {
             conn: Arc::new(conn),
             path,
         };
         store.ensure_schema().await?;
+
+        // WAL creates `-wal`/`-shm` sidecars on first write; they carry the
+        // same rows and need the same protection.
+        restrict_permissions(&store.path)?;
+        for suffix in ["-wal", "-shm"] {
+            let mut sidecar = store.path.clone().into_os_string();
+            sidecar.push(suffix);
+            let sidecar = PathBuf::from(sidecar);
+            if sidecar.exists() {
+                restrict_permissions(&sidecar)?;
+            }
+        }
+
         Ok(store)
     }
 
@@ -229,28 +388,11 @@ impl SqliteJobStore {
 
         // `CREATE TABLE IF NOT EXISTS` above no-ops on an existing ledger and
         // will not add columns, so ledgers written before `submission_id`
-        // need the column bolted on. Idempotent: re-checked against
-        // pragma table_info on every open.
+        // need it bolted on. Idempotent: reconciled against
+        // `pragma table_info` on every open.
         self.conn
             .call(|conn| -> std::result::Result<(), rusqlite::Error> {
-                let has_column = conn
-                    .prepare(
-                        "SELECT 1 FROM pragma_table_info('job_runs') \
-                         WHERE name = 'submission_id'",
-                    )?
-                    .exists([])?;
-                if !has_column {
-                    // The check is not atomic with the ALTER, so a second
-                    // process opening the same file can win the race. Its
-                    // `duplicate column name` is exactly the post-condition
-                    // wanted here — treat it as success rather than failing
-                    // startup over a benign race.
-                    match conn.execute("ALTER TABLE job_runs ADD COLUMN submission_id TEXT", []) {
-                        Ok(_) => {}
-                        Err(e) if is_duplicate_column(&e) => {}
-                        Err(e) => return Err(e),
-                    }
-                }
+                ensure_added_columns(conn, &ADDED_COLUMNS)?;
                 conn.execute_batch(SUBMISSION_ID_INDEX_SQL)?;
                 Ok(())
             })
@@ -666,7 +808,7 @@ mod tests {
                 .submission_id
                 .is_none()
         );
-        assert!(s.list_runs(None, 10).await.unwrap().len() == 2);
+        assert_eq!(s.list_runs(None, 10).await.unwrap().len(), 2);
     }
 
     #[tokio::test]
@@ -716,22 +858,183 @@ mod tests {
         );
 
         // The partial index is applied in the same guarded step as the ALTER,
-        // so a migrated ledger must not be left without it.
-        let has_index = s
+        // so a migrated ledger must not be left without it — and it must be
+        // the *unique* one, not a leftover of the same purpose under the old
+        // name.
+        let (has_unique, has_legacy) = s
             .conn
-            .call(|conn| -> std::result::Result<bool, rusqlite::Error> {
-                conn.prepare(
-                    "SELECT 1 FROM sqlite_master
-                      WHERE type = 'index' AND name = 'idx_job_runs_submission_id'",
-                )?
-                .exists([])
-            })
+            .call(
+                |conn| -> std::result::Result<(bool, bool), rusqlite::Error> {
+                    let unique = conn
+                        .prepare(
+                            "SELECT 1 FROM sqlite_master
+                              WHERE type = 'index'
+                                AND name = 'idx_job_runs_submission_id_unique'",
+                        )?
+                        .exists([])?;
+                    let legacy = conn
+                        .prepare(
+                            "SELECT 1 FROM sqlite_master
+                              WHERE type = 'index' AND name = 'idx_job_runs_submission_id'",
+                        )?
+                        .exists([])?;
+                    Ok((unique, legacy))
+                },
+            )
             .await
             .unwrap();
         assert!(
-            has_index,
-            "migrated ledger is missing the submission_id index"
+            has_unique,
+            "migrated ledger is missing the unique submission_id index"
         );
+        assert!(
+            !has_legacy,
+            "the pre-unique index survived the migration, so uniqueness is not enforced"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_duplicate_submission_id_is_rejected_rather_than_shadowing_a_run() {
+        // `get_run_by_submission_id` resolves `ORDER BY created_at DESC LIMIT
+        // 1`, so without the unique index a reused token would make it return a
+        // confidently wrong run — no error, same shape as a correct answer, for
+        // the one column whose job is saying which run a submission produced.
+        // The constraint turns that into a failure at the moment the mistake is
+        // made.
+        let s = SqliteJobStore::open_in_memory().await.unwrap();
+        s.create_run(&sample_run_with_submission("r1", "ingest", Some("audit-1")))
+            .await
+            .unwrap();
+
+        let err = s
+            .create_run(&sample_run_with_submission("r2", "ingest", Some("audit-1")))
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("UNIQUE constraint failed"),
+            "expected a uniqueness failure, got {err}"
+        );
+
+        // The first run is still the answer, and is still the only one.
+        assert_eq!(
+            s.get_run_by_submission_id("audit-1")
+                .await
+                .unwrap()
+                .unwrap()
+                .id,
+            "r1"
+        );
+    }
+
+    #[tokio::test]
+    async fn many_unattributed_runs_do_not_collide_under_the_unique_index() {
+        // The index is partial (`WHERE submission_id IS NOT NULL`), so runs
+        // submitted through an unaudited server — every run today — must still
+        // insert freely. Without the partial clause this is what would break.
+        let s = SqliteJobStore::open_in_memory().await.unwrap();
+        for i in 0..5 {
+            s.create_run(&sample_run_with_submission(
+                &format!("r{i}"),
+                "ingest",
+                None,
+            ))
+            .await
+            .unwrap();
+        }
+        assert_eq!(s.list_runs(None, 10).await.unwrap().len(), 5);
+    }
+
+    #[tokio::test]
+    async fn open_is_idempotent_across_the_unique_index_rename() {
+        // A ledger written by an earlier build of this change carries the
+        // non-unique index under the old name. `CREATE UNIQUE INDEX IF NOT
+        // EXISTS` matches on name, so without the `DROP` it would no-op and
+        // leave the file looking constrained while accepting duplicates.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        drop(tmp);
+        {
+            let conn = rusqlite::Connection::open(&path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE job_runs (
+                    id TEXT PRIMARY KEY, job_name TEXT NOT NULL,
+                    parameters TEXT NOT NULL, status TEXT NOT NULL,
+                    created_at TEXT NOT NULL, started_at TEXT, finished_at TEXT,
+                    rows_written INTEGER, snapshot_id TEXT, error TEXT,
+                    submission_id TEXT);
+                 CREATE INDEX idx_job_runs_submission_id
+                    ON job_runs (submission_id) WHERE submission_id IS NOT NULL;",
+            )
+            .unwrap();
+        }
+
+        // Opening twice also pins that the DROP/CREATE pair is re-runnable.
+        for _ in 0..2 {
+            let s = SqliteJobStore::open(&path).await.unwrap();
+            drop(s);
+        }
+        let s = SqliteJobStore::open(&path).await.unwrap();
+        s.create_run(&sample_run_with_submission("r1", "ingest", Some("audit-1")))
+            .await
+            .unwrap();
+        let err = s
+            .create_run(&sample_run_with_submission("r2", "ingest", Some("audit-1")))
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("UNIQUE constraint failed"),
+            "the rename left the ledger unconstrained: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn open_restricts_permissions_and_sets_the_concurrency_pragmas() {
+        // `jobs.db` holds `job_runs.parameters` — the raw parameter values the
+        // query-audit ledger refuses to store — and since `submission_id` it
+        // also links each run to a row in that 0600 ledger. The weaker of two
+        // halves of one audit record would otherwise set the real posture.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        drop(tmp);
+
+        let s = SqliteJobStore::open(&path).await.unwrap();
+        // A write, so the WAL sidecars exist to be checked.
+        s.create_run(&sample_run("r1", "ingest")).await.unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "jobs.db is not owner-only: {mode:o}");
+            for suffix in ["-wal", "-shm"] {
+                let mut sidecar = path.clone().into_os_string();
+                sidecar.push(suffix);
+                let sidecar = PathBuf::from(sidecar);
+                if sidecar.exists() {
+                    let mode = std::fs::metadata(&sidecar).unwrap().permissions().mode() & 0o777;
+                    assert_eq!(mode, 0o600, "{sidecar:?} is not owner-only: {mode:o}");
+                }
+            }
+        }
+
+        // WAL and a non-zero busy timeout are what make the migration's
+        // duplicate-column tolerance a complete story: without the timeout the
+        // losing process gets `database is locked` instead, which is not
+        // tolerated and takes startup down.
+        let (journal_mode, busy_timeout) = s
+            .conn
+            .call(
+                |conn| -> std::result::Result<(String, i64), rusqlite::Error> {
+                    let journal: String =
+                        conn.query_row("PRAGMA journal_mode", [], |r| r.get(0))?;
+                    let busy: i64 = conn.query_row("PRAGMA busy_timeout", [], |r| r.get(0))?;
+                    Ok((journal, busy))
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(journal_mode.to_lowercase(), "wal");
+        assert_eq!(busy_timeout, JOBS_BUSY_TIMEOUT.as_millis() as i64);
     }
 
     #[test]

--- a/docs/agent_data_plane.md
+++ b/docs/agent_data_plane.md
@@ -135,7 +135,9 @@ CREATE TABLE IF NOT EXISTS job_runs (
     finished_at   TEXT,
     rows_written  INTEGER,             -- set on succeeded; also on post-commit cancels
     snapshot_id   TEXT,                -- Lance: the version the commit landed on
-    error         TEXT                 -- non-null on failed/cancelled
+    error         TEXT,                -- non-null on failed/cancelled
+    submission_id TEXT                 -- opaque correlation token from the submitter;
+                                       -- the server stores its query-audit row id here
 );
 ```
 

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -171,7 +171,7 @@ On startup the server:
 |----------|--------|-------------|
 | `/jobs` | GET | List every registered job with its destination |
 | `/jobs/:name/run` | POST | Submit a new run; body is the param map |
-| `/jobs/runs` | GET | List recent runs; supports `?job=<name>&limit=N` |
+| `/jobs/runs` | GET | List recent runs; supports `?job=<name>&limit=N` (max 500). `?submission_id=<token>` instead resolves the single run carrying that correlation token, ignoring `job`/`limit` |
 | `/jobs/runs/:run_id` | GET | Current state of one run |
 | `/jobs/runs/:run_id/cancel` | POST | Flag a run for cancellation |
 
@@ -209,7 +209,11 @@ with `400 parameter_validation_error` — the header is always validated once
 the job exists, regardless of audit configuration. When `--query-audit-db`
 is configured, the submission is recorded as a `job` row with the session
 id and `name@version` in the ledger, with the submission's outcome
-(`succeeded` or `failed`) and the `job_run_id` bridge to the run. When the server has
+(`succeeded` or `failed`) and the `job_run_id` bridge to the run. That bridge
+has a second, durable half in the other direction — `job_runs.submission_id`
+holds the audit row's id, written with the run's INSERT — so a lost
+`job_run_id` stamp no longer loses the correlation, and the server re-links
+such rows on its next startup. When the server has
 auditing enabled, a `503` with `error_type: query_audit_error` means the
 job **was not submitted** and the call is safe to retry.
 
@@ -359,6 +363,14 @@ Row fields, matching the CLI `status` response:
 | `rows_written` | Set on `succeeded`; also set on post-commit cancels |
 | `snapshot_id` | For Lance: the version the commit landed on, as a string |
 | `error` | Non-null on failures / cancels; free-form message |
+
+The row carries one field the response does not: `submission_id`, the opaque
+correlation token the submitter supplied — for the server, the `query_audit`
+row id of the submission that created this run. It is withheld from run
+payloads on purpose (it is another ledger's primary key, and any authenticated
+session can list every run) and is reachable as a filter instead:
+`GET /jobs/runs?submission_id=<audit row id>`. See the ledger section of
+[`server.md`](server.md).
 
 ---
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -179,7 +179,7 @@ execution and updated with its outcome afterwards:
 | `ai_context` | the caller's object, verbatim JSON |
 | `session_id` | denormalised from `ai_context` for indexed session lookup |
 | `max_rows` | requested row cap (`0` on pipeline and job rows — not applicable) |
-| `job_run_id` | `job_runs.id` bridge, job rows only. Distinct from the identity envelope's `run_id`, which names the *caller's* run — one column, one meaning. |
+| `job_run_id` | `job_runs.id` bridge, job rows only; NULL if the outcome stamp was lost — see `job_runs.submission_id` for the durable reverse pointer. Distinct from the identity envelope's `run_id`, which names the *caller's* run — one column, one meaning. |
 | `request_id`, `org_id`, `workspace_id`, `user_id`, `run_id` | caller-identity envelope; all NULL on this server, filled by distributions that authenticate their callers |
 | `statement_kind` | `query` or `other` for ad-hoc rows (the server's statement *classification* — not SQL verbs like `select`/`dml`), `pipeline` for pipeline rows, `job` for job rows. Consumers filtering the ledger must match these exact strings. |
 | `status` | `started` → `succeeded` / `failed`, or `unknown` after a crash |
@@ -338,15 +338,20 @@ Two properties of this seam an operator should know before relying on it:
   submissions with another session's id. Read `session_id` as a correlation
   key, never as evidence of who ran what.
 
-- **The `job_run_id` bridge is best-effort and one-directional.** It is
-  stamped after `executor.submit` returns, so if that write fails, times out,
-  or the process dies in the window, the run exists in `job_runs` but the row
-  keeps `job_run_id = NULL` (and reconciles to `unknown` on restart). `job_runs`
-  carries no `session_id` and no audit-row id, so there is no reverse pointer
-  to rebuild the correlation from — it is lost, not merely delayed. Exact
-  correlation is the column's purpose, so treat it as *usually* exact rather
-  than guaranteed; making it reconstructable needs a durable half in the
-  jobs ledger, which is out of scope here.
+- **The `job_run_id` bridge is best-effort, but the correlation is not.**
+  `query_audit.job_run_id` is stamped *after* `executor.submit` returns, so if
+  that write fails, times out, or the process dies in the window, the audit
+  row keeps `job_run_id = NULL` and reconciles to `unknown`. The correlation
+  survives anyway: `job_runs.submission_id` holds the audit row's id, written
+  in the same INSERT that creates the run, so it is durable the moment the
+  run exists. Read the pair as one bridge with a fast half and a reliable
+  half — `job_run_id` for the common lookup, `submission_id` when it is NULL.
+  Both directions are indexed.
+
+  `submission_id` is NULL for runs submitted to a server with no
+  `--query-audit-db`, and is surfaced on `GET /jobs/runs` and
+  `GET /jobs/runs/:run_id`. The jobs subsystem stores it verbatim and never
+  interprets it — it has no notion of the audit ledger.
 
 ---
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -349,9 +349,52 @@ Two properties of this seam an operator should know before relying on it:
   Both directions are indexed.
 
   `submission_id` is NULL for runs submitted to a server with no
-  `--query-audit-db`, and is surfaced on `GET /jobs/runs` and
-  `GET /jobs/runs/:run_id`. The jobs subsystem stores it verbatim and never
+  `--query-audit-db`. The jobs subsystem stores it verbatim and never
   interprets it — it has no notion of the audit ledger.
+
+- **The repair happens on the next boot; you do not need the token by hand.**
+  At startup, once both ledgers are open and each has reconciled its own
+  orphans, the server passes over job rows left `unknown` with
+  `job_run_id IS NULL` and re-links each from `job_runs.submission_id`. The row
+  an auditor reads ends up carrying the run id, so "linkage lost" is a
+  condition that survives a crash but not a restart. `status` stays `unknown` —
+  the outcome genuinely was never observed; only the linkage is recovered. The
+  pass is idempotent, never overwrites a pointer that was written correctly,
+  and never touches a row still `started`. A failure is logged and does not
+  block startup.
+
+- **The token resolves through the runs API as a filter, not as a field.**
+  `GET /jobs/runs?submission_id=<audit row id>` returns the single matching run
+  (an empty list on a miss). It is deliberately *not* included in run payloads:
+  it is a `query_audit` primary key, that ledger is chmod 0600, and
+  `GET /jobs/runs` returns every run to any authenticated session — the
+  `/jobs/*` gate is authentication, not authorization — so emitting it would
+  publish one caller's audit-row id to every other caller. A filter on the way
+  in also serves the operator better: it resolves a run that has already
+  fallen off the 500-row list window, which during an incident is exactly the
+  run being looked for.
+
+- **The two halves expire on different clocks.** `query_audit` has retention
+  (`--query-audit-retention-days`, pruned at startup and hourly); `job_runs`
+  has no pruning at all. So under retention an old run keeps a `submission_id`
+  pointing at a row that has been deleted, indistinguishable from a token that
+  was never valid. The pointer stays durable; its target does not.
+
+  The asymmetry cuts the useful way too. Because `job_runs` is never pruned,
+  **no match for a token is positive evidence that `submit` never created a
+  run** — which is what separates "definitely submitted, linkage lost" from
+  "never ran" for an `unknown` job row. That inference is the operator
+  procedure for the ambiguity this bridge exists to remove, and it stops being
+  sound the moment anything starts pruning `job_runs`.
+
+- **`jobs.db` is protected on the same terms as the audit ledger.** It is
+  created owner-only (0600) and re-chmodded on every open, along with its
+  WAL sidecars, matching `--query-audit-db`. It has to be: `job_runs.parameters`
+  holds the raw submit-time parameter *values* the audit ledger deliberately
+  refuses to store, and since `submission_id` the file also links each run to a
+  protected audit row. Two halves of one audit record with one permission
+  decision — otherwise the weaker half sets the real posture. Off Unix the
+  chmod is a no-op, as with the audit ledger.
 
 ---
 

--- a/docs/superpowers/specs/2026-08-18-jobs-audit-design.md
+++ b/docs/superpowers/specs/2026-08-18-jobs-audit-design.md
@@ -142,22 +142,13 @@ owned by the server.
   (`2026-08-19-jobs-auth-design.md`), because this change is what made the
   gap load-bearing: it turned `POST /jobs/:name/run` into the audit ledger's
   only unauthenticated write path.
-- **Guaranteeing** the `job_run_id` correlation. The column exists because
-  name + timestamp is ambiguous under concurrent submissions of the same
-  job, and it removes that ambiguity on the happy path — but the stamp is
-  written after `executor.submit` has already created the run, best-effort.
-  If it fails, times out, or the process dies first, the run exists in
-  `job_runs` while the audit row keeps `run_id = NULL` and reconciles to
-  `unknown`. Because `job_runs` carries neither `session_id` nor an
-  audit-row id, there is no reverse pointer: the correlation is
-  unrecoverable, not merely delayed, and `unknown` on a job row means
-  "definitely submitted, linkage lost" rather than the "may have run after a
-  crash" it means on a query row. Closing this needs a durable half in the
-  jobs ledger — an `audit_id` (or `session_id`) column on `job_runs`, plumbed
-  through `executor.submit` — which puts a server-layer audit concern into
-  the core `skardi` crate's jobs subsystem, a layering decision this change
-  does not make. Stated in `docs/server.md` so consumers read `job_run_id` as
-  usually-exact rather than guaranteed.
+- **Guaranteeing** the `job_run_id` correlation on its own. The stamp is
+  written after `executor.submit` has already created the run, best-effort, so
+  a failure/timeout/crash in that window leaves `job_run_id = NULL` on a row
+  that reconciles to `unknown`. **Closed as a follow-up**
+  (`2026-08-19-jobs-bridge-design.md`) by giving `job_runs` a durable
+  `submission_id` reverse pointer, written in the INSERT that creates the
+  run.
 - Reconciling the jobs ledger's raw-parameter storage with the query
   ledger's never-store-values stance. Flagged: `job_runs.parameters` holds
   exactly what `query_audit` refuses to hold, and deserves the same

--- a/docs/superpowers/specs/2026-08-19-jobs-bridge-design.md
+++ b/docs/superpowers/specs/2026-08-19-jobs-bridge-design.md
@@ -56,6 +56,26 @@ Read as one bridge with a fast half and a reliable half: `job_run_id` for the
 common lookup, `submission_id` when it is NULL. Both directions are indexed
 (`job_run_id`'s partial index came with #219; `submission_id` gets its own here).
 
+**The pointer is repaired into the ledger at startup, not left to an
+operator.** A durable reverse pointer only makes the correlation *recoverable*;
+on its own, nothing recovers it, and the row an auditor reads still says
+`unknown, NULL` forever — `record_job_outcome` guards on `status = 'started'`,
+so once `reconcile_orphaned` has run no later well-behaved write can stamp it.
+So `setup_app_state`, which is the one place holding both ledgers, passes over
+job rows left `unknown` with `job_run_id IS NULL` after both stores have
+reconciled their own orphans, and re-links each through
+`get_run_by_submission_id`. `status` stays `unknown`, which remains true: the
+outcome was never observed, only the linkage is recovered. The pass is
+idempotent, cannot overwrite a correctly-written pointer (`backfill_job_run_id`
+guards on `unknown` + NULL), cannot touch a row still `started`, and logs
+rather than fails startup — a ledger that cannot be repaired should not stop a
+server serving.
+
+A candidate with no matching run is left alone. `job_runs` is never pruned, so
+that miss is positive evidence `submit` never created a run — the fact that
+separates "definitely submitted, linkage lost" from "never ran", which is the
+ambiguity this whole change is about.
+
 **`submit` takes the token as a required argument** rather than an optional
 one behind a defaulted overload. It is an attribution seam, so a new call
 site should have to decide rather than inherit a silent `None`. Seven
@@ -64,21 +84,69 @@ existing test call sites pass `None` explicitly.
 **Migration.** `CREATE TABLE IF NOT EXISTS` no-ops on an existing `jobs.db`
 and will not add columns, so the column is bolted on with a guarded
 idempotent `ALTER`, reusing #219's duplicate-column tolerance: the
-check-then-ALTER is not atomic, and a process that loses the race gets
-exactly the post-condition it wanted rather than a startup failure.
+check-then-ALTER is not atomic, and a process that loses the race gets exactly
+the post-condition it wanted rather than a startup failure. Factored as
+`ensure_added_columns(conn, &ADDED_COLUMNS)`, mirroring the shape `query-audit`
+already arrived at, so the next column on `job_runs` is a list entry rather
+than a fourth copy of the block.
 
-**Exposure.** `submission_id` is surfaced on `GET /jobs/runs` and
-`GET /jobs/runs/:run_id` — a reverse pointer readable only by opening the
-SQLite file is not much of a recovery path for an operator.
+That tolerance is only half a story without the pragmas underneath it, which
+this change also adds: `jobs.db` set neither `busy_timeout` nor WAL, so
+SQLite's default "fail immediately" busy handler meant the *other*
+interleaving — the winner still mid-write when the loser's `ALTER` fires —
+surfaced as `database is locked`, which is not a `duplicate column name` and so
+took startup down over the same benign race. `query-audit` sets both before its
+own column reconciliation for exactly this reason. Every other `job_runs` write
+was exposed to the same default.
+
+**Uniqueness is enforced**, by a partial unique index
+(`WHERE submission_id IS NOT NULL`). Since `get_run_by_submission_id` resolves
+`ORDER BY created_at DESC LIMIT 1`, an unconstrained duplicate makes it return
+a *confidently wrong* run — no error, same shape as a correct answer, for the
+one column whose purpose is saying which run a submission produced. The
+constraint moves that from a wrong answer during an incident to a `create_run`
+failure where the mistake is made. It constrains nothing that exists today: the
+single production writer mints a fresh audit id per submission. NULLs stay
+unconstrained, so unattributed runs — every run on an unaudited server — are
+unaffected. The index is created under a new name after a `DROP IF EXISTS` of
+the old one, because `CREATE UNIQUE INDEX IF NOT EXISTS` matches on *name* and
+would otherwise silently no-op against the non-unique index earlier builds of
+this branch wrote, leaving a ledger that looks constrained and is not.
+
+**Exposure: a filter on the way in, not a field on the way out.**
+`GET /jobs/runs?submission_id=<token>` resolves the single run carrying that
+token; run payloads deliberately do not include it. A reverse pointer readable
+only by opening the SQLite file is not much of a recovery path — but neither is
+a broadcast one. `submission_id` is a `query_audit` primary key and that ledger
+is chmod 0600, while `GET /jobs/runs` returns every run to any authenticated
+session (`/jobs/*` auth is authentication, not authorization), so emitting it
+would publish one caller's audit-row id to every other caller. The filter also
+serves the operator strictly better: `list_runs` clamps to 500 with no offset,
+so on a server busy enough for the concurrent-submission ambiguity that
+motivated `job_run_id`, the run being looked for is precisely the one that has
+fallen off the window.
+
+**`jobs.db` is protected on the same terms as the audit ledger** — created
+owner-only and re-chmodded on every open, WAL sidecars included. It has to be:
+`job_runs.parameters` holds the raw parameter *values* `query_audit` refuses to
+store, and since `submission_id` the file also links each run to a protected
+audit row. Two halves of one audit record with one permission decision;
+otherwise the weaker half sets the real posture.
 
 ## Non-goals
 
 - Making `job_run_id` itself reliable. It cannot be: the run id does not exist
   until `submit` returns. The fix is a second pointer, not a better first
   one.
-- Uniqueness of `submission_id`. Nothing in `job_runs` can know whether a
-  given token is meant to be unique, so duplicates are a caller error;
-  `get_run_by_submission_id` returns the most recent match.
+- A length cap on the token. `submit` takes an unbounded `&str`, matching the
+  column's opaque-TEXT contract. The only production caller supplies a
+  server-minted audit id, and the failure a cap would prevent — a large string
+  in a TEXT column — is not in the class the unique index addresses, which is a
+  silently *wrong* lookup answer. Contrast `X-Skardi-Session-Id`, capped at 200
+  characters because it arrives from outside.
+- Periodic repair. The pass runs at startup only. Rows lost mid-run stay
+  `unknown, NULL` until the next boot; the pass is safe to call at any time
+  (its guards decline live rows), so a scheduled variant is additive.
 - Putting `session_id` on `job_runs` as well. The audit row already holds it
   and is reachable from the token, so a second copy would be denormalized
   state that can disagree with the ledger.
@@ -90,13 +158,43 @@ SQLite file is not much of a recovery path for an operator.
 **Store unit tests** (`crates/skardi/src/jobs/store.rs`): token round-trips
 and resolves in reverse; a miss returns `None`; unattributed runs keep NULL
 without colliding; a pre-column `jobs.db` migrates on open, keeps its old
-rows readable, accepts attributed writes, and ends up with the index;
+rows readable, accepts attributed writes, and ends up with the *unique* index
+and without the old non-unique one; a duplicate token fails `create_run`
+instead of shadowing a run; many unattributed runs still insert freely under
+the partial index; re-opening a ledger that carries the old index name
+converges on the constrained schema and stays re-runnable; `open` leaves the
+file and its WAL sidecars 0600 with WAL and a non-zero busy timeout set;
 duplicate-column detection is exercised against a real rusqlite error and a
 non-duplicate one so it cannot over-match.
 
+**Ledger unit tests** (`crates/query-audit/src/lib.rs`): only `unknown` job
+rows with a NULL pointer are repair candidates (a stamped job row and a
+reconciled *query* row are both excluded); a backfill restores the pointer,
+leaves `status` and `session_id` alone, is idempotent, and declines a row still
+`started`. One test pins the premise the whole pass rests on — that
+`record_job_outcome` cannot stamp a row `reconcile_orphaned` has already
+touched — so if that guard ever changes, the pass is flagged as dead code
+rather than left in place.
+
 **HTTP integration** (`crates/server/tests/jobs_audit_http.rs`): the bridge
 points both ways after a real submission; `submission_id` is NULL on an
-unaudited server; the runs API exposes it.
+unaudited server; the token resolves through `?submission_id=` and is absent
+from both the list and detail payloads; an unmatched token is an empty result
+rather than an error; the lookup finds a run that has fallen off the list
+window, and `job`/`limit` cannot narrow it away.
+
+The startup repair is driven through the same `repair_lost_job_correlations`
+the server calls, not a re-implementation: it re-links the row an auditor
+reads, is idempotent across a second boot, leaves a submission that never
+created a run alone, and cannot touch a submission still in flight.
+
+**Startup wiring** (`crates/server/tests/jobs_bridge_startup.rs`): those tests
+pin what the pass does but not that anything calls it, and a repair pass with
+no call site leaves the ledger exactly as broken as no pass at all. So this
+boots `setup_app_state` twice over the same two on-disk ledgers — planting a
+run carrying a token and an audit row that never got its stamp, then asserting
+the second boot re-linked it — and pins that a clean restart leaves a correctly
+stamped row untouched. Mutation-checked: disabling the call site fails it.
 
 The load-bearing one is `correlation_survives_a_lost_forward_stamp`: it
 submits through the executor with a token, **never** records an outcome, runs

--- a/docs/superpowers/specs/2026-08-19-jobs-bridge-design.md
+++ b/docs/superpowers/specs/2026-08-19-jobs-bridge-design.md
@@ -1,0 +1,109 @@
+# Making the job-submission correlation reconstructable
+
+**Date:** 2026-08-19
+**Scope:** `crates/skardi` (jobs store + executor), `crates/server` (jobs
+handler), docs. Stacked on the jobs-auth change, which is stacked on the
+jobs-audit change (#219). Closes the second non-goal #219 recorded.
+
+## Why now
+
+#219 added `query_audit.job_run_id` because "name + timestamp correlation is
+ambiguous under concurrent submissions of the same job." The column removes
+that ambiguity on the happy path, but not in general: it is stamped *after*
+`executor.submit` has already returned and created the run.
+
+- If `record_job_outcome` fails or times out, `finish_job_audit` logs and
+  moves on — correct, since you cannot un-submit. The row keeps
+  `status = started`, `job_run_id = NULL`.
+- If the process dies in that window, `reconcile_orphaned` rewrites the row
+  to `status = unknown`, `job_run_id = NULL`.
+
+In both cases the run exists in `job_runs` and really did execute, but the
+correlation was **permanently unrecoverable**: `job_runs` carried neither a
+session id nor an audit-row id, so nothing could rebuild it. The exact
+ambiguity `job_run_id` was introduced to eliminate came back, silently — and the
+surviving row was the least informative one, since `unknown` means "may have
+run after a crash" for a query row but "definitely submitted, linkage lost"
+for a job row.
+
+This is structurally weaker than the pipeline case, where a lost outcome
+stamp costs only the result, not the identity of the thing that ran.
+
+## What
+
+`job_runs` gains a nullable `submission_id`: an **opaque correlation token
+supplied by the submitter, stored verbatim and never interpreted by the jobs
+subsystem**. The server writes its audit-row id there; a caller with no
+ledger passes `None`.
+
+The framing matters for layering. The core `skardi` crate has no notion of
+the server's query-audit ledger and does not acquire one here — it stores a
+token whose meaning lives entirely with whoever supplied it. What it does
+provide is the lookup that makes the token useful:
+`JobStore::get_run_by_submission_id`.
+
+**Written in the same INSERT that creates the run**, not stamped afterwards.
+That is the whole point: the reverse pointer is durable the moment the run
+exists, so it cannot be lost to the same window that loses the forward one.
+The two halves are asymmetric on purpose —
+
+| direction | column | when written | reliability |
+| --- | --- | --- | --- |
+| audit row → run | `query_audit.job_run_id` | after `submit` returns | best-effort |
+| run → audit row | `job_runs.submission_id` | with the run's INSERT | durable |
+
+Read as one bridge with a fast half and a reliable half: `job_run_id` for the
+common lookup, `submission_id` when it is NULL. Both directions are indexed
+(`job_run_id`'s partial index came with #219; `submission_id` gets its own here).
+
+**`submit` takes the token as a required argument** rather than an optional
+one behind a defaulted overload. It is an attribution seam, so a new call
+site should have to decide rather than inherit a silent `None`. Seven
+existing test call sites pass `None` explicitly.
+
+**Migration.** `CREATE TABLE IF NOT EXISTS` no-ops on an existing `jobs.db`
+and will not add columns, so the column is bolted on with a guarded
+idempotent `ALTER`, reusing #219's duplicate-column tolerance: the
+check-then-ALTER is not atomic, and a process that loses the race gets
+exactly the post-condition it wanted rather than a startup failure.
+
+**Exposure.** `submission_id` is surfaced on `GET /jobs/runs` and
+`GET /jobs/runs/:run_id` — a reverse pointer readable only by opening the
+SQLite file is not much of a recovery path for an operator.
+
+## Non-goals
+
+- Making `job_run_id` itself reliable. It cannot be: the run id does not exist
+  until `submit` returns. The fix is a second pointer, not a better first
+  one.
+- Uniqueness of `submission_id`. Nothing in `job_runs` can know whether a
+  given token is meant to be unique, so duplicates are a caller error;
+  `get_run_by_submission_id` returns the most recent match.
+- Putting `session_id` on `job_runs` as well. The audit row already holds it
+  and is reachable from the token, so a second copy would be denormalized
+  state that can disagree with the ledger.
+- `job_runs.parameters` storing raw parameter values — still the open
+  threat-model question from #219 and #217.
+
+## Testing
+
+**Store unit tests** (`crates/skardi/src/jobs/store.rs`): token round-trips
+and resolves in reverse; a miss returns `None`; unattributed runs keep NULL
+without colliding; a pre-column `jobs.db` migrates on open, keeps its old
+rows readable, accepts attributed writes, and ends up with the index;
+duplicate-column detection is exercised against a real rusqlite error and a
+non-duplicate one so it cannot over-match.
+
+**HTTP integration** (`crates/server/tests/jobs_audit_http.rs`): the bridge
+points both ways after a real submission; `submission_id` is NULL on an
+unaudited server; the runs API exposes it.
+
+The load-bearing one is `correlation_survives_a_lost_forward_stamp`: it
+submits through the executor with a token, **never** records an outcome, runs
+`reconcile_orphaned` to reproduce the crash, asserts the audit row really is
+`unknown` with `job_run_id = NULL`, and then recovers the run from the token
+alone. Driven at the executor seam rather than over HTTP precisely because
+the handler would race to write the forward stamp this test needs absent.
+
+Mutation-checked: passing `None` instead of the audit id in the handler fails
+the bridge tests.


### PR DESCRIPTION
> **Stacked on #221**, which has landed. Rebased onto `main`; this branch carries its own 2 commits (the change, then the review fixes).

Closes the second non-goal #219 recorded rather than fixed, raised in [review](https://github.com/SkardiLabs/skardi/pull/219#discussion_r3802536385).

## Why

#219 added `query_audit.job_run_id` because "name + timestamp correlation is ambiguous under concurrent submissions of the same job." True — but the column only removes that ambiguity on the happy path, because the stamp is written **after** `executor.submit` has already returned and created the run:

- `record_job_outcome` fails or times out → `finish_job_audit` logs and moves on (correct — you can't un-submit). Row keeps `status = started`, `job_run_id = NULL`.
- process dies in that window → `reconcile_orphaned` rewrites it to `status = unknown`, `job_run_id = NULL`.

In both cases the run exists in `job_runs` and really did execute, but the correlation was **permanently unrecoverable** — `job_runs` carried neither a session id nor an audit-row id, so there was nothing to rebuild from. The ambiguity `job_run_id` exists to eliminate came back silently, and the surviving row was the *least* informative one: `unknown` means "may have run after a crash" for a query row, but "definitely submitted, linkage lost" for a job row — a different fact wearing the same label.

Structurally weaker than the pipeline case, where a lost outcome stamp costs the result, not the identity of the thing that ran.

## What

`job_runs` gains a nullable `submission_id`: **an opaque correlation token supplied by the submitter, stored verbatim, never interpreted by the jobs subsystem.**

That framing is the layering answer. The core `skardi` crate has no notion of the server's query-audit ledger and does not acquire one here — it stores a token whose meaning lives entirely with whoever supplied it. What it *does* add is the lookup that makes the token useful: `JobStore::get_run_by_submission_id`.

**Written in the same INSERT that creates the run**, not stamped afterwards. That is the whole point — the reverse pointer is durable the moment the run exists, so it cannot be lost to the same window that loses the forward one. The two halves are asymmetric on purpose:

| direction | column | when written | reliability |
| --- | --- | --- | --- |
| audit row → run | `query_audit.job_run_id` | after `submit` returns | best-effort |
| run → audit row | `job_runs.submission_id` | with the run's INSERT | **durable** |

Read the pair as one bridge with a fast half and a reliable half: `job_run_id` for the common lookup, `submission_id` when it is NULL. Both directions are indexed (`job_run_id`'s partial index came with #219; `submission_id` gets its own here).

**`submit` takes the token as a required argument**, not an optional one behind a defaulted overload. It's an attribution seam, so a new call site should have to decide rather than inherit a silent `None`. Seven existing test call sites pass `None` explicitly.

**Migration** reuses #219's pattern: `CREATE TABLE IF NOT EXISTS` no-ops on an existing `jobs.db` and won't add columns, so a guarded idempotent `ALTER` bolts it on — and a process that loses the check-then-act race gets exactly the post-condition it wanted instead of a startup failure.

**Repaired into the ledger at startup, not left to an operator.** A durable pointer only makes the correlation *recoverable* — on its own nothing recovers it, and `record_job_outcome` guards on `status = 'started'`, so once `reconcile_orphaned` has run no later well-behaved write can stamp the row. `setup_app_state` holds both ledgers, so after each has reconciled its own orphans it passes over job rows left `unknown` with `job_run_id IS NULL` and re-links each through `get_run_by_submission_id`. `status` stays `unknown` — the outcome was never observed, only the linkage is recovered. Idempotent, cannot overwrite a correct pointer, cannot touch a row still `started`, logs rather than fails startup.

**Exposure: a filter on the way in, not a field on the way out.** `GET /jobs/runs?submission_id=<token>` resolves the single matching run; run payloads deliberately omit it. A pointer readable only by opening the SQLite file is no recovery path — but neither is a broadcast one: `submission_id` is a `query_audit` primary key, that ledger is chmod 0600, and `GET /jobs/runs` returns every run to any authenticated session (#221 added authentication, not authorization). The filter also serves the operator strictly better, since `list_runs` clamps to 500 with no offset and the run wanted during an incident is exactly the one off the window.

**Uniqueness is enforced** by a partial unique index. `get_run_by_submission_id` resolves `ORDER BY created_at DESC LIMIT 1`, so an unconstrained duplicate returned a *confidently wrong* run — no error, same shape as a right answer. Constrains nothing today (one writer, fresh audit id per submission); NULLs stay free.

**`jobs.db` gets the audit ledger's file posture** — owner-only create, chmod on every open, WAL sidecars included. `job_runs.parameters` holds the raw values `query_audit` refuses to store, and the reverse pointer now links the file to a protected row; two halves of one audit record cannot have two permission decisions.

**WAL + `busy_timeout`**, which is what makes the migration's duplicate-column tolerance complete rather than half: without them the *other* interleaving returns `database is locked`, which is not tolerated and took startup down over the same benign race.

## Tests

**Store units** (5): token round-trips and resolves in reverse; a miss returns `None`; unattributed runs keep NULL without colliding; a pre-column `jobs.db` migrates on open, keeps its old rows readable, accepts attributed writes, and ends up with the index; duplicate-column detection exercised against a real rusqlite error *and* a non-duplicate one so it can't over-match.

**HTTP integration** (4): the bridge points both ways after a real submission; `submission_id` is NULL on an unaudited server; the runs API exposes it.

The load-bearing one is **`correlation_survives_a_lost_forward_stamp`** — it submits with a token, **never** records an outcome, runs `reconcile_orphaned` to reproduce the crash, asserts the audit row really is `unknown` with `job_run_id = NULL`, then recovers the run from the token alone. Driven at the executor seam rather than over HTTP precisely because the handler would race to write the forward stamp the test needs absent.

Mutation-checked: passing `None` instead of the audit id in the handler fails the bridge tests; disabling the startup repair call site fails `jobs_bridge_startup.rs`. Full workspace: **1517 passed, 0 failed**.\n\n### Review round (9dfd447)\n\nAll ten findings from the review are addressed — see the inline replies. Three changed shipped behaviour: the startup repair pass, the token becoming a filter rather than a response field, and `jobs.db` permissions. One sub-point pushed back on with reasoning (a length cap on the token) and recorded as a non-goal.\n\n`pipeline_audit_http::unknown_pipeline_request_is_logged` fails intermittently under full-workspace load and passes in isolation — pre-existing on `main`, in a file this PR does not touch.

## Non-goals

- Making `job_run_id` itself reliable. It can't be — the run id doesn't exist until `submit` returns. The fix is a second pointer, not a better first one.
- A length cap on the token. `submit` takes an unbounded `&str`, matching the column's opaque-TEXT contract; the only production caller supplies a server-minted audit id, and a large string in a TEXT column is not the class of failure the unique index addresses.
- Periodic repair. The pass runs at startup only; its guards make a scheduled variant additive.
- Putting `session_id` on `job_runs` too. The audit row holds it and is reachable from the token, so a second copy would be denormalized state that can disagree with the ledger.
- `job_runs.parameters` storing raw parameter values — still the open threat-model question from #219 and #217.

Design notes in `docs/superpowers/specs/2026-08-19-jobs-bridge-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

