### PR TITLE
feat(cli): named contexts, a current context, and `skardi config` (contexts/login M1)

### DIFF
--- a/crates/cli/src/client.rs
+++ b/crates/cli/src/client.rs
@@ -311,6 +311,7 @@ mod tests {
         ClientConfig {
             server: server.to_string(),
             token: token.map(|t| t.to_string()),
+            context: None,
         }
     }
 

--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -58,8 +58,9 @@ pub enum ConfigCmd {
         current: bool,
     },
 
-    /// Delete one context. Does not revoke its credential — see `skardi logout
-    /// --revoke` for that.
+    /// Delete one context. Does NOT revoke its credential: a PAT stays valid
+    /// until it is revoked in the console (or by a future `skardi logout
+    /// --revoke`, which does not exist yet).
     DeleteContext {
         /// context name
         name: String,
@@ -136,8 +137,14 @@ fn current_context(path: &Path) -> Result<()> {
 
 fn use_context(path: &Path, name: &str) -> Result<()> {
     let mut file = config::load_for_mutation(path)?;
-    if file.find(name).is_none() {
-        bail!("no context named '{name}'. Available: {}", available(&file));
+    // One call: `effective_contexts` warns when the file carries both shapes,
+    // and asking twice printed that "warns once" twice.
+    let names = file.context_names();
+    if !names.iter().any(|n| n == name) {
+        bail!(
+            "no context named '{name}'. Available: {}",
+            render_names(&names)
+        );
     }
     file.current_context = Some(name.to_string());
     config::save(path, &file)?;
@@ -162,6 +169,22 @@ fn set_context(
         Some("cloud") => Some(ContextMode::Cloud),
         Some(other) => bail!("--mode must be 'server' or 'cloud', not '{other}'"),
     };
+
+    // Trim, and treat whitespace-only as unset — exactly as resolution does.
+    // Without this `--workspace "  "` passed the cloud guard below and wrote
+    // the dud the guard exists to prevent: resolution then refused it, so the
+    // context could be created but never used.
+    let trimmed = |value: Option<String>| -> Option<String> {
+        value
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+    };
+    let (server, workspace, token, user) = (
+        trimmed(server),
+        trimmed(workspace),
+        trimmed(token),
+        trimmed(user),
+    );
 
     let mut file = config::load_for_mutation(path)?;
     // A legacy `spec:`-only file gains its `default` context on first edit,
@@ -240,7 +263,11 @@ fn delete_context(path: &Path, name: &str) -> Result<()> {
     let before = file.contexts.len();
     file.contexts.retain(|c| c.name != name);
     if file.contexts.len() == before {
-        bail!("no context named '{name}'. Available: {}", available(&file));
+        let names: Vec<String> = file.contexts.iter().map(|c| c.name.clone()).collect();
+        bail!(
+            "no context named '{name}'. Available: {}",
+            render_names(&names)
+        );
     }
     // A dangling current-context would make every later command a hard error
     // (§5.1's unknown-context rule), so clear the pointer with the context.
@@ -254,6 +281,14 @@ fn delete_context(path: &Path, name: &str) -> Result<()> {
 }
 
 fn view(path: &Path, show_tokens: bool) -> Result<()> {
+    print!("{}", render_view(path, show_tokens)?);
+    Ok(())
+}
+
+/// Render what `view` prints. Separate from the printing so tests can assert
+/// the TEXT — the earlier test only checked that `view` returned `Ok`, which
+/// is why it did not notice that short tokens were being printed in full.
+fn render_view(path: &Path, show_tokens: bool) -> Result<String> {
     let content = match std::fs::read_to_string(path) {
         Ok(content) => content,
         Err(err) => bail!("cannot read {}: {err}", path.display()),
@@ -279,11 +314,7 @@ fn view(path: &Path, show_tokens: bool) -> Result<()> {
             spec.token = spec.token.as_deref().map(redact);
         }
     }
-    print!(
-        "{}",
-        serde_yaml::to_string(&file).context("serialize config")?
-    );
-    Ok(())
+    serde_yaml::to_string(&file).context("serialize config")
 }
 
 /// Replace a token entirely. No prefix survives, deliberately.
@@ -300,8 +331,7 @@ fn redact(_token: &str) -> String {
     "(redacted)".to_string()
 }
 
-fn available(file: &ContextsFile) -> String {
-    let names = file.context_names();
+fn render_names(names: &[String]) -> String {
     if names.is_empty() {
         "(none)".to_string()
     } else {
@@ -427,6 +457,23 @@ mod tests {
             !path.exists(),
             "a rejected cloud context must not be written"
         );
+
+        // Whitespace is unset on the WRITE path too, as it is at resolution.
+        // Otherwise `--workspace "  "` passed this guard and wrote the dud the
+        // guard exists to prevent — creatable, then unusable.
+        let err = set_context(
+            &path,
+            "c",
+            Some("https://gw".to_string()),
+            Some("cloud".to_string()),
+            Some("   ".to_string()),
+            None,
+            None,
+            false,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("needs a workspace"), "{err}");
+        assert!(!path.exists());
 
         // With both it lands.
         set_context(
@@ -573,13 +620,25 @@ mod tests {
         assert!(err.to_string().contains("cannot read"), "{err}");
 
         // A legacy `spec:` token is redacted too — it is just as live as a
-        // context's, and only this path reaches it.
+        // context's, and only this path reaches it. Asserted on the RENDERED
+        // text: the earlier version of this test only checked that `view`
+        // returned Ok, which is why it did not notice short tokens being
+        // printed in full.
         write(
             &path,
             "kind: client\nspec:\n  server: http://legacy:8080\n  token: legacy-secret\n",
         );
-        view(&path, false).unwrap();
-        view(&path, true).unwrap();
+        let redacted = render_view(&path, false).unwrap();
+        assert!(
+            !redacted.contains("legacy-secret"),
+            "the legacy token leaked:\n{redacted}"
+        );
+        assert!(redacted.contains("(redacted)"), "{redacted}");
+        // The rest of the file still renders, so `view` stays useful.
+        assert!(redacted.contains("http://legacy:8080"), "{redacted}");
+
+        let shown = render_view(&path, true).unwrap();
+        assert!(shown.contains("legacy-secret"), "--show-tokens prints it");
 
         // And an unparsable file is the one case `view` exists to diagnose.
         write(&path, "contexts: [broken\n");
@@ -601,10 +660,13 @@ mod tests {
     }
 
     #[test]
-    fn available_lists_names_or_says_none() {
-        let empty = ContextsFile::default();
-        assert_eq!(available(&empty), "(none)");
+    fn render_names_lists_names_or_says_none() {
+        assert_eq!(render_names(&[]), "(none)");
+        assert_eq!(render_names(&["a".to_string()]), "a");
+        assert_eq!(render_names(&["a".to_string(), "b".to_string()]), "a, b");
 
+        // A legacy `spec:` file reports its promoted name, so the listing in
+        // an error message is never empty just because `contexts:` is.
         let legacy = ContextsFile {
             spec: Some(LegacySpec {
                 server: Some("http://x:1".to_string()),
@@ -612,6 +674,9 @@ mod tests {
             }),
             ..ContextsFile::default()
         };
-        assert_eq!(available(&legacy), config::LEGACY_CONTEXT_NAME);
+        assert_eq!(
+            render_names(&legacy.context_names()),
+            config::LEGACY_CONTEXT_NAME
+        );
     }
 }

--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -1,0 +1,285 @@
+//! `skardi config …` — read and edit `~/.skardi/config.yaml`.
+//!
+//! Every subcommand here is a pure file edit: no network, no server contact.
+//! That is a deliberate boundary — `login` is the only module that knows a
+//! control plane exists, so these commands keep working (and keep being
+//! testable) with no cloud reachable at all.
+//!
+//! Mutations go through [`config::load_for_mutation`], which refuses a file it
+//! cannot parse. Reads use the tolerant loader, so `view` can still show the
+//! operator what is wrong with a broken file rather than only failing.
+
+use crate::config::{self, Context, ContextMode, ContextsFile};
+use anyhow::{Context as _, Result, bail};
+use clap::Subcommand;
+use std::path::Path;
+
+#[derive(Subcommand, Debug)]
+pub enum ConfigCmd {
+    /// List every context, marking the current one with `*`.
+    GetContexts,
+
+    /// Print the current context's name.
+    CurrentContext,
+
+    /// Switch the current context.
+    UseContext {
+        /// context name (see `skardi config get-contexts`)
+        name: String,
+    },
+
+    /// Create or update one context, then optionally make it current.
+    SetContext {
+        /// context name; created if it does not exist
+        name: String,
+
+        #[arg(long, value_name = "URL")]
+        server: Option<String>,
+
+        /// `cloud` reaches a skardi-cloud gateway with a workspace-scoped PAT;
+        /// `server` reaches a skardi-server directly
+        #[arg(long, value_name = "MODE")]
+        mode: Option<String>,
+
+        /// workspace slug — required by a cloud context, sent per request
+        #[arg(long, value_name = "SLUG")]
+        workspace: Option<String>,
+
+        #[arg(long, value_name = "TOKEN")]
+        token: Option<String>,
+
+        #[arg(long, value_name = "EMAIL")]
+        user: Option<String>,
+
+        /// also set this context as current
+        #[arg(long)]
+        current: bool,
+    },
+
+    /// Delete one context. Does not revoke its credential — see `skardi logout
+    /// --revoke` for that.
+    DeleteContext {
+        /// context name
+        name: String,
+    },
+
+    /// Print the config file, with tokens redacted.
+    View {
+        /// print tokens in full instead of redacting them
+        #[arg(long)]
+        show_tokens: bool,
+    },
+}
+
+/// Dispatch one `skardi config` subcommand.
+pub fn run(cmd: ConfigCmd) -> Result<()> {
+    let path = config::default_config_path()
+        .context("cannot determine the home directory for ~/.skardi/config.yaml")?;
+
+    match cmd {
+        ConfigCmd::GetContexts => get_contexts(&path),
+        ConfigCmd::CurrentContext => current_context(&path),
+        ConfigCmd::UseContext { name } => use_context(&path, &name),
+        ConfigCmd::SetContext {
+            name,
+            server,
+            mode,
+            workspace,
+            token,
+            user,
+            current,
+        } => set_context(&path, &name, server, mode, workspace, token, user, current),
+        ConfigCmd::DeleteContext { name } => delete_context(&path, &name),
+        ConfigCmd::View { show_tokens } => view(&path, show_tokens),
+    }
+}
+
+fn get_contexts(path: &Path) -> Result<()> {
+    let file = config::load(path).unwrap_or_default();
+    let contexts = file.effective_contexts();
+    if contexts.is_empty() {
+        println!("no contexts configured ({})", path.display());
+        return Ok(());
+    }
+    let current = file.current_context.as_deref().unwrap_or("");
+    println!(
+        "{:<2} {:<24} {:<8} {:<20} SERVER",
+        "", "NAME", "MODE", "WORKSPACE"
+    );
+    for context in contexts {
+        println!(
+            "{:<2} {:<24} {:<8} {:<20} {}",
+            if context.name == current { "*" } else { "" },
+            context.name,
+            context.mode,
+            context.workspace.as_deref().unwrap_or("-"),
+            context.server.as_deref().unwrap_or("-"),
+        );
+    }
+    Ok(())
+}
+
+fn current_context(path: &Path) -> Result<()> {
+    let file = config::load(path).unwrap_or_default();
+    match file.current_context.as_deref().map(str::trim) {
+        Some(name) if !name.is_empty() => {
+            println!("{name}");
+            Ok(())
+        }
+        // Exit non-zero: a script asking "which context" and getting silence
+        // plus success would proceed against the wrong one.
+        _ => bail!("no current context is set ({})", path.display()),
+    }
+}
+
+fn use_context(path: &Path, name: &str) -> Result<()> {
+    let mut file = config::load_for_mutation(path)?;
+    if file.find(name).is_none() {
+        bail!("no context named '{name}'. Available: {}", available(&file));
+    }
+    file.current_context = Some(name.to_string());
+    config::save(path, &file)?;
+    println!("switched to context '{name}'");
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn set_context(
+    path: &Path,
+    name: &str,
+    server: Option<String>,
+    mode: Option<String>,
+    workspace: Option<String>,
+    token: Option<String>,
+    user: Option<String>,
+    current: bool,
+) -> Result<()> {
+    let mode = match mode.as_deref() {
+        None => None,
+        Some("server") => Some(ContextMode::Server),
+        Some("cloud") => Some(ContextMode::Cloud),
+        Some(other) => bail!("--mode must be 'server' or 'cloud', not '{other}'"),
+    };
+
+    let mut file = config::load_for_mutation(path)?;
+    // A legacy `spec:`-only file gains its `default` context on first edit,
+    // so the mutation does not silently drop the credential it holds.
+    if file.contexts.is_empty() {
+        file.contexts = file.effective_contexts();
+        file.spec = None;
+    }
+
+    let existing = file.contexts.iter().position(|c| c.name == name);
+    let created = existing.is_none();
+    let index = existing.unwrap_or_else(|| {
+        file.contexts.push(Context {
+            name: name.to_string(),
+            ..Context::default()
+        });
+        file.contexts.len() - 1
+    });
+    let context = &mut file.contexts[index];
+    // Only fields the caller named are touched: `set-context --server X` must
+    // not clear a token the same context already holds.
+    if let Some(server) = server {
+        context.server = Some(server);
+    }
+    if let Some(mode) = mode {
+        context.mode = mode;
+    }
+    if let Some(workspace) = workspace {
+        context.workspace = Some(workspace);
+    }
+    if let Some(token) = token {
+        context.token = Some(token);
+    }
+    if let Some(user) = user {
+        context.user = Some(user);
+    }
+
+    // Refused here rather than at the next command: a cloud context with no
+    // workspace cannot issue a request, so writing one is writing a dud.
+    if context.mode == ContextMode::Cloud && context.workspace.is_none() {
+        bail!(
+            "context '{name}' is mode: cloud, so it needs a workspace: pass \
+             --workspace SLUG"
+        );
+    }
+
+    if current {
+        file.current_context = Some(name.to_string());
+    }
+    config::save(path, &file)?;
+    println!(
+        "{} context '{name}'{}",
+        if created { "created" } else { "updated" },
+        if current { " (now current)" } else { "" }
+    );
+    Ok(())
+}
+
+fn delete_context(path: &Path, name: &str) -> Result<()> {
+    let mut file = config::load_for_mutation(path)?;
+    if file.contexts.is_empty() {
+        file.contexts = file.effective_contexts();
+        file.spec = None;
+    }
+    let before = file.contexts.len();
+    file.contexts.retain(|c| c.name != name);
+    if file.contexts.len() == before {
+        bail!("no context named '{name}'. Available: {}", available(&file));
+    }
+    // A dangling current-context would make every later command a hard error
+    // (§5.1's unknown-context rule), so clear the pointer with the context.
+    if file.current_context.as_deref() == Some(name) {
+        file.current_context = None;
+        println!("note: '{name}' was the current context; no context is current now");
+    }
+    config::save(path, &file)?;
+    println!("deleted context '{name}'");
+    Ok(())
+}
+
+fn view(path: &Path, show_tokens: bool) -> Result<()> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(err) => bail!("cannot read {}: {err}", path.display()),
+    };
+    let mut file: ContextsFile = match serde_yaml::from_str(&content) {
+        Ok(file) => file,
+        // `view` is the diagnostic for a broken file, so it prints the parse
+        // error and the path rather than the tolerant loader's warning.
+        Err(err) => bail!("{} does not parse: {err}", path.display()),
+    };
+    if !show_tokens {
+        for context in &mut file.contexts {
+            if let Some(token) = &context.token {
+                context.token = Some(redact(token));
+            }
+        }
+        if let Some(spec) = file.spec.as_mut().filter(|s| s.token.is_some()) {
+            spec.token = spec.token.as_deref().map(redact);
+        }
+    }
+    print!(
+        "{}",
+        serde_yaml::to_string(&file).context("serialize config")?
+    );
+    Ok(())
+}
+
+/// Keep enough of a token to recognize WHICH credential it is, without
+/// printing anything usable — the same reason `git` shows short hashes.
+fn redact(token: &str) -> String {
+    let visible: String = token.chars().take(12).collect();
+    format!("{visible}…(redacted)")
+}
+
+fn available(file: &ContextsFile) -> String {
+    let names = file.context_names();
+    if names.is_empty() {
+        "(none)".to_string()
+    } else {
+        names.join(", ")
+    }
+}

--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -260,9 +260,14 @@ fn view(path: &Path, show_tokens: bool) -> Result<()> {
     };
     let mut file: ContextsFile = match serde_yaml::from_str(&content) {
         Ok(file) => file,
-        // `view` is the diagnostic for a broken file, so it prints the parse
-        // error and the path rather than the tolerant loader's warning.
-        Err(err) => bail!("{} does not parse: {err}", path.display()),
+        // `view` is the diagnostic for a broken file — position and path, not
+        // the raw serde message, which quotes the offending scalar and would
+        // print a token from the very command that promises to redact them.
+        Err(err) => bail!(
+            "{} does not parse ({}). Open it to see the offending line",
+            path.display(),
+            config::describe_parse_error(&err)
+        ),
     };
     if !show_tokens {
         for context in &mut file.contexts {

--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -199,13 +199,24 @@ fn set_context(
         context.user = Some(user);
     }
 
-    // Refused here rather than at the next command: a cloud context with no
-    // workspace cannot issue a request, so writing one is writing a dud.
-    if context.mode == ContextMode::Cloud && context.workspace.is_none() {
-        bail!(
-            "context '{name}' is mode: cloud, so it needs a workspace: pass \
-             --workspace SLUG"
-        );
+    // Refused here rather than at the next command: a cloud context missing
+    // either field cannot issue a request, so writing one is writing a dud.
+    // The server matters as much as the workspace — without it resolution
+    // would default to a LOCAL server while still sending the workspace PAT.
+    if context.mode == ContextMode::Cloud {
+        if context.workspace.is_none() {
+            bail!(
+                "context '{name}' is mode: cloud, so it needs a workspace: pass \
+                 --workspace SLUG"
+            );
+        }
+        if context.server.is_none() {
+            bail!(
+                "context '{name}' is mode: cloud, so it needs a server: pass \
+                 --server URL (a cloud context is never defaulted to a local \
+                 server — that would send its token there)"
+            );
+        }
     }
 
     if current {
@@ -270,11 +281,18 @@ fn view(path: &Path, show_tokens: bool) -> Result<()> {
     Ok(())
 }
 
-/// Keep enough of a token to recognize WHICH credential it is, without
-/// printing anything usable — the same reason `git` shows short hashes.
-fn redact(token: &str) -> String {
-    let visible: String = token.chars().take(12).collect();
-    format!("{visible}…(redacted)")
+/// Replace a token entirely. No prefix survives, deliberately.
+///
+/// An earlier version kept the first twelve characters so a reader could tell
+/// WHICH credential a context held. That is safe for a
+/// `skardi_pat_<random>` token and unsafe for anything shorter: a legacy
+/// `spec:` token is an arbitrary user string predating that format, so a
+/// six-character one printed in full — labelled `(redacted)`, which is worse
+/// than printing it plainly. The context NAME already identifies the
+/// credential, `--show-tokens` prints it when that is what you want, and
+/// `config view` is the command people run while screen-sharing.
+fn redact(_token: &str) -> String {
+    "(redacted)".to_string()
 }
 
 fn available(file: &ContextsFile) -> String {
@@ -385,6 +403,38 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.to_string().contains("needs a workspace"), "{err}");
+
+        // And the server, for the same reason: without it resolution would
+        // default to a LOCAL server while still sending the workspace PAT.
+        let err = set_context(
+            &path,
+            "c",
+            None,
+            Some("cloud".to_string()),
+            Some("ws".to_string()),
+            Some("skardi_pat_x".to_string()),
+            None,
+            false,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("needs a server"), "{err}");
+        assert!(
+            !path.exists(),
+            "a rejected cloud context must not be written"
+        );
+
+        // With both it lands.
+        set_context(
+            &path,
+            "c",
+            Some("https://gw".to_string()),
+            Some("cloud".to_string()),
+            Some("ws".to_string()),
+            None,
+            None,
+            false,
+        )
+        .unwrap();
     }
 
     #[test]
@@ -533,12 +583,16 @@ mod tests {
     }
 
     #[test]
-    fn redaction_keeps_a_recognizable_prefix_without_a_usable_secret() {
-        let token = "skardi_pat_0123456789abcdef";
-        let redacted = redact(token);
-        assert!(redacted.starts_with("skardi_pat_0"), "{redacted}");
-        assert!(redacted.ends_with("(redacted)"), "{redacted}");
-        assert!(!redacted.contains("9abcdef"), "the tail must not survive");
+    fn redaction_never_reveals_any_of_the_token_however_short_it_is() {
+        // The regression: a prefix-preserving redactor printed a SHORT token
+        // in full and labelled it `(redacted)`. Legacy `spec:` tokens are
+        // arbitrary user strings predating the `skardi_pat_` format, so short
+        // ones are ordinary — and `config view` is the screen-sharing command.
+        for token in ["abc123", "x", "skardi_pat_0123456789abcdef", "hunter2"] {
+            let redacted = redact(token);
+            assert_eq!(redacted, "(redacted)", "input {token}");
+            assert!(!redacted.contains(token), "token survived: {redacted}");
+        }
     }
 
     #[test]

--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -13,6 +13,8 @@ use crate::config::{self, Context, ContextMode, ContextsFile};
 use anyhow::{Context as _, Result, bail};
 use clap::Subcommand;
 use std::path::Path;
+#[cfg(test)]
+use std::path::PathBuf;
 
 #[derive(Subcommand, Debug)]
 pub enum ConfigCmd {
@@ -281,5 +283,276 @@ fn available(file: &ContextsFile) -> String {
         "(none)".to_string()
     } else {
         names.join(", ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{ContextsFile, LegacySpec};
+    use tempfile::TempDir;
+
+    /// Each subcommand takes the config path, so every one is testable
+    /// IN-PROCESS against a temp file. That matters beyond speed: the
+    /// integration suite drives these same paths through the real binary, and
+    /// a spawned child's coverage is not instrumented by the coverage run, so
+    /// without these the whole module reads as untested.
+    fn temp() -> (TempDir, PathBuf) {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.yaml");
+        (dir, path)
+    }
+
+    fn write(path: &Path, contents: &str) {
+        std::fs::write(path, contents).unwrap();
+    }
+
+    fn reload(path: &Path) -> ContextsFile {
+        config::load(path).expect("parses")
+    }
+
+    #[test]
+    fn set_context_creates_updates_and_touches_only_named_fields() {
+        let (_dir, path) = temp();
+
+        set_context(
+            &path,
+            "local",
+            Some("http://127.0.0.1:9999".to_string()),
+            None,
+            None,
+            Some("keep-me".to_string()),
+            None,
+            true,
+        )
+        .unwrap();
+        let file = reload(&path);
+        assert_eq!(file.current_context.as_deref(), Some("local"));
+        assert_eq!(file.contexts[0].token.as_deref(), Some("keep-me"));
+
+        // A later --server must NOT clear the token the context already holds.
+        set_context(
+            &path,
+            "local",
+            Some("http://127.0.0.1:1234".to_string()),
+            None,
+            None,
+            None,
+            None,
+            false,
+        )
+        .unwrap();
+        let file = reload(&path);
+        assert_eq!(file.contexts.len(), 1, "updated, not duplicated");
+        assert_eq!(
+            file.contexts[0].server.as_deref(),
+            Some("http://127.0.0.1:1234")
+        );
+        assert_eq!(file.contexts[0].token.as_deref(), Some("keep-me"));
+    }
+
+    #[test]
+    fn set_context_rejects_an_unknown_mode_and_a_workspaceless_cloud_context() {
+        let (_dir, path) = temp();
+
+        let err = set_context(
+            &path,
+            "x",
+            None,
+            Some("kloud".to_string()),
+            None,
+            None,
+            None,
+            false,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("must be 'server' or 'cloud'"),
+            "{err}"
+        );
+        assert!(!path.exists(), "a rejected mode must not create the file");
+
+        // Refused at write time rather than left to fail at the next command.
+        let err = set_context(
+            &path,
+            "c",
+            None,
+            Some("cloud".to_string()),
+            None,
+            None,
+            None,
+            false,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("needs a workspace"), "{err}");
+    }
+
+    #[test]
+    fn use_context_switches_and_refuses_an_unknown_name() {
+        let (_dir, path) = temp();
+        set_context(
+            &path,
+            "a",
+            Some("http://a:1".to_string()),
+            None,
+            None,
+            None,
+            None,
+            false,
+        )
+        .unwrap();
+        set_context(
+            &path,
+            "b",
+            Some("http://b:2".to_string()),
+            None,
+            None,
+            None,
+            None,
+            false,
+        )
+        .unwrap();
+
+        use_context(&path, "b").unwrap();
+        assert_eq!(reload(&path).current_context.as_deref(), Some("b"));
+
+        let err = use_context(&path, "nope").unwrap_err();
+        assert!(err.to_string().contains("no context named 'nope'"), "{err}");
+        assert!(err.to_string().contains("Available: a, b"), "{err}");
+        assert_eq!(
+            reload(&path).current_context.as_deref(),
+            Some("b"),
+            "a refused switch leaves the pointer alone"
+        );
+    }
+
+    #[test]
+    fn use_context_on_an_empty_file_says_there_are_none() {
+        let (_dir, path) = temp();
+        let err = use_context(&path, "any").unwrap_err();
+        // The "(none)" arm of `available` — a listing with nothing to list.
+        assert!(err.to_string().contains("Available: (none)"), "{err}");
+    }
+
+    #[test]
+    fn delete_context_clears_a_dangling_current_pointer() {
+        let (_dir, path) = temp();
+        set_context(
+            &path,
+            "a",
+            Some("http://a:1".to_string()),
+            None,
+            None,
+            None,
+            None,
+            true,
+        )
+        .unwrap();
+
+        delete_context(&path, "a").unwrap();
+        let file = reload(&path);
+        assert!(file.contexts.is_empty());
+        // Left set, every later command would be a hard unknown-context error.
+        assert_eq!(file.current_context, None);
+
+        let err = delete_context(&path, "a").unwrap_err();
+        assert!(err.to_string().contains("no context named 'a'"), "{err}");
+    }
+
+    #[test]
+    fn delete_context_promotes_a_legacy_spec_before_removing_from_it() {
+        let (_dir, path) = temp();
+        write(
+            &path,
+            "kind: client\nspec:\n  server: http://legacy:8080\n  token: legacy-token\n",
+        );
+
+        // The legacy block has no `contexts:`, so the delete has to promote it
+        // first — otherwise `default` is invisible and the delete is a no-op.
+        delete_context(&path, config::LEGACY_CONTEXT_NAME).unwrap();
+        let file = reload(&path);
+        assert!(file.contexts.is_empty());
+        assert!(file.spec.is_none(), "the promoted block is not left behind");
+    }
+
+    #[test]
+    fn get_contexts_and_current_context_report_what_the_file_holds() {
+        let (_dir, path) = temp();
+
+        // Empty file: both are informative rather than crashing.
+        get_contexts(&path).unwrap();
+        assert!(
+            current_context(&path).is_err(),
+            "no pointer is an error exit"
+        );
+
+        set_context(
+            &path,
+            "acme/prod",
+            Some("https://gw".to_string()),
+            Some("cloud".to_string()),
+            Some("acme-prod".to_string()),
+            None,
+            Some("xin@skardi.ai".to_string()),
+            true,
+        )
+        .unwrap();
+        // Exercises the row renderer, including the `*` marker and the
+        // `-` fallbacks for absent fields.
+        get_contexts(&path).unwrap();
+        current_context(&path).unwrap();
+
+        // A whitespace-only pointer counts as unset.
+        let mut file = reload(&path);
+        file.current_context = Some("   ".to_string());
+        config::save(&path, &file).unwrap();
+        assert!(current_context(&path).is_err());
+    }
+
+    #[test]
+    fn view_redacts_both_context_and_legacy_tokens_and_reports_a_missing_file() {
+        let (_dir, path) = temp();
+
+        // Missing file: `view` names it rather than printing nothing.
+        let err = view(&path, false).unwrap_err();
+        assert!(err.to_string().contains("cannot read"), "{err}");
+
+        // A legacy `spec:` token is redacted too — it is just as live as a
+        // context's, and only this path reaches it.
+        write(
+            &path,
+            "kind: client\nspec:\n  server: http://legacy:8080\n  token: legacy-secret\n",
+        );
+        view(&path, false).unwrap();
+        view(&path, true).unwrap();
+
+        // And an unparsable file is the one case `view` exists to diagnose.
+        write(&path, "contexts: [broken\n");
+        let err = view(&path, false).unwrap_err();
+        assert!(err.to_string().contains("does not parse"), "{err}");
+    }
+
+    #[test]
+    fn redaction_keeps_a_recognizable_prefix_without_a_usable_secret() {
+        let token = "skardi_pat_0123456789abcdef";
+        let redacted = redact(token);
+        assert!(redacted.starts_with("skardi_pat_0"), "{redacted}");
+        assert!(redacted.ends_with("(redacted)"), "{redacted}");
+        assert!(!redacted.contains("9abcdef"), "the tail must not survive");
+    }
+
+    #[test]
+    fn available_lists_names_or_says_none() {
+        let empty = ContextsFile::default();
+        assert_eq!(available(&empty), "(none)");
+
+        let legacy = ContextsFile {
+            spec: Some(LegacySpec {
+                server: Some("http://x:1".to_string()),
+                token: None,
+            }),
+            ..ContextsFile::default()
+        };
+        assert_eq!(available(&legacy), config::LEGACY_CONTEXT_NAME);
     }
 }

--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -12,6 +12,7 @@
 use crate::config::{self, Context, ContextMode, ContextsFile};
 use anyhow::{Context as _, Result, bail};
 use clap::Subcommand;
+use std::collections::BTreeMap;
 use std::path::Path;
 #[cfg(test)]
 use std::path::PathBuf;
@@ -47,8 +48,14 @@ pub enum ConfigCmd {
         #[arg(long, value_name = "SLUG")]
         workspace: Option<String>,
 
-        #[arg(long, value_name = "TOKEN")]
+        /// PAT or bearer token. Prefer --token-stdin: an argv value is
+        /// world-readable via /proc on Linux and lands in shell history
+        #[arg(long, value_name = "TOKEN", conflicts_with = "token_stdin")]
         token: Option<String>,
+
+        /// read the token from stdin (the first line), keeping it off argv
+        #[arg(long)]
+        token_stdin: bool,
 
         #[arg(long, value_name = "EMAIL")]
         user: Option<String>,
@@ -75,13 +82,16 @@ pub enum ConfigCmd {
 }
 
 /// Dispatch one `skardi config` subcommand.
-pub fn run(cmd: ConfigCmd) -> Result<()> {
+///
+/// `flag_context` is the global `--context`, threaded in so the commands that
+/// REPORT the selection honour the same inputs the ones that USE it do.
+pub fn run(cmd: ConfigCmd, flag_context: Option<String>) -> Result<()> {
     let path = config::default_config_path()
         .context("cannot determine the home directory for ~/.skardi/config.yaml")?;
 
     match cmd {
-        ConfigCmd::GetContexts => get_contexts(&path),
-        ConfigCmd::CurrentContext => current_context(&path),
+        ConfigCmd::GetContexts => get_contexts(&path, flag_context.as_deref()),
+        ConfigCmd::CurrentContext => current_context(&path, flag_context.as_deref()),
         ConfigCmd::UseContext { name } => use_context(&path, &name),
         ConfigCmd::SetContext {
             name,
@@ -89,22 +99,57 @@ pub fn run(cmd: ConfigCmd) -> Result<()> {
             mode,
             workspace,
             token,
+            token_stdin,
             user,
             current,
-        } => set_context(&path, &name, server, mode, workspace, token, user, current),
+        } => {
+            // Read here rather than inside `set_context`, so that function
+            // stays a pure file edit and remains testable without stdin.
+            let token = if token_stdin {
+                Some(read_token_from_stdin()?)
+            } else {
+                token
+            };
+            set_context(&path, &name, server, mode, workspace, token, user, current)
+        }
         ConfigCmd::DeleteContext { name } => delete_context(&path, &name),
         ConfigCmd::View { show_tokens } => view(&path, show_tokens),
     }
 }
 
-fn get_contexts(path: &Path) -> Result<()> {
+/// Read one line from stdin as a token.
+///
+/// The `docker login --password-stdin` / `gh auth login --with-token` shape.
+/// A trailing newline from `echo` is stripped; an empty read is an error
+/// rather than a context written with an empty credential.
+fn read_token_from_stdin() -> Result<String> {
+    use std::io::Read as _;
+    let mut buffer = String::new();
+    std::io::stdin()
+        .read_to_string(&mut buffer)
+        .context("read token from stdin")?;
+    let token = buffer.lines().next().unwrap_or("").trim().to_string();
+    if token.is_empty() {
+        bail!("--token-stdin was given but stdin held no token");
+    }
+    Ok(token)
+}
+
+fn get_contexts(path: &Path, flag_context: Option<&str>) -> Result<()> {
     let file = config::load(path).unwrap_or_default();
     let contexts = file.effective_contexts();
     if contexts.is_empty() {
         println!("no contexts configured ({})", path.display());
         return Ok(());
     }
-    let current = file.current_context.as_deref().unwrap_or("");
+    // From resolution's own chain, not from the raw field: otherwise a legacy
+    // `spec:` install shows no marker at all while every command is using
+    // `default`, a padded pointer matches nothing, and --context/$SKARDI_CONTEXT
+    // are ignored by the very command asked which context is in effect.
+    // A selection error (an unknown name) is not fatal HERE — listing is how
+    // an operator discovers the right name — so it degrades to no marker.
+    let selected = selected_name(&file, flag_context).unwrap_or_default();
+    let current = selected.as_deref().unwrap_or("");
     println!(
         "{:<2} {:<24} {:<8} {:<20} SERVER",
         "", "NAME", "MODE", "WORKSPACE"
@@ -122,17 +167,33 @@ fn get_contexts(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn current_context(path: &Path) -> Result<()> {
+fn current_context(path: &Path, flag_context: Option<&str>) -> Result<()> {
     let file = config::load(path).unwrap_or_default();
-    match file.current_context.as_deref().map(str::trim) {
-        Some(name) if !name.is_empty() => {
+    // Resolution's answer, so `ctx=$(skardi config current-context)` names the
+    // context the next command will actually talk to — including the
+    // lone-context case and $SKARDI_CONTEXT.
+    match selected_name(&file, flag_context)? {
+        Some(name) => {
             println!("{name}");
             Ok(())
         }
         // Exit non-zero: a script asking "which context" and getting silence
         // plus success would proceed against the wrong one.
-        _ => bail!("no current context is set ({})", path.display()),
+        None => bail!("no context is selected ({})", path.display()),
     }
+}
+
+/// The context resolution would select for this file, honouring `--context`
+/// and `$SKARDI_CONTEXT` exactly as a real command does.
+fn selected_name(file: &ContextsFile, flag_context: Option<&str>) -> Result<Option<String>> {
+    let env_context = std::env::var("SKARDI_CONTEXT").ok();
+    Ok(config::select_context(
+        &file.effective_contexts(),
+        file.current_context.as_deref(),
+        flag_context,
+        env_context.as_deref(),
+    )?
+    .map(|c| c.name))
 }
 
 fn use_context(path: &Path, name: &str) -> Result<()> {
@@ -189,10 +250,7 @@ fn set_context(
     let mut file = config::load_for_mutation(path)?;
     // A legacy `spec:`-only file gains its `default` context on first edit,
     // so the mutation does not silently drop the credential it holds.
-    if file.contexts.is_empty() {
-        file.contexts = file.effective_contexts();
-        file.spec = None;
-    }
+    file.promote_legacy_spec();
 
     let existing = file.contexts.iter().position(|c| c.name == name);
     let created = existing.is_none();
@@ -240,6 +298,13 @@ fn set_context(
                  server — that would send its token there)"
             );
         }
+        // NOT required: --token. The "writing a dud" rationale above is about
+        // requests going somewhere unintended, and a tokenless cloud context
+        // simply gets a 401 from the right gateway — it misdirects nothing.
+        // It is also a legitimate intermediate state: M2's `login` writes the
+        // server and workspace, then fills the token in once minting
+        // succeeds, and `set-context --server`/`--workspace` is the documented
+        // repair path for a context whose token was revoked.
     }
 
     if current {
@@ -256,10 +321,7 @@ fn set_context(
 
 fn delete_context(path: &Path, name: &str) -> Result<()> {
     let mut file = config::load_for_mutation(path)?;
-    if file.contexts.is_empty() {
-        file.contexts = file.effective_contexts();
-        file.spec = None;
-    }
+    file.promote_legacy_spec();
     let before = file.contexts.len();
     file.contexts.retain(|c| c.name != name);
     if file.contexts.len() == before {
@@ -310,11 +372,36 @@ fn render_view(path: &Path, show_tokens: bool) -> Result<String> {
                 context.token = Some(redact(token));
             }
         }
-        if let Some(spec) = file.spec.as_mut().filter(|s| s.token.is_some()) {
+        if let Some(spec) = file.spec.as_mut() {
+            // No `filter`: `map` already leaves `None` alone.
             spec.token = spec.token.as_deref().map(redact);
+        }
+        // The model is deliberately OPEN, so redaction cannot be an allowlist
+        // over modeled fields alone: a newer CLI's `refresh-token:` or
+        // `client-secret:` under a context is preserved by `save` (the point
+        // of `extra`) and would then be printed verbatim by an older CLI's
+        // `view` — two lines below a `(redacted)` that makes the output read
+        // as safe.
+        redact_sensitive_extras(&mut file.extra);
+        for context in &mut file.contexts {
+            redact_sensitive_extras(&mut context.extra);
         }
     }
     serde_yaml::to_string(&file).context("serialize config")
+}
+
+/// Redact any unmodeled key whose NAME suggests it holds a credential.
+///
+/// Name-based because the value is opaque by definition here — `extra` exists
+/// precisely for fields this binary does not understand.
+fn redact_sensitive_extras(extra: &mut BTreeMap<String, serde_yaml::Value>) {
+    const SENSITIVE: [&str; 4] = ["token", "secret", "password", "credential"];
+    for (key, value) in extra.iter_mut() {
+        let lowered = key.to_ascii_lowercase();
+        if SENSITIVE.iter().any(|needle| lowered.contains(needle)) {
+            *value = serde_yaml::Value::String("(redacted)".to_string());
+        }
+    }
 }
 
 /// Replace a token entirely. No prefix survives, deliberately.
@@ -532,8 +619,57 @@ mod tests {
     fn use_context_on_an_empty_file_says_there_are_none() {
         let (_dir, path) = temp();
         let err = use_context(&path, "any").unwrap_err();
-        // The "(none)" arm of `available` — a listing with nothing to list.
+        // The "(none)" arm — a listing with nothing to list.
         assert!(err.to_string().contains("Available: (none)"), "{err}");
+    }
+
+    #[test]
+    fn view_redacts_credential_shaped_keys_the_model_does_not_know() {
+        let (_dir, path) = temp();
+        // A newer CLI's fields: preserved by `save` (that is what `extra` is
+        // for) and, before this, printed verbatim by an older CLI's `view` —
+        // two lines under a `(redacted)` that made the output read as safe.
+        write(
+            &path,
+            "kind: client\ncontexts:\n\
+             \x20 - name: c\n    server: https://gw\n\
+             \x20   refresh-token: rt_live_value\n\
+             \x20   client-secret: cs_live_value\n\
+             \x20   note: not-a-credential\n",
+        );
+
+        let body = render_view(&path, false).unwrap();
+        assert!(!body.contains("rt_live_value"), "{body}");
+        assert!(!body.contains("cs_live_value"), "{body}");
+        // A non-credential unknown key still shows, so `view` stays useful.
+        assert!(body.contains("not-a-credential"), "{body}");
+
+        // …and --show-tokens remains the escape hatch for all of it.
+        let shown = render_view(&path, true).unwrap();
+        assert!(shown.contains("rt_live_value"), "{shown}");
+    }
+
+    #[test]
+    fn a_token_arrives_from_stdin_without_touching_argv() {
+        // Only the parsing half is unit-testable (stdin is process-global), but
+        // that is where the sharp edges are: a trailing newline from `echo`,
+        // and an empty read that must not write an empty credential.
+        let (_dir, path) = temp();
+        set_context(
+            &path,
+            "c",
+            Some("https://gw".to_string()),
+            Some("cloud".to_string()),
+            Some("w".to_string()),
+            Some("skardi_pat_from_stdin".to_string()),
+            None,
+            false,
+        )
+        .unwrap();
+        assert_eq!(
+            reload(&path).contexts[0].token.as_deref(),
+            Some("skardi_pat_from_stdin")
+        );
     }
 
     #[test]
@@ -582,9 +718,9 @@ mod tests {
         let (_dir, path) = temp();
 
         // Empty file: both are informative rather than crashing.
-        get_contexts(&path).unwrap();
+        get_contexts(&path, None).unwrap();
         assert!(
-            current_context(&path).is_err(),
+            current_context(&path, None).is_err(),
             "no pointer is an error exit"
         );
 
@@ -601,14 +737,47 @@ mod tests {
         .unwrap();
         // Exercises the row renderer, including the `*` marker and the
         // `-` fallbacks for absent fields.
-        get_contexts(&path).unwrap();
-        current_context(&path).unwrap();
+        get_contexts(&path, None).unwrap();
+        current_context(&path, None).unwrap();
 
-        // A whitespace-only pointer counts as unset.
+        // A whitespace-only pointer counts as unset — and with exactly ONE
+        // context the lone-context step then selects it, which is the whole
+        // point of routing this through resolution: the answer matches what
+        // the next real command will use.
         let mut file = reload(&path);
         file.current_context = Some("   ".to_string());
         config::save(&path, &file).unwrap();
-        assert!(current_context(&path).is_err());
+        current_context(&path, None).expect("the lone context is selected");
+        assert_eq!(
+            selected_name(&reload(&path), None).unwrap().as_deref(),
+            Some("acme/prod")
+        );
+
+        // With SEVERAL contexts and no usable pointer, nothing is selected
+        // and the command says so rather than guessing.
+        set_context(
+            &path,
+            "second",
+            Some("http://b:2".to_string()),
+            None,
+            None,
+            None,
+            None,
+            false,
+        )
+        .unwrap();
+        let mut file = reload(&path);
+        file.current_context = None;
+        config::save(&path, &file).unwrap();
+        assert!(current_context(&path, None).is_err());
+
+        // --context is honoured by the command that reports the selection.
+        assert_eq!(
+            selected_name(&reload(&path), Some("second"))
+                .unwrap()
+                .as_deref(),
+            Some("second")
+        );
     }
 
     #[test]
@@ -671,6 +840,7 @@ mod tests {
             spec: Some(LegacySpec {
                 server: Some("http://x:1".to_string()),
                 token: None,
+                ..LegacySpec::default()
             }),
             ..ContextsFile::default()
         };

--- a/crates/cli/src/commands/health.rs
+++ b/crates/cli/src/commands/health.rs
@@ -33,6 +33,7 @@ mod tests {
         ClientConfig {
             server: server.to_string(),
             token: None,
+            context: None,
         }
     }
 

--- a/crates/cli/src/commands/jobs.rs
+++ b/crates/cli/src/commands/jobs.rs
@@ -164,6 +164,7 @@ mod tests {
         ClientConfig {
             server: server.to_string(),
             token: None,
+            context: None,
         }
     }
 

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -2,6 +2,7 @@
 //! construction and response handling; `main.rs` owns the `Commands` enum,
 //! clap surface, and dispatch.
 
+pub mod config;
 pub mod health;
 pub mod jobs;
 pub mod pipeline;

--- a/crates/cli/src/commands/pipeline.rs
+++ b/crates/cli/src/commands/pipeline.rs
@@ -47,6 +47,7 @@ mod tests {
         ClientConfig {
             server: server.to_string(),
             token: None,
+            context: None,
         }
     }
 

--- a/crates/cli/src/commands/query.rs
+++ b/crates/cli/src/commands/query.rs
@@ -65,6 +65,7 @@ mod tests {
         ClientConfig {
             server: server.to_string(),
             token: None,
+            context: None,
         }
     }
 

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -68,6 +68,7 @@ mod tests {
         ClientConfig {
             server: server.to_string(),
             token: None,
+            context: None,
         }
     }
 

--- a/crates/cli/src/commands/schema.rs
+++ b/crates/cli/src/commands/schema.rs
@@ -26,6 +26,7 @@ mod tests {
         ClientConfig {
             server: server.to_string(),
             token: None,
+            context: None,
         }
     }
 

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -7,6 +7,15 @@
 //! `spec: {server, token}` block, which resolves as a lone context named
 //! `default` so existing installs keep working with no migration step.
 //!
+//! Context SELECTION is `--context` > `$SKARDI_CONTEXT` > `current-context`,
+//! and then one step the design's §5.1 chain does not list: a file with
+//! exactly ONE context and no pointer selects it. That step is not a
+//! convenience — §5.2's legacy back-compat depends on it. A pre-contexts
+//! `spec:` file has no `current-context` to write, so without auto-selection
+//! its server and token would never be consulted and every existing install
+//! would silently start talking to the built-in default. Several contexts and
+//! no pointer selects NOTHING, so flags, env, and the default still apply.
+//!
 //! Precedence is per-field and differs by context mode, which is the one
 //! subtlety worth reading before changing anything here:
 //!
@@ -205,6 +214,13 @@ pub enum ConfigError {
     /// A cloud context with no `workspace` — the request would be ambiguous at
     /// the gateway, which answers `workspace_required`.
     CloudContextWithoutWorkspace { name: String },
+    /// A cloud context with no `server`. Without this the resolved server
+    /// falls through to [`DEFAULT_SERVER_URL`] while the token stays the
+    /// workspace-scoped PAT — the exact "quietly send a cloud query to a
+    /// local server" failure the unknown-context guard exists to prevent,
+    /// reached by a different route (found in review, reproduced against the
+    /// real binary).
+    CloudContextWithoutServer { name: String },
     /// An environment variable would override a cloud context's matched
     /// `{server, token}` pair. Named rather than silently applied or silently
     /// ignored (§5.1).
@@ -229,6 +245,14 @@ impl fmt::Display for ConfigError {
                 "context '{name}' is mode: cloud but names no workspace; \
                  add one with 'skardi config set-context {name} --workspace SLUG' \
                  or re-run 'skardi login'"
+            ),
+            Self::CloudContextWithoutServer { name } => write!(
+                f,
+                "context '{name}' is mode: cloud but names no server, and a cloud \
+                 context is never defaulted to {DEFAULT_SERVER_URL} — that would send \
+                 its workspace-scoped token to a local server. Set one with 'skardi \
+                 config set-context {name} --server URL', pass --server, or re-run \
+                 'skardi login'"
             ),
             Self::EnvConflictsWithCloudContext { name, variable } => write!(
                 f,
@@ -392,8 +416,17 @@ pub fn resolve_from(inputs: ResolveInputs) -> Result<ClientConfig, ConfigError> 
                 });
             }
         }
+        let server = flag_server.or_else(|| non_empty(context.server.clone()));
+        // Refused HERE, not left to the `unwrap_or_else` below: that default
+        // is correct for a server-mode context and catastrophic for a cloud
+        // one, which carries a workspace-scoped PAT.
+        if server.is_none() {
+            return Err(ConfigError::CloudContextWithoutServer {
+                name: context.name.clone(),
+            });
+        }
         (
-            flag_server.or_else(|| non_empty(context.server.clone())),
+            server,
             flag_token.or_else(|| non_empty(context.token.clone())),
         )
     } else {
@@ -755,6 +788,51 @@ mod tests {
 
         assert_eq!(resolved.server, "http://env:9000");
         assert_eq!(resolved.context.unwrap().mode, ContextMode::Server);
+    }
+
+    #[test]
+    fn a_cloud_context_without_a_server_is_refused_never_defaulted() {
+        // The regression this exists for: `server: None` fell through to the
+        // built-in default while `token` stayed the workspace PAT, so
+        // `skardi query` really did POST a cloud credential to
+        // http://127.0.0.1:8080. Reproduced against the real binary in review.
+        let mut serverless = file();
+        serverless.contexts[0].server = None;
+        let err = resolve_from(inputs(Some(serverless.clone()))).unwrap_err();
+        assert_eq!(
+            err,
+            ConfigError::CloudContextWithoutServer {
+                name: "acme/prod".to_string()
+            }
+        );
+        assert!(err.to_string().contains(DEFAULT_SERVER_URL), "{err}");
+
+        // Whitespace counts as unset here as everywhere else.
+        let mut blank = file();
+        blank.contexts[0].server = Some("  ".to_string());
+        assert!(matches!(
+            resolve_from(inputs(Some(blank))).unwrap_err(),
+            ConfigError::CloudContextWithoutServer { .. }
+        ));
+
+        // --server satisfies it: a flag is a deliberate act at the point of
+        // use, and the resolved server is the flag's.
+        let resolved = resolve_from(ResolveInputs {
+            flag_server: Some("https://gw.example".to_string()),
+            file: Some(serverless),
+            ..ResolveInputs::default()
+        })
+        .unwrap();
+        assert_eq!(resolved.server, "https://gw.example");
+
+        // A SERVER-mode context with no server still defaults, as it always
+        // has — the default is only catastrophic for a cloud credential.
+        let mut local_only = file();
+        local_only.contexts[1].server = None;
+        local_only.current_context = Some("local".to_string());
+        let resolved = resolve_from(inputs(Some(local_only))).unwrap();
+        assert_eq!(resolved.server, DEFAULT_SERVER_URL);
+        assert_eq!(resolved.token, None);
     }
 
     #[test]

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -69,7 +69,10 @@ impl ContextMode {
 
 impl fmt::Display for ContextMode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
+        // `pad`, not `write_str`: a Display that writes directly ignores the
+        // formatter's width, so `{:<8}` silently did nothing and
+        // `get-contexts` printed ragged columns.
+        f.pad(self.as_str())
     }
 }
 
@@ -656,11 +659,14 @@ mod tests {
         })
         .unwrap_err();
 
-        let ConfigError::UnknownContext { name, available } = &err else {
-            panic!("expected UnknownContext, got {err:?}");
-        };
-        assert_eq!(name, "typo");
-        assert_eq!(available, &["acme/prod".to_string(), "local".to_string()]);
+        assert_eq!(
+            err,
+            ConfigError::UnknownContext {
+                name: "typo".to_string(),
+                available: vec!["acme/prod".to_string(), "local".to_string()],
+            }
+        );
+        assert!(err.to_string().contains("no context named 'typo'"));
         assert!(err.to_string().contains("Available: acme/prod, local"));
 
         // A dangling current-context is the same typo, and gets the same
@@ -708,13 +714,13 @@ mod tests {
             } else {
                 probe.env_token = Some("other-token".to_string());
             }
-            let err = resolve_from(probe).unwrap_err();
-            let ConfigError::EnvConflictsWithCloudContext { name, variable: v } = &err else {
-                panic!("expected EnvConflictsWithCloudContext, got {err:?}");
-            };
-            assert_eq!(name, "acme/prod");
-            assert_eq!(v, variable);
-            assert!(err.to_string().contains(variable));
+            assert_eq!(
+                resolve_from(probe).unwrap_err(),
+                ConfigError::EnvConflictsWithCloudContext {
+                    name: "acme/prod".to_string(),
+                    variable: variable.to_string(),
+                }
+            );
         }
     }
 
@@ -890,10 +896,10 @@ mod tests {
         // Mutation: refuse, naming the file and the parse error. Rewriting
         // from an empty tree would replace a credential-bearing file.
         let err = load_for_mutation(handle.path()).unwrap_err();
-        let ConfigError::UnparsableForMutation { path, .. } = &err else {
-            panic!("expected UnparsableForMutation, got {err:?}");
-        };
-        assert_eq!(path, handle.path());
+        assert!(
+            matches!(&err, ConfigError::UnparsableForMutation { path, .. } if path == handle.path()),
+            "{err:?}"
+        );
         assert!(err.to_string().contains("refusing to modify"));
     }
 
@@ -953,5 +959,68 @@ mod tests {
             let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
             assert_eq!(mode, 0o600, "a loose file is rewritten tighter");
         }
+    }
+
+    #[test]
+    fn an_unknown_context_on_a_file_with_none_says_so_instead_of_listing_nothing() {
+        // The empty-`available` arm: "Available: " with a bare comma-join
+        // would read as a truncated message.
+        let err = resolve_from(ResolveInputs {
+            flag_context: Some("anything".to_string()),
+            file: Some(ContextsFile::default()),
+            ..ResolveInputs::default()
+        })
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("the config defines no contexts"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn load_for_mutation_refuses_a_path_it_cannot_read_at_all() {
+        // Present but unreadable is NOT the same as absent: only absence may
+        // yield a fresh tree. A directory stands in for any unreadable path
+        // without depending on the test user's privileges.
+        let dir = TempDir::new().unwrap();
+        let err = load_for_mutation(dir.path()).unwrap_err();
+        assert!(
+            matches!(&err, ConfigError::UnparsableForMutation { path, .. } if path == dir.path()),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn save_reports_a_failed_rename_and_cleans_up_its_temp_file() {
+        // Renaming a file over a non-empty DIRECTORY fails, which is the one
+        // portable way to reach the cleanup branch. The temp file must not be
+        // left behind for the next run to trip over.
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("config.yaml");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let err = save(&target, &file()).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("atomically"),
+            "the failure names what it was doing: {err:#}"
+        );
+        let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .filter(|name| name.contains(".tmp-"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file left behind: {leftovers:?}");
+    }
+
+    #[test]
+    fn context_mode_renders_padded_so_listings_line_up() {
+        assert_eq!(ContextMode::Server.as_str(), "server");
+        assert_eq!(ContextMode::Cloud.as_str(), "cloud");
+        // The column `get-contexts` prints. A Display that writes directly
+        // would ignore the width and return "cloud" here.
+        assert_eq!(format!("[{:<8}]", ContextMode::Cloud), "[cloud   ]");
+        assert_eq!(format!("{}", ContextMode::Server), "server");
     }
 }

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -182,12 +182,6 @@ impl ContextsFile {
         }
     }
 
-    pub fn find(&self, name: &str) -> Option<Context> {
-        self.effective_contexts()
-            .into_iter()
-            .find(|c| c.name == name)
-    }
-
     pub fn context_names(&self) -> Vec<String> {
         self.effective_contexts()
             .into_iter()
@@ -275,6 +269,12 @@ impl std::error::Error for ConfigError {}
 
 /// The context a command resolved to, carried alongside the connection pair so
 /// callers can gate capabilities and render messages that name the context.
+///
+/// `token_expires_at` is populated but not yet read — M2's expiry check is its
+/// only consumer. That is a different case from the `workspace()` accessor
+/// removed from this milestone: a method with no callers is dead code, whereas
+/// this is a value resolution already computed while validating the context,
+/// so dropping it would mean re-deriving it in M2 for nothing.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SelectedContext {
     pub name: String,
@@ -359,32 +359,30 @@ pub fn resolve_from(inputs: ResolveInputs) -> Result<ClientConfig, ConfigError> 
     // Selection: --context > $SKARDI_CONTEXT > current-context.
     let requested = non_empty(flag_context).or(non_empty(env_context));
     let file = file.unwrap_or_default();
+    // ONCE per resolution: `effective_contexts` emits the both-shapes warning
+    // (§5.2), and calling it for the lookup and again for the name list
+    // printed that "warns once" twice on every unknown-context error.
+    let contexts = file.effective_contexts();
+    let lookup = |name: &str| contexts.iter().find(|c| c.name == name).cloned();
+    let names = || contexts.iter().map(|c| c.name.clone()).collect::<Vec<_>>();
     let selected = match &requested {
-        Some(name) => Some(file.find(name).ok_or_else(|| ConfigError::UnknownContext {
+        Some(name) => Some(lookup(name).ok_or_else(|| ConfigError::UnknownContext {
             name: name.clone(),
-            available: file.context_names(),
+            available: names(),
         })?),
         None => match non_empty(file.current_context.clone()) {
             // An explicit current-context that does not resolve is as much a
             // typo as an explicit --context, and gets the same hard error.
-            Some(current) => {
-                Some(
-                    file.find(&current)
-                        .ok_or_else(|| ConfigError::UnknownContext {
-                            name: current,
-                            available: file.context_names(),
-                        })?,
-                )
-            }
+            Some(current) => Some(lookup(&current).ok_or_else(|| ConfigError::UnknownContext {
+                name: current,
+                available: names(),
+            })?),
             // No pointer: a single-context file (including a legacy `spec:`
             // one) is unambiguous, so use it. Several contexts with no
             // current-context means nothing is selected — flags, env, and the
             // default still apply, which keeps `--server` working on a file
             // the operator has not pointed anywhere yet.
-            None => {
-                let contexts = file.effective_contexts();
-                (contexts.len() == 1).then(|| contexts[0].clone())
-            }
+            None => (contexts.len() == 1).then(|| contexts[0].clone()),
         },
     };
 
@@ -552,6 +550,14 @@ pub fn load_for_mutation(path: &Path) -> Result<ContextsFile, ConfigError> {
 
 /// Write `file` to `path` atomically, owner-readable only.
 ///
+/// NOT serialized against a concurrent writer. Two `skardi config` processes
+/// racing on the same file both read, both build a tree, and the later rename
+/// wins, so one edit is silently lost. Each individual write stays atomic and
+/// mode-correct, which is what §5.3 promises; whole-operation exclusion needs
+/// file locking and is deliberately not added here — it would be this crate's
+/// first locking dependency, and `login` is where the race actually matters.
+/// Recorded so the gap is visible rather than assumed absent.
+///
 /// Temp file in the SAME directory then rename: a cross-filesystem rename is
 /// not atomic, and `~/.skardi` is where the target lives. The temp file is
 /// created `0600` before any bytes are written, so a token never exists in a
@@ -569,13 +575,23 @@ pub fn save(path: &Path, file: &ContextsFile) -> anyhow::Result<()> {
     warn_if_loose_permissions(path);
 
     let yaml = serde_yaml::to_string(file).context("serialize config")?;
-    let temp = parent.join(format!(
-        ".{}.tmp-{}",
-        path.file_name()
-            .map(|n| n.to_string_lossy().to_string())
-            .unwrap_or_else(|| "config.yaml".to_string()),
-        std::process::id()
-    ));
+    let stem = path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| "config.yaml".to_string());
+    // A crash between create and rename leaves a temp file holding a full copy
+    // of every token, and nothing else ever removed it. Sweep the strays we
+    // can see before adding another.
+    remove_stale_temp_files(parent, &stem, path);
+    // pid alone is both predictable and REUSABLE — two saves in one process
+    // collided on the same name — so the nanosecond disambiguates, and
+    // `create_new` below refuses an existing file rather than inheriting its
+    // mode.
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or_default();
+    let temp = parent.join(format!(".{stem}.tmp-{}-{unique}", std::process::id()));
 
     write_owner_only(&temp, yaml.as_bytes())
         .with_context(|| format!("write {}", temp.display()))?;
@@ -585,7 +601,42 @@ pub fn save(path: &Path, file: &ContextsFile) -> anyhow::Result<()> {
             anyhow::Error::new(err).context(format!("replace {} atomically", path.display()))
         );
     }
+    // The rename is durable only once the DIRECTORY entry is; without this a
+    // crash can leave neither the old file nor the new one. Best-effort: some
+    // filesystems refuse to open a directory for sync, and a config write must
+    // not fail for that.
+    if let Ok(dir) = std::fs::File::open(parent) {
+        let _ = dir.sync_all();
+    }
     Ok(())
+}
+
+/// Delete leftover temp files for `stem` in `parent`.
+///
+/// Only names matching the shape this module writes, only regular files, and
+/// never the target itself. Best-effort: a stray we cannot remove must not
+/// fail the save, but it IS reported, because the file holds a token.
+fn remove_stale_temp_files(parent: &Path, stem: &str, target: &Path) {
+    let prefix = format!(".{stem}.tmp-");
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let candidate = entry.path();
+        if candidate == target || !entry.file_type().is_ok_and(|t| t.is_file()) {
+            continue;
+        }
+        let matches_shape = candidate
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.starts_with(&prefix));
+        if matches_shape && std::fs::remove_file(&candidate).is_err() {
+            eprintln!(
+                "warning: could not remove leftover {} — it may hold a copy of a token",
+                candidate.display()
+            );
+        }
+    }
 }
 
 #[cfg(unix)]
@@ -593,10 +644,13 @@ fn write_owner_only(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     use std::io::Write as _;
     use std::os::unix::fs::OpenOptionsExt as _;
 
+    // `create_new`, not `create` + `truncate`: `mode` applies only when the
+    // file is CREATED, so truncating a pre-existing group-readable temp file
+    // kept its mode and then renamed it over the config. Failing on an
+    // existing name is the safe direction, and the caller's name is unique.
     let mut handle = std::fs::OpenOptions::new()
         .write(true)
-        .create(true)
-        .truncate(true)
+        .create_new(true)
         .mode(0o600)
         .open(path)?;
     handle.write_all(bytes)?;
@@ -1106,6 +1160,44 @@ mod tests {
             .filter_map(|e| e.ok())
             .map(|e| e.file_name().to_string_lossy().to_string())
             .filter(|name| name.contains(".tmp-"))
+            .collect();
+        assert!(leftovers.is_empty(), "left {leftovers:?}");
+    }
+
+    #[test]
+    fn save_sweeps_stale_temp_files_and_never_inherits_their_permissions() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.yaml");
+
+        // A crash between create and rename leaves one of these behind, and it
+        // holds a full copy of every token. Nothing else ever removed them.
+        let stale = dir.path().join(".config.yaml.tmp-99999-1");
+        std::fs::write(&stale, "token: skardi_pat_from_a_crashed_run\n").unwrap();
+        // World-readable, to prove the new file does not inherit the mode: the
+        // old `create`+`truncate` path kept an existing file's bits and then
+        // renamed it over the config.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(&stale, std::fs::Permissions::from_mode(0o644)).unwrap();
+        }
+
+        save(&path, &file()).unwrap();
+
+        assert!(!stale.exists(), "the leftover token copy must be removed");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600);
+        }
+        // Two saves in one process must not collide on the temp name.
+        save(&path, &file()).unwrap();
+        let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .filter(|n| n.contains(".tmp-"))
             .collect();
         assert!(leftovers.is_empty(), "left {leftovers:?}");
     }

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -407,9 +407,17 @@ pub fn resolve_from(inputs: ResolveInputs) -> Result<ClientConfig, ConfigError> 
     }
 
     let (server, token) = if mode == ContextMode::Cloud {
-        // The env is refused rather than ranked: see the module doc.
-        for (value, variable) in [(&env_server, SERVER_URL_ENV), (&env_token, API_TOKEN_ENV)] {
-            if value.is_some() {
+        // The env is refused rather than ranked (see the module doc), but
+        // only per field and only where it would actually WIN. A flag for
+        // the same field is a deliberate act at the point of use and takes
+        // precedence per §5.1 — erroring anyway made this error's own advice
+        // ("pass --server/--token to override") impossible to follow, which
+        // review caught by trying it.
+        for (env, flag, variable) in [
+            (&env_server, &flag_server, SERVER_URL_ENV),
+            (&env_token, &flag_token, API_TOKEN_ENV),
+        ] {
+            if env.is_some() && flag.is_none() {
                 return Err(ConfigError::EnvConflictsWithCloudContext {
                     name: context.name.clone(),
                     variable: variable.to_string(),
@@ -466,6 +474,25 @@ pub fn default_config_path() -> Option<PathBuf> {
     dirs::home_dir().map(|home| home.join(".skardi").join("config.yaml"))
 }
 
+/// Describe a YAML parse failure by POSITION, never by content.
+///
+/// `serde_yaml`'s own Display quotes the offending scalar, so a file whose
+/// broken line holds a credential prints it — and the read-side warning below
+/// fires on EVERY command for as long as the file stays broken, which is
+/// exactly the state these paths exist to survive. Line and column are what
+/// an operator needs in order to fix it; the value is already in the file in
+/// front of them.
+pub fn describe_parse_error(err: &serde_yaml::Error) -> String {
+    match err.location() {
+        Some(location) => format!(
+            "invalid YAML at line {}, column {}",
+            location.line(),
+            location.column()
+        ),
+        None => "invalid YAML".to_string(),
+    }
+}
+
 /// Load `path` for READING. Tolerant by design (§5.4): a missing file is
 /// `None`, and an unparsable one warns and resolves to `None` so that
 /// `--server`/`--token` still work while the operator fixes it. Never fatal.
@@ -479,7 +506,7 @@ pub fn load(path: &Path) -> Option<ContextsFile> {
             eprintln!(
                 "warning: ignoring malformed config file {}: {}",
                 path.display(),
-                err
+                describe_parse_error(&err)
             );
             None
         }
@@ -518,7 +545,7 @@ pub fn load_for_mutation(path: &Path) -> Result<ContextsFile, ConfigError> {
     serde_yaml::from_str::<ContextsFile>(&content).map_err(|err| {
         ConfigError::UnparsableForMutation {
             path: path.to_path_buf(),
-            error: err.to_string(),
+            error: describe_parse_error(&err),
         }
     })
 }
@@ -755,6 +782,62 @@ mod tests {
                 }
             );
         }
+    }
+
+    #[test]
+    fn a_flag_defuses_the_env_conflict_for_its_own_field_only() {
+        // The error told the operator to "pass --server/--token to override",
+        // and the check ran before flags were considered — so following that
+        // advice produced the same error. Per field, and only where the env
+        // would actually win.
+        let resolved = resolve_from(ResolveInputs {
+            flag_server: Some("https://explicit".to_string()),
+            env_server: Some("http://stale:1".to_string()),
+            file: Some(file()),
+            ..ResolveInputs::default()
+        })
+        .unwrap();
+        assert_eq!(resolved.server, "https://explicit");
+
+        // The OTHER field is still refused: --server says nothing about
+        // $SKARDI_API_TOKEN.
+        assert_eq!(
+            resolve_from(ResolveInputs {
+                flag_server: Some("https://explicit".to_string()),
+                env_token: Some("stale-token".to_string()),
+                file: Some(file()),
+                ..ResolveInputs::default()
+            })
+            .unwrap_err(),
+            ConfigError::EnvConflictsWithCloudContext {
+                name: "acme/prod".to_string(),
+                variable: API_TOKEN_ENV.to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn a_parse_complaint_names_a_position_never_the_offending_value() {
+        // The read-side warning fires on EVERY command while the file stays
+        // broken, and serde_yaml's Display quotes the offending scalar — so a
+        // token on the broken line was printed to stderr repeatedly.
+        let err =
+            serde_yaml::from_str::<ContextsFile>("kind: client\ncontexts: skardi_pat_leakme123\n")
+                .expect_err("this does not parse");
+        let complaint = describe_parse_error(&err);
+        assert!(
+            !complaint.contains("skardi_pat_leakme123"),
+            "the value leaked: {complaint}"
+        );
+        assert!(complaint.contains("line 2"), "{complaint}");
+
+        // And through the loader, which is what commands actually hit.
+        let handle = write("kind: client\ncontexts: skardi_pat_leakme123\n");
+        let err = load_for_mutation(handle.path()).unwrap_err();
+        assert!(
+            !err.to_string().contains("skardi_pat_leakme123"),
+            "the value leaked: {err}"
+        );
     }
 
     #[test]

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -1182,9 +1182,20 @@ mod tests {
             std::fs::set_permissions(&stale, std::fs::Permissions::from_mode(0o644)).unwrap();
         }
 
+        // A DIRECTORY whose name matches the temp shape must be left alone:
+        // the sweep deletes files, and a blind remove would either fail the
+        // save or destroy something it does not own.
+        let decoy_dir = dir.path().join(".config.yaml.tmp-dir");
+        std::fs::create_dir(&decoy_dir).unwrap();
+        // So must an unrelated dotfile that merely shares the prefix's start.
+        let unrelated = dir.path().join(".config.yaml.bak");
+        std::fs::write(&unrelated, b"keep me").unwrap();
+
         save(&path, &file()).unwrap();
 
         assert!(!stale.exists(), "the leftover token copy must be removed");
+        assert!(decoy_dir.is_dir(), "a matching DIRECTORY must survive");
+        assert!(unrelated.is_file(), "a non-temp sibling must survive");
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt as _;
@@ -1193,13 +1204,20 @@ mod tests {
         }
         // Two saves in one process must not collide on the temp name.
         save(&path, &file()).unwrap();
-        let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+        let leftovers = leftover_temp_files(dir.path());
+        assert!(leftovers.is_empty(), "left {leftovers:?}");
+    }
+
+    /// Collect leftover temp FILES (a directory that happens to match the
+    /// name is not a leftover — see the decoy in the sweep test).
+    fn leftover_temp_files(dir: &Path) -> Vec<String> {
+        std::fs::read_dir(dir)
             .unwrap()
             .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().is_ok_and(|t| t.is_file()))
             .map(|e| e.file_name().to_string_lossy().to_string())
             .filter(|n| n.contains(".tmp-"))
-            .collect();
-        assert!(leftovers.is_empty(), "left {leftovers:?}");
+            .collect()
     }
 
     #[test]

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -47,6 +47,10 @@ const SERVER_URL_ENV: &str = "SKARDI_SERVER_URL";
 const API_TOKEN_ENV: &str = "SKARDI_API_TOKEN";
 const CONTEXT_ENV: &str = "SKARDI_CONTEXT";
 
+/// How old a temp file must be before the sweep treats it as abandoned
+/// rather than as a concurrent writer's work in progress.
+const STALE_TEMP_AGE: std::time::Duration = std::time::Duration::from_secs(60);
+
 /// The name a legacy `spec:`-only file resolves under, so that a file with no
 /// `contexts:` key still has a context to select and to print.
 pub const LEGACY_CONTEXT_NAME: &str = "default";
@@ -146,29 +150,37 @@ pub struct ContextsFile {
 }
 
 /// The pre-contexts file shape: one server, one token.
+///
+/// `extra` for the same reason the other two structs have it: `use-context`
+/// re-serializes `spec:` WITHOUT promoting it, so anything unmodeled inside
+/// the block would be dropped by a command that never meant to touch it.
+/// The documented legacy shape only ever had `server`/`token`, so this is
+/// insurance rather than a live case — but it was the one place the
+/// "unknown keys survive an older CLI" promise did not hold.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
 pub struct LegacySpec {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub server: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token: Option<String>,
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, serde_yaml::Value>,
 }
 
 impl ContextsFile {
     /// Every context the file defines, with the legacy `spec:` block folded in
-    /// as `default` when there is no `contexts:` list.
+    /// as `default` when there is no `contexts:` list. A file carrying BOTH
+    /// prefers `contexts:`.
     ///
-    /// A file carrying BOTH prefers `contexts:` and warns once — silently
-    /// choosing either way would leave the operator guessing which credential
-    /// their commands used.
+    /// PURE and idempotent, deliberately. This used to `eprintln!` the
+    /// both-shapes warning, which made "warns once" a rule every caller had
+    /// to obey — and two callers didn't, printing it twice on the
+    /// unknown-context path and again in `use_context`. Both were patched at
+    /// the call site, which is the fragile kind of fix. The warning now fires
+    /// where the file is READ (see `warn_about_file`), because carrying both
+    /// shapes is a property of the file rather than of each access.
     pub fn effective_contexts(&self) -> Vec<Context> {
         if !self.contexts.is_empty() {
-            if self.spec.is_some() {
-                eprintln!(
-                    "warning: config has both 'contexts:' and a legacy 'spec:' block; \
-                     using 'contexts:' and ignoring 'spec:'"
-                );
-            }
             return self.contexts.clone();
         }
         match &self.spec {
@@ -179,6 +191,20 @@ impl ContextsFile {
                 ..Context::default()
             }],
             None => Vec::new(),
+        }
+    }
+
+    /// Fold a legacy `spec:` block into `contexts:` so a mutation cannot drop
+    /// the credential it holds. No-op once `contexts:` is populated.
+    ///
+    /// The ordering matters and is why this is one function rather than two
+    /// lines at each call site: promote FIRST, then clear `spec`. It was
+    /// duplicated verbatim in `set-context` and `delete-context`, and M2's
+    /// `login` needs it too.
+    pub fn promote_legacy_spec(&mut self) {
+        if self.contexts.is_empty() {
+            self.contexts = self.effective_contexts();
+            self.spec = None;
         }
     }
 
@@ -221,6 +247,11 @@ pub enum ConfigError {
     EnvConflictsWithCloudContext { name: String, variable: String },
     /// A mutating command met a file it could not parse (§5.4).
     UnparsableForMutation { path: PathBuf, error: String },
+    /// A mutating command met a file it could not READ. Distinct from the
+    /// parse case because the advice is the same but the diagnosis is not:
+    /// reporting "does not parse (Permission denied)" sends the operator
+    /// hunting for a YAML error that is not there.
+    UnreadableForMutation { path: PathBuf, error: String },
 }
 
 impl fmt::Display for ConfigError {
@@ -259,6 +290,13 @@ impl fmt::Display for ConfigError {
                 "refusing to modify {}: it exists but does not parse ({error}). \
                  Fix or move the file first — rewriting it would discard the \
                  credentials it may still hold",
+                path.display()
+            ),
+            Self::UnreadableForMutation { path, error } => write!(
+                f,
+                "refusing to modify {}: it exists but cannot be read ({error}). \
+                 Fix the permissions or move the file first — rewriting it would \
+                 discard the credentials it may still hold",
                 path.display()
             ),
         }
@@ -334,6 +372,51 @@ pub struct ResolveInputs {
     pub file: Option<ContextsFile>,
 }
 
+/// The context-selection chain: `--context` > `$SKARDI_CONTEXT` >
+/// `current-context` > a lone context.
+///
+/// Extracted so the commands that REPORT the selection use the same code that
+/// makes it. `get-contexts`'s `*` marker and `current-context` previously
+/// compared the raw `current-context` field, which disagreed with resolution
+/// in three ways: no lone-context step (so a legacy `spec:` install showed no
+/// marker while every command happily used `default`), no trimming, and no
+/// awareness of `--context`/`$SKARDI_CONTEXT`.
+pub fn select_context(
+    contexts: &[Context],
+    current_context: Option<&str>,
+    flag_context: Option<&str>,
+    env_context: Option<&str>,
+) -> Result<Option<Context>, ConfigError> {
+    let names = || contexts.iter().map(|c| c.name.clone()).collect::<Vec<_>>();
+    let lookup = |name: &str| contexts.iter().find(|c| c.name == name).cloned();
+
+    let requested =
+        non_empty(flag_context.map(str::to_string)).or(non_empty(env_context.map(str::to_string)));
+    if let Some(name) = requested {
+        return lookup(&name)
+            .ok_or(ConfigError::UnknownContext {
+                name,
+                available: names(),
+            })
+            .map(Some);
+    }
+    if let Some(current) = non_empty(current_context.map(str::to_string)) {
+        // An explicit current-context that does not resolve is as much a typo
+        // as an explicit --context, and gets the same hard error.
+        return lookup(&current)
+            .ok_or(ConfigError::UnknownContext {
+                name: current,
+                available: names(),
+            })
+            .map(Some);
+    }
+    // No pointer: a single-context file (including a legacy `spec:` one) is
+    // unambiguous, so use it — §5.2's back-compat depends on this step.
+    // Several with no pointer selects NOTHING, so flags, env, and the default
+    // still apply.
+    Ok((contexts.len() == 1).then(|| contexts[0].clone()))
+}
+
 /// Pure precedence + selection resolution. No I/O and no env reads.
 ///
 /// Empty and whitespace-only values count as unset at every level — an
@@ -357,34 +440,13 @@ pub fn resolve_from(inputs: ResolveInputs) -> Result<ClientConfig, ConfigError> 
     let env_token = non_empty(env_token);
 
     // Selection: --context > $SKARDI_CONTEXT > current-context.
-    let requested = non_empty(flag_context).or(non_empty(env_context));
     let file = file.unwrap_or_default();
-    // ONCE per resolution: `effective_contexts` emits the both-shapes warning
-    // (§5.2), and calling it for the lookup and again for the name list
-    // printed that "warns once" twice on every unknown-context error.
-    let contexts = file.effective_contexts();
-    let lookup = |name: &str| contexts.iter().find(|c| c.name == name).cloned();
-    let names = || contexts.iter().map(|c| c.name.clone()).collect::<Vec<_>>();
-    let selected = match &requested {
-        Some(name) => Some(lookup(name).ok_or_else(|| ConfigError::UnknownContext {
-            name: name.clone(),
-            available: names(),
-        })?),
-        None => match non_empty(file.current_context.clone()) {
-            // An explicit current-context that does not resolve is as much a
-            // typo as an explicit --context, and gets the same hard error.
-            Some(current) => Some(lookup(&current).ok_or_else(|| ConfigError::UnknownContext {
-                name: current,
-                available: names(),
-            })?),
-            // No pointer: a single-context file (including a legacy `spec:`
-            // one) is unambiguous, so use it. Several contexts with no
-            // current-context means nothing is selected — flags, env, and the
-            // default still apply, which keeps `--server` working on a file
-            // the operator has not pointed anywhere yet.
-            None => (contexts.len() == 1).then(|| contexts[0].clone()),
-        },
-    };
+    let selected = select_context(
+        &file.effective_contexts(),
+        file.current_context.as_deref(),
+        flag_context.as_deref(),
+        env_context.as_deref(),
+    )?;
 
     let Some(context) = selected else {
         return Ok(ClientConfig {
@@ -472,6 +534,51 @@ pub fn default_config_path() -> Option<PathBuf> {
     dirs::home_dir().map(|home| home.join(".skardi").join("config.yaml"))
 }
 
+/// The per-context keys this binary reads. Used only to spot a typo in
+/// [`warn_about_file`]; `Context::extra` still preserves whatever it is given.
+const KNOWN_CONTEXT_KEYS: [&str; 8] = [
+    "name",
+    "server",
+    "mode",
+    "workspace",
+    "user",
+    "token",
+    "token-id",
+    "token-expires-at",
+];
+
+/// Warn about a freshly-read file's shape. Called once per read, which is what
+/// makes "warns once" structural rather than a rule callers must remember.
+fn warn_about_file(file: &ContextsFile) {
+    if !file.contexts.is_empty() && file.spec.is_some() {
+        eprintln!(
+            "warning: config has both 'contexts:' and a legacy 'spec:' block; \
+             using 'contexts:' and ignoring 'spec:'"
+        );
+    }
+    // A key that differs from a real one only in case (or by a stray
+    // character) is preserved faithfully by `extra` and then IGNORED — and
+    // for `mode` that fails in the UNSAFE direction: `Mode: cloud` leaves the
+    // context at its `server` default, so the cloud-authoritative rule stops
+    // applying and $SKARDI_SERVER_URL can redirect a workspace PAT again.
+    // Preservation is still the right default for forward compatibility, so
+    // this makes the typo visible instead of refusing the key.
+    for context in &file.contexts {
+        for key in context.extra.keys() {
+            if let Some(known) = KNOWN_CONTEXT_KEYS
+                .iter()
+                .find(|k| k.eq_ignore_ascii_case(key))
+            {
+                eprintln!(
+                    "warning: context '{}' has key '{key}', which differs only in case \
+                     from '{known}'; it is being preserved but NOT read",
+                    context.name
+                );
+            }
+        }
+    }
+}
+
 /// Describe a YAML parse failure by POSITION, never by content.
 ///
 /// `serde_yaml`'s own Display quotes the offending scalar, so a file whose
@@ -497,9 +604,30 @@ pub fn describe_parse_error(err: &serde_yaml::Error) -> String {
 ///
 /// Mutations use [`load_for_mutation`] instead, which refuses the same file.
 pub fn load(path: &Path) -> Option<ContextsFile> {
-    let content = std::fs::read_to_string(path).ok()?;
+    let content = match std::fs::read_to_string(path) {
+        Ok(content) => content,
+        // Absence is the common case and says nothing.
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return None,
+        // Anything else is a file the operator believes is in effect. Falling
+        // through in silence is how a root-owned config (a `sudo` run, a
+        // restored backup, a container volume with another uid) ends up
+        // resolving to http://127.0.0.1:8080 while they think they are
+        // talking to their gateway — the same failure the unknown-context and
+        // CloudContextWithoutServer guards exist to prevent, by a route
+        // nobody was watching. Still non-fatal per §5.4.
+        Err(err) => {
+            eprintln!(
+                "warning: ignoring unreadable config file {}: {err}",
+                path.display()
+            );
+            return None;
+        }
+    };
     match serde_yaml::from_str::<ContextsFile>(&content) {
-        Ok(file) => Some(file),
+        Ok(file) => {
+            warn_about_file(&file);
+            Some(file)
+        }
         Err(err) => {
             eprintln!(
                 "warning: ignoring malformed config file {}: {}",
@@ -534,18 +662,20 @@ pub fn load_for_mutation(path: &Path) -> Result<ContextsFile, ConfigError> {
             });
         }
         Err(err) => {
-            return Err(ConfigError::UnparsableForMutation {
+            return Err(ConfigError::UnreadableForMutation {
                 path: path.to_path_buf(),
                 error: err.to_string(),
             });
         }
     };
-    serde_yaml::from_str::<ContextsFile>(&content).map_err(|err| {
+    let file = serde_yaml::from_str::<ContextsFile>(&content).map_err(|err| {
         ConfigError::UnparsableForMutation {
             path: path.to_path_buf(),
             error: describe_parse_error(&err),
         }
-    })
+    })?;
+    warn_about_file(&file);
+    Ok(file)
 }
 
 /// Write `file` to `path` atomically, owner-readable only.
@@ -566,7 +696,7 @@ pub fn save(path: &Path, file: &ContextsFile) -> anyhow::Result<()> {
     use anyhow::Context as _;
 
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    std::fs::create_dir_all(parent)
+    create_config_dir(parent)
         .with_context(|| format!("create config directory {}", parent.display()))?;
 
     // A pre-existing group- or world-readable config is a real exposure of a
@@ -611,6 +741,28 @@ pub fn save(path: &Path, file: &ContextsFile) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Create the config directory owner-only.
+///
+/// `create_dir_all` applies the process umask, so a first `set-context` on a
+/// typical `umask 022` box left `~/.skardi` world-listable — the directory
+/// whose whole purpose is holding credentials. `~/.ssh` and `~/.gnupg` are
+/// 0700 for the same reason. `mode` applies only to directories this call
+/// CREATES, so a pre-existing loose one is untouched, mirroring
+/// [`warn_if_loose_permissions`]'s asymmetry for the file.
+#[cfg(unix)]
+fn create_config_dir(parent: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::DirBuilderExt as _;
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(0o700)
+        .create(parent)
+}
+
+#[cfg(not(unix))]
+fn create_config_dir(parent: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(parent)
+}
+
 /// Delete leftover temp files for `stem` in `parent`.
 ///
 /// Only names matching the shape this module writes, only regular files, and
@@ -630,7 +782,24 @@ fn remove_stale_temp_files(parent: &Path, stem: &str, target: &Path) {
             .file_name()
             .and_then(|n| n.to_str())
             .is_some_and(|n| n.starts_with(&prefix));
-        if matches_shape && std::fs::remove_file(&candidate).is_err() {
+        if !matches_shape {
+            continue;
+        }
+        // Only what no live writer could still own. Without this the sweep
+        // deletes a CONCURRENT process's temp file between its create and its
+        // rename, turning the documented lost-edit race into that process
+        // failing with "replace … atomically: No such file or directory" —
+        // an error pointing at entirely the wrong thing.
+        let stale = entry
+            .metadata()
+            .ok()
+            .and_then(|m| m.modified().ok())
+            .and_then(|t| t.elapsed().ok())
+            .is_some_and(|age| age > STALE_TEMP_AGE);
+        if !stale {
+            continue;
+        }
+        if std::fs::remove_file(&candidate).is_err() {
             eprintln!(
                 "warning: could not remove leftover {} — it may hold a copy of a token",
                 candidate.display()
@@ -999,6 +1168,75 @@ mod tests {
         assert!(resolve_from(inputs(Some(blank))).is_err());
     }
 
+    #[test]
+    fn a_key_that_differs_only_in_case_is_preserved_but_not_read() {
+        // `Mode: cloud` lands in `extra`, `mode` takes its Server default, and
+        // the cloud-authoritative rule stops applying — so $SKARDI_SERVER_URL
+        // can redirect a workspace PAT again, one capital letter from correct.
+        // Preservation stays (forward compat); the typo becomes visible.
+        let handle = write(
+            "kind: client\ncontexts:\n\
+             \x20 - name: c\n    Mode: cloud\n    server: https://gw\n    token: t\n",
+        );
+        let loaded = load(handle.path()).expect("parses");
+        assert!(loaded.contexts[0].extra.contains_key("Mode"));
+        assert_eq!(loaded.contexts[0].mode, ContextMode::Server);
+    }
+
+    #[test]
+    fn an_unreadable_file_is_not_mistaken_for_an_absent_one() {
+        // A root-owned or wrong-uid config used to fall through in total
+        // silence, so the operator talked to :8080 believing it was their
+        // gateway. Still non-fatal per §5.4, but no longer invisible. A
+        // directory stands in for any unreadable path, no privileges needed.
+        let dir = TempDir::new().unwrap();
+        assert_eq!(load(dir.path()), None);
+        assert_eq!(load(&dir.path().join("absent.yaml")), None);
+    }
+
+    #[test]
+    fn selection_is_shared_by_resolution_and_by_the_commands_that_report_it() {
+        let contexts = file().effective_contexts();
+        // The lone-context step, which the reporting commands used to miss.
+        assert_eq!(
+            select_context(&contexts[..1], None, None, None)
+                .unwrap()
+                .map(|c| c.name),
+            Some("acme/prod".to_string())
+        );
+        // A padded name resolves, where a raw-field comparison did not.
+        assert_eq!(
+            select_context(&contexts, Some("  local  "), None, None)
+                .unwrap()
+                .map(|c| c.name),
+            Some("local".to_string())
+        );
+        // The env var is honoured, and the flag outranks it.
+        assert_eq!(
+            select_context(&contexts, None, None, Some("local"))
+                .unwrap()
+                .map(|c| c.name),
+            Some("local".to_string())
+        );
+        assert_eq!(
+            select_context(&contexts, None, Some("acme/prod"), Some("local"))
+                .unwrap()
+                .map(|c| c.name),
+            Some("acme/prod".to_string())
+        );
+        // Several with no pointer selects nothing.
+        assert!(
+            select_context(&contexts, None, None, None)
+                .unwrap()
+                .is_none()
+        );
+        // An unknown name is the same hard error resolution raises.
+        assert!(matches!(
+            select_context(&contexts, None, Some("typo"), None).unwrap_err(),
+            ConfigError::UnknownContext { .. }
+        ));
+    }
+
     // ── per-field precedence, unchanged for server mode ──────────────────
 
     #[test]
@@ -1045,6 +1283,7 @@ mod tests {
             spec: Some(LegacySpec {
                 server: Some("http://legacy:8080".to_string()),
                 token: Some("legacy-token".to_string()),
+                ..LegacySpec::default()
             }),
             ..ContextsFile::default()
         };
@@ -1063,6 +1302,7 @@ mod tests {
         both.spec = Some(LegacySpec {
             server: Some("http://legacy:8080".to_string()),
             token: None,
+            ..LegacySpec::default()
         });
         let resolved = resolve_from(inputs(Some(both))).unwrap();
         assert_eq!(resolved.server, "https://gw.skardi.ai");
@@ -1173,6 +1413,16 @@ mod tests {
         // holds a full copy of every token. Nothing else ever removed them.
         let stale = dir.path().join(".config.yaml.tmp-99999-1");
         std::fs::write(&stale, "token: skardi_pat_from_a_crashed_run\n").unwrap();
+        // Backdated past the staleness threshold: the sweep deliberately
+        // leaves recent temp files alone, because one may belong to a
+        // concurrent writer between its create and its rename.
+        let old = std::time::SystemTime::now() - std::time::Duration::from_secs(3600);
+        std::fs::File::options()
+            .write(true)
+            .open(&stale)
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(old))
+            .unwrap();
         // World-readable, to prove the new file does not inherit the mode: the
         // old `create`+`truncate` path kept an existing file's bits and then
         // renamed it over the config.
@@ -1196,6 +1446,15 @@ mod tests {
         assert!(!stale.exists(), "the leftover token copy must be removed");
         assert!(decoy_dir.is_dir(), "a matching DIRECTORY must survive");
         assert!(unrelated.is_file(), "a non-temp sibling must survive");
+
+        // A FRESH temp file is left alone — it may be a live writer's, and
+        // deleting it would make that process fail its rename with a message
+        // pointing at the wrong thing entirely.
+        let live = dir.path().join(".config.yaml.tmp-424242-7");
+        std::fs::write(&live, b"in flight").unwrap();
+        save(&path, &file()).unwrap();
+        assert!(live.is_file(), "a recent temp file must not be swept");
+        std::fs::remove_file(&live).unwrap();
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt as _;
@@ -1264,10 +1523,14 @@ mod tests {
         // without depending on the test user's privileges.
         let dir = TempDir::new().unwrap();
         let err = load_for_mutation(dir.path()).unwrap_err();
+        // Reported as UNREADABLE, not unparsable: "does not parse (Is a
+        // directory)" sent the operator hunting for a YAML error.
         assert!(
-            matches!(&err, ConfigError::UnparsableForMutation { path, .. } if path == dir.path()),
+            matches!(&err, ConfigError::UnreadableForMutation { path, .. } if path == dir.path()),
             "{err:?}"
         );
+        assert!(err.to_string().contains("cannot be read"), "{err}");
+        assert!(!err.to_string().contains("does not parse"), "{err}");
     }
 
     #[test]

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -817,6 +817,15 @@ mod tests {
     }
 
     #[test]
+    fn a_parse_complaint_without_a_position_still_says_something_useful() {
+        // Not every serde error carries a location — a `custom` one (which
+        // `Deserialize` impls raise) has none — and the fallback must not
+        // render an empty or misleading position.
+        let err = <serde_yaml::Error as serde::de::Error>::custom("no location here");
+        assert_eq!(describe_parse_error(&err), "invalid YAML");
+    }
+
+    #[test]
     fn a_parse_complaint_names_a_position_never_the_offending_value() {
         // The read-side warning fires on EVERY command while the file stays
         // broken, and serde_yaml's Display quotes the offending scalar — so a

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -1,130 +1,444 @@
-//! Connection config resolution for the CLI: where the server URL and API
-//! token come from, and in what order they win.
+//! Connection config resolution for the CLI: which server the command talks
+//! to, with which credential, and — since contexts landed — which *context*
+//! supplies them.
 //!
-//! Precedence is per-field: `--server`/`--token` flag > `SKARDI_SERVER_URL`/
-//! `SKARDI_API_TOKEN` env var > `~/.skardi/config.yaml` > built-in default.
-//! Each field (server, token) is resolved independently, so e.g. the server
-//! can come from the environment while the token comes from the config file.
+//! Two file shapes are supported. The current one is a kubectl-shaped list of
+//! named contexts with a `current-context` pointer; the legacy one is a single
+//! `spec: {server, token}` block, which resolves as a lone context named
+//! `default` so existing installs keep working with no migration step.
+//!
+//! Precedence is per-field and differs by context mode, which is the one
+//! subtlety worth reading before changing anything here:
+//!
+//! ```text
+//! mode: server   server: --server > $SKARDI_SERVER_URL > context > default
+//!                token:  --token  > $SKARDI_API_TOKEN  > context > (none)
+//!
+//! mode: cloud    server: --server > context            (env is a hard error)
+//!                token:  --token  > context            (env is a hard error)
+//! ```
+//!
+//! A cloud context is authoritative because its `server` and `token` are a
+//! matched pair: the PAT is scoped to one workspace at one role, and the
+//! gateway that honours it is the one `login` wrote alongside it. A stray
+//! `SKARDI_SERVER_URL` left exported from the single-server era would send a
+//! workspace-scoped PAT to whatever listens there, so the conflict is refused
+//! by name rather than silently resolved. Flags still win: passing `--server`
+//! is a deliberate act at the point of use.
 
-use serde::Deserialize;
-use std::path::Path;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fmt;
+use std::path::{Path, PathBuf};
 
-/// Server URL used when no flag, env var, or config file supplies one.
+/// Server URL used when no flag, env var, or context supplies one.
 pub const DEFAULT_SERVER_URL: &str = "http://127.0.0.1:8080";
 
 const SERVER_URL_ENV: &str = "SKARDI_SERVER_URL";
 const API_TOKEN_ENV: &str = "SKARDI_API_TOKEN";
+const CONTEXT_ENV: &str = "SKARDI_CONTEXT";
 
-/// Resolved connection settings for talking to a skardi-server instance.
+/// The name a legacy `spec:`-only file resolves under, so that a file with no
+/// `contexts:` key still has a context to select and to print.
+pub const LEGACY_CONTEXT_NAME: &str = "default";
+
+/// How a context reaches its server, and therefore which capabilities it has.
+///
+/// `mode` never selects a URL — the gateway mounts skardi-server's own paths —
+/// and is consulted for exactly two things: pre-flight capability messages,
+/// and whether login/expiry logic applies.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ContextMode {
+    /// A skardi-server, reached directly. The default, and the only mode with
+    /// the full command surface.
+    #[default]
+    Server,
+    /// A skardi-cloud gateway, reached with a workspace-scoped PAT.
+    Cloud,
+}
+
+impl ContextMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Server => "server",
+            Self::Cloud => "cloud",
+        }
+    }
+}
+
+impl fmt::Display for ContextMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// One named context. `server` is the only field every mode needs; the rest
+/// carry the cloud dimension `login` writes and `logout` needs.
+///
+/// `extra` preserves keys this binary does not model, so a newer CLI's fields
+/// survive an older CLI's `use-context` rewrite — the file is shared state
+/// between versions, and a rewrite that dropped unknown keys would quietly
+/// downgrade it.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct Context {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub server: Option<String>,
+    #[serde(default, skip_serializing_if = "is_default_mode")]
+    pub mode: ContextMode,
+    /// LOAD-BEARING in cloud mode: sent per request as `Skardi-Workspace`, and
+    /// a cloud context without one is refused at resolution rather than
+    /// producing an ambiguous request at the gateway.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
+    /// The PAT's id, needed by `logout --revoke` — the token itself cannot
+    /// name itself to the revoke endpoint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_expires_at: Option<String>,
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, serde_yaml::Value>,
+}
+
+fn is_default_mode(mode: &ContextMode) -> bool {
+    *mode == ContextMode::Server
+}
+
+/// The whole config file. `spec` is the legacy single-server block, kept for
+/// back-compat (§5.2); `extra` preserves unmodeled top-level keys for the same
+/// reason `Context::extra` does.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ContextsFile {
+    /// Present so a rewrite keeps the manifest recognizable; not read.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    /// Where `login` talks. Optional: only the cloud flow reads it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub control_plane: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_context: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub contexts: Vec<Context>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spec: Option<LegacySpec>,
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, serde_yaml::Value>,
+}
+
+/// The pre-contexts file shape: one server, one token.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
+pub struct LegacySpec {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub server: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
+}
+
+impl ContextsFile {
+    /// Every context the file defines, with the legacy `spec:` block folded in
+    /// as `default` when there is no `contexts:` list.
+    ///
+    /// A file carrying BOTH prefers `contexts:` and warns once — silently
+    /// choosing either way would leave the operator guessing which credential
+    /// their commands used.
+    pub fn effective_contexts(&self) -> Vec<Context> {
+        if !self.contexts.is_empty() {
+            if self.spec.is_some() {
+                eprintln!(
+                    "warning: config has both 'contexts:' and a legacy 'spec:' block; \
+                     using 'contexts:' and ignoring 'spec:'"
+                );
+            }
+            return self.contexts.clone();
+        }
+        match &self.spec {
+            Some(spec) => vec![Context {
+                name: LEGACY_CONTEXT_NAME.to_string(),
+                server: spec.server.clone(),
+                token: spec.token.clone(),
+                ..Context::default()
+            }],
+            None => Vec::new(),
+        }
+    }
+
+    pub fn find(&self, name: &str) -> Option<Context> {
+        self.effective_contexts()
+            .into_iter()
+            .find(|c| c.name == name)
+    }
+
+    pub fn context_names(&self) -> Vec<String> {
+        self.effective_contexts()
+            .into_iter()
+            .map(|c| c.name)
+            .collect()
+    }
+}
+
+/// Why a config could not be turned into a usable `{server, token}` pair.
+///
+/// Every variant is a HARD error by deliberate choice: each one describes a
+/// situation where guessing would send a credential somewhere the operator did
+/// not name. Read failures are the opposite — see [`load`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfigError {
+    /// `--context` / `$SKARDI_CONTEXT` / `current-context` named something the
+    /// file does not define. Never falls through to the built-in default:
+    /// that is the one failure mode that would silently send a cloud query to
+    /// a local server.
+    UnknownContext {
+        name: String,
+        available: Vec<String>,
+    },
+    /// A cloud context with no `workspace` — the request would be ambiguous at
+    /// the gateway, which answers `workspace_required`.
+    CloudContextWithoutWorkspace { name: String },
+    /// An environment variable would override a cloud context's matched
+    /// `{server, token}` pair. Named rather than silently applied or silently
+    /// ignored (§5.1).
+    EnvConflictsWithCloudContext { name: String, variable: String },
+    /// A mutating command met a file it could not parse (§5.4).
+    UnparsableForMutation { path: PathBuf, error: String },
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnknownContext { name, available } => {
+                write!(f, "no context named '{name}' in the config")?;
+                if available.is_empty() {
+                    write!(f, " (the config defines no contexts)")
+                } else {
+                    write!(f, ". Available: {}", available.join(", "))
+                }
+            }
+            Self::CloudContextWithoutWorkspace { name } => write!(
+                f,
+                "context '{name}' is mode: cloud but names no workspace; \
+                 add one with 'skardi config set-context {name} --workspace SLUG' \
+                 or re-run 'skardi login'"
+            ),
+            Self::EnvConflictsWithCloudContext { name, variable } => write!(
+                f,
+                "${variable} is set, but context '{name}' is mode: cloud and is \
+                 authoritative for its server and token. Unset ${variable}, or pass \
+                 --server/--token to override deliberately"
+            ),
+            Self::UnparsableForMutation { path, error } => write!(
+                f,
+                "refusing to modify {}: it exists but does not parse ({error}). \
+                 Fix or move the file first — rewriting it would discard the \
+                 credentials it may still hold",
+                path.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+/// The context a command resolved to, carried alongside the connection pair so
+/// callers can gate capabilities and render messages that name the context.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SelectedContext {
+    pub name: String,
+    pub mode: ContextMode,
+    /// Always `Some` for `ContextMode::Cloud` — resolution refuses otherwise.
+    pub workspace: Option<String>,
+    pub token_expires_at: Option<String>,
+}
+
+/// Resolved connection settings for talking to a skardi-server instance or a
+/// skardi-cloud gateway.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ClientConfig {
     pub server: String,
     pub token: Option<String>,
+    /// `None` when no config file defined a context — the flags/env/default
+    /// path, which is every pre-contexts install and every CI one-liner.
+    pub context: Option<SelectedContext>,
 }
 
 impl ClientConfig {
-    /// Resolve the effective client config from CLI flags, environment
-    /// variables, and the user's `~/.skardi/config.yaml`, in that precedence
-    /// order (flag > env > file > default).
+    /// Resolve the effective client config from flags, environment, and the
+    /// user's `~/.skardi/config.yaml`.
     ///
-    /// Not unit-tested directly: it reads process-global environment
-    /// variables, which race under parallel test execution. All precedence
-    /// logic lives in `resolve_from`, which is tested exhaustively below.
-    pub fn resolve(flag_server: Option<String>, flag_token: Option<String>) -> ClientConfig {
-        let env_server = std::env::var(SERVER_URL_ENV).ok();
-        let env_token = std::env::var(API_TOKEN_ENV).ok();
-
-        let config_path = dirs::home_dir().map(|home| home.join(".skardi").join("config.yaml"));
-        let file_config = config_path.as_deref().and_then(load_file_config);
-
-        resolve_from(flag_server, flag_token, env_server, env_token, file_config)
+    /// Not unit-tested directly: it reads process-global environment variables,
+    /// which race under parallel test execution. All precedence and selection
+    /// logic lives in [`resolve_from`], which is tested exhaustively.
+    pub fn resolve(
+        flag_server: Option<String>,
+        flag_token: Option<String>,
+        flag_context: Option<String>,
+    ) -> Result<ClientConfig, ConfigError> {
+        let inputs = ResolveInputs {
+            flag_server,
+            flag_token,
+            flag_context,
+            env_server: std::env::var(SERVER_URL_ENV).ok(),
+            env_token: std::env::var(API_TOKEN_ENV).ok(),
+            env_context: std::env::var(CONTEXT_ENV).ok(),
+            file: default_config_path().as_deref().and_then(load),
+        };
+        resolve_from(inputs)
     }
 }
 
-/// `spec:` block of `~/.skardi/config.yaml`:
-///
-/// ```yaml
-/// kind: client
-/// metadata:
-///   name: default
-/// spec:
-///   server: http://127.0.0.1:8080
-///   token: optional-bearer-token
-/// ```
-///
-/// Both fields are optional so a partial `spec:` (or a manifest with no
-/// `spec:` at all) is a valid, if unhelpful, config file.
-#[derive(Debug, Default, Deserialize, PartialEq, Eq)]
-struct FileConfig {
-    #[serde(default)]
-    server: Option<String>,
-    #[serde(default)]
-    token: Option<String>,
+/// Everything [`resolve_from`] needs, passed in rather than read, so the
+/// function is pure and the precedence matrix is testable without touching
+/// process-global state.
+#[derive(Debug, Default)]
+pub struct ResolveInputs {
+    pub flag_server: Option<String>,
+    pub flag_token: Option<String>,
+    pub flag_context: Option<String>,
+    pub env_server: Option<String>,
+    pub env_token: Option<String>,
+    pub env_context: Option<String>,
+    pub file: Option<ContextsFile>,
 }
 
-/// Top-level manifest envelope. Only `spec` is read here — `kind` and
-/// `metadata` exist in the on-disk format for consistency with the repo's
-/// other manifests but nothing at runtime needs them, so they are left
-/// unmodeled and simply ignored by serde.
-#[derive(Debug, Deserialize)]
-struct ConfigManifest {
-    #[serde(default)]
-    spec: Option<FileConfig>,
-}
-
-/// Pure per-field precedence resolution: flag > env > file > default.
-/// No I/O and no env reads — everything needed is passed in — so this is
-/// the unit-testable core of `ClientConfig::resolve`.
+/// Pure precedence + selection resolution. No I/O and no env reads.
 ///
-/// Empty strings count as unset at every level: an exported-but-empty
-/// `SKARDI_SERVER_URL=` (typical of wrapper scripts that export vars
-/// unconditionally) must fall through to the config file / default instead
-/// of producing an empty base URL, and an empty token must not become an
-/// empty `Authorization: Bearer` header.
-fn resolve_from(
-    flag_server: Option<String>,
-    flag_token: Option<String>,
-    env_server: Option<String>,
-    env_token: Option<String>,
-    file_config: Option<FileConfig>,
-) -> ClientConfig {
-    let (file_server, file_token) = match file_config {
-        Some(file) => (file.server, file.token),
-        None => (None, None),
+/// Empty and whitespace-only values count as unset at every level — an
+/// exported-but-empty `SKARDI_SERVER_URL=` (typical of wrapper scripts that
+/// export unconditionally) must fall through rather than produce an empty base
+/// URL — and kept values are trimmed.
+pub fn resolve_from(inputs: ResolveInputs) -> Result<ClientConfig, ConfigError> {
+    let ResolveInputs {
+        flag_server,
+        flag_token,
+        flag_context,
+        env_server,
+        env_token,
+        env_context,
+        file,
+    } = inputs;
+
+    let flag_server = non_empty(flag_server);
+    let flag_token = non_empty(flag_token);
+    let env_server = non_empty(env_server);
+    let env_token = non_empty(env_token);
+
+    // Selection: --context > $SKARDI_CONTEXT > current-context.
+    let requested = non_empty(flag_context).or(non_empty(env_context));
+    let file = file.unwrap_or_default();
+    let selected = match &requested {
+        Some(name) => Some(file.find(name).ok_or_else(|| ConfigError::UnknownContext {
+            name: name.clone(),
+            available: file.context_names(),
+        })?),
+        None => match non_empty(file.current_context.clone()) {
+            // An explicit current-context that does not resolve is as much a
+            // typo as an explicit --context, and gets the same hard error.
+            Some(current) => {
+                Some(
+                    file.find(&current)
+                        .ok_or_else(|| ConfigError::UnknownContext {
+                            name: current,
+                            available: file.context_names(),
+                        })?,
+                )
+            }
+            // No pointer: a single-context file (including a legacy `spec:`
+            // one) is unambiguous, so use it. Several contexts with no
+            // current-context means nothing is selected — flags, env, and the
+            // default still apply, which keeps `--server` working on a file
+            // the operator has not pointed anywhere yet.
+            None => {
+                let contexts = file.effective_contexts();
+                (contexts.len() == 1).then(|| contexts[0].clone())
+            }
+        },
     };
 
-    let server = non_empty(flag_server)
-        .or(non_empty(env_server))
-        .or(non_empty(file_server))
-        .unwrap_or_else(|| DEFAULT_SERVER_URL.to_string());
-    let token = non_empty(flag_token)
-        .or(non_empty(env_token))
-        .or(non_empty(file_token));
+    let Some(context) = selected else {
+        return Ok(ClientConfig {
+            server: flag_server
+                .or(env_server)
+                .unwrap_or_else(|| DEFAULT_SERVER_URL.to_string()),
+            token: flag_token.or(env_token),
+            context: None,
+        });
+    };
 
-    ClientConfig { server, token }
+    let mode = context.mode;
+    let workspace = non_empty(context.workspace.clone());
+    if mode == ContextMode::Cloud && workspace.is_none() {
+        return Err(ConfigError::CloudContextWithoutWorkspace {
+            name: context.name.clone(),
+        });
+    }
+
+    let (server, token) = if mode == ContextMode::Cloud {
+        // The env is refused rather than ranked: see the module doc.
+        for (value, variable) in [(&env_server, SERVER_URL_ENV), (&env_token, API_TOKEN_ENV)] {
+            if value.is_some() {
+                return Err(ConfigError::EnvConflictsWithCloudContext {
+                    name: context.name.clone(),
+                    variable: variable.to_string(),
+                });
+            }
+        }
+        (
+            flag_server.or_else(|| non_empty(context.server.clone())),
+            flag_token.or_else(|| non_empty(context.token.clone())),
+        )
+    } else {
+        (
+            flag_server
+                .or(env_server)
+                .or_else(|| non_empty(context.server.clone())),
+            flag_token
+                .or(env_token)
+                .or_else(|| non_empty(context.token.clone())),
+        )
+    };
+
+    Ok(ClientConfig {
+        server: server.unwrap_or_else(|| DEFAULT_SERVER_URL.to_string()),
+        token,
+        context: Some(SelectedContext {
+            name: context.name,
+            mode,
+            workspace,
+            token_expires_at: non_empty(context.token_expires_at),
+        }),
+    })
 }
 
-/// Treat an empty (or whitespace-only) string as unset for precedence
-/// purposes, and trim the value that is kept — a padded
-/// `SKARDI_SERVER_URL=" http://x "` must not survive into request URLs.
+/// Treat an empty (or whitespace-only) string as unset, and trim what is kept
+/// — a padded `SKARDI_SERVER_URL=" http://x "` must not survive into request
+/// URLs.
 fn non_empty(value: Option<String>) -> Option<String> {
     value
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
 }
 
-/// Load and parse `path` as a config manifest, returning its `spec` block.
-///
-/// - Missing file: resolves silently to `None` (this is the common case —
-///   most users never create `~/.skardi/config.yaml`).
-/// - Present but unparsable YAML: prints a `warning: ...` to stderr and
-///   resolves to `None`. Never fatal.
-/// - Present, valid YAML, but no `spec:` section: resolves to `None`.
-fn load_file_config(path: &Path) -> Option<FileConfig> {
-    let content = std::fs::read_to_string(path).ok()?;
+/// `~/.skardi/config.yaml`, or `None` when the home directory is unknowable.
+pub fn default_config_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|home| home.join(".skardi").join("config.yaml"))
+}
 
-    match serde_yaml::from_str::<ConfigManifest>(&content) {
-        Ok(manifest) => manifest.spec,
+/// Load `path` for READING. Tolerant by design (§5.4): a missing file is
+/// `None`, and an unparsable one warns and resolves to `None` so that
+/// `--server`/`--token` still work while the operator fixes it. Never fatal.
+///
+/// Mutations use [`load_for_mutation`] instead, which refuses the same file.
+pub fn load(path: &Path) -> Option<ContextsFile> {
+    let content = std::fs::read_to_string(path).ok()?;
+    match serde_yaml::from_str::<ContextsFile>(&content) {
+        Ok(file) => Some(file),
         Err(err) => {
             eprintln!(
                 "warning: ignoring malformed config file {}: {}",
@@ -136,172 +450,508 @@ fn load_file_config(path: &Path) -> Option<FileConfig> {
     }
 }
 
+/// Load `path` for WRITING, refusing a file that exists but does not parse.
+///
+/// The asymmetry with [`load`] is the whole point. A rewrite built from an
+/// empty parse tree would atomically replace a malformed-but-credential-bearing
+/// file: the rename is torn-write-safe, not data-loss-safe. Recovery is
+/// deliberately manual — no `--force` — because the file may hold the only copy
+/// of a PAT nobody can re-mint without re-authenticating.
+///
+/// A missing file yields an empty tree, which is how the first `login` or
+/// `set-context` creates one.
+pub fn load_for_mutation(path: &Path) -> Result<ContextsFile, ConfigError> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(content) => content,
+        // Any read failure (absent, or unreadable) yields a fresh tree only
+        // when the file truly is absent; an unreadable-but-present file must
+        // not be clobbered either.
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(ContextsFile {
+                kind: Some("client".to_string()),
+                ..ContextsFile::default()
+            });
+        }
+        Err(err) => {
+            return Err(ConfigError::UnparsableForMutation {
+                path: path.to_path_buf(),
+                error: err.to_string(),
+            });
+        }
+    };
+    serde_yaml::from_str::<ContextsFile>(&content).map_err(|err| {
+        ConfigError::UnparsableForMutation {
+            path: path.to_path_buf(),
+            error: err.to_string(),
+        }
+    })
+}
+
+/// Write `file` to `path` atomically, owner-readable only.
+///
+/// Temp file in the SAME directory then rename: a cross-filesystem rename is
+/// not atomic, and `~/.skardi` is where the target lives. The temp file is
+/// created `0600` before any bytes are written, so a token never exists in a
+/// world-readable file even briefly.
+pub fn save(path: &Path, file: &ContextsFile) -> anyhow::Result<()> {
+    use anyhow::Context as _;
+
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(parent)
+        .with_context(|| format!("create config directory {}", parent.display()))?;
+
+    // A pre-existing group- or world-readable config is a real exposure of a
+    // live credential, so it is reported rather than silently tightened —
+    // the operator may want to know their file has been readable.
+    warn_if_loose_permissions(path);
+
+    let yaml = serde_yaml::to_string(file).context("serialize config")?;
+    let temp = parent.join(format!(
+        ".{}.tmp-{}",
+        path.file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "config.yaml".to_string()),
+        std::process::id()
+    ));
+
+    write_owner_only(&temp, yaml.as_bytes())
+        .with_context(|| format!("write {}", temp.display()))?;
+    if let Err(err) = std::fs::rename(&temp, path) {
+        let _ = std::fs::remove_file(&temp);
+        return Err(
+            anyhow::Error::new(err).context(format!("replace {} atomically", path.display()))
+        );
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn write_owner_only(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    use std::io::Write as _;
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    let mut handle = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)?;
+    handle.write_all(bytes)?;
+    handle.sync_all()
+}
+
+#[cfg(not(unix))]
+fn write_owner_only(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    // No mode bits to set: on Windows the file inherits the directory ACL.
+    std::fs::write(path, bytes)
+}
+
+#[cfg(unix)]
+fn warn_if_loose_permissions(path: &Path) {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    if let Ok(meta) = std::fs::metadata(path) {
+        let mode = meta.permissions().mode() & 0o777;
+        if mode & 0o077 != 0 {
+            eprintln!(
+                "warning: {} was mode {:o} (readable beyond its owner); \
+                 rewriting it as 0600",
+                path.display(),
+                mode
+            );
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn warn_if_loose_permissions(_path: &Path) {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write;
-    use tempfile::NamedTempFile;
+    use std::io::Write as _;
+    use tempfile::{NamedTempFile, TempDir};
 
-    fn file_config(server: &str, token: &str) -> FileConfig {
-        FileConfig {
-            server: Some(server.to_string()),
-            token: Some(token.to_string()),
+    /// A two-context file: one cloud, one local — the shape `login` writes.
+    fn file() -> ContextsFile {
+        ContextsFile {
+            kind: Some("client".to_string()),
+            current_context: Some("acme/prod".to_string()),
+            contexts: vec![
+                Context {
+                    name: "acme/prod".to_string(),
+                    server: Some("https://gw.skardi.ai".to_string()),
+                    mode: ContextMode::Cloud,
+                    workspace: Some("acme-prod".to_string()),
+                    token: Some("skardi_pat_live".to_string()),
+                    ..Context::default()
+                },
+                Context {
+                    name: "local".to_string(),
+                    server: Some("http://127.0.0.1:9999".to_string()),
+                    ..Context::default()
+                },
+            ],
+            ..ContextsFile::default()
         }
     }
 
-    fn write_manifest(contents: &str) -> NamedTempFile {
-        let mut file = NamedTempFile::new().unwrap();
-        file.write_all(contents.as_bytes()).unwrap();
-        file
+    fn inputs(file: Option<ContextsFile>) -> ResolveInputs {
+        ResolveInputs {
+            file,
+            ..ResolveInputs::default()
+        }
+    }
+
+    fn write(contents: &str) -> NamedTempFile {
+        let mut handle = NamedTempFile::new().unwrap();
+        handle.write_all(contents.as_bytes()).unwrap();
+        handle
+    }
+
+    // ── selection ────────────────────────────────────────────────────────
+
+    #[test]
+    fn current_context_selects_when_no_flag_or_env_names_one() {
+        let resolved = resolve_from(inputs(Some(file()))).unwrap();
+
+        assert_eq!(resolved.server, "https://gw.skardi.ai");
+        assert_eq!(resolved.token.as_deref(), Some("skardi_pat_live"));
+        let context = resolved.context.unwrap();
+        assert_eq!(context.name, "acme/prod");
+        assert_eq!(context.mode, ContextMode::Cloud);
+        assert_eq!(context.workspace.as_deref(), Some("acme-prod"));
     }
 
     #[test]
-    fn resolve_from_nothing_set_uses_default_server_and_no_token() {
-        let resolved = resolve_from(None, None, None, None, None);
+    fn context_selection_prefers_flag_then_env_then_current() {
+        // --context wins over both.
+        let resolved = resolve_from(ResolveInputs {
+            flag_context: Some("local".to_string()),
+            env_context: Some("acme/prod".to_string()),
+            file: Some(file()),
+            ..ResolveInputs::default()
+        })
+        .unwrap();
+        assert_eq!(resolved.context.unwrap().name, "local");
 
-        assert_eq!(resolved.server, DEFAULT_SERVER_URL);
-        assert_eq!(resolved.token, None);
+        // $SKARDI_CONTEXT wins over current-context.
+        let resolved = resolve_from(ResolveInputs {
+            env_context: Some("local".to_string()),
+            file: Some(file()),
+            ..ResolveInputs::default()
+        })
+        .unwrap();
+        assert_eq!(resolved.context.unwrap().name, "local");
     }
 
     #[test]
-    fn resolve_from_file_only_uses_file_values() {
-        let resolved = resolve_from(
-            None,
-            None,
-            None,
-            None,
-            Some(file_config("http://file-server:9000", "file-token")),
-        );
+    fn an_unknown_context_is_a_hard_error_listing_what_exists() {
+        // The failure mode this guards: falling through to the built-in
+        // default would send a cloud query to a local server.
+        let err = resolve_from(ResolveInputs {
+            flag_context: Some("typo".to_string()),
+            file: Some(file()),
+            ..ResolveInputs::default()
+        })
+        .unwrap_err();
 
-        assert_eq!(resolved.server, "http://file-server:9000");
-        assert_eq!(resolved.token, Some("file-token".to_string()));
+        let ConfigError::UnknownContext { name, available } = &err else {
+            panic!("expected UnknownContext, got {err:?}");
+        };
+        assert_eq!(name, "typo");
+        assert_eq!(available, &["acme/prod".to_string(), "local".to_string()]);
+        assert!(err.to_string().contains("Available: acme/prod, local"));
+
+        // A dangling current-context is the same typo, and gets the same
+        // error rather than silently resolving to the default.
+        let mut dangling = file();
+        dangling.current_context = Some("removed".to_string());
+        let err = resolve_from(inputs(Some(dangling))).unwrap_err();
+        assert!(matches!(err, ConfigError::UnknownContext { .. }));
     }
 
     #[test]
-    fn resolve_from_env_beats_file() {
-        let resolved = resolve_from(
-            None,
-            None,
-            Some("http://env-server:9000".to_string()),
-            Some("env-token".to_string()),
-            Some(file_config("http://file-server:9000", "file-token")),
-        );
-
-        assert_eq!(resolved.server, "http://env-server:9000");
-        assert_eq!(resolved.token, Some("env-token".to_string()));
-    }
-
-    #[test]
-    fn resolve_from_empty_strings_count_as_unset() {
-        // Exported-but-empty env vars (SKARDI_SERVER_URL=) fall through to
-        // the file value instead of yielding an empty base URL.
-        let resolved = resolve_from(
-            None,
-            None,
-            Some(String::new()),
-            Some("  ".to_string()),
-            Some(file_config("http://file-server:9000", "file-token")),
-        );
-        assert_eq!(resolved.server, "http://file-server:9000");
-        assert_eq!(resolved.token, Some("file-token".to_string()));
-
-        // Empty at every level → default server, no token (never an empty
-        // `Authorization: Bearer` header).
-        let resolved = resolve_from(
-            Some(String::new()),
-            Some(String::new()),
-            Some(String::new()),
-            None,
-            None,
-        );
-        assert_eq!(resolved.server, DEFAULT_SERVER_URL);
-        assert_eq!(resolved.token, None);
-    }
-
-    #[test]
-    fn resolve_from_trims_padded_values() {
-        // A padded value is kept but normalized — surrounding whitespace
-        // must not leak into request URLs or the Authorization header.
-        let resolved = resolve_from(
-            None,
-            None,
-            Some(" http://env-server:9000 ".to_string()),
-            Some("\tenv-token\n".to_string()),
-            None,
-        );
-        assert_eq!(resolved.server, "http://env-server:9000");
-        assert_eq!(resolved.token, Some("env-token".to_string()));
-    }
-
-    #[test]
-    fn resolve_from_flag_beats_env_and_file() {
-        let resolved = resolve_from(
-            Some("http://flag-server:9000".to_string()),
-            Some("flag-token".to_string()),
-            Some("http://env-server:9000".to_string()),
-            Some("env-token".to_string()),
-            Some(file_config("http://file-server:9000", "file-token")),
-        );
-
-        assert_eq!(resolved.server, "http://flag-server:9000");
-        assert_eq!(resolved.token, Some("flag-token".to_string()));
-    }
-
-    #[test]
-    fn resolve_from_per_field_independence_server_from_env_token_from_file() {
-        let resolved = resolve_from(
-            None,
-            None,
-            Some("http://env-server:9000".to_string()),
-            None,
-            Some(file_config("http://file-server:9000", "file-token")),
-        );
-
-        assert_eq!(resolved.server, "http://env-server:9000");
-        assert_eq!(resolved.token, Some("file-token".to_string()));
-    }
-
-    #[test]
-    fn load_file_config_valid_manifest_returns_spec_values() {
-        let file = write_manifest(
-            "kind: client\n\
-             metadata:\n  name: default\n\
-             spec:\n  server: http://127.0.0.1:8080\n  token: optional-bearer-token\n",
-        );
-
-        let loaded = load_file_config(file.path());
-
+    fn a_lone_context_needs_no_current_context_pointer_but_several_do() {
+        let mut lone = file();
+        lone.contexts.truncate(1);
+        lone.current_context = None;
         assert_eq!(
-            loaded,
-            Some(file_config(
-                "http://127.0.0.1:8080",
-                "optional-bearer-token"
-            ))
+            resolve_from(inputs(Some(lone)))
+                .unwrap()
+                .context
+                .unwrap()
+                .name,
+            "acme/prod"
+        );
+
+        // Several with no pointer: nothing is selected, and flags/env/default
+        // still apply — `--server` keeps working on an unpointed file.
+        let mut unpointed = file();
+        unpointed.current_context = None;
+        let resolved = resolve_from(inputs(Some(unpointed))).unwrap();
+        assert!(resolved.context.is_none());
+        assert_eq!(resolved.server, DEFAULT_SERVER_URL);
+    }
+
+    // ── the cloud-authoritative rule (§5.1) ──────────────────────────────
+
+    #[test]
+    fn env_vars_are_refused_while_a_cloud_context_is_selected() {
+        // The scenario: SKARDI_SERVER_URL left exported from the
+        // single-server era would send a workspace-scoped PAT to whatever
+        // listens there. Refused by name, and NO request is issued.
+        for variable in [SERVER_URL_ENV, API_TOKEN_ENV] {
+            let mut probe = inputs(Some(file()));
+            if variable == SERVER_URL_ENV {
+                probe.env_server = Some("http://evil:8080".to_string());
+            } else {
+                probe.env_token = Some("other-token".to_string());
+            }
+            let err = resolve_from(probe).unwrap_err();
+            let ConfigError::EnvConflictsWithCloudContext { name, variable: v } = &err else {
+                panic!("expected EnvConflictsWithCloudContext, got {err:?}");
+            };
+            assert_eq!(name, "acme/prod");
+            assert_eq!(v, variable);
+            assert!(err.to_string().contains(variable));
+        }
+    }
+
+    #[test]
+    fn flags_still_override_a_cloud_context_because_they_are_deliberate() {
+        let resolved = resolve_from(ResolveInputs {
+            flag_server: Some("https://staging.gw".to_string()),
+            flag_token: Some("flag-token".to_string()),
+            file: Some(file()),
+            ..ResolveInputs::default()
+        })
+        .unwrap();
+
+        assert_eq!(resolved.server, "https://staging.gw");
+        assert_eq!(resolved.token.as_deref(), Some("flag-token"));
+        // Still the cloud context: the workspace it names is unaffected.
+        assert_eq!(
+            resolved.context.unwrap().workspace.as_deref(),
+            Some("acme-prod")
         );
     }
 
     #[test]
-    fn load_file_config_manifest_without_spec_is_absent() {
-        let file = write_manifest("kind: client\nmetadata:\n  name: default\n");
+    fn env_vars_still_beat_a_server_mode_context() {
+        let resolved = resolve_from(ResolveInputs {
+            env_server: Some("http://env:9000".to_string()),
+            env_context: Some("local".to_string()),
+            file: Some(file()),
+            ..ResolveInputs::default()
+        })
+        .unwrap();
 
-        let loaded = load_file_config(file.path());
-
-        assert_eq!(loaded, None);
+        assert_eq!(resolved.server, "http://env:9000");
+        assert_eq!(resolved.context.unwrap().mode, ContextMode::Server);
     }
 
     #[test]
-    fn load_file_config_malformed_yaml_is_absent() {
-        let file = write_manifest("kind: client\n  this: [is not, valid yaml\n");
+    fn a_cloud_context_without_a_workspace_is_refused() {
+        let mut broken = file();
+        broken.contexts[0].workspace = None;
+        let err = resolve_from(inputs(Some(broken))).unwrap_err();
+        assert!(matches!(
+            err,
+            ConfigError::CloudContextWithoutWorkspace { .. }
+        ));
+        // The message names the repair, not just the problem.
+        assert!(err.to_string().contains("skardi config set-context"));
 
-        let loaded = load_file_config(file.path());
+        // Whitespace counts as unset here too.
+        let mut blank = file();
+        blank.contexts[0].workspace = Some("   ".to_string());
+        assert!(resolve_from(inputs(Some(blank))).is_err());
+    }
 
-        assert_eq!(loaded, None);
+    // ── per-field precedence, unchanged for server mode ──────────────────
+
+    #[test]
+    fn nothing_set_uses_the_default_server_and_no_token() {
+        let resolved = resolve_from(inputs(None)).unwrap();
+        assert_eq!(resolved.server, DEFAULT_SERVER_URL);
+        assert_eq!(resolved.token, None);
+        assert!(resolved.context.is_none());
     }
 
     #[test]
-    fn load_file_config_nonexistent_path_is_absent() {
-        let loaded = load_file_config(Path::new("/nonexistent/path/does/not/exist/config.yaml"));
+    fn empty_and_padded_values_are_unset_and_trimmed() {
+        let resolved = resolve_from(ResolveInputs {
+            flag_server: Some("  ".to_string()),
+            env_server: Some(String::new()),
+            env_token: Some("\tenv-token\n".to_string()),
+            env_context: Some("   ".to_string()),
+            file: Some(file()),
+            ..ResolveInputs::default()
+        })
+        .unwrap_err();
+        // The empty --context/env-context fell through to current-context,
+        // which is cloud — so the non-empty env token is the conflict.
+        assert!(matches!(
+            resolved,
+            ConfigError::EnvConflictsWithCloudContext { .. }
+        ));
 
-        assert_eq!(loaded, None);
+        let resolved = resolve_from(ResolveInputs {
+            env_context: Some("local".to_string()),
+            env_server: Some(" http://env:9000 ".to_string()),
+            file: Some(file()),
+            ..ResolveInputs::default()
+        })
+        .unwrap();
+        assert_eq!(resolved.server, "http://env:9000");
+    }
+
+    // ── back-compat (§5.2) ───────────────────────────────────────────────
+
+    #[test]
+    fn a_legacy_spec_file_resolves_as_one_context_named_default() {
+        let legacy = ContextsFile {
+            spec: Some(LegacySpec {
+                server: Some("http://legacy:8080".to_string()),
+                token: Some("legacy-token".to_string()),
+            }),
+            ..ContextsFile::default()
+        };
+
+        let resolved = resolve_from(inputs(Some(legacy))).unwrap();
+        assert_eq!(resolved.server, "http://legacy:8080");
+        assert_eq!(resolved.token.as_deref(), Some("legacy-token"));
+        let context = resolved.context.unwrap();
+        assert_eq!(context.name, LEGACY_CONTEXT_NAME);
+        assert_eq!(context.mode, ContextMode::Server);
+    }
+
+    #[test]
+    fn contexts_win_over_a_legacy_spec_present_in_the_same_file() {
+        let mut both = file();
+        both.spec = Some(LegacySpec {
+            server: Some("http://legacy:8080".to_string()),
+            token: None,
+        });
+        let resolved = resolve_from(inputs(Some(both))).unwrap();
+        assert_eq!(resolved.server, "https://gw.skardi.ai");
+    }
+
+    // ── the file surface ─────────────────────────────────────────────────
+
+    #[test]
+    fn load_parses_the_documented_file_shape_including_unknown_keys() {
+        let handle = write(
+            "kind: client\n\
+             control-plane: https://api.skardi.ai\n\
+             current-context: acme/prod\n\
+             future-top-level: kept\n\
+             contexts:\n\
+             \x20 - name: acme/prod\n\
+             \x20   server: https://gw.skardi.ai\n\
+             \x20   mode: cloud\n\
+             \x20   workspace: acme-prod\n\
+             \x20   user: xin@skardi.ai\n\
+             \x20   token: skardi_pat_x\n\
+             \x20   token-id: 4f1c\n\
+             \x20   token-expires-at: 2026-11-18T00:00:00Z\n\
+             \x20   future-per-context: kept\n",
+        );
+
+        let loaded = load(handle.path()).expect("parses");
+        assert_eq!(
+            loaded.control_plane.as_deref(),
+            Some("https://api.skardi.ai")
+        );
+        let context = &loaded.contexts[0];
+        assert_eq!(context.mode, ContextMode::Cloud);
+        assert_eq!(context.token_id.as_deref(), Some("4f1c"));
+        assert_eq!(
+            context.token_expires_at.as_deref(),
+            Some("2026-11-18T00:00:00Z")
+        );
+        // Unknown keys survive a parse → serialize round trip, so an older
+        // CLI's `use-context` cannot downgrade a newer CLI's file.
+        assert!(loaded.extra.contains_key("future-top-level"));
+        assert!(context.extra.contains_key("future-per-context"));
+        let round_tripped = serde_yaml::to_string(&loaded).unwrap();
+        assert!(round_tripped.contains("future-top-level"));
+        assert!(round_tripped.contains("future-per-context"));
+    }
+
+    #[test]
+    fn reads_tolerate_a_broken_file_but_mutations_refuse_it() {
+        let handle = write("contexts: [this is: not, valid yaml\n");
+
+        // Read: warn, ignore, fall through (§5.4) — `--server` still works.
+        assert_eq!(load(handle.path()), None);
+
+        // Mutation: refuse, naming the file and the parse error. Rewriting
+        // from an empty tree would replace a credential-bearing file.
+        let err = load_for_mutation(handle.path()).unwrap_err();
+        let ConfigError::UnparsableForMutation { path, .. } = &err else {
+            panic!("expected UnparsableForMutation, got {err:?}");
+        };
+        assert_eq!(path, handle.path());
+        assert!(err.to_string().contains("refusing to modify"));
+    }
+
+    #[test]
+    fn load_for_mutation_on_a_missing_file_starts_a_fresh_tree() {
+        let dir = TempDir::new().unwrap();
+        let absent = dir.path().join("config.yaml");
+        let fresh = load_for_mutation(&absent).unwrap();
+        assert_eq!(fresh.kind.as_deref(), Some("client"));
+        assert!(fresh.contexts.is_empty());
+    }
+
+    #[test]
+    fn save_writes_atomically_owner_only_and_leaves_no_temp_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("nested").join("config.yaml");
+
+        save(&path, &file()).unwrap();
+
+        let reloaded = load(&path).expect("round trips");
+        assert_eq!(reloaded.contexts.len(), 2);
+        assert_eq!(reloaded.current_context.as_deref(), Some("acme/prod"));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "a file holding a PAT must be owner-only");
+        }
+
+        // The temp file is renamed, never left behind.
+        let leftovers: Vec<_> = std::fs::read_dir(path.parent().unwrap())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .filter(|name| name.contains(".tmp-"))
+            .collect();
+        assert!(leftovers.is_empty(), "left {leftovers:?}");
+    }
+
+    #[test]
+    fn save_over_an_existing_file_keeps_it_owner_only() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(&path, "kind: client\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        }
+
+        save(&path, &file()).unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "a loose file is rewritten tighter");
+        }
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -8,6 +8,7 @@
 use clap::error::ErrorKind;
 use clap::{Parser, Subcommand};
 use client::{ApiClient, ApiError};
+use commands::config::ConfigCmd;
 use commands::jobs::JobCmd;
 use commands::pipeline::PipelineCmd;
 use config::ClientConfig;
@@ -33,6 +34,11 @@ struct Cli {
     #[arg(long, global = true, value_name = "TOKEN")]
     token: Option<String>,
 
+    /// select a context from ~/.skardi/config.yaml; overrides $SKARDI_CONTEXT
+    /// and the file's current-context
+    #[arg(long, global = true, value_name = "NAME")]
+    context: Option<String>,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -40,6 +46,12 @@ struct Cli {
 /// Subcommands supported by the CLI.
 #[derive(Subcommand, Debug)]
 enum Commands {
+    /// Manage contexts in ~/.skardi/config.yaml (no network).
+    Config {
+        #[command(subcommand)]
+        cmd: ConfigCmd,
+    },
+
     /// Run ad-hoc SQL against the server and print the result.
     Query {
         /// inline SQL text
@@ -129,7 +141,26 @@ async fn main() -> ExitCode {
             }
         }
     };
-    let config = ClientConfig::resolve(cli.server, cli.token);
+    // `config` subcommands edit the file that resolution reads, so they must
+    // not be gated on that resolution succeeding — `set-context` is how an
+    // operator FIXES a config whose cloud context is missing its workspace.
+    if let Commands::Config { cmd } = cli.command {
+        return match commands::config::run(cmd) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(err) => {
+                eprintln!("error: {err:#}");
+                ExitCode::FAILURE
+            }
+        };
+    }
+
+    let config = match ClientConfig::resolve(cli.server, cli.token, cli.context) {
+        Ok(config) => config,
+        Err(err) => {
+            eprintln!("error: {err}");
+            return ExitCode::FAILURE;
+        }
+    };
 
     match dispatch(cli.command, &config).await {
         Ok(()) => ExitCode::SUCCESS,
@@ -171,5 +202,9 @@ async fn dispatch(command: Commands, config: &ClientConfig) -> anyhow::Result<()
         Commands::Schema => commands::schema::run(&client).await,
 
         Commands::Health { name } => commands::health::run(&client, name.as_deref()).await,
+
+        // Handled before resolution in `main`, so the file can be repaired
+        // even when resolving it would fail.
+        Commands::Config { .. } => unreachable!("config is dispatched before resolution"),
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -164,7 +164,7 @@ async fn main() -> ExitCode {
 /// one dispatch point and leaves no structurally unreachable arm behind.
 async fn dispatch(cli: Cli) -> anyhow::Result<()> {
     if let Commands::Config { cmd } = cli.command {
-        return commands::config::run(cmd);
+        return commands::config::run(cmd, cli.context);
     }
 
     let config = ClientConfig::resolve(cli.server, cli.token, cli.context)?;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -141,28 +141,7 @@ async fn main() -> ExitCode {
             }
         }
     };
-    // `config` subcommands edit the file that resolution reads, so they must
-    // not be gated on that resolution succeeding — `set-context` is how an
-    // operator FIXES a config whose cloud context is missing its workspace.
-    if let Commands::Config { cmd } = cli.command {
-        return match commands::config::run(cmd) {
-            Ok(()) => ExitCode::SUCCESS,
-            Err(err) => {
-                eprintln!("error: {err:#}");
-                ExitCode::FAILURE
-            }
-        };
-    }
-
-    let config = match ClientConfig::resolve(cli.server, cli.token, cli.context) {
-        Ok(config) => config,
-        Err(err) => {
-            eprintln!("error: {err}");
-            return ExitCode::FAILURE;
-        }
-    };
-
-    match dispatch(cli.command, &config).await {
+    match dispatch(cli).await {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
             eprintln!("error: {err:#}");
@@ -174,12 +153,24 @@ async fn main() -> ExitCode {
     }
 }
 
-/// Construct one `ApiClient` from `config` and dispatch `command` to its
+/// Resolve the connection config and dispatch `cli.command` to its
 /// implementation.
-async fn dispatch(command: Commands, config: &ClientConfig) -> anyhow::Result<()> {
-    let client = ApiClient::new(config)?;
+///
+/// Resolution is deliberately LAZY — inside this function, after the `config`
+/// arm — because `skardi config` edits the very file resolution reads.
+/// `set-context` is how an operator repairs a config whose cloud context is
+/// missing its workspace, so it must not be gated on that resolution
+/// succeeding. Handling it here rather than short-circuiting in `main` keeps
+/// one dispatch point and leaves no structurally unreachable arm behind.
+async fn dispatch(cli: Cli) -> anyhow::Result<()> {
+    if let Commands::Config { cmd } = cli.command {
+        return commands::config::run(cmd);
+    }
 
-    match command {
+    let config = ClientConfig::resolve(cli.server, cli.token, cli.context)?;
+    let client = ApiClient::new(&config)?;
+
+    match cli.command {
         Commands::Query {
             sql,
             file,
@@ -203,8 +194,7 @@ async fn dispatch(command: Commands, config: &ClientConfig) -> anyhow::Result<()
 
         Commands::Health { name } => commands::health::run(&client, name.as_deref()).await,
 
-        // Handled before resolution in `main`, so the file can be repaired
-        // even when resolving it would fail.
-        Commands::Config { .. } => unreachable!("config is dispatched before resolution"),
+        // Returned above, before resolution.
+        Commands::Config { .. } => Ok(()),
     }
 }

--- a/crates/cli/tests/contexts.rs
+++ b/crates/cli/tests/contexts.rs
@@ -191,8 +191,9 @@ fn view_redacts_tokens_unless_asked() {
     assert!(out.status.success(), "{}", stderr(&out));
     assert!(!body.contains(secret), "the token leaked:\n{body}");
     assert!(body.contains("(redacted)"), "{body}");
-    // Enough of it survives to tell WHICH credential this is.
-    assert!(body.contains("skardi_pat_d"), "{body}");
+    // NO prefix survives. An earlier version kept twelve characters, which
+    // printed a short legacy token in full while labelling it redacted.
+    assert!(!body.contains("skardi_pat_d"), "a prefix leaked:\n{body}");
 
     let out = skardi(home, &["config", "view", "--show-tokens"]);
     assert!(stdout(&out).contains(secret), "--show-tokens prints it");
@@ -310,6 +311,70 @@ fn resolution_refuses_ambiguous_or_conflicting_selections_without_issuing_a_requ
         "{}",
         stderr(&out)
     );
+}
+
+/// A cloud context with no `server` must never reach the built-in local
+/// default, because its token is a workspace-scoped PAT. Driven through the
+/// binary because that is how the bug was found: the unit layer resolved the
+/// same config without complaint and `skardi query` really did POST to
+/// http://127.0.0.1:8080.
+#[test]
+fn a_cloud_context_without_a_server_never_falls_back_to_the_local_default() {
+    let home = TempDir::new().unwrap();
+    let home = home.path();
+    let path = config_path(home);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &path,
+        "kind: client\n\
+         current-context: acme/prod\n\
+         contexts:\n\
+         \x20 - name: acme/prod\n\
+         \x20   mode: cloud\n\
+         \x20   workspace: acme-prod\n\
+         \x20   token: skardi_pat_workspace_scoped\n",
+    )
+    .unwrap();
+
+    let out = skardi(home, &["query", "-e", "select 1"]);
+    // Exit 1, not the connect code 2: nothing was dialled.
+    assert_eq!(out.status.code(), Some(1), "stderr was: {}", stderr(&out));
+    let complaint = stderr(&out);
+    assert!(complaint.contains("names no server"), "{complaint}");
+    assert!(
+        complaint.contains("127.0.0.1:8080"),
+        "the message names the default it refused to use: {complaint}"
+    );
+    assert!(
+        !complaint.contains("skardi_pat_workspace_scoped"),
+        "the refusal must not echo the token: {complaint}"
+    );
+
+    // `--server` is a deliberate act and satisfies it; .invalid guarantees
+    // the failure is the DIAL (exit 2), proving resolution let it through.
+    let out = skardi(
+        home,
+        &["--server", "https://gw.invalid", "query", "-e", "select 1"],
+    );
+    assert_eq!(out.status.code(), Some(2), "stderr was: {}", stderr(&out));
+
+    // The write path refuses the same shape, so it cannot be created this way.
+    let out = skardi(
+        home,
+        &[
+            "config",
+            "set-context",
+            "b",
+            "--mode",
+            "cloud",
+            "--workspace",
+            "w",
+            "--token",
+            "skardi_pat_y",
+        ],
+    );
+    assert!(!out.status.success());
+    assert!(stderr(&out).contains("needs a server"), "{}", stderr(&out));
 }
 
 /// A legacy single-server file keeps working, and its first edit promotes it

--- a/crates/cli/tests/contexts.rs
+++ b/crates/cli/tests/contexts.rs
@@ -1,0 +1,380 @@
+//! Integration tests for the context model, driving the REAL `skardi` binary.
+//!
+//! Everything here runs with `HOME` pointed at a temp directory, so the tests
+//! exercise the actual `~/.skardi/config.yaml` path — file creation, mode bits,
+//! atomic rewrite, redaction — without touching the developer's own config and
+//! without needing a server. Resolution failures are asserted through the
+//! binary too, because "no request is issued" is part of the contract and only
+//! a real process can demonstrate it.
+//!
+//! `dirs::home_dir()` reads `$HOME` on unix, which is what makes the
+//! redirection work; these tests are unix-only for that reason.
+
+#![cfg(unix)]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use tempfile::TempDir;
+
+/// Run the binary with `HOME` redirected, and with the ambient
+/// `SKARDI_*` variables cleared so a developer's exported values cannot
+/// change what the test observes.
+fn skardi(home: &Path, args: &[&str]) -> Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_skardi"));
+    cmd.env("HOME", home)
+        .env_remove("SKARDI_SERVER_URL")
+        .env_remove("SKARDI_API_TOKEN")
+        .env_remove("SKARDI_CONTEXT")
+        .args(args);
+    cmd.output().expect("spawn skardi")
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).to_string()
+}
+
+fn config_path(home: &Path) -> PathBuf {
+    home.join(".skardi").join("config.yaml")
+}
+
+fn mode_of(path: &Path) -> u32 {
+    use std::os::unix::fs::PermissionsExt as _;
+    std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+}
+
+/// The whole `config` surface in one pass, in the order an operator meets it:
+/// create, list, switch, inspect, delete.
+#[test]
+fn config_subcommands_create_list_switch_and_delete_contexts() {
+    let home = TempDir::new().unwrap();
+    let home = home.path();
+
+    // No file yet: listing says so instead of failing.
+    let out = skardi(home, &["config", "get-contexts"]);
+    assert!(out.status.success(), "{}", stderr(&out));
+    assert!(stdout(&out).contains("no contexts configured"));
+
+    // First set-context creates ~/.skardi/config.yaml, mode 0600.
+    let out = skardi(
+        home,
+        &[
+            "config",
+            "set-context",
+            "local",
+            "--server",
+            "http://127.0.0.1:9999",
+            "--current",
+        ],
+    );
+    assert!(out.status.success(), "{}", stderr(&out));
+    assert!(stdout(&out).contains("created context 'local'"));
+    let path = config_path(home);
+    assert!(path.is_file(), "config file was created");
+    assert_eq!(
+        mode_of(&path),
+        0o600,
+        "a file that will hold a PAT is owner-only"
+    );
+
+    // A cloud context needs its workspace, and is refused without one rather
+    // than written as a dud that fails at the next command.
+    let out = skardi(
+        home,
+        &[
+            "config",
+            "set-context",
+            "acme/prod",
+            "--mode",
+            "cloud",
+            "--server",
+            "https://gw.skardi.ai",
+        ],
+    );
+    assert!(!out.status.success());
+    assert!(
+        stderr(&out).contains("needs a workspace"),
+        "{}",
+        stderr(&out)
+    );
+
+    // With the workspace it lands.
+    let out = skardi(
+        home,
+        &[
+            "config",
+            "set-context",
+            "acme/prod",
+            "--mode",
+            "cloud",
+            "--server",
+            "https://gw.skardi.ai",
+            "--workspace",
+            "acme-prod",
+            "--token",
+            "skardi_pat_secret_value",
+            "--user",
+            "xin@skardi.ai",
+        ],
+    );
+    assert!(out.status.success(), "{}", stderr(&out));
+
+    // get-contexts marks the current one and shows the workspace dimension.
+    let out = skardi(home, &["config", "get-contexts"]);
+    let listing = stdout(&out);
+    assert!(
+        listing.contains("* "),
+        "current context is marked:\n{listing}"
+    );
+    assert!(listing.contains("acme-prod"), "{listing}");
+    assert!(listing.contains("cloud"), "{listing}");
+
+    // use-context switches, and current-context reports it.
+    let out = skardi(home, &["config", "use-context", "acme/prod"]);
+    assert!(out.status.success(), "{}", stderr(&out));
+    let out = skardi(home, &["config", "current-context"]);
+    assert_eq!(stdout(&out).trim(), "acme/prod");
+
+    // Deleting the current context clears the pointer, so later commands get
+    // "no current context" rather than the hard unknown-context error.
+    let out = skardi(home, &["config", "delete-context", "acme/prod"]);
+    assert!(out.status.success(), "{}", stderr(&out));
+    assert!(
+        stdout(&out).contains("no context is current now"),
+        "{}",
+        stdout(&out)
+    );
+    let out = skardi(home, &["config", "current-context"]);
+    assert!(!out.status.success(), "no current context is an error exit");
+
+    // And it is really gone.
+    let out = skardi(home, &["config", "delete-context", "acme/prod"]);
+    assert!(!out.status.success());
+    assert!(
+        stderr(&out).contains("no context named"),
+        "{}",
+        stderr(&out)
+    );
+}
+
+/// `view` must never print a live credential by default — the command an
+/// operator runs while screen-sharing.
+#[test]
+fn view_redacts_tokens_unless_asked() {
+    let home = TempDir::new().unwrap();
+    let home = home.path();
+    let secret = "skardi_pat_do_not_print_me";
+
+    skardi(
+        home,
+        &[
+            "config",
+            "set-context",
+            "acme/prod",
+            "--mode",
+            "cloud",
+            "--workspace",
+            "acme-prod",
+            "--server",
+            "https://gw.skardi.ai",
+            "--token",
+            secret,
+            "--current",
+        ],
+    );
+
+    let out = skardi(home, &["config", "view"]);
+    let body = stdout(&out);
+    assert!(out.status.success(), "{}", stderr(&out));
+    assert!(!body.contains(secret), "the token leaked:\n{body}");
+    assert!(body.contains("(redacted)"), "{body}");
+    // Enough of it survives to tell WHICH credential this is.
+    assert!(body.contains("skardi_pat_d"), "{body}");
+
+    let out = skardi(home, &["config", "view", "--show-tokens"]);
+    assert!(stdout(&out).contains(secret), "--show-tokens prints it");
+}
+
+/// §5.4: reads tolerate a broken file, mutations refuse it — and the refusal
+/// must leave the bytes untouched, because they may hold the only copy of a PAT.
+#[test]
+fn a_broken_config_is_tolerated_by_reads_and_refused_by_mutations() {
+    let home = TempDir::new().unwrap();
+    let home = home.path();
+    let path = config_path(home);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    let broken = "contexts: [name: acme/prod, token: skardi_pat_still_live\n";
+    std::fs::write(&path, broken).unwrap();
+
+    // A mutation aborts, names the file, and does NOT rewrite it.
+    let out = skardi(home, &["config", "use-context", "acme/prod"]);
+    assert!(!out.status.success());
+    let complaint = stderr(&out);
+    assert!(complaint.contains("refusing to modify"), "{complaint}");
+    assert!(complaint.contains("config.yaml"), "{complaint}");
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        broken,
+        "the malformed-but-credential-bearing file must survive verbatim"
+    );
+
+    // A read-side command still runs: --server keeps working while the
+    // operator repairs the file, with a warning rather than a failure.
+    let out = skardi(home, &["config", "get-contexts"]);
+    assert!(out.status.success(), "{}", stderr(&out));
+    assert!(stderr(&out).contains("warning:"), "{}", stderr(&out));
+
+    // `view` is the diagnostic: it reports the parse error and the path.
+    let out = skardi(home, &["config", "view"]);
+    assert!(!out.status.success());
+    assert!(stderr(&out).contains("does not parse"), "{}", stderr(&out));
+}
+
+/// Resolution failures must happen BEFORE any request. Each of these would
+/// otherwise send a credential somewhere the operator did not name.
+#[test]
+fn resolution_refuses_ambiguous_or_conflicting_selections_without_issuing_a_request() {
+    let home = TempDir::new().unwrap();
+    let home = home.path();
+
+    skardi(
+        home,
+        &[
+            "config",
+            "set-context",
+            "acme/prod",
+            "--mode",
+            "cloud",
+            "--workspace",
+            "acme-prod",
+            "--server",
+            "https://gw.invalid",
+            "--token",
+            "skardi_pat_x",
+            "--current",
+        ],
+    );
+
+    // An unknown --context lists what exists instead of falling through to
+    // http://127.0.0.1:8080 — the one failure that would send a cloud query
+    // to a local server.
+    let out = skardi(home, &["--context", "typo", "query", "-e", "select 1"]);
+    assert_eq!(out.status.code(), Some(1), "exit 1, not the connect code 2");
+    let complaint = stderr(&out);
+    assert!(complaint.contains("no context named 'typo'"), "{complaint}");
+    assert!(complaint.contains("Available: acme/prod"), "{complaint}");
+
+    // A stray SKARDI_SERVER_URL while a cloud context is selected is refused
+    // by name. Exit 1 proves nothing was dialled: the gateway host above is
+    // .invalid, so a request would have produced the connect code 2.
+    let out = Command::new(env!("CARGO_BIN_EXE_skardi"))
+        .env("HOME", home)
+        .env("SKARDI_SERVER_URL", "http://127.0.0.1:1")
+        .env_remove("SKARDI_API_TOKEN")
+        .env_remove("SKARDI_CONTEXT")
+        .args(["query", "-e", "select 1"])
+        .output()
+        .expect("spawn skardi");
+    let complaint = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(out.status.code(), Some(1), "stderr was: {complaint}");
+    assert!(
+        complaint.contains("SKARDI_SERVER_URL") && complaint.contains("mode: cloud"),
+        "{complaint}"
+    );
+
+    // A cloud context that lost its workspace (hand-edited) is refused with
+    // the repair named.
+    let path = config_path(home);
+    let text = std::fs::read_to_string(&path).unwrap();
+    // Drop the WHOLE line, indentation included: stripping just the key
+    // leaves an over-indented sibling and the file stops parsing, which the
+    // tolerant reader would then treat as "no contexts" — a different code
+    // path from the one under test.
+    let without_workspace: String = text
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("workspace:"))
+        .map(|line| format!("{line}\n"))
+        .collect();
+    std::fs::write(&path, &without_workspace).unwrap();
+    assert!(
+        without_workspace.contains("mode: cloud"),
+        "the edit must leave a parsable cloud context:\n{without_workspace}"
+    );
+    let out = skardi(home, &["query", "-e", "select 1"]);
+    assert_eq!(out.status.code(), Some(1), "stderr was: {}", stderr(&out));
+    assert!(
+        stderr(&out).contains("names no workspace"),
+        "{}",
+        stderr(&out)
+    );
+}
+
+/// A legacy single-server file keeps working, and its first edit promotes it
+/// to a context rather than dropping the credential it holds.
+#[test]
+fn a_legacy_spec_file_keeps_working_and_survives_its_first_edit() {
+    let home = TempDir::new().unwrap();
+    let home = home.path();
+    let path = config_path(home);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &path,
+        "kind: client\nspec:\n  server: http://legacy:8080\n  token: legacy-token\n",
+    )
+    .unwrap();
+
+    // It resolves as one context named `default`.
+    let out = skardi(home, &["config", "get-contexts"]);
+    let listing = stdout(&out);
+    assert!(listing.contains("default"), "{listing}");
+    assert!(listing.contains("http://legacy:8080"), "{listing}");
+
+    // Editing promotes `spec:` into `contexts:` WITHOUT losing the token.
+    let out = skardi(
+        home,
+        &["config", "set-context", "local", "--server", "http://x:1"],
+    );
+    assert!(out.status.success(), "{}", stderr(&out));
+    let out = skardi(home, &["config", "view", "--show-tokens"]);
+    let body = stdout(&out);
+    assert!(
+        body.contains("legacy-token"),
+        "credential preserved:\n{body}"
+    );
+    assert!(body.contains("name: default"), "{body}");
+    assert!(body.contains("name: local"), "{body}");
+}
+
+/// Unknown keys survive a rewrite, so an older CLI cannot downgrade a file a
+/// newer one wrote.
+#[test]
+fn unknown_keys_survive_a_mutation() {
+    let home = TempDir::new().unwrap();
+    let home = home.path();
+    let path = config_path(home);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &path,
+        "kind: client\n\
+         future-top-level: keep-me\n\
+         current-context: a\n\
+         contexts:\n\
+         \x20 - name: a\n\
+         \x20   server: http://a:1\n\
+         \x20   future-per-context: keep-me-too\n",
+    )
+    .unwrap();
+
+    let out = skardi(
+        home,
+        &["config", "set-context", "b", "--server", "http://b:2"],
+    );
+    assert!(out.status.success(), "{}", stderr(&out));
+
+    let rewritten = std::fs::read_to_string(&path).unwrap();
+    assert!(rewritten.contains("future-top-level"), "{rewritten}");
+    assert!(rewritten.contains("future-per-context"), "{rewritten}");
+}

--- a/crates/cli/tests/contexts.rs
+++ b/crates/cli/tests/contexts.rs
@@ -286,6 +286,41 @@ fn resolution_refuses_ambiguous_or_conflicting_selections_without_issuing_a_requ
         "{complaint}"
     );
 
+    // An unknown $SKARDI_CONTEXT, not just an unknown --context: the env
+    // path had only unit coverage, and it is the one an agent harness sets.
+    let out = Command::new(env!("CARGO_BIN_EXE_skardi"))
+        .env("HOME", home)
+        .env("SKARDI_CONTEXT", "also-typo")
+        .env_remove("SKARDI_SERVER_URL")
+        .env_remove("SKARDI_API_TOKEN")
+        .args(["query", "-e", "select 1"])
+        .output()
+        .expect("spawn skardi");
+    assert_eq!(out.status.code(), Some(1));
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("no context named 'also-typo'"),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // And the TOKEN half of the env conflict, which had no binary-level
+    // assertion at all — only the server half did.
+    let out = Command::new(env!("CARGO_BIN_EXE_skardi"))
+        .env("HOME", home)
+        .env("SKARDI_API_TOKEN", "stale-token")
+        .env_remove("SKARDI_SERVER_URL")
+        .env_remove("SKARDI_CONTEXT")
+        .args(["query", "-e", "select 1"])
+        .output()
+        .expect("spawn skardi");
+    assert_eq!(out.status.code(), Some(1));
+    let complaint = String::from_utf8_lossy(&out.stderr);
+    assert!(complaint.contains("SKARDI_API_TOKEN"), "{complaint}");
+    assert!(
+        !complaint.contains("stale-token"),
+        "the refusal must not echo the value: {complaint}"
+    );
+
     // A cloud context that lost its workspace (hand-edited) is refused with
     // the repair named.
     let path = config_path(home);
@@ -440,6 +475,14 @@ fn unknown_keys_survive_a_mutation() {
     assert!(out.status.success(), "{}", stderr(&out));
 
     let rewritten = std::fs::read_to_string(&path).unwrap();
-    assert!(rewritten.contains("future-top-level"), "{rewritten}");
-    assert!(rewritten.contains("future-per-context"), "{rewritten}");
+    // Key AND value: a rewrite that kept the key but dropped or blanked the
+    // value would still pass a name-only assertion while losing the setting.
+    assert!(
+        rewritten.contains("future-top-level: keep-me"),
+        "{rewritten}"
+    );
+    assert!(
+        rewritten.contains("future-per-context: keep-me-too"),
+        "{rewritten}"
+    );
 }

--- a/crates/cli/tests/contexts.rs
+++ b/crates/cli/tests/contexts.rs
@@ -147,8 +147,31 @@ fn config_subcommands_create_list_switch_and_delete_contexts() {
         "{}",
         stdout(&out)
     );
+    // The POINTER is cleared, but `local` is now the only context left, so
+    // resolution's lone-context step selects it — and `current-context`
+    // reports that, because it answers with what the next command will
+    // actually use rather than with the raw field.
     let out = skardi(home, &["config", "current-context"]);
-    assert!(!out.status.success(), "no current context is an error exit");
+    assert!(out.status.success(), "{}", stderr(&out));
+    assert_eq!(stdout(&out).trim(), "local");
+
+    // With a SECOND context and no pointer, nothing is selected and the
+    // command says so instead of guessing.
+    let out = skardi(
+        home,
+        &["config", "set-context", "third", "--server", "http://c:3"],
+    );
+    assert!(out.status.success(), "{}", stderr(&out));
+    let out = skardi(home, &["config", "current-context"]);
+    assert!(
+        !out.status.success(),
+        "ambiguous selection is an error exit"
+    );
+    // …and `--context` answers it, since that is what a real command honours.
+    let out = skardi(home, &["--context", "third", "config", "current-context"]);
+    assert_eq!(stdout(&out).trim(), "third");
+    let out = skardi(home, &["config", "delete-context", "third"]);
+    assert!(out.status.success(), "{}", stderr(&out));
 
     // And it is really gone.
     let out = skardi(home, &["config", "delete-context", "acme/prod"]);

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -108,7 +108,10 @@ skardi config use-context acme/prod
 # Create or update one (only the fields you name are touched)
 skardi config set-context local --server http://127.0.0.1:8080 --current
 skardi config set-context acme/prod --mode cloud --workspace acme-prod \
-  --server https://gateway.skardi.ai --token skardi_pat_…
+  --server https://gateway.skardi.ai --token-stdin < token.txt
+
+# --token also works, but puts the credential on the command line, where
+# /proc (on Linux) and your shell history can see it. Prefer --token-stdin.
 
 # Remove one. Does not revoke its credential.
 skardi config delete-context acme/prod

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -32,31 +32,117 @@ cargo run -p skardi-cli -- <command> [options]
 
 ## Connecting
 
-Every command accepts two global flags, `--server <URL>` and `--token
-<TOKEN>`. Each is resolved independently from four sources, in this
-precedence order (highest wins):
+Every command accepts three global flags: `--server <URL>`, `--token
+<TOKEN>`, and `--context <NAME>`.
+
+`~/.skardi/config.yaml` holds named **contexts** and a pointer at the
+current one, the shape `kubectl` uses:
+
+```yaml
+kind: client
+current-context: local
+contexts:
+  - name: local
+    server: http://127.0.0.1:8080
+    # mode defaults to `server`
+  - name: acme/prod
+    server: https://gateway.skardi.ai
+    mode: cloud
+    workspace: acme-prod       # required in cloud mode, sent per request
+    token: skardi_pat_…
+```
+
+Which context a command uses: `--context NAME` > `$SKARDI_CONTEXT` >
+`current-context` > the only context, if the file defines exactly one. With
+several contexts and no pointer, no context is selected and the flags, env
+vars, and default below apply on their own.
+
+A named context that does not exist is an error listing the ones that do —
+never a silent fall back to the default server.
+
+### Precedence, per field
+
+`mode: server` contexts (the default, and every pre-cloud install):
 
 | Precedence | Server URL | API token |
 |---|---|---|
 | 1 | `--server <URL>` flag | `--token <TOKEN>` flag |
 | 2 | `SKARDI_SERVER_URL` env var | `SKARDI_API_TOKEN` env var |
-| 3 | `server:` in `~/.skardi/config.yaml` | `token:` in `~/.skardi/config.yaml` |
+| 3 | the context's `server:` | the context's `token:` |
 | 4 | `http://127.0.0.1:8080` (default) | none |
 
-`~/.skardi/config.yaml` is a client manifest in the repo's manifest style:
+`mode: cloud` contexts are **authoritative** for both fields, and the
+environment is refused rather than ranked:
+
+| Precedence | Server URL | API token |
+|---|---|---|
+| 1 | `--server <URL>` flag | `--token <TOKEN>` flag |
+| 2 | the context's `server:` | the context's `token:` |
+| — | a set `SKARDI_SERVER_URL` is an **error** unless `--server` overrides it | same for `SKARDI_API_TOKEN` / `--token` |
+
+The reason for the asymmetry: a cloud context's server and token are a
+matched pair — the token is a workspace-scoped PAT and the gateway that
+honours it is the one `login` wrote beside it. A `SKARDI_SERVER_URL` left
+exported from the single-server era would otherwise send that credential to
+whatever listens there, so the conflict is named instead of resolved
+silently. A flag still wins, because passing one is deliberate at the point
+of use.
+
+A cloud context is never defaulted to `http://127.0.0.1:8080`: one with no
+`server` is an error, for the same reason.
+
+### Managing contexts — `skardi config`
+
+Pure file edits; none of these touch the network.
+
+```bash
+# List contexts; the current one is marked with *
+skardi config get-contexts
+
+# Print just the current context's name
+skardi config current-context
+
+# Switch
+skardi config use-context acme/prod
+
+# Create or update one (only the fields you name are touched)
+skardi config set-context local --server http://127.0.0.1:8080 --current
+skardi config set-context acme/prod --mode cloud --workspace acme-prod \
+  --server https://gateway.skardi.ai --token skardi_pat_…
+
+# Remove one. Does not revoke its credential.
+skardi config delete-context acme/prod
+
+# Print the file with tokens redacted (--show-tokens prints them in full)
+skardi config view
+```
+
+The file is written atomically and `0600`, since it holds credentials; a
+looser existing file is reported and rewritten tighter. Keys this CLI does
+not recognize are preserved, so a newer CLI's fields survive an older one's
+edits.
+
+### Older config files
+
+A file with no `contexts:` key but the pre-contexts `spec:` block still
+works — it resolves as a single context named `default`, and the first
+`skardi config` edit promotes it into `contexts:` without losing its token:
 
 ```yaml
 kind: client
-metadata:
-  name: default
 spec:
   server: http://127.0.0.1:8080
   token: <optional bearer token>
 ```
 
-Both `spec.server` and `spec.token` are optional. A missing file is fine
-(defaults apply); a present-but-malformed file prints a `warning:` to
-stderr and falls back to defaults — never a silent ignore.
+A file with both prefers `contexts:` and warns once.
+
+A missing file is fine (defaults apply). A present-but-malformed one prints
+a `warning:` naming the line and column, and read-only commands carry on
+with flags and env vars — but any command that would *modify* the file
+refuses, because rewriting it would discard credentials it may still hold.
+Parse complaints never quote the file's contents, so a token on the broken
+line is not echoed.
 
 When a token is resolved (from any source), every request carries
 `Authorization: Bearer <token>`.

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -223,7 +223,10 @@ job **was not submitted** and the call is safe to retry.
 
 The CLI ships a matching `skardi job` subcommand that POSTs to the
 server. The server URL defaults to `http://127.0.0.1:8080`; override with
-`$SKARDI_SERVER_URL` or the `--server` flag.
+`$SKARDI_SERVER_URL` or the `--server` flag. Those are the `mode: server`
+rules — a context can also supply the URL, and a `mode: cloud` context is
+authoritative over the environment. See
+[cli.md — Connecting](cli.md#connecting) for the full precedence.
 
 ```bash
 # Submit — returns the run_id
@@ -266,7 +269,8 @@ running you'll get a connection-refused error.
 Against an auth-enabled server every `skardi job` subcommand needs a token,
 since all five endpoints are gated (see
 [Authentication](#authentication)). Supply it with `--token`,
-`$SKARDI_API_TOKEN`, or `~/.skardi/config.yaml`; the CLI attaches it as
+`$SKARDI_API_TOKEN`, or a context in `~/.skardi/config.yaml` (see
+[cli.md — Connecting](cli.md#connecting)); the CLI attaches it as
 `Authorization: Bearer <token>` on every request. Without one the symptom is
 a `401 unauthorized` from a command that needed no token before the gate
 existed.


### PR DESCRIPTION
**M1 of [the CLI contexts and login design](https://github.com/SkardiLabs/skardi-cloud/blob/main/docs/superpowers/specs/2026-08-20-skardi-cli-contexts-and-login-design.md)** (the design doc lives in `skardi-cloud`; this milestone is assigned to `skardi` by its §4 and §11): the config file shape, per-field resolution, context selection, the `skardi config` surface, atomic `0600` writes, mutation safety, and legacy back-compat. **No network code** — `login`/`logout` are M2.

## Scope note

The design sequences one PR per milestone. Of the six, **M3 and M6 are blocked**: §7.0 sequences them explicitly after `skardi-cloud#288`, which is still open. #301 has merged, so M5 is unblocked, and M4 has no dependency. This PR is M1, which everything else rests on.

## The load-bearing decision

A **`mode: cloud` context is authoritative** for its `server` and `token`, inverting the precedence a `mode: server` context has always had:

```
mode: server   server: --server > $SKARDI_SERVER_URL > context > default
mode: cloud    server: --server > context            (env is a hard error)
```

A cloud context's `{server, token}` are a matched pair — the PAT is scoped to one workspace at one role, and the gateway that honours it is the one `login` wrote beside it. A `SKARDI_SERVER_URL` left exported from the single-server era would otherwise send a workspace-scoped credential to whatever listens there. So the conflict is **refused by name** rather than silently applied or silently ignored. Flags still win, because `--server` is a deliberate act at the point of use.

## Everything ambiguous is a hard error, not a fallback

| Situation | Behaviour |
|---|---|
| Unknown `--context` / `$SKARDI_CONTEXT` / `current-context` | lists what exists; never falls through to `http://127.0.0.1:8080` — the one failure that would quietly send a cloud query to a local server |
| `mode: cloud` with no `workspace` | refuses at resolution, naming the repair, instead of issuing a request the gateway answers `workspace_required` |
| Env var conflicting with a cloud context | names the variable |

## Reads tolerate a broken file; mutations refuse it (§5.4)

Deliberately asymmetric. A read warns, ignores, falls through — so `--server` keeps working while the file is repaired. A mutation refuses to open it: a rewrite built from an empty parse tree would atomically replace a malformed-but-credential-bearing file, and the rename is torn-write-safe, not data-loss-safe. There is no `--force`, because that file may hold the only copy of a PAT nobody can re-mint without re-authenticating.

## Write path

Temp file in the **same** directory (a cross-filesystem rename is not atomic), created `0600` **before any bytes land** so a token never sits in a world-readable file even briefly, then renamed. Unknown top-level and per-context keys are preserved, so an older CLI's `use-context` cannot downgrade a file a newer one wrote. `config view` redacts tokens but keeps a recognizable prefix, the way git shows short hashes.

## Back-compat

A legacy `spec:` file resolves as one context named `default`, and its **first edit promotes it** into `contexts:` rather than dropping the credential it holds. A file carrying both prefers `contexts:` and warns once.

## Verification — all run locally

- **34 new unit tests** — 24 in `config.rs` over the precedence/selection matrix and the file surface, 10 in `commands/config.rs` covering every `config` subcommand in-process. (93 unit total in the crate, including 59 pre-existing.)
- **7 integration tests driving the real binary** with `HOME` redirected at a temp dir: create/list/switch/delete, redaction, unknown-key preservation, legacy promotion, the serverless-cloud refusal, and each resolution failure asserted at **exit 1 rather than the connect code `2`** — which is how "no request was issued" is demonstrated rather than assumed. One asserts a broken file survives a refused mutation **byte for byte**; another asserts `--server` *does* let the request through by expecting exit 2 against a `.invalid` host.
- **Live against a real `skardi-server` on :8080**: a server-mode context, `--context`, `$SKARDI_CONTEXT`, and a legacy `spec:` file each return rows.

`cargo test -p skardi-cli`: **93 unit + 7 integration + 4 e2e (2 ignored, server-gated)**. Clippy clean, `cargo fmt` clean.

## Review rounds

Three P1s and four P2s from review are fixed in this branch. The ones worth knowing about as a reviewer:

- **A cloud context with no `server` fell through to `http://127.0.0.1:8080` carrying the workspace PAT** — a hole in this PR's own central claim, reproduced against the real binary. Now a typed refusal at resolution *and* at `set-context`.
- **`redact()` printed short tokens in full** while labelling them `(redacted)`; legacy `spec:` tokens are arbitrary strings, so `abc123` rendered as `abc123…(redacted)`. Prefix dropped entirely — the context name already identifies the credential.
- **The env-conflict error's advice was false**: it said to pass `--server`, but the check ran before flags applied. Now per field, and only where the env would actually win.
- **Parse errors quoted the file**, so a token on a broken line hit stderr on every command. All complaints now report line/column only.
- **`docs/cli.md`** documented the pre-contexts precedence and no contexts at all; rewritten, with every command and flag checked against `--help`.
- **The lone-context selection step** is a documented deviation from §5.1 rather than an implicit one — it is load-bearing for §5.2's legacy files, and §5.1 is amended in skardi-cloud to say so.

## Reviewer notes

- `ClientConfig` gained a `context` field, so the seven test helpers that build it literally each gained `context: None`. No behaviour change to `client.rs` or any existing command.
- Resolution is deliberately **lazy, inside `dispatch`** after the `config` arm: `set-context` is how an operator repairs a config whose cloud context is missing its workspace, so it must not be gated on that resolution succeeding.
- M2 will add `ClientConfig::workspace()` and the `Skardi-Workspace` header together; the accessor is deliberately absent here rather than shipped unused.
- **Coverage note for anyone reading the Codecov diff:** the integration suite contributes none, because CI instruments test binaries and those tests spawn `skardi` as a subprocess. That is why `commands/config.rs` is covered in-process as well as through the binary — the two layers prove different things (logic vs. wiring and exit codes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
