### PR TITLE
feat(cli): skardi login/logout, cloud capability gating, and the workspace selector (contexts/login M2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9648,13 +9648,17 @@ name = "skardi-cli"
 version = "0.5.0"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
+ "chrono",
  "clap",
  "dirs 5.0.1",
+ "getrandom 0.2.17",
  "percent-encoding",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2 0.10.9",
  "tempfile",
  "tokio",
  "wiremock",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
 dirs = "5.0"
 percent-encoding = "2.3"
@@ -21,7 +22,13 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "io-util", "time"] }
+# PKCE S256 (§6.1 step 2): the code challenge is base64url(sha256(verifier)),
+# and the verifier/state must come from the OS CSPRNG — `getrandom` is that
+# and nothing more, with no PRNG state to seed or reason about.
+sha2 = "0.10"
+base64 = "0.22"
+getrandom = "0.2"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/cli/src/client.rs
+++ b/crates/cli/src/client.rs
@@ -665,8 +665,57 @@ mod tests {
 }
 
 #[cfg(test)]
+mod retry_after_tests {
+    use super::{ApiClient, ApiError};
+    use crate::config::ClientConfig;
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// Delta-seconds is parsed; an HTTP-date and any other unparsable value
+    /// read as ABSENT, so §8 falls back to the plain error instead of printing
+    /// a guessed retry interval.
+    #[tokio::test]
+    async fn only_delta_seconds_are_read_as_a_retry_interval() {
+        for (header, expected) in [
+            ("7", Some(7)),
+            (" 7 ", Some(7)),
+            ("Wed, 21 Oct 2026 07:28:00 GMT", None),
+            ("soon", None),
+            ("-1", None),
+        ] {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .respond_with(
+                    ResponseTemplate::new(503)
+                        .insert_header("Retry-After", header)
+                        .set_body_string("unavailable"),
+                )
+                .mount(&server)
+                .await;
+
+            let config = ClientConfig {
+                server: server.uri(),
+                token: None,
+                context: None,
+            };
+            let err = ApiClient::new(&config)
+                .unwrap()
+                .get("/x")
+                .await
+                .unwrap_err();
+            match err {
+                ApiError::Http { retry_after, .. } => {
+                    assert_eq!(retry_after, expected, "Retry-After: {header:?}")
+                }
+                other => panic!("expected Http, got {other:?}"),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
 mod workspace_selector_tests {
-    use super::{ApiClient, WORKSPACE_HEADER};
+    use super::{ApiClient, ApiError, WORKSPACE_HEADER};
     use crate::config::{ClientConfig, ContextMode, SelectedContext};
     use serde_json::json;
     use wiremock::matchers::{header, method, path};
@@ -724,6 +773,108 @@ mod workspace_selector_tests {
             requests[0].headers.get(WORKSPACE_HEADER).is_none(),
             "a server-mode context must not send the gateway's workspace selector"
         );
+    }
+
+    /// Both header values are built at construction, so a value that cannot
+    /// be sent is one clear config error instead of a failure at every
+    /// request — and neither message may echo the value.
+    #[test]
+    fn a_credential_that_cannot_be_sent_as_a_header_fails_at_construction() {
+        let mut config = cloud_config("https://gw.example", Some("acme-prod"), ContextMode::Cloud);
+        config.token = Some("secret-with-a\nnewline".to_string());
+        let err = construction_error(&config);
+        assert!(err.contains("cannot be sent in an HTTP header"), "{err}");
+        assert!(
+            !err.contains("secret-with-a"),
+            "the token must not be echoed: {err}"
+        );
+
+        let config = cloud_config(
+            "https://gw.example",
+            Some("bad\nworkspace"),
+            ContextMode::Cloud,
+        );
+        assert!(construction_error(&config).contains(WORKSPACE_HEADER));
+    }
+
+    /// Sending a bearer over cleartext to a non-loopback host is warned about
+    /// once, at construction — the token still goes, because refusing would
+    /// break a deployment behind a TLS-terminating proxy, but silence would
+    /// hide it.
+    #[test]
+    fn a_cleartext_remote_server_warns_when_a_token_is_configured() {
+        let mut config = cloud_config("http://gateway.example", None, ContextMode::Server);
+        config.token = Some("a-token".to_string());
+        assert!(ApiClient::new(&config).is_ok());
+    }
+
+    /// A server URL that is not a URL surfaces as `Connect` — so `main` exits
+    /// 2 and the message names the flags, rather than panicking somewhere
+    /// inside reqwest.
+    #[tokio::test]
+    async fn an_unusable_server_url_is_a_connect_failure() {
+        let config = ClientConfig {
+            server: "not even a url".to_string(),
+            token: None,
+            context: None,
+        };
+        let err = ApiClient::new(&config)
+            .unwrap()
+            .get("/status")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, ApiError::Connect { .. }),
+            "expected Connect, got {err:?}"
+        );
+        assert!(err.to_string().contains("--server"), "{err}");
+    }
+
+    /// A 200 whose body is not JSON is an `Http` error naming the parse
+    /// failure, not a panic and not a silent empty result.
+    #[tokio::test]
+    async fn a_success_status_with_an_unparsable_body_is_reported() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("<html>not json</html>"))
+            .mount(&server)
+            .await;
+
+        let config = ClientConfig {
+            server: server.uri(),
+            token: None,
+            context: None,
+        };
+        let err = ApiClient::new(&config)
+            .unwrap()
+            .get("/status")
+            .await
+            .unwrap_err();
+        match err {
+            ApiError::Http {
+                status,
+                message,
+                retry_after,
+                ..
+            } => {
+                assert_eq!(status, 200);
+                assert!(
+                    message.contains("failed to parse response body"),
+                    "{message}"
+                );
+                assert_eq!(retry_after, None);
+            }
+            other => panic!("expected Http, got {other:?}"),
+        }
+    }
+
+    /// `unwrap_err` would require `ApiClient: Debug`, which it deliberately
+    /// does not derive — it holds the bearer header value.
+    fn construction_error(config: &ClientConfig) -> String {
+        match ApiClient::new(config) {
+            Ok(_) => panic!("expected ApiClient::new to refuse this config"),
+            Err(err) => err.to_string(),
+        }
     }
 
     #[tokio::test]

--- a/crates/cli/src/client.rs
+++ b/crates/cli/src/client.rs
@@ -357,7 +357,7 @@ impl ApiClient {
 /// True when `base_url` is plain `http://` to a host other than loopback
 /// (`localhost`, `127.0.0.0/8`, or `::1`) — the case where a configured
 /// bearer token would travel in cleartext across a real network.
-fn is_cleartext_remote(base_url: &str) -> bool {
+pub(crate) fn is_cleartext_remote(base_url: &str) -> bool {
     let Some(rest) = base_url.strip_prefix("http://") else {
         return false;
     };

--- a/crates/cli/src/client.rs
+++ b/crates/cli/src/client.rs
@@ -1,9 +1,11 @@
 //! Thin HTTP client for talking to skardi-server: a small wrapper around
-//! `reqwest` that attaches Bearer auth when a token is configured and maps
-//! non-success responses (and transport failures) into a uniform `ApiError`.
+//! `reqwest` that attaches Bearer auth when a token is configured, names the
+//! workspace when a cloud context selected one, and maps non-success
+//! responses (and transport failures) into a uniform `ApiError`.
 
 use crate::config::ClientConfig;
 use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
+use reqwest::header::{AUTHORIZATION, HeaderName, HeaderValue};
 use reqwest::{Client, RequestBuilder, Response, StatusCode};
 use serde_json::Value;
 use std::error::Error as StdError;
@@ -21,11 +23,40 @@ const URL_COMPONENT: &AsciiSet = &NON_ALPHANUMERIC
     .remove(b'_')
     .remove(b'~');
 
+/// [`WORKSPACE_HEADER`] lowercased, for `HeaderName::from_static` — which
+/// panics on any uppercase byte, and is the only constructor that cannot fail
+/// at runtime.
+const WORKSPACE_HEADER_LOWER: &str = "skardi-workspace";
+
+/// The workspace selector a `mode: cloud` context sends on every request
+/// (§7.3). Deliberately outside the reserved `x-skardi-*` prefix, which the
+/// gateway strips from client-supplied headers before forwarding upstream.
+pub const WORKSPACE_HEADER: &str = "Skardi-Workspace";
+
 /// Ceiling on buffered response-body size. The server's `max_rows` cap
 /// bounds honest responses far below this; the client-side cap is
 /// defense-in-depth so a runaway or misconfigured endpoint fails cleanly
 /// instead of exhausting memory.
 const MAX_RESPONSE_BYTES: usize = 256 * 1024 * 1024;
+
+/// Parse `Retry-After` in its delta-seconds form.
+///
+/// The header's other legal form is an HTTP-date, which is deliberately NOT
+/// parsed: rendering it as "retry in Ns" needs a clock and a date parser to
+/// produce a number the caller could read off the header themselves, and the
+/// route that emits it (§7.4.2's schema-read limiter) sends delta-seconds.
+/// An unparsable value reads as absent, so the caller falls back to the plain
+/// error rather than printing a guess.
+fn retry_after_seconds(response: &Response) -> Option<u64> {
+    response
+        .headers()
+        .get(reqwest::header::RETRY_AFTER)?
+        .to_str()
+        .ok()?
+        .trim()
+        .parse()
+        .ok()
+}
 
 /// Percent-encode one URL path segment or query value (user-supplied
 /// pipeline/job names, run ids) so characters like `/`, `?`, `#`, `%`, and
@@ -42,7 +73,14 @@ pub fn encode_component(raw: &str) -> String {
 pub struct ApiClient {
     http: Client,
     base_url: String,
-    token: Option<String>,
+    /// `Authorization: Bearer <token>`, pre-built so an unsendable token fails
+    /// at construction with one clear message instead of at every request.
+    /// Marked sensitive, as `RequestBuilder::bearer_auth` does, so it stays
+    /// out of reqwest's own debug output.
+    auth: Option<HeaderValue>,
+    /// The `Skardi-Workspace` value, set only for a cloud context. See
+    /// [`ClientConfig::workspace`] for why it is not an `x-skardi-*` header.
+    workspace: Option<HeaderValue>,
     max_response_bytes: usize,
 }
 
@@ -62,6 +100,11 @@ pub enum ApiError {
         status: u16,
         error_type: Option<String>,
         message: String,
+        /// `Retry-After` in whole seconds, when the response carried one in
+        /// delta-seconds form. Kept because §8 turns a `503` WITH this value
+        /// into a load message and one without it into a plain failure — the
+        /// distinction is the header, so it has to survive this far.
+        retry_after: Option<u64>,
     },
 }
 
@@ -82,11 +125,13 @@ impl fmt::Display for ApiError {
                 status,
                 error_type: Some(error_type),
                 message,
+                ..
             } => write!(f, "[{error_type}] {message} (HTTP {status})"),
             ApiError::Http {
                 status,
                 error_type: None,
                 message,
+                ..
             } => write!(f, "server returned HTTP {status}: {message}"),
         }
     }
@@ -117,6 +162,31 @@ impl ApiClient {
         let http = Client::builder().no_proxy().build()?;
         let base_url = cfg.server.trim_end_matches('/').to_string();
 
+        // Built here, not per request: `HeaderValue` conversion is the only
+        // way a config value can be unsendable, and the caller deserves that
+        // as a config error rather than as a request failure. Neither message
+        // includes the value — `InvalidHeaderValue` does not carry it.
+        let auth = match &cfg.token {
+            Some(token) => {
+                let mut value = HeaderValue::from_str(&format!("Bearer {token}")).map_err(|_| {
+                    anyhow::anyhow!(
+                        "the configured token cannot be sent in an HTTP header (it contains a control character or a non-ASCII byte)"
+                    )
+                })?;
+                value.set_sensitive(true);
+                Some(value)
+            }
+            None => None,
+        };
+        let workspace = match cfg.workspace() {
+            Some(workspace) => Some(HeaderValue::from_str(workspace).map_err(|_| {
+                anyhow::anyhow!(
+                    "context workspace '{workspace}' cannot be sent in the {WORKSPACE_HEADER} header"
+                )
+            })?),
+            None => None,
+        };
+
         if cfg.token.is_some() && is_cleartext_remote(&base_url) {
             eprintln!(
                 "warning: bearer token will be sent over cleartext http to a non-loopback host — prefer an https:// server URL"
@@ -126,7 +196,8 @@ impl ApiClient {
         Ok(ApiClient {
             http,
             base_url,
-            token: cfg.token.clone(),
+            auth,
+            workspace,
             max_response_bytes: MAX_RESPONSE_BYTES,
         })
     }
@@ -135,9 +206,7 @@ impl ApiClient {
     /// return the parsed JSON body, or an `ApiError` on failure.
     pub async fn get(&self, path: &str) -> Result<Value, ApiError> {
         let url = format!("{}{}", self.base_url, path);
-        let mut request = self.http.get(&url);
-        request = self.with_auth(request);
-
+        let request = self.http.get(&url);
         self.send(request, url).await
     }
 
@@ -162,8 +231,6 @@ impl ApiClient {
         for (name, value) in headers {
             request = request.header(*name, *value);
         }
-        request = self.with_auth(request);
-
         self.send(request, url).await
     }
 
@@ -175,12 +242,25 @@ impl ApiClient {
         self
     }
 
-    /// Attach `Authorization: Bearer <token>` when a token is configured;
-    /// otherwise leave the request untouched (no auth header at all).
-    fn with_auth(&self, request: RequestBuilder) -> RequestBuilder {
-        match &self.token {
-            Some(token) => request.bearer_auth(token),
-            None => request,
+    /// Set the headers every request carries: `Authorization: Bearer <token>`
+    /// when a token is configured, and `Skardi-Workspace` when a cloud context
+    /// named one (§7.3).
+    ///
+    /// `insert`, on a built `Request`, rather than `RequestBuilder::header`:
+    /// the builder APPENDS, so a per-call header of the same name would
+    /// produce two values and leave which one the peer honours up to its
+    /// parser. For the workspace selector that is an authorization-relevant
+    /// difference, so these two names are set here and cannot be displaced.
+    fn set_reserved_headers(&self, request: &mut reqwest::Request) {
+        let headers = request.headers_mut();
+        if let Some(auth) = &self.auth {
+            headers.insert(AUTHORIZATION, auth.clone());
+        }
+        if let Some(workspace) = &self.workspace {
+            headers.insert(
+                HeaderName::from_static(WORKSPACE_HEADER_LOWER),
+                workspace.clone(),
+            );
         }
     }
 
@@ -188,23 +268,35 @@ impl ApiClient {
     /// responses to `ApiError`. `url` is the request URL, kept for
     /// `ApiError::Connect` messages.
     async fn send(&self, request: RequestBuilder, url: String) -> Result<Value, ApiError> {
-        let response = request.send().await.map_err(|err| ApiError::Connect {
+        let mut request = request.build().map_err(|err| ApiError::Connect {
             url: url.clone(),
             message: err.to_string(),
         })?;
+        self.set_reserved_headers(&mut request);
+        let response = self
+            .http
+            .execute(request)
+            .await
+            .map_err(|err| ApiError::Connect {
+                url: url.clone(),
+                message: err.to_string(),
+            })?;
 
         let status = response.status();
+        // Read before the body: `read_body_capped` consumes the response.
+        let retry_after = retry_after_seconds(&response);
         let body_bytes = Self::read_body_capped(response, self.max_response_bytes, &url).await?;
         let body_text = String::from_utf8_lossy(&body_bytes);
 
         if !status.is_success() {
-            return Err(Self::map_error_body(status, &body_text));
+            return Err(Self::map_error_body(status, &body_text, retry_after));
         }
 
         serde_json::from_str(&body_text).map_err(|err| ApiError::Http {
             status: status.as_u16(),
             error_type: None,
             message: format!("failed to parse response body as JSON: {err}"),
+            retry_after: None,
         })
     }
 
@@ -233,6 +325,7 @@ impl ApiClient {
                     message: format!(
                         "response body exceeded the client cap of {cap} bytes — refusing to buffer it"
                     ),
+                    retry_after: None,
                 });
             }
             buf.extend_from_slice(&chunk);
@@ -243,17 +336,19 @@ impl ApiClient {
     /// server's JSON error envelope first (a string `error` field, with an
     /// optional `error_type`); fall back to the first line of the raw body
     /// with no `error_type` when the body isn't that envelope.
-    fn map_error_body(status: StatusCode, body_text: &str) -> ApiError {
+    fn map_error_body(status: StatusCode, body_text: &str, retry_after: Option<u64>) -> ApiError {
         match serde_json::from_str::<ErrorEnvelope>(body_text) {
             Ok(envelope) => ApiError::Http {
                 status: status.as_u16(),
                 error_type: envelope.error_type,
                 message: envelope.error,
+                retry_after,
             },
             Err(_) => ApiError::Http {
                 status: status.as_u16(),
                 error_type: None,
                 message: body_text.lines().next().unwrap_or("").to_string(),
+                retry_after,
             },
         }
     }
@@ -393,10 +488,12 @@ mod tests {
                 status,
                 error_type,
                 message,
+                retry_after,
             } => {
                 assert_eq!(*status, 400);
                 assert_eq!(error_type.as_deref(), Some("sql_validation_error"));
                 assert_eq!(message, "column foo does not exist");
+                assert_eq!(*retry_after, None);
             }
             other => panic!("expected Http, got {other:?}"),
         }
@@ -428,10 +525,14 @@ mod tests {
                 status,
                 error_type,
                 message,
+                retry_after,
             } => {
                 assert_eq!(*status, 503);
                 assert_eq!(*error_type, None);
                 assert_eq!(message, "service unavailable");
+                // No `Retry-After` on the wire reads as absent, which is what
+                // keeps §8's schema-limit message off a plain outage.
+                assert_eq!(*retry_after, None);
             }
             other => panic!("expected Http, got {other:?}"),
         }
@@ -560,5 +661,102 @@ mod tests {
             .with_max_response_bytes(1024);
         let body = client.get("/status").await.unwrap();
         assert_eq!(body["ok"], true);
+    }
+}
+
+#[cfg(test)]
+mod workspace_selector_tests {
+    use super::{ApiClient, WORKSPACE_HEADER};
+    use crate::config::{ClientConfig, ContextMode, SelectedContext};
+    use serde_json::json;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn cloud_config(server: &str, workspace: Option<&str>, mode: ContextMode) -> ClientConfig {
+        ClientConfig {
+            server: server.to_string(),
+            token: Some("pat-value".to_string()),
+            context: Some(SelectedContext {
+                name: "acme/prod".to_string(),
+                mode,
+                workspace: workspace.map(str::to_string),
+                token_expires_at: None,
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn cloud_context_names_its_workspace_on_every_request() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/data_source"))
+            .and(header(WORKSPACE_HEADER, "acme-prod"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"ok": true})))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let config = cloud_config(&server.uri(), Some("acme-prod"), ContextMode::Cloud);
+        let client = ApiClient::new(&config).unwrap();
+        client.get("/data_source").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn server_context_sends_no_workspace_selector() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"ok": true})))
+            .mount(&server)
+            .await;
+
+        // A server-mode context with a workspace set anyway: the header is
+        // keyed off `mode`, not off the field being populated.
+        let config = cloud_config(&server.uri(), Some("acme-prod"), ContextMode::Server);
+        ApiClient::new(&config)
+            .unwrap()
+            .get("/status")
+            .await
+            .unwrap();
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+        assert!(
+            requests[0].headers.get(WORKSPACE_HEADER).is_none(),
+            "a server-mode context must not send the gateway's workspace selector"
+        );
+    }
+
+    #[tokio::test]
+    async fn per_call_headers_cannot_displace_auth_or_the_selector() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"ok": true})))
+            .mount(&server)
+            .await;
+
+        let config = cloud_config(&server.uri(), Some("acme-prod"), ContextMode::Cloud);
+        ApiClient::new(&config)
+            .unwrap()
+            .post_with_headers(
+                "/query",
+                &json!({"sql": "select 1"}),
+                &[
+                    (WORKSPACE_HEADER, "someone-elses-workspace"),
+                    ("Authorization", "Bearer forged"),
+                ],
+            )
+            .await
+            .unwrap();
+
+        let requests = server.received_requests().await.unwrap();
+        let headers = &requests[0].headers;
+        assert_eq!(
+            headers.get_all(WORKSPACE_HEADER).iter().count(),
+            1,
+            "selector must appear exactly once: {:?}",
+            headers.get_all(WORKSPACE_HEADER).iter().collect::<Vec<_>>()
+        );
+        assert_eq!(headers.get(WORKSPACE_HEADER).unwrap(), "acme-prod");
+        assert_eq!(headers.get("Authorization").unwrap(), "Bearer pat-value");
     }
 }

--- a/crates/cli/src/cloud.rs
+++ b/crates/cli/src/cloud.rs
@@ -180,8 +180,9 @@ pub fn diagnose(
         // and `Retry-After` is what separates it from a gateway that is simply
         // down. Scoped to `schema` because that is the only route that
         // bounds concurrency this way.
-        503 if capability == Capability::Schema && retry_after.is_some() => {
-            let seconds = retry_after.unwrap_or_default();
+        503 if capability == Capability::Schema
+            && let Some(seconds) = *retry_after =>
+        {
             anyhow!("the gateway is at its schema-read limit; retry in {seconds}s")
         }
         _ => err,

--- a/crates/cli/src/cloud.rs
+++ b/crates/cli/src/cloud.rs
@@ -1,0 +1,475 @@
+//! What a `mode: cloud` context changes about a command's outcome (§8).
+//!
+//! Three things, all of them pre- or post-processing around an unchanged
+//! request path — `mode` never selects a URL, so nothing here touches routing:
+//!
+//! 1. **Capability gating.** A skardi-cloud gateway mounts `query` and
+//!    `schema`; it has no jobs, pipelines, or health surface. Those commands
+//!    fail before a request is built, because a 404 from a gateway that never
+//!    served the route reads as "the server is broken" rather than "this
+//!    context cannot do that".
+//! 2. **Credential expiry.** A context carries `token-expires-at`, so an
+//!    expired PAT is knowable without spending a round trip.
+//! 3. **Error translation.** The gateway's typed refusals name the *deployment*
+//!    ("the token's org has no workspace matching the one this gateway
+//!    serves"); the operator thinks in contexts. Translation happens here, at
+//!    the one place that knows both.
+//!
+//! Everything is a pure function of `(error, capability, config)` so the
+//! matrix is unit-testable without a server.
+
+use crate::client::ApiError;
+use crate::config::ClientConfig;
+use anyhow::anyhow;
+use chrono::{DateTime, Utc};
+
+/// One remote subcommand, for gating and for the error mapping that is
+/// specific to one route (§7.4.2's schema-read limit).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Capability {
+    Query,
+    Schema,
+    Run,
+    Pipeline,
+    Job,
+    Health,
+}
+
+impl Capability {
+    /// The subcommand name as the user typed it.
+    ///
+    /// §8's example message says `'jobs'`; this CLI's subcommand is `job`
+    /// (`skardi job list`), and naming a command that does not exist would be
+    /// a worse message than the design's illustration.
+    pub const fn command(self) -> &'static str {
+        match self {
+            Capability::Query => "query",
+            Capability::Schema => "schema",
+            Capability::Run => "run",
+            Capability::Pipeline => "pipeline",
+            Capability::Job => "job",
+            Capability::Health => "health",
+        }
+    }
+
+    /// Whether a skardi-cloud gateway serves this command.
+    ///
+    /// The gateway's route table is `POST /query` and `GET /data_source`
+    /// (§7.4); everything else is an engine-local surface that only a
+    /// `mode: server` context reaches.
+    pub const fn served_by_gateway(self) -> bool {
+        matches!(self, Capability::Query | Capability::Schema)
+    }
+}
+
+/// Every capability, so the "Available:" list is DERIVED from
+/// [`Capability::served_by_gateway`] rather than restated next to it — a
+/// hand-written list is the kind that survives the table changing under it.
+const ALL_CAPABILITIES: [Capability; 6] = [
+    Capability::Query,
+    Capability::Schema,
+    Capability::Run,
+    Capability::Pipeline,
+    Capability::Job,
+    Capability::Health,
+];
+
+/// The comma-separated commands a cloud context can run.
+fn cloud_capability_list() -> String {
+    ALL_CAPABILITIES
+        .iter()
+        .filter(|c| c.served_by_gateway())
+        .map(|c| c.command())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Refuse a command the selected cloud context cannot serve, before any
+/// request is built (§8, row 1). Exits `1` through `main`'s mapping — `2` is
+/// reserved for "cannot reach the server", and this never reached it.
+pub fn ensure_available(capability: Capability, config: &ClientConfig) -> anyhow::Result<()> {
+    let Some(context) = config.cloud_context() else {
+        return Ok(());
+    };
+    if capability.served_by_gateway() {
+        return Ok(());
+    }
+    Err(anyhow!(
+        "'{}' is not available in a cloud context ({}). Available: {}.",
+        capability.command(),
+        context.name,
+        cloud_capability_list()
+    ))
+}
+
+/// Refuse when the stored PAT's `token-expires-at` has already passed (§8,
+/// row 3), so an expired credential costs no round trip.
+///
+/// `now` is a parameter rather than a `Utc::now()` call so the check stays a
+/// pure function, the way resolution is.
+pub fn ensure_credential_fresh(config: &ClientConfig, now: DateTime<Utc>) -> anyhow::Result<()> {
+    let Some(context) = config.cloud_context() else {
+        return Ok(());
+    };
+    let Some(raw) = context.token_expires_at.as_deref() else {
+        return Ok(());
+    };
+    // An unparsable stamp is NOT fatal. It is an optional field in a file a
+    // human may have hand-edited, and refusing every command over a malformed
+    // annotation would be a worse outcome than sending one request the gateway
+    // answers authoritatively.
+    let Ok(expires_at) = DateTime::parse_from_rfc3339(raw) else {
+        return Ok(());
+    };
+    if expires_at.with_timezone(&Utc) > now {
+        return Ok(());
+    }
+    // §8 prescribes the 401 message verbatim here ("was rejected"). Said
+    // pre-flight that is untrue — nothing rejected anything, no request was
+    // sent — so this keeps the design's shape (context named, `skardi login`
+    // as the action) and states what was actually observed.
+    Err(anyhow!(
+        "credential for context '{}' expired at {raw}. Run 'skardi login'.",
+        context.name
+    ))
+}
+
+/// Rewrite a gateway failure into the context's vocabulary (§8, rows 2, 4, 5).
+///
+/// Non-cloud contexts and unrecognised failures pass through untouched: this
+/// only ever replaces a message it can improve. `ApiError::Connect` is never
+/// touched either — its own message already names the URL and the flags, and
+/// `main` reads the same error back out to choose exit code `2`.
+pub fn diagnose(
+    err: anyhow::Error,
+    capability: Capability,
+    config: &ClientConfig,
+) -> anyhow::Error {
+    let Some(context) = config.cloud_context() else {
+        return err;
+    };
+    let Some(ApiError::Http {
+        status,
+        error_type,
+        message,
+        retry_after,
+    }) = err.downcast_ref::<ApiError>()
+    else {
+        return err;
+    };
+
+    match *status {
+        // REPLACED, not annotated: the transport-level 401 message tells the
+        // caller to set SKARDI_API_TOKEN or edit `token` in the config, and
+        // for a cloud context that advice is actively wrong — resolution
+        // refuses the env var (§5.1) and the PAT is `login`'s to write.
+        401 => anyhow!(
+            "credential for context '{}' was rejected — it may be expired or revoked. Run 'skardi login'.",
+            context.name
+        ),
+        // ANNOTATED, not replaced: the gateway's own sentence says which
+        // boundary was crossed (not a member / no matching workspace), which
+        // is the detail that distinguishes the two, and it never leaks a slug
+        // the caller didn't already send.
+        403 if names_workspace(error_type.as_deref(), message) => err.context(format!(
+            "context '{}' names workspace '{}', which this gateway does not serve",
+            context.name,
+            context.workspace.as_deref().unwrap_or("(unset)"),
+        )),
+        // §7.4.2's schema-read limiter is a LOAD signal, not a schema error,
+        // and `Retry-After` is what separates it from a gateway that is simply
+        // down. Scoped to `schema` because that is the only route that
+        // bounds concurrency this way.
+        503 if capability == Capability::Schema && retry_after.is_some() => {
+            let seconds = retry_after.unwrap_or_default();
+            anyhow!("the gateway is at its schema-read limit; retry in {seconds}s")
+        }
+        _ => err,
+    }
+}
+
+/// Whether a `403` is the workspace boundary rather than an authorization
+/// failure inside the workspace.
+///
+/// Today's gateway answers every `PatAuthError::NotAuthorized` with
+/// `error_type: "forbidden"` and a deliberately caller-safe message that names
+/// no slug ("the token's org has no workspace matching the one this gateway
+/// serves"), so the word in the message is the only discriminator available.
+/// The typed tokens are matched too: §7.3's org-admission path maps
+/// `Directory.Resolve`'s `workspace_not_found` to a typed 403, and accepting
+/// them now means the CLI reads that release without needing one of its own.
+///
+/// `identity_required` and `identity_unresolved` also mention "workspace" —
+/// they are excluded because they carry their own `error_type`, and they are
+/// genuinely a different failure (a credential with no envelope, not a slug
+/// the deployment refuses).
+fn names_workspace(error_type: Option<&str>, message: &str) -> bool {
+    match error_type {
+        Some("workspace_not_found" | "workspace_required") => true,
+        Some("forbidden") => message.to_ascii_lowercase().contains("workspace"),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ALL_CAPABILITIES, Capability, diagnose, ensure_available, ensure_credential_fresh,
+    };
+    use crate::client::ApiError;
+    use crate::config::{ClientConfig, ContextMode, SelectedContext};
+    use chrono::{DateTime, Utc};
+
+    fn at(rfc3339: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(rfc3339)
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    fn config(mode: Option<ContextMode>, expires: Option<&str>) -> ClientConfig {
+        ClientConfig {
+            server: "https://gw.example".to_string(),
+            token: Some("pat".to_string()),
+            context: mode.map(|mode| SelectedContext {
+                name: "acme/prod".to_string(),
+                mode,
+                workspace: Some("acme-prod".to_string()),
+                token_expires_at: expires.map(str::to_string),
+            }),
+        }
+    }
+
+    fn http(
+        status: u16,
+        error_type: Option<&str>,
+        message: &str,
+        retry_after: Option<u64>,
+    ) -> anyhow::Error {
+        anyhow::Error::new(ApiError::Http {
+            status,
+            error_type: error_type.map(str::to_string),
+            message: message.to_string(),
+            retry_after,
+        })
+    }
+
+    /// §10's "table test over (subcommand, mode)". The mode column is what
+    /// decides, so both non-cloud shapes (server context, no context at all)
+    /// are exercised for every capability.
+    #[test]
+    fn gating_matrix_refuses_exactly_the_engine_local_commands() {
+        for capability in ALL_CAPABILITIES {
+            let cloud = ensure_available(capability, &config(Some(ContextMode::Cloud), None));
+            assert_eq!(
+                cloud.is_err(),
+                !capability.served_by_gateway(),
+                "cloud gating disagreed with served_by_gateway for '{}'",
+                capability.command()
+            );
+            for non_cloud in [Some(ContextMode::Server), None] {
+                assert!(
+                    ensure_available(capability, &config(non_cloud, None)).is_ok(),
+                    "'{}' must stay available without a cloud context",
+                    capability.command()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn refusal_names_the_command_the_context_and_what_is_left() {
+        let err = ensure_available(Capability::Job, &config(Some(ContextMode::Cloud), None))
+            .unwrap_err()
+            .to_string();
+        assert_eq!(
+            err,
+            "'job' is not available in a cloud context (acme/prod). Available: query, schema."
+        );
+    }
+
+    #[test]
+    fn expiry_is_checked_only_for_a_cloud_context_and_only_when_it_has_passed() {
+        let now = at("2026-06-01T12:00:00Z");
+
+        let expired = ensure_credential_fresh(
+            &config(Some(ContextMode::Cloud), Some("2026-05-31T12:00:00Z")),
+            now,
+        );
+        assert_eq!(
+            expired.unwrap_err().to_string(),
+            "credential for context 'acme/prod' expired at 2026-05-31T12:00:00Z. Run 'skardi login'."
+        );
+
+        // Fresh, absent, unparsable, and non-cloud all pass without a request.
+        for (mode, expires) in [
+            (Some(ContextMode::Cloud), Some("2026-06-01T12:00:01Z")),
+            (Some(ContextMode::Cloud), None),
+            (Some(ContextMode::Cloud), Some("not-a-timestamp")),
+            (Some(ContextMode::Server), Some("2020-01-01T00:00:00Z")),
+            (None, None),
+        ] {
+            assert!(
+                ensure_credential_fresh(&config(mode, expires), now).is_ok(),
+                "unexpected refusal for mode={mode:?} expires={expires:?}"
+            );
+        }
+    }
+
+    /// A non-UTC offset is a legal RFC 3339 stamp and must be compared as an
+    /// instant, not as text: this one is 23:00Z, an hour AFTER `now`, while
+    /// its digits sort before it.
+    #[test]
+    fn expiry_compares_instants_not_strings() {
+        assert!(
+            ensure_credential_fresh(
+                &config(Some(ContextMode::Cloud), Some("2026-06-01T18:00:00-05:00")),
+                at("2026-06-01T22:00:00Z"),
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn unauthorized_is_replaced_with_the_context_and_the_login_action() {
+        let err = diagnose(
+            http(401, Some("unauthorized"), "invalid token", None),
+            Capability::Query,
+            &config(Some(ContextMode::Cloud), None),
+        );
+        assert_eq!(
+            format!("{err:#}"),
+            "credential for context 'acme/prod' was rejected — it may be expired or revoked. Run 'skardi login'."
+        );
+        // Replaced outright: the transport message's advice (set
+        // SKARDI_API_TOKEN) is refused by resolution for a cloud context.
+        assert!(!format!("{err:#}").contains("SKARDI_API_TOKEN"));
+    }
+
+    #[test]
+    fn workspace_boundary_403_names_the_context_and_keeps_the_gateway_reason() {
+        let err = diagnose(
+            http(
+                403,
+                Some("forbidden"),
+                "the token's org has no workspace matching the one this gateway serves",
+                None,
+            ),
+            Capability::Query,
+            &config(Some(ContextMode::Cloud), None),
+        );
+        let rendered = format!("{err:#}");
+        assert!(
+            rendered.starts_with(
+                "context 'acme/prod' names workspace 'acme-prod', which this gateway does not serve"
+            ),
+            "rendered: {rendered}"
+        );
+        assert!(
+            rendered.contains("no workspace matching"),
+            "rendered: {rendered}"
+        );
+        // Still an ApiError underneath, so `main` keeps choosing exit 1 (not
+        // 2) from the same downcast.
+        assert!(matches!(
+            err.downcast_ref::<ApiError>(),
+            Some(ApiError::Http { status: 403, .. })
+        ));
+    }
+
+    /// The 403s that are NOT the workspace boundary pass through untouched,
+    /// including `identity_required` — whose message mentions "workspace" and
+    /// would be misclassified by a message-only rule.
+    #[test]
+    fn other_403s_are_left_alone() {
+        for (error_type, message) in [
+            (
+                Some("identity_required"),
+                "this deployment routes queries per workspace; the presented credential resolved locally",
+            ),
+            (
+                Some("identity_unresolved"),
+                "resolved identity could not be turned into a request envelope",
+            ),
+            (
+                Some("forbidden"),
+                "the caller's role does not permit this operation",
+            ),
+            (None, "forbidden"),
+        ] {
+            let err = diagnose(
+                http(403, error_type, message, None),
+                Capability::Query,
+                &config(Some(ContextMode::Cloud), None),
+            );
+            assert!(
+                !format!("{err:#}").contains("does not serve"),
+                "{error_type:?} was rewritten as a workspace boundary miss"
+            );
+        }
+    }
+
+    #[test]
+    fn schema_read_limit_is_reported_as_load_only_with_retry_after() {
+        let cloud = config(Some(ContextMode::Cloud), None);
+        let limited = diagnose(
+            http(
+                503,
+                Some("schema_read_limit"),
+                "too many concurrent schema reads",
+                Some(7),
+            ),
+            Capability::Schema,
+            &cloud,
+        );
+        assert_eq!(
+            format!("{limited:#}"),
+            "the gateway is at its schema-read limit; retry in 7s"
+        );
+
+        // No Retry-After: a plain outage, reported as the gateway phrased it.
+        let outage = diagnose(
+            http(503, Some("backend_unavailable"), "engine unreachable", None),
+            Capability::Schema,
+            &cloud,
+        );
+        assert!(format!("{outage:#}").contains("engine unreachable"));
+
+        // Same 503 on another route is not the schema limiter.
+        let query = diagnose(
+            http(
+                503,
+                Some("backend_unavailable"),
+                "engine unreachable",
+                Some(7),
+            ),
+            Capability::Query,
+            &cloud,
+        );
+        assert!(format!("{query:#}").contains("engine unreachable"));
+    }
+
+    #[test]
+    fn non_cloud_contexts_and_transport_failures_pass_through() {
+        for mode in [Some(ContextMode::Server), None] {
+            let err = diagnose(
+                http(401, Some("unauthorized"), "invalid token", None),
+                Capability::Query,
+                &config(mode, None),
+            );
+            assert!(!format!("{err:#}").contains("skardi login"));
+        }
+
+        let connect = diagnose(
+            anyhow::Error::new(ApiError::Connect {
+                url: "https://gw.example/query".to_string(),
+                message: "connection refused".to_string(),
+            }),
+            Capability::Query,
+            &config(Some(ContextMode::Cloud), None),
+        );
+        assert!(matches!(
+            connect.downcast_ref::<ApiError>(),
+            Some(ApiError::Connect { .. })
+        ));
+    }
+}

--- a/crates/cli/src/commands/login.rs
+++ b/crates/cli/src/commands/login.rs
@@ -150,6 +150,7 @@ fn options_from(
         server_override: flag_server,
         env_gateway_url: std::env::var(GATEWAY_URL_ENV).ok(),
         endpoints: oauth::Endpoints::default(),
+        open_browser: oauth::open_in_browser,
         callback_timeout: oauth::CALLBACK_TIMEOUT,
         token_name: login::default_token_name(),
         now: chrono::Utc::now(),
@@ -362,6 +363,25 @@ mod tests {
         // A revocation failure warns on stderr and is deliberately NOT part of
         // the summary: the login itself succeeded (§6.5).
         assert!(!rendered.contains("tok-stuck"), "{rendered}");
+    }
+
+    /// `print_report` writes the summary to stdout and only the revocation
+    /// warnings to stderr. Called for the warning path specifically, since
+    /// that is the branch `render_report` deliberately does not carry.
+    #[test]
+    fn print_report_emits_the_summary_and_warns_separately() {
+        let report = LoginReport {
+            written: vec![WrittenContext {
+                name: "acme/prod".to_string(),
+                server: "https://gw.example".to_string(),
+                workspace: "acme-prod".to_string(),
+                role: "admin".to_string(),
+                expires_at: None,
+            }],
+            revoke_failures: vec![("tok-stuck".to_string(), "HTTP 500".to_string())],
+            ..LoginReport::default()
+        };
+        super::print_report(&report);
     }
 
     /// A control plane that returned no expiry renders without a dangling

--- a/crates/cli/src/commands/login.rs
+++ b/crates/cli/src/commands/login.rs
@@ -1,0 +1,289 @@
+//! `skardi login` — the flag surface, the URL precedence around it, and the
+//! summary it prints (§6.1, §6.2).
+//!
+//! The flow itself lives in [`crate::login`]; this module is the part that
+//! reads flags and environment, so the flow stays a pure function of its
+//! options and remains testable without a process.
+
+use crate::config::{self, ContextsFile};
+use crate::login::{self, LoginOptions, LoginReport, Selection, oauth};
+use anyhow::{Context as _, Result, bail};
+use clap::Args;
+use std::path::Path;
+
+/// `--control-plane`'s environment step (§6.1 step 1).
+const CONTROL_PLANE_ENV: &str = "SKARDI_CONTROL_PLANE_URL";
+/// `--server`'s environment step for the gateway URL (§6.2).
+const GATEWAY_URL_ENV: &str = "SKARDI_GATEWAY_URL";
+/// The OAuth client id, so a deployment can pin it once per shell instead of
+/// per command.
+const CLIENT_ID_ENV: &str = "SKARDI_OAUTH_CLIENT_ID";
+/// `--identity`'s environment step (§6.3).
+const DEV_IDENTITY_ENV: &str = "SKARDI_DEV_IDENTITY";
+
+#[derive(Args, Debug)]
+pub struct LoginArgs {
+    /// control-plane URL; overrides $SKARDI_CONTROL_PLANE_URL and
+    /// `control-plane:` in ~/.skardi/config.yaml
+    #[arg(long, value_name = "URL")]
+    pub control_plane: Option<String>,
+
+    /// log in to one workspace by slug (non-interactive)
+    #[arg(long, value_name = "SLUG", conflicts_with = "all_workspaces")]
+    pub workspace: Option<String>,
+
+    /// log in to every active workspace this identity belongs to
+    #[arg(long)]
+    pub all_workspaces: bool,
+
+    /// PAT lifetime, as days (`90d`, `90`) or hours (`12h`)
+    #[arg(long, value_name = "DURATION", default_value = login::DEFAULT_EXPIRES)]
+    pub expires: String,
+
+    /// print the sign-in URL instead of opening a browser
+    #[arg(long)]
+    pub no_browser: bool,
+
+    /// OAuth client id; overrides $SKARDI_OAUTH_CLIENT_ID
+    #[arg(long, value_name = "ID")]
+    pub client_id: Option<String>,
+
+    /// dev-auth bearer (`dev:<external-id>[:<email>]`), skipping the browser.
+    /// Refused unless the control plane is loopback
+    #[arg(long, value_name = "IDENTITY")]
+    pub identity: Option<String>,
+
+    /// allow --identity against a non-loopback control plane
+    #[arg(long)]
+    pub i_know_this_is_dev_auth: bool,
+
+    /// skip the post-mint gateway probe (for an air-gapped mint)
+    #[arg(long)]
+    pub no_verify: bool,
+
+    /// keep the credential a re-login replaces, instead of revoking it
+    #[arg(long)]
+    pub keep_old_token: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct LogoutArgs {
+    /// every cloud context, rather than just the selected one
+    #[arg(long)]
+    pub all: bool,
+
+    /// also revoke the PAT at the control plane. A PAT cannot revoke itself,
+    /// so this re-authenticates first
+    #[arg(long)]
+    pub revoke: bool,
+
+    /// control-plane URL for --revoke
+    #[arg(long, value_name = "URL")]
+    pub control_plane: Option<String>,
+
+    /// OAuth client id for --revoke
+    #[arg(long, value_name = "ID")]
+    pub client_id: Option<String>,
+
+    /// dev-auth bearer for --revoke (loopback control planes only)
+    #[arg(long, value_name = "IDENTITY")]
+    pub identity: Option<String>,
+
+    /// allow --identity against a non-loopback control plane
+    #[arg(long)]
+    pub i_know_this_is_dev_auth: bool,
+}
+
+/// Run `skardi login`, reading the ambient environment for the steps flags do
+/// not cover.
+pub async fn run(
+    args: LoginArgs,
+    flag_context: Option<String>,
+    flag_server: Option<String>,
+) -> Result<()> {
+    let path = config::default_config_path()
+        .context("cannot determine the home directory for ~/.skardi/config.yaml")?;
+    let options = options_from(&args, flag_context, flag_server, &path)?;
+    let report = login::login(options, &path).await?;
+    print_report(&report);
+    Ok(())
+}
+
+/// Assemble [`LoginOptions`] from flags, environment, and the config file.
+///
+/// Split out so the precedence is testable without running the flow: it is the
+/// part §6.2 pins, and the part a stray exported variable changes.
+fn options_from(
+    args: &LoginArgs,
+    flag_context: Option<String>,
+    flag_server: Option<String>,
+    path: &Path,
+) -> Result<LoginOptions> {
+    let file = config::load(path);
+    let control_plane = resolve_control_plane(
+        args.control_plane.clone(),
+        std::env::var(CONTROL_PLANE_ENV).ok(),
+        file.as_ref(),
+    )?;
+    let selection = match (&args.workspace, args.all_workspaces) {
+        (Some(slug), _) => Selection::Named(slug.clone()),
+        (None, true) => Selection::All,
+        (None, false) => Selection::Auto,
+    };
+    Ok(LoginOptions {
+        control_plane,
+        client_id: args
+            .client_id
+            .clone()
+            .or_else(|| std::env::var(CLIENT_ID_ENV).ok()),
+        identity: args
+            .identity
+            .clone()
+            .or_else(|| std::env::var(DEV_IDENTITY_ENV).ok()),
+        allow_dev_auth_off_loopback: args.i_know_this_is_dev_auth,
+        selection,
+        context_name: flag_context,
+        expires: login::parse_expires(&args.expires)?,
+        no_browser: args.no_browser,
+        no_verify: args.no_verify,
+        keep_old_token: args.keep_old_token,
+        server_override: flag_server,
+        env_gateway_url: std::env::var(GATEWAY_URL_ENV).ok(),
+        endpoints: oauth::Endpoints::default(),
+        callback_timeout: oauth::CALLBACK_TIMEOUT,
+        token_name: login::default_token_name(),
+        now: chrono::Utc::now(),
+    })
+}
+
+/// §6.1 step 1: `--control-plane` > `$SKARDI_CONTROL_PLANE_URL` >
+/// `control-plane:` in the file > hard error.
+///
+/// The design's chain ends in a "built-in default"; there is no hosted
+/// skardi-cloud control plane to encode yet, and inventing a hostname that
+/// answers nothing would fail at DNS with no mention of the three real inputs.
+/// So the chain ends the way §6.2's does — a typed error naming them — and a
+/// one-line constant replaces it the day the hosted URL exists.
+fn resolve_control_plane(
+    flag: Option<String>,
+    env: Option<String>,
+    file: Option<&ContextsFile>,
+) -> Result<String> {
+    let from_file = file.and_then(|f| f.control_plane.clone());
+    let resolved = [flag, env, from_file]
+        .into_iter()
+        .flatten()
+        .map(|url| url.trim().to_string())
+        .find(|url| !url.is_empty());
+    let Some(url) = resolved else {
+        bail!(
+            "no control plane configured: pass --control-plane <URL>, set ${CONTROL_PLANE_ENV}, or add 'control-plane:' to ~/.skardi/config.yaml"
+        )
+    };
+    Ok(url)
+}
+
+/// The control plane `logout --revoke` should talk to, resolved by the same
+/// chain `login` uses so the two cannot disagree about where a token lives.
+pub(super) fn control_plane_for_revoke(
+    args: &LogoutArgs,
+    path: &Path,
+    env_control_plane: Option<&str>,
+) -> Result<String> {
+    resolve_control_plane(
+        args.control_plane.clone(),
+        env_control_plane.map(str::to_string),
+        config::load(path).as_ref(),
+    )
+}
+
+/// Print what the run did. Tokens never appear — only the context that now
+/// holds one, and the id of anything revoked.
+fn print_report(report: &LoginReport) {
+    for (name, state) in &report.skipped {
+        println!("skipped {name}: workspace is {state}, not active");
+    }
+    for context in &report.written {
+        let expiry = match &context.expires_at {
+            Some(at) => format!(", expires {at}"),
+            None => String::new(),
+        };
+        println!(
+            "wrote context {} → {} (workspace {}, role {}{expiry})",
+            context.name, context.server, context.workspace, context.role
+        );
+    }
+    if let Some(current) = &report.current_context {
+        println!("current context is now {current}");
+    }
+    for token_id in &report.replaced_revoked {
+        println!("revoked the credential this login replaced ({token_id})");
+    }
+    for token_id in &report.replaced_kept {
+        println!(
+            "kept the credential this login replaced ({token_id}) — it stays valid until it expires"
+        );
+    }
+    for (token_id, reason) in &report.revoke_failures {
+        // Not a failure of the login (§6.5): the new context is already good.
+        eprintln!(
+            "warning: could not revoke the replaced credential {token_id} ({reason}) — revoke it in the console"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_control_plane;
+    use crate::config::ContextsFile;
+
+    fn file_with(control_plane: Option<&str>) -> ContextsFile {
+        ContextsFile {
+            control_plane: control_plane.map(str::to_string),
+            ..ContextsFile::default()
+        }
+    }
+
+    #[test]
+    fn control_plane_precedence_is_flag_then_env_then_file() {
+        let file = file_with(Some("https://file.example"));
+        assert_eq!(
+            resolve_control_plane(
+                Some("https://flag.example".into()),
+                Some("https://env.example".into()),
+                Some(&file)
+            )
+            .unwrap(),
+            "https://flag.example"
+        );
+        assert_eq!(
+            resolve_control_plane(None, Some("https://env.example".into()), Some(&file)).unwrap(),
+            "https://env.example"
+        );
+        assert_eq!(
+            resolve_control_plane(None, None, Some(&file)).unwrap(),
+            "https://file.example"
+        );
+    }
+
+    /// A blank flag or an exported-but-empty variable must not win the chain,
+    /// or `SKARDI_CONTROL_PLANE_URL=` would shadow a configured file.
+    #[test]
+    fn blank_values_are_skipped_not_honoured() {
+        let file = file_with(Some("https://file.example"));
+        assert_eq!(
+            resolve_control_plane(Some("   ".into()), Some(String::new()), Some(&file)).unwrap(),
+            "https://file.example"
+        );
+    }
+
+    #[test]
+    fn no_control_plane_names_all_three_inputs() {
+        let err = resolve_control_plane(None, None, Some(&file_with(None)))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("--control-plane"), "{err}");
+        assert!(err.contains("SKARDI_CONTROL_PLANE_URL"), "{err}");
+        assert!(err.contains("control-plane:"), "{err}");
+    }
+}

--- a/crates/cli/src/commands/login.rs
+++ b/crates/cli/src/commands/login.rs
@@ -197,45 +197,192 @@ pub(super) fn control_plane_for_revoke(
     )
 }
 
-/// Print what the run did. Tokens never appear — only the context that now
-/// holds one, and the id of anything revoked.
+/// Print what the run did.
+///
+/// The summary is rendered by [`render_report`] and only the warnings go to
+/// stderr, split the way `config`'s `render_view` is: the text a user reads is
+/// then asserted directly, instead of only through a subprocess's stdout.
 fn print_report(report: &LoginReport) {
-    for (name, state) in &report.skipped {
-        println!("skipped {name}: workspace is {state}, not active");
-    }
-    for context in &report.written {
-        let expiry = match &context.expires_at {
-            Some(at) => format!(", expires {at}"),
-            None => String::new(),
-        };
-        println!(
-            "wrote context {} → {} (workspace {}, role {}{expiry})",
-            context.name, context.server, context.workspace, context.role
-        );
-    }
-    if let Some(current) = &report.current_context {
-        println!("current context is now {current}");
-    }
-    for token_id in &report.replaced_revoked {
-        println!("revoked the credential this login replaced ({token_id})");
-    }
-    for token_id in &report.replaced_kept {
-        println!(
-            "kept the credential this login replaced ({token_id}) — it stays valid until it expires"
-        );
-    }
+    print!("{}", render_report(report));
     for (token_id, reason) in &report.revoke_failures {
-        // Not a failure of the login (§6.5): the new context is already good.
+        // Not a failure of the login (§6.5): the new context is already good,
+        // so this warns on stderr rather than joining the summary.
         eprintln!(
             "warning: could not revoke the replaced credential {token_id} ({reason}) — revoke it in the console"
         );
     }
 }
 
+/// The summary, one newline-terminated line per outcome. Token VALUES never
+/// appear — only the context that now holds one, and the id of anything
+/// revoked or kept.
+fn render_report(report: &LoginReport) -> String {
+    use std::fmt::Write as _;
+
+    let mut out = String::new();
+    for (name, state) in &report.skipped {
+        let _ = writeln!(out, "skipped {name}: workspace is {state}, not active");
+    }
+    for context in &report.written {
+        let expiry = match &context.expires_at {
+            Some(at) => format!(", expires {at}"),
+            None => String::new(),
+        };
+        let _ = writeln!(
+            out,
+            "wrote context {} → {} (workspace {}, role {}{expiry})",
+            context.name, context.server, context.workspace, context.role
+        );
+    }
+    if let Some(current) = &report.current_context {
+        let _ = writeln!(out, "current context is now {current}");
+    }
+    for token_id in &report.replaced_revoked {
+        let _ = writeln!(
+            out,
+            "revoked the credential this login replaced ({token_id})"
+        );
+    }
+    for token_id in &report.replaced_kept {
+        let _ = writeln!(
+            out,
+            "kept the credential this login replaced ({token_id}) — it stays valid until it expires"
+        );
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
-    use super::resolve_control_plane;
+    use super::{LoginArgs, options_from, render_report, resolve_control_plane};
     use crate::config::ContextsFile;
+    use crate::login::{LoginReport, Selection, WrittenContext};
+    use chrono::Duration;
+    use std::path::Path;
+
+    fn login_args() -> LoginArgs {
+        LoginArgs {
+            control_plane: Some("http://127.0.0.1:18090".to_string()),
+            workspace: None,
+            all_workspaces: false,
+            expires: "90d".to_string(),
+            no_browser: false,
+            client_id: None,
+            identity: None,
+            i_know_this_is_dev_auth: false,
+            no_verify: false,
+            keep_old_token: false,
+        }
+    }
+
+    /// The flag → option mapping, including the two global flags that mean
+    /// something different under `login`: `--server` is the gateway URL to
+    /// write, and `--context` is the name to write it under.
+    #[test]
+    fn flags_map_onto_the_flows_options() {
+        let missing = Path::new("/nonexistent/skardi/config.yaml");
+
+        let mut args = login_args();
+        args.workspace = Some("acme-prod".to_string());
+        let options = options_from(
+            &args,
+            Some("named-by-hand".to_string()),
+            Some("https://gw.example".to_string()),
+            missing,
+        )
+        .unwrap();
+        assert_eq!(options.selection, Selection::Named("acme-prod".to_string()));
+        assert_eq!(options.context_name.as_deref(), Some("named-by-hand"));
+        assert_eq!(
+            options.server_override.as_deref(),
+            Some("https://gw.example")
+        );
+        assert_eq!(options.expires, Duration::try_days(90).unwrap());
+        assert_eq!(options.token_name, crate::login::default_token_name());
+
+        let mut args = login_args();
+        args.all_workspaces = true;
+        args.expires = "12h".to_string();
+        args.no_verify = true;
+        args.keep_old_token = true;
+        let options = options_from(&args, None, None, missing).unwrap();
+        assert_eq!(options.selection, Selection::All);
+        assert_eq!(options.expires, Duration::try_hours(12).unwrap());
+        assert!(options.no_verify && options.keep_old_token);
+
+        assert_eq!(
+            options_from(&login_args(), None, None, missing)
+                .unwrap()
+                .selection,
+            Selection::Auto
+        );
+    }
+
+    /// A bad `--expires` fails while the options are assembled — before the
+    /// browser opens, not after a credential exists.
+    #[test]
+    fn an_unparsable_expiry_fails_before_anything_happens() {
+        let mut args = login_args();
+        args.expires = "next tuesday".to_string();
+        // `unwrap_err` would require `LoginOptions: Debug`, which it
+        // deliberately does not derive (see its definition).
+        let err = match options_from(&args, None, None, Path::new("/nonexistent/c.yaml")) {
+            Ok(_) => panic!("'next tuesday' must not parse as a duration"),
+            Err(err) => err.to_string(),
+        };
+        assert!(err.contains("--expires"), "{err}");
+    }
+
+    #[test]
+    fn the_summary_names_every_outcome_and_no_token_value() {
+        let report = LoginReport {
+            written: vec![WrittenContext {
+                name: "acme/acme-prod".to_string(),
+                server: "https://gw.example".to_string(),
+                workspace: "acme-prod".to_string(),
+                role: "admin".to_string(),
+                expires_at: Some("2026-11-22T12:00:00Z".to_string()),
+            }],
+            skipped: vec![("acme/staging".to_string(), "provisioning".to_string())],
+            current_context: Some("acme/acme-prod".to_string()),
+            replaced_revoked: vec!["tok-old".to_string()],
+            replaced_kept: vec!["tok-kept".to_string()],
+            revoke_failures: vec![("tok-stuck".to_string(), "HTTP 500".to_string())],
+        };
+
+        let rendered = render_report(&report);
+        assert_eq!(
+            rendered,
+            "skipped acme/staging: workspace is provisioning, not active\n\
+             wrote context acme/acme-prod → https://gw.example (workspace acme-prod, role admin, expires 2026-11-22T12:00:00Z)\n\
+             current context is now acme/acme-prod\n\
+             revoked the credential this login replaced (tok-old)\n\
+             kept the credential this login replaced (tok-kept) — it stays valid until it expires\n"
+        );
+        // A revocation failure warns on stderr and is deliberately NOT part of
+        // the summary: the login itself succeeded (§6.5).
+        assert!(!rendered.contains("tok-stuck"), "{rendered}");
+    }
+
+    /// A control plane that returned no expiry renders without a dangling
+    /// clause.
+    #[test]
+    fn a_context_without_an_expiry_renders_cleanly() {
+        let report = LoginReport {
+            written: vec![WrittenContext {
+                name: "acme/prod".to_string(),
+                server: "https://gw.example".to_string(),
+                workspace: "acme-prod".to_string(),
+                role: "viewer".to_string(),
+                expires_at: None,
+            }],
+            ..LoginReport::default()
+        };
+        assert_eq!(
+            render_report(&report),
+            "wrote context acme/prod → https://gw.example (workspace acme-prod, role viewer)\n"
+        );
+    }
 
     fn file_with(control_plane: Option<&str>) -> ContextsFile {
         ContextsFile {

--- a/crates/cli/src/commands/login.rs
+++ b/crates/cli/src/commands/login.rs
@@ -182,6 +182,19 @@ fn resolve_control_plane(
             "no control plane configured: pass --control-plane <URL>, set ${CONTROL_PLANE_ENV}, or add 'control-plane:' to ~/.skardi/config.yaml"
         )
     };
+    // This is the leg carrying the most sensitive traffic in the flow — the ID
+    // token goes up on every call and `POST /v1/me/tokens` returns the RAW PAT
+    // — and it had no scheme check at all, while `ApiClient` warns for a mere
+    // bearer. Said HERE, at resolution, so it lands before the browser opens
+    // rather than after a completed sign-in, and covers `logout --revoke` too.
+    //
+    // A warning, not a refusal, for the same reason `ApiClient`'s is: a
+    // deployment may terminate TLS at a proxy the CLI cannot see.
+    if crate::client::is_cleartext_remote(&url) {
+        eprintln!(
+            "warning: {url} is plain http to a non-loopback host — the sign-in assertion and the minted credential would cross the network in the clear; prefer an https:// control plane"
+        );
+    }
     Ok(url)
 }
 

--- a/crates/cli/src/commands/login.rs
+++ b/crates/cli/src/commands/login.rs
@@ -6,7 +6,7 @@
 //! options and remains testable without a process.
 
 use crate::config::{self, ContextsFile};
-use crate::login::{self, LoginOptions, LoginReport, Selection, oauth};
+use crate::login::{self, LoginOptions, LoginReport, Selection, control_plane, oauth};
 use anyhow::{Context as _, Result, bail};
 use clap::Args;
 use std::path::Path;
@@ -152,6 +152,7 @@ fn options_from(
         endpoints: oauth::Endpoints::default(),
         open_browser: oauth::open_in_browser,
         callback_timeout: oauth::CALLBACK_TIMEOUT,
+        verify_timeout: control_plane::CONTROL_PLANE_TIMEOUT,
         token_name: login::default_token_name(),
         now: chrono::Utc::now(),
     })

--- a/crates/cli/src/commands/logout.rs
+++ b/crates/cli/src/commands/logout.rs
@@ -463,6 +463,79 @@ mod tests {
         );
     }
 
+    /// Several contexts and no pointer selects nothing (§5.1), so `logout`
+    /// with no `--context` and no `--all` says which flags resolve it.
+    #[tokio::test]
+    async fn no_selectable_context_names_the_flags_that_would_pick_one() {
+        let home = TempDir::new().unwrap();
+        let path = home.path().join(".skardi").join("config.yaml");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            "contexts:\n\
+             \x20 - name: one\n\
+             \x20   mode: cloud\n\
+             \x20   server: http://gw.example\n\
+             \x20   workspace: w-one\n\
+             \x20   token: t1\n\
+             \x20 - name: two\n\
+             \x20   mode: cloud\n\
+             \x20   server: http://gw.example\n\
+             \x20   workspace: w-two\n\
+             \x20   token: t2\n",
+        )
+        .unwrap();
+        let before = std::fs::read_to_string(&path).unwrap();
+
+        let err = run_at(&path, args(false, false), None, None, None)
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("--context <NAME>"), "{err}");
+        assert!(err.contains("--all"), "{err}");
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), before);
+    }
+
+    /// A cloud context that holds no credential is skipped by `--all` rather
+    /// than rewritten, so a repeated `logout --all` is a no-op.
+    #[tokio::test]
+    async fn logout_all_is_idempotent() {
+        let home = TempDir::new().unwrap();
+        let path = seed(&home, "http://127.0.0.1:1");
+
+        run_at(&path, args(true, false), None, None, None)
+            .await
+            .unwrap();
+        let after_first = std::fs::read_to_string(&path).unwrap();
+
+        run_at(&path, args(true, false), None, None, None)
+            .await
+            .unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), after_first);
+    }
+
+    /// `--revoke` without `--identity` re-authenticates through the browser,
+    /// which needs a client id — named, rather than surfacing as an opaque
+    /// failure once the credential is already gone locally.
+    #[tokio::test]
+    async fn revoke_without_an_identity_or_a_client_id_says_which_is_missing() {
+        let home = TempDir::new().unwrap();
+        let path = seed(&home, "http://127.0.0.1:1");
+        let mut args = args(false, true);
+        args.identity = None;
+
+        let err = run_at(&path, args, None, None, None)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("--client-id"), "{err}");
+        assert!(err.contains("--identity dev:<id>"), "{err}");
+        // The local clear still happened: the credential is off this machine
+        // whether or not the control plane can be reached.
+        assert!(yaml(&path)["contexts"][0].get("token").is_none());
+    }
+
     #[tokio::test]
     async fn an_explicit_context_flag_wins_over_the_current_one() {
         let home = TempDir::new().unwrap();

--- a/crates/cli/src/commands/logout.rs
+++ b/crates/cli/src/commands/logout.rs
@@ -29,6 +29,8 @@ pub async fn run(args: LogoutArgs, flag_context: Option<String>) -> Result<()> {
         flag_context: flag_context.as_deref(),
         env_context: std::env::var("SKARDI_CONTEXT").ok(),
         env_control_plane: std::env::var("SKARDI_CONTROL_PLANE_URL").ok(),
+        env_dev_identity: std::env::var("SKARDI_DEV_IDENTITY").ok(),
+        env_client_id: std::env::var("SKARDI_OAUTH_CLIENT_ID").ok(),
         request_timeout: control_plane::CONTROL_PLANE_TIMEOUT,
     };
     run_at(path.as_path(), args, &env).await
@@ -41,6 +43,12 @@ pub(crate) struct LogoutEnv<'a> {
     pub flag_context: Option<&'a str>,
     pub env_context: Option<String>,
     pub env_control_plane: Option<String>,
+    /// `$SKARDI_DEV_IDENTITY`, the same env step `login` honours for
+    /// `--identity`. Read off the struct rather than inline so `--revoke` is
+    /// testable, which is what the struct is for.
+    pub env_dev_identity: Option<String>,
+    /// `$SKARDI_OAUTH_CLIENT_ID`, likewise.
+    pub env_client_id: Option<String>,
     pub request_timeout: Duration,
 }
 
@@ -161,6 +169,17 @@ fn clear_credentials(
             env_context,
         );
         match selected? {
+            // The SAME rule `--all` applies, and for the same stated reason: a
+            // server-mode token was configured by hand and no `login` can put
+            // it back. Applying it only under `--all` meant a bare `skardi
+            // logout` against a plain skardi-server — the default shape for
+            // this CLI — deleted the only copy of that token and then printed
+            // advice about a control plane that is not in play.
+            Some(context) if context.mode != ContextMode::Cloud => bail!(
+                "context '{}' is a server context, and its token was configured by hand — 'logout' only clears credentials that 'login' can mint again. To remove it, edit ~/.skardi/config.yaml, or drop the context with 'skardi config delete-context {}'",
+                context.name,
+                context.name
+            ),
             Some(context) => vec![context.name],
             None => bail!(
                 "no context selected: pass --context <NAME>, set a current-context, or use --all"
@@ -199,7 +218,16 @@ async fn authenticate(args: &LogoutArgs, path: &Path, env: &LogoutEnv<'_>) -> Re
     let http = control_plane::client(env.request_timeout)?;
     let control_plane =
         super::login::control_plane_for_revoke(args, path, env.env_control_plane.as_deref())?;
-    let bearer = match &args.identity {
+    // Flag then env, exactly as `login` resolves it: a dev shell where
+    // `$SKARDI_DEV_IDENTITY` makes `skardi login` work must not send
+    // `logout --revoke` down the browser branch to fail for a "missing" input
+    // it was given — after the token ids have already left the disk.
+    let identity = args
+        .identity
+        .clone()
+        .or_else(|| env.env_dev_identity.clone())
+        .filter(|id| !id.trim().is_empty());
+    let bearer = match &identity {
         Some(identity) => {
             crate::login::check_dev_identity(
                 identity,
@@ -212,7 +240,7 @@ async fn authenticate(args: &LogoutArgs, path: &Path, env: &LogoutEnv<'_>) -> Re
             let client_id = args
                 .client_id
                 .clone()
-                .or_else(|| std::env::var("SKARDI_OAUTH_CLIENT_ID").ok())
+                .or_else(|| env.env_client_id.clone())
                 .filter(|id| !id.trim().is_empty())
                 .context(
                     "--revoke re-authenticates, which needs --client-id (or $SKARDI_OAUTH_CLIENT_ID), or --identity dev:<id> against a loopback control plane",
@@ -258,6 +286,8 @@ mod tests {
             flag_context,
             env_context: None,
             env_control_plane: None,
+            env_dev_identity: None,
+            env_client_id: None,
             request_timeout: Duration::from_millis(200),
         }
     }
@@ -527,6 +557,90 @@ mod tests {
         );
         assert!(err.contains("still live"), "{err}");
         assert!(err.contains("tok-prod"), "{err}");
+    }
+
+    /// The rule `--all` applies must apply to a `current-context` selection
+    /// too: a server-mode token was pasted in by hand and no `login` can mint
+    /// it again, so clearing it silently destroyed the only copy — and then
+    /// printed advice about a control plane that was never in play.
+    #[tokio::test]
+    async fn logout_refuses_a_server_mode_context_rather_than_destroying_its_token() {
+        let home = TempDir::new().unwrap();
+        let path = home.path().join(".skardi").join("config.yaml");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            "current-context: local\n\
+             contexts:\n\
+             \x20 - name: local\n\
+             \x20   server: http://127.0.0.1:8080\n\
+             \x20   token: a-hand-configured-token\n",
+        )
+        .unwrap();
+        let before = std::fs::read_to_string(&path).unwrap();
+
+        let err = run_at(&path, args(false, false), &env(None))
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("is a server context"), "{err}");
+        assert!(err.contains("config delete-context local"), "{err}");
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            before,
+            "the token must survive the refusal"
+        );
+    }
+
+    /// Naming it explicitly is refused for the same reason — the token is
+    /// equally unrecoverable either way.
+    #[tokio::test]
+    async fn naming_a_server_mode_context_is_refused_too() {
+        let home = TempDir::new().unwrap();
+        let path = seed(&home, "http://127.0.0.1:1");
+
+        let err = run_at(&path, args(false, false), &env(Some("local")))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("is a server context"), "{err}");
+        assert_eq!(
+            yaml(&path)["contexts"][2]["token"],
+            "a-hand-configured-token"
+        );
+    }
+
+    /// `--revoke` must honour `$SKARDI_DEV_IDENTITY`, as `login` does: a dev
+    /// shell where plain `skardi login` works must not send this down the
+    /// browser branch to fail for a "missing" input it was given.
+    #[tokio::test]
+    async fn revoke_honours_the_dev_identity_environment_variable() {
+        let cp = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path_regex(r"^/v1/me/tokens/.+$"))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&cp)
+            .await;
+
+        let home = TempDir::new().unwrap();
+        let path = seed(&home, &cp.uri());
+        let mut args = args(false, true);
+        args.identity = None;
+        let mut env = env(None);
+        env.env_dev_identity = Some("dev:alice".to_string());
+
+        run_at(&path, args, &env).await.unwrap();
+
+        let revoked: Vec<String> = cp
+            .received_requests()
+            .await
+            .unwrap()
+            .iter()
+            .map(|r| r.url.path().rsplit('/').next().unwrap().to_string())
+            .collect();
+        assert_eq!(revoked, ["tok-prod"]);
     }
 
     #[tokio::test]

--- a/crates/cli/src/commands/logout.rs
+++ b/crates/cli/src/commands/logout.rs
@@ -63,7 +63,18 @@ pub(crate) async fn run_at(
         return Ok(());
     }
 
-    let revocable: Vec<&Cleared> = cleared.iter().filter(|c| c.token_id.is_some()).collect();
+    let (revocable, unrevocable): (Vec<&Cleared>, Vec<&Cleared>) =
+        cleared.iter().partition(|c| c.token_id.is_some());
+    // Named individually, not skipped: a context written by `config
+    // set-context` has no `token-id`, and a PAT cannot name itself to the
+    // revoke endpoint. Clearing it locally while saying nothing would read as
+    // a revocation that happened.
+    for entry in &unrevocable {
+        println!(
+            "cannot revoke the credential from context {}: it has no token-id, so only the console can revoke it",
+            entry.context
+        );
+    }
     if revocable.is_empty() {
         bail!(
             "--revoke needs the credential's token id, and no cleared context recorded one (a context written by 'config set-context' has no token-id). Revoke it in the console"
@@ -373,6 +384,60 @@ mod tests {
             .to_string();
         assert!(err.contains("token id"), "{err}");
         assert!(err.contains("console"), "{err}");
+    }
+
+    /// A mix: one context has a `token-id`, one does not. The revocable one is
+    /// revoked and the other is NAMED, because clearing it locally while
+    /// saying nothing reads as a revocation that happened.
+    #[tokio::test]
+    async fn revoke_names_the_contexts_it_cannot_revoke() {
+        let cp = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&cp)
+            .await;
+
+        let home = TempDir::new().unwrap();
+        let path = home.path().join(".skardi").join("config.yaml");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            format!(
+                "control-plane: {}\n\
+                 contexts:\n\
+                 \x20 - name: acme/prod\n\
+                 \x20   mode: cloud\n\
+                 \x20   server: http://gw.example\n\
+                 \x20   workspace: acme-prod\n\
+                 \x20   token: skardi_pat_prod\n\
+                 \x20   token-id: tok-prod\n\
+                 \x20 - name: acme/hand-made\n\
+                 \x20   mode: cloud\n\
+                 \x20   server: http://gw.example\n\
+                 \x20   workspace: acme-other\n\
+                 \x20   token: hand-written\n",
+                cp.uri()
+            ),
+        )
+        .unwrap();
+
+        run_at(&path, args(true, true), None, None, None)
+            .await
+            .unwrap();
+
+        // Both credentials left the disk; only one could be revoked.
+        let file = yaml(&path);
+        assert!(file["contexts"][0].get("token").is_none());
+        assert!(file["contexts"][1].get("token").is_none());
+        let revoked: Vec<String> = cp
+            .received_requests()
+            .await
+            .unwrap()
+            .iter()
+            .map(|r| r.url.path().rsplit('/').next().unwrap().to_string())
+            .collect();
+        assert_eq!(revoked, ["tok-prod"]);
     }
 
     #[tokio::test]

--- a/crates/cli/src/commands/logout.rs
+++ b/crates/cli/src/commands/logout.rs
@@ -10,10 +10,11 @@
 
 use super::login::LogoutArgs;
 use crate::config::{self, ContextMode, ContextsFile};
-use crate::login::control_plane::ControlPlane;
+use crate::login::control_plane::{self, ControlPlane};
 use crate::login::oauth;
 use anyhow::{Context as _, Result, bail};
 use std::path::Path;
+use std::time::Duration;
 
 /// One context's credential, as it was before this command cleared it.
 struct Cleared {
@@ -24,29 +25,30 @@ struct Cleared {
 pub async fn run(args: LogoutArgs, flag_context: Option<String>) -> Result<()> {
     let path = config::default_config_path()
         .context("cannot determine the home directory for ~/.skardi/config.yaml")?;
-    run_at(
-        &path,
-        args,
-        flag_context.as_deref(),
-        std::env::var("SKARDI_CONTEXT").ok().as_deref(),
-        std::env::var("SKARDI_CONTROL_PLANE_URL").ok().as_deref(),
-    )
-    .await
+    let env = LogoutEnv {
+        flag_context: flag_context.as_deref(),
+        env_context: std::env::var("SKARDI_CONTEXT").ok(),
+        env_control_plane: std::env::var("SKARDI_CONTROL_PLANE_URL").ok(),
+        request_timeout: control_plane::CONTROL_PLANE_TIMEOUT,
+    };
+    run_at(path.as_path(), args, &env).await
 }
 
-/// The command with every ambient input passed in, so the whole thing —
-/// including `--revoke` — is testable in-process against a mock control plane.
-pub(crate) async fn run_at(
-    path: &Path,
-    args: LogoutArgs,
-    flag_context: Option<&str>,
-    env_context: Option<&str>,
-    env_control_plane: Option<&str>,
-) -> Result<()> {
+/// Everything `logout` reads from outside its own arguments, grouped so the
+/// command — `--revoke` included — is testable in-process against a mock
+/// control plane, and so the timeout is one value a caller cannot forget.
+pub(crate) struct LogoutEnv<'a> {
+    pub flag_context: Option<&'a str>,
+    pub env_context: Option<String>,
+    pub env_control_plane: Option<String>,
+    pub request_timeout: Duration,
+}
+
+pub(crate) async fn run_at(path: &Path, args: LogoutArgs, env: &LogoutEnv<'_>) -> Result<()> {
     // Read the ids BEFORE clearing them: after the write they are gone, and
     // --revoke needs them. The revoke runs after the local edit so a control
     // plane that cannot be reached still leaves the credential off this disk.
-    let cleared = clear_credentials(path, &args, flag_context, env_context)?;
+    let cleared = clear_credentials(path, &args, env.flag_context, env.env_context.as_deref())?;
     if cleared.is_empty() {
         println!("no cloud context held a credential — nothing to do");
         return Ok(());
@@ -81,7 +83,14 @@ pub(crate) async fn run_at(
         );
     }
 
-    let cp = authenticate(&args, path, env_control_plane).await?;
+    // Any failure BEFORE the first revoke — no client id, a timed-out
+    // browser, an unreachable control plane — happens after the ids have left
+    // the disk, so it must carry them. Otherwise the PAT stays live, its id is
+    // unrecoverable, and a retry answers "nothing to do" (round-7 P1).
+    let cp = match authenticate(&args, path, env).await {
+        Ok(cp) => cp,
+        Err(err) => return Err(err.context(unrevoked_warning(&revocable))),
+    };
     let mut failures = Vec::new();
     for entry in revocable {
         let token_id = entry.token_id.as_deref().unwrap_or_default();
@@ -97,6 +106,30 @@ pub(crate) async fn run_at(
         );
     }
     Ok(())
+}
+
+/// The line a pre-revoke failure must carry: which credentials are still live,
+/// which context each came from, and what to do about it.
+///
+/// The ids are already gone from the config file by the time this is needed —
+/// that ordering is deliberate, so an unreachable control plane still gets the
+/// credential off this machine — which is exactly why the error has to name
+/// them. They appear nowhere else.
+fn unrevoked_warning(revocable: &[&Cleared]) -> String {
+    let listed = revocable
+        .iter()
+        .map(|entry| {
+            format!(
+                "  {} (from context {})",
+                entry.token_id.as_deref().unwrap_or("(no token id)"),
+                entry.context
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "could not authenticate to revoke, and these credentials are STILL LIVE with their ids no longer on this machine — revoke them in the console:\n{listed}"
+    )
 }
 
 /// Clear `token`/`token-id`/`token-expires-at` from the selected contexts,
@@ -160,13 +193,12 @@ fn clear_credentials(
 
 /// Re-authenticate for `--revoke`, reusing `login`'s acquirers so the dev path
 /// and its loopback guard behave identically here.
-async fn authenticate(
-    args: &LogoutArgs,
-    path: &Path,
-    env_control_plane: Option<&str>,
-) -> Result<ControlPlane> {
-    let http = reqwest::Client::builder().no_proxy().build()?;
-    let control_plane = super::login::control_plane_for_revoke(args, path, env_control_plane)?;
+async fn authenticate(args: &LogoutArgs, path: &Path, env: &LogoutEnv<'_>) -> Result<ControlPlane> {
+    // The SAME bounded builder `login` uses. Rolling a local client here is
+    // how this path ended up unbounded, so there is now one place to get one.
+    let http = control_plane::client(env.request_timeout)?;
+    let control_plane =
+        super::login::control_plane_for_revoke(args, path, env.env_control_plane.as_deref())?;
     let bearer = match &args.identity {
         Some(identity) => {
             crate::login::check_dev_identity(
@@ -201,7 +233,7 @@ async fn authenticate(
 
 #[cfg(test)]
 mod tests {
-    use super::{LogoutArgs, run_at};
+    use super::{Duration, LogoutArgs, LogoutEnv, run_at};
     use serde_json::json;
     use std::path::{Path, PathBuf};
     use tempfile::TempDir;
@@ -216,6 +248,17 @@ mod tests {
             client_id: None,
             identity: Some("dev:alice".to_string()),
             i_know_this_is_dev_auth: false,
+        }
+    }
+
+    /// The ambient inputs, with a short timeout so a stalled control plane
+    /// fails inside a test rather than after the production 30 seconds.
+    fn env(flag_context: Option<&str>) -> LogoutEnv<'_> {
+        LogoutEnv {
+            flag_context,
+            env_context: None,
+            env_control_plane: None,
+            request_timeout: Duration::from_millis(200),
         }
     }
 
@@ -262,9 +305,7 @@ mod tests {
         let home = TempDir::new().unwrap();
         let path = seed(&home, "http://127.0.0.1:1");
 
-        run_at(&path, args(false, false), None, None, None)
-            .await
-            .unwrap();
+        run_at(&path, args(false, false), &env(None)).await.unwrap();
 
         let file = yaml(&path);
         let prod = &file["contexts"][0];
@@ -287,9 +328,7 @@ mod tests {
         let home = TempDir::new().unwrap();
         let path = seed(&home, "http://127.0.0.1:1");
 
-        run_at(&path, args(true, false), None, None, None)
-            .await
-            .unwrap();
+        run_at(&path, args(true, false), &env(None)).await.unwrap();
 
         let file = yaml(&path);
         assert!(file["contexts"][0].get("token").is_none());
@@ -313,9 +352,7 @@ mod tests {
         let home = TempDir::new().unwrap();
         let path = seed(&home, &cp.uri());
 
-        run_at(&path, args(true, true), None, None, None)
-            .await
-            .unwrap();
+        run_at(&path, args(true, true), &env(None)).await.unwrap();
 
         let mut revoked: Vec<String> = cp
             .received_requests()
@@ -348,7 +385,7 @@ mod tests {
         let home = TempDir::new().unwrap();
         let path = seed(&home, &cp.uri());
 
-        let err = run_at(&path, args(false, true), None, None, None)
+        let err = run_at(&path, args(false, true), &env(None))
             .await
             .unwrap_err()
             .to_string();
@@ -378,7 +415,7 @@ mod tests {
         )
         .unwrap();
 
-        let err = run_at(&path, args(false, true), None, None, None)
+        let err = run_at(&path, args(false, true), &env(None))
             .await
             .unwrap_err()
             .to_string();
@@ -422,9 +459,7 @@ mod tests {
         )
         .unwrap();
 
-        run_at(&path, args(true, true), None, None, None)
-            .await
-            .unwrap();
+        run_at(&path, args(true, true), &env(None)).await.unwrap();
 
         // Both credentials left the disk; only one could be revoked.
         let file = yaml(&path);
@@ -440,6 +475,60 @@ mod tests {
         assert_eq!(revoked, ["tok-prod"]);
     }
 
+    /// A pre-revoke failure happens AFTER the ids have left the disk, so it
+    /// must name them — otherwise the PAT stays live, its id is unrecoverable,
+    /// and a retry answers "nothing to do" (round-7 P1).
+    #[tokio::test]
+    async fn a_failure_before_revoking_names_every_still_live_credential() {
+        let home = TempDir::new().unwrap();
+        let path = seed(&home, "http://127.0.0.1:1");
+        let mut args = args(true, true);
+        args.identity = None; // forces the browser path, which has no client id
+
+        let err = format!("{:#}", run_at(&path, args, &env(None)).await.unwrap_err());
+
+        // Both ids, both contexts, and the recovery action.
+        assert!(err.contains("STILL LIVE"), "{err}");
+        assert!(err.contains("tok-prod"), "{err}");
+        assert!(err.contains("tok-staging"), "{err}");
+        assert!(err.contains("from context acme/prod"), "{err}");
+        assert!(err.contains("revoke them in the console"), "{err}");
+        // The underlying cause survives the annotation.
+        assert!(err.contains("--client-id"), "{err}");
+        // And the ids really are gone from disk, which is why the error had to
+        // carry them.
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(!written.contains("tok-prod"), "{written}");
+    }
+
+    /// A control plane that accepts the DELETE and never answers must fail
+    /// within the bound rather than hanging after the credential is already
+    /// gone locally (round-7 P1).
+    #[tokio::test]
+    async fn a_stalled_revocation_fails_within_the_timeout() {
+        let cp = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .respond_with(ResponseTemplate::new(204).set_delay(Duration::from_secs(30)))
+            .mount(&cp)
+            .await;
+
+        let home = TempDir::new().unwrap();
+        let path = seed(&home, &cp.uri());
+
+        let started = std::time::Instant::now();
+        let err = run_at(&path, args(false, true), &env(None))
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "the revoke must be bounded, not wait out the control plane"
+        );
+        assert!(err.contains("still live"), "{err}");
+        assert!(err.contains("tok-prod"), "{err}");
+    }
+
     #[tokio::test]
     async fn nothing_to_clear_is_reported_rather_than_failing() {
         let home = TempDir::new().unwrap();
@@ -452,9 +541,7 @@ mod tests {
         .unwrap();
         let before = std::fs::read_to_string(&path).unwrap();
 
-        run_at(&path, args(true, false), None, None, None)
-            .await
-            .unwrap();
+        run_at(&path, args(true, false), &env(None)).await.unwrap();
 
         assert_eq!(
             std::fs::read_to_string(&path).unwrap(),
@@ -487,7 +574,7 @@ mod tests {
         .unwrap();
         let before = std::fs::read_to_string(&path).unwrap();
 
-        let err = run_at(&path, args(false, false), None, None, None)
+        let err = run_at(&path, args(false, false), &env(None))
             .await
             .unwrap_err()
             .to_string();
@@ -504,14 +591,10 @@ mod tests {
         let home = TempDir::new().unwrap();
         let path = seed(&home, "http://127.0.0.1:1");
 
-        run_at(&path, args(true, false), None, None, None)
-            .await
-            .unwrap();
+        run_at(&path, args(true, false), &env(None)).await.unwrap();
         let after_first = std::fs::read_to_string(&path).unwrap();
 
-        run_at(&path, args(true, false), None, None, None)
-            .await
-            .unwrap();
+        run_at(&path, args(true, false), &env(None)).await.unwrap();
         assert_eq!(std::fs::read_to_string(&path).unwrap(), after_first);
     }
 
@@ -525,12 +608,13 @@ mod tests {
         let mut args = args(false, true);
         args.identity = None;
 
-        let err = run_at(&path, args, None, None, None)
-            .await
-            .unwrap_err()
-            .to_string();
+        // `{:#}` renders the whole chain: the annotation names the still-live
+        // credential, and the cause names what was missing.
+        let err = format!("{:#}", run_at(&path, args, &env(None)).await.unwrap_err());
         assert!(err.contains("--client-id"), "{err}");
         assert!(err.contains("--identity dev:<id>"), "{err}");
+        // The id is reported, because it is no longer anywhere else.
+        assert!(err.contains("tok-prod"), "{err}");
         // The local clear still happened: the credential is off this machine
         // whether or not the control plane can be reached.
         assert!(yaml(&path)["contexts"][0].get("token").is_none());
@@ -541,7 +625,7 @@ mod tests {
         let home = TempDir::new().unwrap();
         let path = seed(&home, "http://127.0.0.1:1");
 
-        run_at(&path, args(false, false), Some("acme/staging"), None, None)
+        run_at(&path, args(false, false), &env(Some("acme/staging")))
             .await
             .unwrap();
 

--- a/crates/cli/src/commands/logout.rs
+++ b/crates/cli/src/commands/logout.rs
@@ -1,0 +1,414 @@
+//! `skardi logout` — drop the local credential, and optionally revoke it at
+//! the control plane (§6.4).
+//!
+//! The two halves are deliberately separate. A PAT cannot manage PATs, so
+//! plain `logout` is a purely local edit that says the PAT stays valid, and
+//! `--revoke` re-authenticates (browser or `--identity`) to call
+//! `DELETE /v1/me/tokens/{id}`. Presenting the local delete as a revocation
+//! would be the more dangerous message: a token nobody holds is still a token
+//! that works.
+
+use super::login::LogoutArgs;
+use crate::config::{self, ContextMode, ContextsFile};
+use crate::login::control_plane::ControlPlane;
+use crate::login::oauth;
+use anyhow::{Context as _, Result, bail};
+use std::path::Path;
+
+/// One context's credential, as it was before this command cleared it.
+struct Cleared {
+    context: String,
+    token_id: Option<String>,
+}
+
+pub async fn run(args: LogoutArgs, flag_context: Option<String>) -> Result<()> {
+    let path = config::default_config_path()
+        .context("cannot determine the home directory for ~/.skardi/config.yaml")?;
+    run_at(
+        &path,
+        args,
+        flag_context.as_deref(),
+        std::env::var("SKARDI_CONTEXT").ok().as_deref(),
+        std::env::var("SKARDI_CONTROL_PLANE_URL").ok().as_deref(),
+    )
+    .await
+}
+
+/// The command with every ambient input passed in, so the whole thing —
+/// including `--revoke` — is testable in-process against a mock control plane.
+pub(crate) async fn run_at(
+    path: &Path,
+    args: LogoutArgs,
+    flag_context: Option<&str>,
+    env_context: Option<&str>,
+    env_control_plane: Option<&str>,
+) -> Result<()> {
+    // Read the ids BEFORE clearing them: after the write they are gone, and
+    // --revoke needs them. The revoke runs after the local edit so a control
+    // plane that cannot be reached still leaves the credential off this disk.
+    let cleared = clear_credentials(path, &args, flag_context, env_context)?;
+    if cleared.is_empty() {
+        println!("no cloud context held a credential — nothing to do");
+        return Ok(());
+    }
+
+    for entry in &cleared {
+        println!("cleared the credential in context {}", entry.context);
+    }
+
+    if !args.revoke {
+        println!(
+            "the credential is gone from this machine but stays VALID until it expires — run 'skardi logout --revoke' to revoke it at the control plane"
+        );
+        return Ok(());
+    }
+
+    let revocable: Vec<&Cleared> = cleared.iter().filter(|c| c.token_id.is_some()).collect();
+    if revocable.is_empty() {
+        bail!(
+            "--revoke needs the credential's token id, and no cleared context recorded one (a context written by 'config set-context' has no token-id). Revoke it in the console"
+        );
+    }
+
+    let cp = authenticate(&args, path, env_control_plane).await?;
+    let mut failures = Vec::new();
+    for entry in revocable {
+        let token_id = entry.token_id.as_deref().unwrap_or_default();
+        match cp.revoke(token_id).await {
+            Ok(()) => println!("revoked {token_id} ({})", entry.context),
+            Err(err) => failures.push(format!("  {token_id} ({}): {err}", entry.context)),
+        }
+    }
+    if !failures.is_empty() {
+        bail!(
+            "these credentials are still live at the control plane — revoke them in the console:\n{}",
+            failures.join("\n")
+        );
+    }
+    Ok(())
+}
+
+/// Clear `token`/`token-id`/`token-expires-at` from the selected contexts,
+/// leaving the context itself (server, workspace, mode) in place so a later
+/// `login` refills it. Deleting the context is `config delete-context`'s job.
+fn clear_credentials(
+    path: &Path,
+    args: &LogoutArgs,
+    flag_context: Option<&str>,
+    env_context: Option<&str>,
+) -> Result<Vec<Cleared>> {
+    let mut file: ContextsFile = config::load_for_mutation(path)?;
+    file.promote_legacy_spec();
+
+    let targets: Vec<String> = if args.all {
+        // Cloud contexts only: a server-mode context's token is one the
+        // operator configured by hand, and `logout --all` sweeping it away
+        // would be a surprise with no login to undo it.
+        file.contexts
+            .iter()
+            .filter(|c| c.mode == ContextMode::Cloud)
+            .map(|c| c.name.clone())
+            .collect()
+    } else {
+        let selected = config::select_context(
+            &file.contexts,
+            file.current_context.as_deref(),
+            flag_context,
+            env_context,
+        );
+        match selected? {
+            Some(context) => vec![context.name],
+            None => bail!(
+                "no context selected: pass --context <NAME>, set a current-context, or use --all"
+            ),
+        }
+    };
+
+    let mut cleared = Vec::new();
+    for name in targets {
+        let Some(context) = file.contexts.iter_mut().find(|c| c.name == name) else {
+            continue;
+        };
+        if context.token.is_none() && context.token_id.is_none() {
+            continue;
+        }
+        cleared.push(Cleared {
+            context: name,
+            token_id: context.token_id.clone(),
+        });
+        context.token = None;
+        context.token_id = None;
+        context.token_expires_at = None;
+    }
+
+    if !cleared.is_empty() {
+        config::save(path, &file)?;
+    }
+    Ok(cleared)
+}
+
+/// Re-authenticate for `--revoke`, reusing `login`'s acquirers so the dev path
+/// and its loopback guard behave identically here.
+async fn authenticate(
+    args: &LogoutArgs,
+    path: &Path,
+    env_control_plane: Option<&str>,
+) -> Result<ControlPlane> {
+    let http = reqwest::Client::builder().no_proxy().build()?;
+    let control_plane = super::login::control_plane_for_revoke(args, path, env_control_plane)?;
+    let bearer = match &args.identity {
+        Some(identity) => {
+            crate::login::check_dev_identity(
+                identity,
+                &control_plane,
+                args.i_know_this_is_dev_auth,
+            )?;
+            identity.clone()
+        }
+        None => {
+            let client_id = args
+                .client_id
+                .clone()
+                .or_else(|| std::env::var("SKARDI_OAUTH_CLIENT_ID").ok())
+                .filter(|id| !id.trim().is_empty())
+                .context(
+                    "--revoke re-authenticates, which needs --client-id (or $SKARDI_OAUTH_CLIENT_ID), or --identity dev:<id> against a loopback control plane",
+                )?;
+            oauth::acquire_id_token(
+                &http,
+                &oauth::Endpoints::default(),
+                &client_id,
+                false,
+                oauth::CALLBACK_TIMEOUT,
+                &oauth::open_in_browser,
+            )
+            .await?
+        }
+    };
+    Ok(ControlPlane::new(http, &control_plane, bearer))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LogoutArgs, run_at};
+    use serde_json::json;
+    use std::path::{Path, PathBuf};
+    use tempfile::TempDir;
+    use wiremock::matchers::{method, path_regex};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn args(all: bool, revoke: bool) -> LogoutArgs {
+        LogoutArgs {
+            all,
+            revoke,
+            control_plane: None,
+            client_id: None,
+            identity: Some("dev:alice".to_string()),
+            i_know_this_is_dev_auth: false,
+        }
+    }
+
+    /// Two cloud contexts with credentials, one server-mode context with one.
+    fn seed(dir: &TempDir, control_plane: &str) -> PathBuf {
+        let path = dir.path().join(".skardi").join("config.yaml");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            format!(
+                "control-plane: {control_plane}\n\
+                 current-context: acme/prod\n\
+                 contexts:\n\
+                 \x20 - name: acme/prod\n\
+                 \x20   mode: cloud\n\
+                 \x20   server: http://gw.example\n\
+                 \x20   workspace: acme-prod\n\
+                 \x20   token: skardi_pat_prod\n\
+                 \x20   token-id: tok-prod\n\
+                 \x20   token-expires-at: 2026-11-22T12:00:00Z\n\
+                 \x20 - name: acme/staging\n\
+                 \x20   mode: cloud\n\
+                 \x20   server: http://gw.example\n\
+                 \x20   workspace: acme-staging\n\
+                 \x20   token: skardi_pat_staging\n\
+                 \x20   token-id: tok-staging\n\
+                 \x20 - name: local\n\
+                 \x20   server: http://127.0.0.1:8080\n\
+                 \x20   token: a-hand-configured-token\n"
+            ),
+        )
+        .unwrap();
+        path
+    }
+
+    fn yaml(path: &Path) -> serde_yaml::Value {
+        serde_yaml::from_str(&std::fs::read_to_string(path).unwrap()).unwrap()
+    }
+
+    /// The selected context loses its credential; the context itself stays, so
+    /// a later `login` refills it rather than re-deriving server and workspace.
+    #[tokio::test]
+    async fn logout_clears_the_selected_contexts_credential_and_keeps_the_context() {
+        let home = TempDir::new().unwrap();
+        let path = seed(&home, "http://127.0.0.1:1");
+
+        run_at(&path, args(false, false), None, None, None)
+            .await
+            .unwrap();
+
+        let file = yaml(&path);
+        let prod = &file["contexts"][0];
+        assert_eq!(prod["name"], "acme/prod");
+        assert_eq!(prod["server"], "http://gw.example");
+        assert_eq!(prod["workspace"], "acme-prod");
+        assert!(prod.get("token").is_none(), "token must be gone");
+        assert!(prod.get("token-id").is_none());
+        assert!(prod.get("token-expires-at").is_none());
+        // Untouched contexts keep theirs.
+        assert_eq!(file["contexts"][1]["token"], "skardi_pat_staging");
+        assert_eq!(file["contexts"][2]["token"], "a-hand-configured-token");
+        assert_eq!(file["current-context"], "acme/prod");
+    }
+
+    /// `--all` is scoped to cloud contexts: a server-mode token is one the
+    /// operator configured by hand, and there is no `login` to put it back.
+    #[tokio::test]
+    async fn logout_all_clears_every_cloud_context_and_leaves_server_mode_alone() {
+        let home = TempDir::new().unwrap();
+        let path = seed(&home, "http://127.0.0.1:1");
+
+        run_at(&path, args(true, false), None, None, None)
+            .await
+            .unwrap();
+
+        let file = yaml(&path);
+        assert!(file["contexts"][0].get("token").is_none());
+        assert!(file["contexts"][1].get("token").is_none());
+        assert_eq!(
+            file["contexts"][2]["token"], "a-hand-configured-token",
+            "a hand-configured server token is not login's to remove"
+        );
+    }
+
+    #[tokio::test]
+    async fn revoke_deletes_the_pat_at_the_control_plane() {
+        let cp = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path_regex(r"^/v1/me/tokens/.+$"))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(2)
+            .mount(&cp)
+            .await;
+
+        let home = TempDir::new().unwrap();
+        let path = seed(&home, &cp.uri());
+
+        run_at(&path, args(true, true), None, None, None)
+            .await
+            .unwrap();
+
+        let mut revoked: Vec<String> = cp
+            .received_requests()
+            .await
+            .unwrap()
+            .iter()
+            .map(|r| r.url.path().rsplit('/').next().unwrap().to_string())
+            .collect();
+        revoked.sort();
+        assert_eq!(revoked, ["tok-prod", "tok-staging"]);
+        // The local edit happened too, and first: a control plane that cannot
+        // be reached must still leave the credential off this disk.
+        assert!(yaml(&path)["contexts"][0].get("token").is_none());
+    }
+
+    /// A control plane that refuses the revoke is a non-zero exit naming the
+    /// live token, not a silent success.
+    #[tokio::test]
+    async fn a_failed_revocation_reports_the_still_live_token() {
+        let cp = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .respond_with(
+                ResponseTemplate::new(500).set_body_json(
+                    json!({"error": {"code": "internal", "message": "internal error"}}),
+                ),
+            )
+            .mount(&cp)
+            .await;
+
+        let home = TempDir::new().unwrap();
+        let path = seed(&home, &cp.uri());
+
+        let err = run_at(&path, args(false, true), None, None, None)
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("still live"), "{err}");
+        assert!(err.contains("tok-prod"), "{err}");
+        // Local removal still stands: the credential is off this machine.
+        assert!(yaml(&path)["contexts"][0].get("token").is_none());
+    }
+
+    /// A context written by `config set-context` has no `token-id`, and a PAT
+    /// cannot name itself to the revoke endpoint.
+    #[tokio::test]
+    async fn revoke_without_a_token_id_says_what_to_do_instead() {
+        let home = TempDir::new().unwrap();
+        let path = home.path().join(".skardi").join("config.yaml");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            "current-context: acme/prod\n\
+             contexts:\n\
+             \x20 - name: acme/prod\n\
+             \x20   mode: cloud\n\
+             \x20   server: http://gw.example\n\
+             \x20   workspace: acme-prod\n\
+             \x20   token: hand-written\n",
+        )
+        .unwrap();
+
+        let err = run_at(&path, args(false, true), None, None, None)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("token id"), "{err}");
+        assert!(err.contains("console"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn nothing_to_clear_is_reported_rather_than_failing() {
+        let home = TempDir::new().unwrap();
+        let path = home.path().join(".skardi").join("config.yaml");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            "contexts:\n  - name: local\n    server: http://127.0.0.1:8080\n",
+        )
+        .unwrap();
+        let before = std::fs::read_to_string(&path).unwrap();
+
+        run_at(&path, args(true, false), None, None, None)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            before,
+            "a no-op must not rewrite the file"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_explicit_context_flag_wins_over_the_current_one() {
+        let home = TempDir::new().unwrap();
+        let path = seed(&home, "http://127.0.0.1:1");
+
+        run_at(&path, args(false, false), Some("acme/staging"), None, None)
+            .await
+            .unwrap();
+
+        let file = yaml(&path);
+        assert_eq!(file["contexts"][0]["token"], "skardi_pat_prod");
+        assert!(file["contexts"][1].get("token").is_none());
+    }
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -5,6 +5,8 @@
 pub mod config;
 pub mod health;
 pub mod jobs;
+pub mod login;
+pub mod logout;
 pub mod pipeline;
 pub mod query;
 pub mod run;

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -334,6 +334,29 @@ pub struct ClientConfig {
 }
 
 impl ClientConfig {
+    /// The selected context when it is a CLOUD one — the single guard for
+    /// everything §8 changes (capability gating, credential expiry, the
+    /// gateway's typed errors). Server-mode and file-less resolutions answer
+    /// `None`, so those paths cannot accidentally inherit cloud behaviour.
+    pub fn cloud_context(&self) -> Option<&SelectedContext> {
+        self.context
+            .as_ref()
+            .filter(|c| c.mode == ContextMode::Cloud)
+    }
+
+    /// The workspace a cloud context names, sent per request as
+    /// `Skardi-Workspace` (§7.3).
+    ///
+    /// Deliberately OUTSIDE the reserved `x-skardi-*` prefix: the gateway
+    /// strips client-supplied headers in that namespace before forwarding to
+    /// the engine, so a selector wearing it would be silently dropped.
+    ///
+    /// Always `Some` for a cloud context — resolution refuses one without a
+    /// workspace — so this is `Some` exactly when the header applies.
+    pub fn workspace(&self) -> Option<&str> {
+        self.cloud_context()?.workspace.as_deref()
+    }
+
     /// Resolve the effective client config from flags, environment, and the
     /// user's `~/.skardi/config.yaml`.
     ///

--- a/crates/cli/src/login/control_plane.rs
+++ b/crates/cli/src/login/control_plane.rs
@@ -373,7 +373,7 @@ mod tests {
     /// first `login`.
     #[test]
     fn the_control_planes_membership_projection_deserializes_verbatim() {
-        let body: super::MembershipsBody = serde_json::from_str(
+        let body: MembershipsBody = serde_json::from_str(
             r#"{"workspaces": [
                 {"org_slug": "acme", "tenant_slug": "acme-prod",
                  "display_name": "Prod", "role": "member",

--- a/crates/cli/src/login/control_plane.rs
+++ b/crates/cli/src/login/control_plane.rs
@@ -50,9 +50,16 @@ const MAX_BODY_BYTES: usize = 1024 * 1024;
 
 /// One membership as `/v1/me/workspaces` returns it (`MembershipView`).
 ///
-/// `gateway_url` is `Option` because it is M4's addition (§7.1): a control
-/// plane that predates it simply omits the key, and §6.2's precedence then
-/// decides — flag, env, or a typed error naming `--server`.
+/// `gateway_url` is `Option` PERMANENTLY, not just until the control plane
+/// grows it (§7.1): the field is omitted whenever the deployment has no gateway
+/// URL configured, and §6.2's precedence then decides — flag, env, or a typed
+/// error naming `--server`.
+///
+/// It is read per MEMBERSHIP, which is the unit that becomes a context. The
+/// first control-plane release projects one deployment-wide value onto every
+/// membership; a later one supplies each workspace runtime's own endpoint
+/// through the same field. Honouring whatever each membership says is what
+/// makes the CLI work unchanged across both.
 #[derive(Debug, Clone, Deserialize)]
 pub struct Membership {
     pub org_slug: String,
@@ -310,7 +317,7 @@ fn parse_error(status: u16, text: &str) -> CpError {
 
 #[cfg(test)]
 mod tests {
-    use super::{Membership, Minted, parse_error};
+    use super::{Membership, MembershipsBody, Minted, parse_error};
 
     /// The raw token must not reach a log line, a panic message, or an
     /// `{err:?}` rendering through this type — so `Debug` is hand-written, and
@@ -354,6 +361,40 @@ mod tests {
         }))
         .unwrap();
         assert!(!provisioning.is_active());
+    }
+
+    /// The literal shape skardi-cloud's `/v1/me/workspaces` emits: five
+    /// `MembershipView` fields flattened alongside an optional `gateway_url`,
+    /// with the key OMITTED (not null, not empty) when the deployment has no
+    /// gateway URL configured.
+    ///
+    /// Pinned against the control plane's own projection rather than against
+    /// prose, so a change to that wire shape fails here instead of at a user's
+    /// first `login`.
+    #[test]
+    fn the_control_planes_membership_projection_deserializes_verbatim() {
+        let body: super::MembershipsBody = serde_json::from_str(
+            r#"{"workspaces": [
+                {"org_slug": "acme", "tenant_slug": "acme-prod",
+                 "display_name": "Prod", "role": "member",
+                 "provisioning_state": "active",
+                 "gateway_url": "https://gateway-test.skardi.ai"},
+                {"org_slug": "acme", "tenant_slug": "acme-staging",
+                 "display_name": "Staging", "role": "member",
+                 "provisioning_state": "active"}
+            ]}"#,
+        )
+        .unwrap();
+
+        assert_eq!(body.workspaces.len(), 2);
+        assert_eq!(
+            body.workspaces[0].gateway_url.as_deref(),
+            Some("https://gateway-test.skardi.ai")
+        );
+        assert_eq!(body.workspaces[0].display_name.as_deref(), Some("Prod"));
+        assert_eq!(body.workspaces[0].context_name(), "acme/acme-prod");
+        // Omitted, not null: §6.2's precedence takes over from here.
+        assert_eq!(body.workspaces[1].gateway_url, None);
     }
 
     /// The nested envelope, and the fallbacks for a body that is not one — a

--- a/crates/cli/src/login/control_plane.rs
+++ b/crates/cli/src/login/control_plane.rs
@@ -1,0 +1,284 @@
+//! The skardi-cloud control-plane API `login` and `logout --revoke` speak:
+//! `GET /v1/me/workspaces`, `POST /v1/me/tokens`, `DELETE /v1/me/tokens/{id}`.
+//!
+//! Deliberately NOT [`crate::client::ApiClient`]. That client is for the
+//! engine surface, whose error envelope is flat
+//! (`{"error": msg, "error_type": tok}`); the control plane nests it
+//! (`{"error": {"code": …, "message": …}}`) and adds keys per code — the
+//! `org_ambiguous` org list among them (§6.4). One client cannot read both
+//! without guessing, and the credential differs too: an ID token (or a `dev:`
+//! bearer), never the PAT.
+//!
+//! The wire shapes here are pinned against skardi-global's handlers, not
+//! against prose: `workspaces` returns `{"workspaces": [MembershipView…]}`,
+//! and a mint answers `201 {"token": "<raw>", "pat": {"token_id": …}}`.
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use std::fmt;
+
+/// Cap on a control-plane response body. Memberships and one PAT are a few
+/// hundred bytes; this is the "something is very wrong" bound, and small
+/// enough that a runaway endpoint cannot exhaust memory.
+const MAX_BODY_BYTES: usize = 1024 * 1024;
+
+/// One membership as `/v1/me/workspaces` returns it (`MembershipView`).
+///
+/// `gateway_url` is `Option` because it is M4's addition (§7.1): a control
+/// plane that predates it simply omits the key, and §6.2's precedence then
+/// decides — flag, env, or a typed error naming `--server`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Membership {
+    pub org_slug: String,
+    pub tenant_slug: String,
+    #[serde(default)]
+    pub display_name: Option<String>,
+    pub role: String,
+    pub provisioning_state: String,
+    #[serde(default)]
+    pub gateway_url: Option<String>,
+}
+
+impl Membership {
+    /// `<org_slug>/<tenant_slug>` — the context name §6.1 step 7 writes.
+    pub fn context_name(&self) -> String {
+        format!("{}/{}", self.org_slug, self.tenant_slug)
+    }
+
+    /// Only `active` workspaces can be minted for (§6.1 step 4); `ready` is
+    /// not a value skardi-global ever sets.
+    pub fn is_active(&self) -> bool {
+        self.provisioning_state == "active"
+    }
+}
+
+/// A freshly minted PAT. The raw token is here and nowhere else until it is
+/// written to the config file.
+pub struct Minted {
+    pub token: String,
+    pub token_id: String,
+    pub expires_at: Option<String>,
+}
+
+/// Hand-written so the raw token cannot reach a log line, a panic message, or
+/// an `{err:?}` rendering through this type.
+impl fmt::Debug for Minted {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Minted")
+            .field("token", &"(redacted)")
+            .field("token_id", &self.token_id)
+            .field("expires_at", &self.expires_at)
+            .finish()
+    }
+}
+
+/// A typed control-plane failure. `code` is what the flow branches on (§6.4's
+/// `org_ambiguous`), `orgs` carries that code's extra payload.
+#[derive(Debug)]
+pub struct CpError {
+    pub status: u16,
+    pub code: Option<String>,
+    pub message: String,
+    /// `org_slug` values from an `org_ambiguous` body, in the order returned.
+    pub orgs: Vec<String>,
+}
+
+impl fmt::Display for CpError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.code {
+            Some(code) => write!(f, "[{code}] {} (HTTP {})", self.message, self.status),
+            None => write!(f, "{} (HTTP {})", self.message, self.status),
+        }
+    }
+}
+
+impl std::error::Error for CpError {}
+
+/// A client for one control plane, authenticated as one identity.
+pub struct ControlPlane {
+    http: reqwest::Client,
+    base_url: String,
+    /// An ID token, or a `dev:<external-id>` bearer (§6.3). Never a PAT.
+    bearer: String,
+}
+
+impl ControlPlane {
+    /// `base_url` may carry a trailing slash; paths are appended after it is
+    /// trimmed, so `https://cp.example/` and `https://cp.example` behave the
+    /// same.
+    pub fn new(http: reqwest::Client, base_url: &str, bearer: String) -> ControlPlane {
+        ControlPlane {
+            http,
+            base_url: base_url.trim_end_matches('/').to_string(),
+            bearer,
+        }
+    }
+
+    /// `GET /v1/me/workspaces` (§6.1 step 4).
+    pub async fn memberships(&self) -> Result<Vec<Membership>> {
+        let body = self
+            .request(reqwest::Method::GET, "/v1/me/workspaces", None)
+            .await?;
+        let parsed: MembershipsBody = serde_json::from_value(body)
+            .context("the control plane's workspace list was not the expected shape")?;
+        Ok(parsed.workspaces)
+    }
+
+    /// `POST /v1/me/tokens` (§6.1 step 5).
+    ///
+    /// The scope is the point of the whole flow: `{"workspaces": [one],
+    /// "max_role": role}` is intersected with live memberships on every
+    /// resolve, so a leaked CLI credential reaches one workspace at one role.
+    pub async fn mint(
+        &self,
+        name: &str,
+        workspace: &str,
+        max_role: &str,
+        expires_at: &str,
+    ) -> Result<Minted> {
+        let body = json!({
+            "name": name,
+            "scope": { "workspaces": [workspace], "max_role": max_role },
+            "expires_at": expires_at,
+        });
+        let response = self
+            .request(reqwest::Method::POST, "/v1/me/tokens", Some(body))
+            .await?;
+        let parsed: MintBody = serde_json::from_value(response)
+            .context("the control plane's mint response was not the expected shape")?;
+        Ok(Minted {
+            token: parsed.token,
+            token_id: parsed.pat.token_id,
+            expires_at: parsed.pat.expires_at,
+        })
+    }
+
+    /// `DELETE /v1/me/tokens/{token_id}` — the saga's rollback and
+    /// `logout --revoke` (§6.4, §6.5).
+    pub async fn revoke(&self, token_id: &str) -> Result<()> {
+        let path = format!(
+            "/v1/me/tokens/{}",
+            crate::client::encode_component(token_id)
+        );
+        self.request(reqwest::Method::DELETE, &path, None).await?;
+        Ok(())
+    }
+
+    /// One request, with the typed-error mapping every caller shares.
+    async fn request(
+        &self,
+        method: reqwest::Method,
+        path: &str,
+        body: Option<Value>,
+    ) -> Result<Value> {
+        let url = format!("{}{path}", self.base_url);
+        let mut request = self.http.request(method, &url).bearer_auth(&self.bearer);
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+        let response = request
+            .send()
+            .await
+            .with_context(|| format!("cannot reach the control plane at {url}"))?;
+
+        let status = response.status();
+        let text = read_capped(response, &url).await?;
+
+        if !status.is_success() {
+            return Err(parse_error(status.as_u16(), &text).into());
+        }
+        // `DELETE` answers 204 with no body, and a mint/list always has one.
+        if text.trim().is_empty() {
+            return Ok(Value::Null);
+        }
+        serde_json::from_str(&text)
+            .with_context(|| format!("{url} returned a body that is not JSON"))
+    }
+}
+
+#[derive(Deserialize)]
+struct MembershipsBody {
+    #[serde(default)]
+    workspaces: Vec<Membership>,
+}
+
+#[derive(Deserialize)]
+struct MintBody {
+    token: String,
+    pat: PatView,
+}
+
+#[derive(Deserialize)]
+struct PatView {
+    token_id: String,
+    #[serde(default)]
+    expires_at: Option<String>,
+}
+
+/// Read a response body, refusing to buffer more than [`MAX_BODY_BYTES`].
+/// Chunk-by-chunk so the cap holds for a chunked response with no declared
+/// length.
+async fn read_capped(mut response: reqwest::Response, url: &str) -> Result<String> {
+    let mut buf: Vec<u8> = Vec::new();
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .with_context(|| format!("read the response from {url}"))?
+    {
+        if buf.len().saturating_add(chunk.len()) > MAX_BODY_BYTES {
+            anyhow::bail!(
+                "{url} returned more than {MAX_BODY_BYTES} bytes — refusing to buffer it"
+            );
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    Ok(String::from_utf8_lossy(&buf).to_string())
+}
+
+/// Map a non-success body to [`CpError`], reading skardi-global's nested
+/// envelope and falling back to the raw first line for anything else (a proxy
+/// error page, an HTML 502).
+fn parse_error(status: u16, text: &str) -> CpError {
+    #[derive(Deserialize)]
+    struct Envelope {
+        error: ErrorBody,
+    }
+    #[derive(Deserialize)]
+    struct ErrorBody {
+        #[serde(default)]
+        code: Option<String>,
+        #[serde(default)]
+        message: Option<String>,
+        #[serde(default)]
+        orgs: Vec<OrgRef>,
+    }
+    #[derive(Deserialize)]
+    struct OrgRef {
+        #[serde(default)]
+        org_slug: Option<String>,
+    }
+
+    match serde_json::from_str::<Envelope>(text) {
+        Ok(envelope) => CpError {
+            status,
+            code: envelope.error.code,
+            message: envelope
+                .error
+                .message
+                .unwrap_or_else(|| "no message".to_string()),
+            orgs: envelope
+                .error
+                .orgs
+                .into_iter()
+                .filter_map(|o| o.org_slug)
+                .collect(),
+        },
+        Err(_) => CpError {
+            status,
+            code: None,
+            message: text.lines().next().unwrap_or("").to_string(),
+            orgs: Vec::new(),
+        },
+    }
+}

--- a/crates/cli/src/login/control_plane.rs
+++ b/crates/cli/src/login/control_plane.rs
@@ -282,3 +282,81 @@ fn parse_error(status: u16, text: &str) -> CpError {
         },
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{Membership, Minted, parse_error};
+
+    /// The raw token must not reach a log line, a panic message, or an
+    /// `{err:?}` rendering through this type — so `Debug` is hand-written, and
+    /// that is worth pinning rather than trusting.
+    #[test]
+    fn a_minted_tokens_debug_output_redacts_the_secret() {
+        let minted = Minted {
+            token: "skardi_pat_the_real_secret".to_string(),
+            token_id: "tok-1".to_string(),
+            expires_at: Some("2026-11-22T12:00:00Z".to_string()),
+        };
+        let rendered = format!("{minted:?}");
+        assert!(!rendered.contains("the_real_secret"), "{rendered}");
+        assert!(rendered.contains("(redacted)"), "{rendered}");
+        // The id and expiry are what a caller legitimately needs to see.
+        assert!(rendered.contains("tok-1"), "{rendered}");
+        assert!(rendered.contains("2026-11-22"), "{rendered}");
+    }
+
+    #[test]
+    fn a_membership_names_its_context_and_knows_when_it_is_usable() {
+        let active: Membership = serde_json::from_value(serde_json::json!({
+            "org_slug": "acme",
+            "tenant_slug": "acme-prod",
+            "role": "admin",
+            "provisioning_state": "active",
+        }))
+        .unwrap();
+        assert_eq!(active.context_name(), "acme/acme-prod");
+        assert!(active.is_active());
+        // `display_name` and `gateway_url` are absent on today's wire (§7.1 is
+        // M4), which must deserialize rather than fail.
+        assert_eq!(active.display_name, None);
+        assert_eq!(active.gateway_url, None);
+
+        let provisioning: Membership = serde_json::from_value(serde_json::json!({
+            "org_slug": "acme",
+            "tenant_slug": "acme-new",
+            "role": "admin",
+            "provisioning_state": "provisioning",
+        }))
+        .unwrap();
+        assert!(!provisioning.is_active());
+    }
+
+    /// The nested envelope, and the fallbacks for a body that is not one — a
+    /// proxy's HTML error page, or an empty 502.
+    #[test]
+    fn error_bodies_map_to_a_typed_failure_or_their_first_line() {
+        let typed = parse_error(
+            400,
+            r#"{"error": {"code": "org_ambiguous", "message": "several orgs",
+                "orgs": [{"org_slug": "acme"}, {"display_name": "no slug here"}]}}"#,
+        );
+        assert_eq!(typed.code.as_deref(), Some("org_ambiguous"));
+        assert_eq!(typed.message, "several orgs");
+        // An entry with no `org_slug` is dropped rather than rendered as an
+        // empty name.
+        assert_eq!(typed.orgs, ["acme"]);
+        assert_eq!(typed.to_string(), "[org_ambiguous] several orgs (HTTP 400)");
+
+        let html = parse_error(502, "<html><body>Bad Gateway</body></html>\nmore");
+        assert_eq!(html.code, None);
+        assert_eq!(html.message, "<html><body>Bad Gateway</body></html>");
+        assert_eq!(
+            html.to_string(),
+            "<html><body>Bad Gateway</body></html> (HTTP 502)"
+        );
+
+        // A well-formed envelope with no message still says something.
+        let bare = parse_error(500, r#"{"error": {"code": "internal"}}"#);
+        assert_eq!(bare.message, "no message");
+    }
+}

--- a/crates/cli/src/login/control_plane.rs
+++ b/crates/cli/src/login/control_plane.rs
@@ -17,6 +17,31 @@ use anyhow::{Context, Result};
 use serde::Deserialize;
 use serde_json::{Value, json};
 use std::fmt;
+use std::time::Duration;
+
+/// Per-request ceiling on control-plane calls.
+///
+/// Bounded because of the ROLLBACK, not the happy path: a revoke that hangs
+/// forever leaves the operator watching a silent terminal while a live
+/// credential goes unreported, which is precisely the outcome §6.5 exists to
+/// prevent. Generous enough that a cold control plane still answers.
+pub const CONTROL_PLANE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// The HTTP client every control-plane conversation uses — `login`'s and
+/// `logout --revoke`'s alike.
+///
+/// One builder, so a caller cannot acquire an UNBOUNDED client by accident:
+/// `logout --revoke` did exactly that, and a stalled `DELETE` would have hung
+/// the command after the local credential was already gone. `timeout` is a
+/// parameter only so a test can prove the bound bites without waiting
+/// [`CONTROL_PLANE_TIMEOUT`] for it.
+pub fn client(timeout: Duration) -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .no_proxy()
+        .timeout(timeout)
+        .build()
+        .context("build the HTTP client for the control plane")
+}
 
 /// Cap on a control-plane response body. Memberships and one PAT are a few
 /// hundred bytes; this is the "something is very wrong" bound, and small

--- a/crates/cli/src/login/loopback.rs
+++ b/crates/cli/src/login/loopback.rs
@@ -28,7 +28,7 @@ use percent_encoding::percent_decode_str;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, TcpStream};
 
 /// The path the authorization server is told to redirect to.
@@ -36,7 +36,17 @@ pub const CALLBACK_PATH: &str = "/callback";
 
 /// Cap on request-line bytes read from one connection. A callback URL carries
 /// a code and a state; anything approaching this is not one.
-const MAX_REQUEST_BYTES: usize = 8 * 1024;
+const MAX_REQUEST_BYTES: u64 = 8 * 1024;
+
+/// How long one connection gets to produce its request line.
+///
+/// The accept loop is sequential, so without this a socket that connects and
+/// sends NOTHING holds the loop until the 120-second callback timeout — with
+/// the real redirect already completed in the accept backlog, unread. That is
+/// reachable adversarially (one idle `nc` to a loopback port denies the
+/// sign-in) and accidentally (browsers open speculative preconnect sockets to
+/// a navigation target and hold them idle).
+const REQUEST_READ_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// How many non-callback requests are answered and ignored before giving up.
 /// Bounded so a chatty client cannot keep the wait alive indefinitely — the
@@ -47,6 +57,9 @@ const MAX_UNRELATED_REQUESTS: usize = 8;
 pub struct Loopback {
     listener: TcpListener,
     port: u16,
+    /// [`REQUEST_READ_TIMEOUT`] in production; shortened by tests so the
+    /// silent-connection case does not cost five seconds per run.
+    read_timeout: Duration,
 }
 
 /// What the authorization server sent back.
@@ -74,7 +87,19 @@ impl Loopback {
             .local_addr()
             .context("read the loopback listener's port")?
             .port();
-        Ok(Loopback { listener, port })
+        Ok(Loopback {
+            listener,
+            port,
+            read_timeout: REQUEST_READ_TIMEOUT,
+        })
+    }
+
+    /// Shorten the per-connection read deadline, so a test can exercise the
+    /// silent-connection path without waiting out the production value.
+    #[cfg(test)]
+    fn with_read_timeout(mut self, read_timeout: Duration) -> Loopback {
+        self.read_timeout = read_timeout;
+        self
     }
 
     /// The `redirect_uri` to register with the authorization request. Literal
@@ -118,10 +143,19 @@ impl Loopback {
                 .await
                 .context("accept the login redirect")?;
 
-            let Some(target) = read_request_target(&mut stream).await? else {
-                respond(&mut stream, "400 Bad Request", "Malformed request.").await;
-                continue;
-            };
+            // A connection that goes quiet is noise, not this sign-in's
+            // response: answer it and move on rather than letting it hold the
+            // loop.
+            let target =
+                match tokio::time::timeout(self.read_timeout, read_request_target(&mut stream))
+                    .await
+                {
+                    Ok(Ok(Some(target))) => target,
+                    _ => {
+                        respond(&mut stream, "400 Bad Request", "Malformed request.").await;
+                        continue;
+                    }
+                };
             let (path, query) = match target.split_once('?') {
                 Some((path, query)) => (path, query),
                 None => (target.as_str(), ""),
@@ -196,22 +230,16 @@ fn describe_ignored(count: usize) -> String {
 
 /// Read the request target out of the first line, bounded. `None` when the
 /// line is not a parseable `GET <target> HTTP/1.x`.
+///
+/// `read_until` under a `take`, rather than a byte at a time: the same
+/// [`MAX_REQUEST_BYTES`] bound in one call instead of up to 8192 awaits.
 async fn read_request_target(stream: &mut TcpStream) -> Result<Option<String>> {
     let mut buf = Vec::new();
-    let mut byte = [0u8; 1];
-    while buf.len() < MAX_REQUEST_BYTES {
-        match stream.read(&mut byte).await {
-            Ok(0) => break,
-            Ok(_) => {
-                if byte[0] == b'\n' {
-                    break;
-                }
-                buf.push(byte[0]);
-            }
-            // A client that hangs up mid-line is noise, not a failure of the
-            // wait: report it as an unparseable line and keep listening.
-            Err(_) => return Ok(None),
-        }
+    let mut reader = BufReader::new(stream).take(MAX_REQUEST_BYTES);
+    // A client that hangs up mid-line is noise, not a failure of the wait:
+    // report it as an unparseable line and keep listening.
+    if reader.read_until(b'\n', &mut buf).await.is_err() {
+        return Ok(None);
     }
     let line = String::from_utf8_lossy(&buf).trim().to_string();
     let mut parts = line.split_whitespace();
@@ -432,6 +460,45 @@ mod tests {
             "the ignored response must be reported: {err}"
         );
         assert!(!err.contains("not-mine"), "no value is echoed: {err}");
+    }
+
+    /// A connection that opens and SENDS NOTHING must not hold the sequential
+    /// accept loop: without a per-connection deadline it blocks until the
+    /// 120-second callback timeout, with the real redirect already completed in
+    /// the accept backlog and unread. One idle `nc` to a loopback port would
+    /// otherwise deny the sign-in.
+    #[tokio::test]
+    async fn a_silent_connection_does_not_hold_the_callback_behind_it() {
+        let loopback = Loopback::bind()
+            .await
+            .unwrap()
+            .with_read_timeout(Duration::from_millis(150));
+        let uri = loopback.redirect_uri();
+        let addr = uri
+            .trim_start_matches("http://")
+            .trim_end_matches("/callback")
+            .to_string();
+
+        // Accepted first, and never says anything — but deliberately kept
+        // OPEN, which is what distinguishes this from the hang-up case.
+        let idle = tokio::net::TcpStream::connect(&addr).await.unwrap();
+
+        let waiter =
+            tokio::spawn(async move { loopback.wait(Duration::from_secs(5), "the-state").await });
+        // Let the loop accept the idle socket before the real redirect
+        // arrives, so the ordering under test is the failing one.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let started = std::time::Instant::now();
+        let _ = reqwest::get(format!("{uri}?code=behind-the-idle&state=the-state")).await;
+
+        let callback = waiter.await.unwrap().unwrap();
+        assert_eq!(callback.code.as_deref(), Some("behind-the-idle"));
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "the callback waited behind the idle socket: {:?}",
+            started.elapsed()
+        );
+        drop(idle);
     }
 
     /// Enough noise to exhaust the allowance ends the wait with a message

--- a/crates/cli/src/login/loopback.rs
+++ b/crates/cli/src/login/loopback.rs
@@ -278,6 +278,63 @@ mod tests {
         assert_eq!(callback.state.as_deref(), Some("the-state"));
     }
 
+    /// The noise a real port sees: a POST, a request line that is not HTTP at
+    /// all, and a connection that opens and closes. None may consume the
+    /// single callback, and each is answered rather than left hanging.
+    #[tokio::test]
+    async fn malformed_and_non_get_requests_are_answered_and_ignored() {
+        use tokio::io::AsyncWriteExt as _;
+
+        let loopback = Loopback::bind().await.unwrap();
+        let uri = loopback.redirect_uri();
+        let addr = uri
+            .trim_start_matches("http://")
+            .trim_end_matches("/callback")
+            .to_string();
+
+        let waiter = tokio::spawn(async move { loopback.wait(Duration::from_secs(5)).await });
+
+        // A POST to the right path: not a redirect, so not the callback.
+        let _ = reqwest::Client::new()
+            .post(&uri)
+            .body("code=nope")
+            .send()
+            .await;
+        // A request line that is not a request line.
+        let mut raw = tokio::net::TcpStream::connect(&addr).await.unwrap();
+        raw.write_all(b"GARBAGE\r\n\r\n").await.unwrap();
+        drop(raw);
+        // A connection that opens and hangs up without sending anything.
+        drop(tokio::net::TcpStream::connect(&addr).await.unwrap());
+
+        let callback = reqwest::get(format!("{uri}?code=real&state=s"))
+            .await
+            .unwrap();
+        assert!(callback.status().is_success());
+        let received = waiter.await.unwrap().unwrap();
+        assert_eq!(received.code.as_deref(), Some("real"));
+    }
+
+    /// Enough noise to exhaust the allowance ends the wait with a message
+    /// naming why, instead of holding the port until the timeout.
+    #[tokio::test]
+    async fn too_much_noise_gives_up_rather_than_waiting_out_the_timeout() {
+        let loopback = Loopback::bind().await.unwrap();
+        let base = loopback
+            .redirect_uri()
+            .trim_end_matches("/callback")
+            .to_string();
+
+        let waiter = tokio::spawn(async move { loopback.wait(Duration::from_secs(30)).await });
+        let http = reqwest::Client::new();
+        for _ in 0..=super::MAX_UNRELATED_REQUESTS {
+            let _ = http.get(format!("{base}/favicon.ico")).send().await;
+        }
+
+        let err = waiter.await.unwrap().unwrap_err().to_string();
+        assert!(err.contains("unrelated requests"), "{err}");
+    }
+
     #[tokio::test]
     async fn a_provider_error_is_returned_rather_than_waited_out() {
         let loopback = Loopback::bind().await.unwrap();

--- a/crates/cli/src/login/loopback.rs
+++ b/crates/cli/src/login/loopback.rs
@@ -1,0 +1,298 @@
+//! The single-use loopback redirect target (§6.1 step 2, §9.1).
+//!
+//! Bound to `127.0.0.1:0` — never `0.0.0.0`, and never a fixed port: the
+//! kernel picks a free one, so two logins can run at once and nothing on the
+//! network can reach the listener. It speaks just enough HTTP to read one
+//! request line and answer one page, because pulling a server framework into
+//! the CLI to serve a single GET would be the larger cost.
+//!
+//! "Single-use" is about the CALLBACK, not the connection: a browser also asks
+//! for `/favicon.ico`, may send a preflight, and may probe the port before
+//! following the redirect. Those get a 404 and the listener keeps waiting, up
+//! to [`MAX_UNRELATED_REQUESTS`], so a favicon cannot consume the one
+//! authorization response. The first request that IS a callback ends the wait.
+
+use anyhow::{Context, Result, bail};
+use percent_encoding::percent_decode_str;
+use std::collections::HashMap;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+/// The path the authorization server is told to redirect to.
+pub const CALLBACK_PATH: &str = "/callback";
+
+/// Cap on request-line bytes read from one connection. A callback URL carries
+/// a code and a state; anything approaching this is not one.
+const MAX_REQUEST_BYTES: usize = 8 * 1024;
+
+/// How many non-callback requests are answered and ignored before giving up.
+/// Bounded so a chatty client cannot keep the wait alive indefinitely — the
+/// timeout is the other bound.
+const MAX_UNRELATED_REQUESTS: usize = 8;
+
+/// A bound loopback listener waiting for the authorization redirect.
+pub struct Loopback {
+    listener: TcpListener,
+    port: u16,
+}
+
+/// What the authorization server sent back.
+///
+/// `Debug` carries the code: it is single-use, already redeemed or refused by
+/// the time anything would print this, and useless without the PKCE verifier
+/// that never leaves memory. It exists so a failed `unwrap` in a test says
+/// what arrived.
+#[derive(Debug)]
+pub struct Callback {
+    pub code: Option<String>,
+    pub state: Option<String>,
+    /// OAuth 2.0 `error` (e.g. `access_denied`) when the user refused or the
+    /// provider rejected the request.
+    pub error: Option<String>,
+    pub error_description: Option<String>,
+}
+
+impl Loopback {
+    pub async fn bind() -> Result<Loopback> {
+        let listener = TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .context("bind a loopback listener for the login redirect")?;
+        let port = listener
+            .local_addr()
+            .context("read the loopback listener's port")?
+            .port();
+        Ok(Loopback { listener, port })
+    }
+
+    /// The `redirect_uri` to register with the authorization request. Literal
+    /// `127.0.0.1` rather than `localhost`: the name can resolve to `::1`
+    /// first, which is a different listener than the one bound above.
+    pub fn redirect_uri(&self) -> String {
+        format!("http://127.0.0.1:{}{CALLBACK_PATH}", self.port)
+    }
+
+    /// Wait for the redirect, or fail once `timeout` elapses.
+    ///
+    /// Consumes `self`, so the listener — and the port — is released when this
+    /// returns, on the timeout path as much as on the success path.
+    pub async fn wait(self, timeout: Duration) -> Result<Callback> {
+        match tokio::time::timeout(timeout, self.accept_callback()).await {
+            Ok(result) => result,
+            Err(_) => bail!(
+                "no authorization response within {}s — the login was not completed",
+                timeout.as_secs()
+            ),
+        }
+    }
+
+    async fn accept_callback(&self) -> Result<Callback> {
+        for _ in 0..=MAX_UNRELATED_REQUESTS {
+            let (mut stream, _peer) = self
+                .listener
+                .accept()
+                .await
+                .context("accept the login redirect")?;
+
+            let Some(target) = read_request_target(&mut stream).await? else {
+                respond(&mut stream, "400 Bad Request", "Malformed request.").await;
+                continue;
+            };
+            let (path, query) = match target.split_once('?') {
+                Some((path, query)) => (path, query),
+                None => (target.as_str(), ""),
+            };
+            if path != CALLBACK_PATH {
+                respond(&mut stream, "404 Not Found", "Not the login callback.").await;
+                continue;
+            }
+
+            let params = parse_query(query);
+            let callback = Callback {
+                code: params.get("code").cloned(),
+                state: params.get("state").cloned(),
+                error: params.get("error").cloned(),
+                error_description: params.get("error_description").cloned(),
+            };
+            // A bare `/callback` with neither is a probe, not a response.
+            if callback.code.is_none() && callback.error.is_none() {
+                respond(&mut stream, "400 Bad Request", "No authorization response.").await;
+                continue;
+            }
+
+            // The page never echoes a query value: it is rendered in a browser
+            // that just followed a redirect built by someone else, and nothing
+            // in the response needs the caller's input to be useful.
+            let body = match callback.error {
+                None => "Signed in. You can close this tab and return to the terminal.",
+                Some(_) => "Sign-in failed. Return to the terminal for the details.",
+            };
+            respond(&mut stream, "200 OK", body).await;
+            return Ok(callback);
+        }
+        bail!(
+            "the login redirect never arrived after {MAX_UNRELATED_REQUESTS} unrelated requests on the callback port"
+        )
+    }
+}
+
+/// Read the request target out of the first line, bounded. `None` when the
+/// line is not a parseable `GET <target> HTTP/1.x`.
+async fn read_request_target(stream: &mut TcpStream) -> Result<Option<String>> {
+    let mut buf = Vec::new();
+    let mut byte = [0u8; 1];
+    while buf.len() < MAX_REQUEST_BYTES {
+        match stream.read(&mut byte).await {
+            Ok(0) => break,
+            Ok(_) => {
+                if byte[0] == b'\n' {
+                    break;
+                }
+                buf.push(byte[0]);
+            }
+            // A client that hangs up mid-line is noise, not a failure of the
+            // wait: report it as an unparseable line and keep listening.
+            Err(_) => return Ok(None),
+        }
+    }
+    let line = String::from_utf8_lossy(&buf).trim().to_string();
+    let mut parts = line.split_whitespace();
+    match (parts.next(), parts.next()) {
+        (Some("GET"), Some(target)) => Ok(Some(target.to_string())),
+        _ => Ok(None),
+    }
+}
+
+/// Percent-decode a `application/x-www-form-urlencoded` query into pairs.
+/// Later duplicates lose to earlier ones, so a second `code=` appended to the
+/// URL cannot displace the real one.
+fn parse_query(query: &str) -> HashMap<String, String> {
+    let mut params = HashMap::new();
+    for pair in query.split('&').filter(|p| !p.is_empty()) {
+        let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
+        let decode = |raw: &str| {
+            percent_decode_str(&raw.replace('+', " "))
+                .decode_utf8_lossy()
+                .to_string()
+        };
+        params.entry(decode(key)).or_insert_with(|| decode(value));
+    }
+    params
+}
+
+/// Write one minimal HTML response. Best-effort: the browser tab's contents
+/// are cosmetic, and a write failure here must not lose an authorization code
+/// that was already read off the wire.
+async fn respond(stream: &mut TcpStream, status: &str, body: &str) {
+    let page = format!(
+        "<!doctype html><html><head><meta charset=\"utf-8\"><title>skardi login</title></head>\
+         <body style=\"font-family:system-ui;margin:3rem\"><p>{body}</p></body></html>"
+    );
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{page}",
+        page.len()
+    );
+    let _ = stream.write_all(response.as_bytes()).await;
+    let _ = stream.flush().await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Loopback, parse_query};
+    use std::time::Duration;
+
+    fn port_of(redirect_uri: &str) -> u16 {
+        redirect_uri
+            .trim_start_matches("http://127.0.0.1:")
+            .trim_end_matches("/callback")
+            .parse()
+            .unwrap()
+    }
+
+    #[test]
+    fn query_parsing_decodes_and_keeps_the_first_of_a_duplicate() {
+        let params = parse_query("code=a%2Fb&state=x+y&code=second&empty=");
+        assert_eq!(params["code"], "a/b", "percent-decoded");
+        assert_eq!(params["state"], "x y", "+ is a space in a query");
+        assert_eq!(params["empty"], "");
+        assert_eq!(
+            params["code"], "a/b",
+            "an appended duplicate must not displace the real code"
+        );
+    }
+
+    #[tokio::test]
+    async fn bind_is_loopback_only_and_the_uri_names_the_bound_port() {
+        let loopback = Loopback::bind().await.unwrap();
+        let uri = loopback.redirect_uri();
+        assert!(uri.starts_with("http://127.0.0.1:"), "{uri}");
+        assert!(uri.ends_with("/callback"), "{uri}");
+        assert!(port_of(&uri) > 0);
+    }
+
+    /// §6.1 step 2: "120-second timeout, then fail cleanly and release the
+    /// port." Rebinding the same port is the check that it was released.
+    #[tokio::test]
+    async fn a_timeout_fails_cleanly_and_releases_the_port() {
+        let loopback = Loopback::bind().await.unwrap();
+        let port = port_of(&loopback.redirect_uri());
+
+        let err = loopback
+            .wait(Duration::from_millis(50))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("no authorization response within"), "{err}");
+
+        tokio::net::TcpListener::bind(("127.0.0.1", port))
+            .await
+            .expect("the port must be free after the wait returns");
+    }
+
+    /// A browser asks for `/favicon.ico`, and something may probe the port
+    /// before the redirect lands. Neither may consume the single callback.
+    #[tokio::test]
+    async fn unrelated_requests_do_not_consume_the_callback() {
+        let loopback = Loopback::bind().await.unwrap();
+        let uri = loopback.redirect_uri();
+        let base = uri.trim_end_matches("/callback").to_string();
+
+        let waiter = tokio::spawn(async move { loopback.wait(Duration::from_secs(5)).await });
+        let http = reqwest::Client::new();
+        // Noise first, each fully awaited so the ordering is deterministic.
+        let _ = http.get(format!("{base}/favicon.ico")).send().await;
+        let _ = http.get(format!("{base}/callback")).send().await;
+        let response = http
+            .get(format!("{uri}?code=the-code&state=the-state"))
+            .send()
+            .await
+            .unwrap();
+        assert!(response.status().is_success());
+        assert!(
+            response.text().await.unwrap().contains("Signed in"),
+            "the browser tab should say the sign-in completed"
+        );
+
+        let callback = waiter.await.unwrap().unwrap();
+        assert_eq!(callback.code.as_deref(), Some("the-code"));
+        assert_eq!(callback.state.as_deref(), Some("the-state"));
+    }
+
+    #[tokio::test]
+    async fn a_provider_error_is_returned_rather_than_waited_out() {
+        let loopback = Loopback::bind().await.unwrap();
+        let uri = loopback.redirect_uri();
+
+        let waiter = tokio::spawn(async move { loopback.wait(Duration::from_secs(5)).await });
+        let response = reqwest::get(format!(
+            "{uri}?error=access_denied&error_description=user%20refused"
+        ))
+        .await
+        .unwrap();
+        assert!(response.text().await.unwrap().contains("Sign-in failed"));
+
+        let callback = waiter.await.unwrap().unwrap();
+        assert_eq!(callback.error.as_deref(), Some("access_denied"));
+        assert_eq!(callback.error_description.as_deref(), Some("user refused"));
+    }
+}

--- a/crates/cli/src/login/loopback.rs
+++ b/crates/cli/src/login/loopback.rs
@@ -6,15 +6,27 @@
 //! request line and answer one page, because pulling a server framework into
 //! the CLI to serve a single GET would be the larger cost.
 //!
-//! "Single-use" is about the CALLBACK, not the connection: a browser also asks
-//! for `/favicon.ico`, may send a preflight, and may probe the port before
-//! following the redirect. Those get a 404 and the listener keeps waiting, up
-//! to [`MAX_UNRELATED_REQUESTS`], so a favicon cannot consume the one
-//! authorization response. The first request that IS a callback ends the wait.
+//! "Single-use" is about THIS sign-in's callback, not the connection: a browser
+//! also asks for `/favicon.ico`, may send a preflight, and may probe the port
+//! before following the redirect. Those get a 404 and the listener keeps
+//! waiting, up to [`MAX_UNRELATED_REQUESTS`], so a favicon cannot consume the
+//! one authorization response.
+//!
+//! `state` is what decides membership, and it is checked HERE rather than by
+//! the caller (§9.1: "a `state` checked on callback", unqualified). Anything on
+//! this machine can reach a loopback port, and a browser can be induced to
+//! fetch one cross-site — so a request carrying `?error=access_denied` with no
+//! `state`, or a planted `?code=…&state=guess`, must not be able to END an
+//! active login. Checking after the fact would only have changed which error
+//! the operator saw; ignoring it, and continuing to wait, is what makes the
+//! stray request harmless. The count of what was ignored is reported if the
+//! wait then runs out, so a genuinely mismatched provider is still diagnosable
+//! rather than silent.
 
 use anyhow::{Context, Result, bail};
 use percent_encoding::percent_decode_str;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
@@ -72,21 +84,33 @@ impl Loopback {
         format!("http://127.0.0.1:{}{CALLBACK_PATH}", self.port)
     }
 
-    /// Wait for the redirect, or fail once `timeout` elapses.
+    /// Wait for THIS sign-in's redirect, or fail once `timeout` elapses.
+    ///
+    /// Only a callback whose `state` equals `expected_state` is returned;
+    /// anything else is answered and ignored (see the module docs).
     ///
     /// Consumes `self`, so the listener — and the port — is released when this
     /// returns, on the timeout path as much as on the success path.
-    pub async fn wait(self, timeout: Duration) -> Result<Callback> {
-        match tokio::time::timeout(timeout, self.accept_callback()).await {
+    pub async fn wait(self, timeout: Duration, expected_state: &str) -> Result<Callback> {
+        // Outside the timeout future, so a wait that runs out can still report
+        // what it ignored. Atomic rather than `Cell` only because the future
+        // must stay `Send` to be spawned.
+        let ignored = AtomicUsize::new(0);
+        match tokio::time::timeout(timeout, self.accept_callback(expected_state, &ignored)).await {
             Ok(result) => result,
             Err(_) => bail!(
-                "no authorization response within {}s — the login was not completed",
-                timeout.as_secs()
+                "no authorization response within {}s — the login was not completed{}",
+                timeout.as_secs(),
+                describe_ignored(ignored.load(Ordering::Relaxed))
             ),
         }
     }
 
-    async fn accept_callback(&self) -> Result<Callback> {
+    async fn accept_callback(
+        &self,
+        expected_state: &str,
+        ignored: &AtomicUsize,
+    ) -> Result<Callback> {
         for _ in 0..=MAX_UNRELATED_REQUESTS {
             let (mut stream, _peer) = self
                 .listener
@@ -119,6 +143,24 @@ impl Loopback {
                 respond(&mut stream, "400 Bad Request", "No authorization response.").await;
                 continue;
             }
+            // Membership in THIS sign-in, checked before either the code or
+            // the error is looked at. A mismatch is treated as one more
+            // unrelated request rather than as a failure, so nothing that can
+            // reach this port can end the login.
+            //
+            // `state` is required on an error response too — RFC 6749 §4.1.2.1
+            // requires it echoed whenever the request carried one — so a
+            // refusal that omits it did not come from the provider we asked.
+            if callback.state.as_deref() != Some(expected_state) {
+                ignored.fetch_add(1, Ordering::Relaxed);
+                respond(
+                    &mut stream,
+                    "400 Bad Request",
+                    "This response does not belong to a sign-in started here.",
+                )
+                .await;
+                continue;
+            }
 
             // The page never echoes a query value: it is rendered in a browser
             // that just followed a redirect built by someone else, and nothing
@@ -131,8 +173,24 @@ impl Loopback {
             return Ok(callback);
         }
         bail!(
-            "the login redirect never arrived after {MAX_UNRELATED_REQUESTS} unrelated requests on the callback port"
+            "the login redirect never arrived after {MAX_UNRELATED_REQUESTS} unrelated requests on the callback port{}",
+            describe_ignored(ignored.load(Ordering::Relaxed))
         )
+    }
+}
+
+/// The clause naming callbacks that were refused for carrying the wrong
+/// `state`, so a mismatch is diagnosable instead of looking like silence.
+fn describe_ignored(count: usize) -> String {
+    match count {
+        0 => String::new(),
+        1 => {
+            " (one response arrived carrying a 'state' this sign-in did not issue, and was ignored)"
+                .to_string()
+        }
+        many => format!(
+            " ({many} responses arrived carrying a 'state' this sign-in did not issue, and were ignored)"
+        ),
     }
 }
 
@@ -238,7 +296,7 @@ mod tests {
         let port = port_of(&loopback.redirect_uri());
 
         let err = loopback
-            .wait(Duration::from_millis(50))
+            .wait(Duration::from_millis(50), "the-state")
             .await
             .unwrap_err()
             .to_string();
@@ -257,7 +315,8 @@ mod tests {
         let uri = loopback.redirect_uri();
         let base = uri.trim_end_matches("/callback").to_string();
 
-        let waiter = tokio::spawn(async move { loopback.wait(Duration::from_secs(5)).await });
+        let waiter =
+            tokio::spawn(async move { loopback.wait(Duration::from_secs(5), "the-state").await });
         let http = reqwest::Client::new();
         // Noise first, each fully awaited so the ordering is deterministic.
         let _ = http.get(format!("{base}/favicon.ico")).send().await;
@@ -292,7 +351,8 @@ mod tests {
             .trim_end_matches("/callback")
             .to_string();
 
-        let waiter = tokio::spawn(async move { loopback.wait(Duration::from_secs(5)).await });
+        let waiter =
+            tokio::spawn(async move { loopback.wait(Duration::from_secs(5), "the-state").await });
 
         // A POST to the right path: not a redirect, so not the callback.
         let _ = reqwest::Client::new()
@@ -307,12 +367,71 @@ mod tests {
         // A connection that opens and hangs up without sending anything.
         drop(tokio::net::TcpStream::connect(&addr).await.unwrap());
 
-        let callback = reqwest::get(format!("{uri}?code=real&state=s"))
+        let callback = reqwest::get(format!("{uri}?code=real&state=the-state"))
             .await
             .unwrap();
         assert!(callback.status().is_success());
         let received = waiter.await.unwrap().unwrap();
         assert_eq!(received.code.as_deref(), Some("real"));
+    }
+
+    /// The finding this exists for: anything on the machine can reach a
+    /// loopback port, and a browser can be induced to fetch one cross-site. A
+    /// planted `?error=` — or a planted code with a guessed state — must not be
+    /// able to END an active login.
+    #[tokio::test]
+    async fn a_response_from_another_sign_in_cannot_end_this_one() {
+        let loopback = Loopback::bind().await.unwrap();
+        let uri = loopback.redirect_uri();
+
+        let waiter =
+            tokio::spawn(async move { loopback.wait(Duration::from_secs(5), "the-state").await });
+        let http = reqwest::Client::new();
+
+        // An error with no state at all, an error with someone else's state,
+        // and a planted code — each answered, none accepted.
+        for planted in [
+            "?error=access_denied",
+            "?error=access_denied&state=someone-elses",
+            "?code=planted&state=someone-elses",
+            "?code=planted",
+        ] {
+            let response = http.get(format!("{uri}{planted}")).send().await.unwrap();
+            assert_eq!(response.status().as_u16(), 400, "{planted}");
+            assert!(
+                response.text().await.unwrap().contains("does not belong"),
+                "{planted}"
+            );
+        }
+
+        // The real redirect still completes.
+        let _ = http
+            .get(format!("{uri}?code=the-real-code&state=the-state"))
+            .send()
+            .await;
+        let callback = waiter.await.unwrap().unwrap();
+        assert_eq!(callback.code.as_deref(), Some("the-real-code"));
+    }
+
+    /// A mismatch that never resolves is not silence: the wait runs out and
+    /// says what it refused, so a genuinely misconfigured provider is
+    /// diagnosable.
+    #[tokio::test]
+    async fn a_wait_that_only_saw_foreign_responses_says_so() {
+        let loopback = Loopback::bind().await.unwrap();
+        let uri = loopback.redirect_uri();
+
+        let waiter =
+            tokio::spawn(async move { loopback.wait(Duration::from_millis(300), "mine").await });
+        let _ = reqwest::get(format!("{uri}?code=c&state=not-mine")).await;
+
+        let err = waiter.await.unwrap().unwrap_err().to_string();
+        assert!(err.contains("no authorization response within"), "{err}");
+        assert!(
+            err.contains("did not issue"),
+            "the ignored response must be reported: {err}"
+        );
+        assert!(!err.contains("not-mine"), "no value is echoed: {err}");
     }
 
     /// Enough noise to exhaust the allowance ends the wait with a message
@@ -325,7 +444,8 @@ mod tests {
             .trim_end_matches("/callback")
             .to_string();
 
-        let waiter = tokio::spawn(async move { loopback.wait(Duration::from_secs(30)).await });
+        let waiter =
+            tokio::spawn(async move { loopback.wait(Duration::from_secs(30), "the-state").await });
         let http = reqwest::Client::new();
         for _ in 0..=super::MAX_UNRELATED_REQUESTS {
             let _ = http.get(format!("{base}/favicon.ico")).send().await;
@@ -340,9 +460,13 @@ mod tests {
         let loopback = Loopback::bind().await.unwrap();
         let uri = loopback.redirect_uri();
 
-        let waiter = tokio::spawn(async move { loopback.wait(Duration::from_secs(5)).await });
+        let waiter =
+            tokio::spawn(async move { loopback.wait(Duration::from_secs(5), "the-state").await });
+        // The provider echoes `state` on an error response too (RFC 6749
+        // §4.1.2.1), so a genuine refusal carries it — and only that reaches
+        // the caller.
         let response = reqwest::get(format!(
-            "{uri}?error=access_denied&error_description=user%20refused"
+            "{uri}?error=access_denied&error_description=user%20refused&state=the-state"
         ))
         .await
         .unwrap();

--- a/crates/cli/src/login/mod.rs
+++ b/crates/cli/src/login/mod.rs
@@ -29,14 +29,6 @@ use chrono::{DateTime, Duration, Utc};
 use control_plane::{ControlPlane, CpError, Membership, Minted};
 use std::path::Path;
 
-/// Per-request ceiling on control-plane and token-endpoint calls.
-///
-/// Bounded because of the ROLLBACK, not the happy path: a revoke that hangs
-/// forever leaves the operator watching a silent terminal while a live
-/// credential goes unreported, which is precisely the outcome §6.5 exists to
-/// prevent. Generous enough that a cold control plane still answers.
-const CONTROL_PLANE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
-
 /// Default PAT lifetime (§6.1 step 5), as `--expires` spells it. A string so
 /// clap's default and this documented value are the same token, parsed by the
 /// same function a user-supplied one goes through.
@@ -90,6 +82,8 @@ pub struct LoginOptions {
     /// browser path covered rather than argued.
     pub open_browser: fn(&str) -> std::io::Result<()>,
     pub callback_timeout: std::time::Duration,
+    /// Ceiling on the post-mint verification probe (§6.1 step 6).
+    pub verify_timeout: std::time::Duration,
     /// The PAT's name at the control plane, `cli@<hostname>`.
     pub token_name: String,
     /// Injected so the expiry a test asserts is not the wall clock.
@@ -135,10 +129,7 @@ struct MintedRef {
 /// Run the whole flow. `config_path` is a parameter so tests write to a temp
 /// directory instead of the developer's own config.
 pub async fn login(options: LoginOptions, config_path: &Path) -> Result<LoginReport> {
-    let http = reqwest::Client::builder()
-        .no_proxy()
-        .timeout(CONTROL_PLANE_TIMEOUT)
-        .build()?;
+    let http = control_plane::client(control_plane::CONTROL_PLANE_TIMEOUT)?;
     let bearer = acquire_bearer(&http, &options).await?;
     let cp = ControlPlane::new(http.clone(), &options.control_plane, bearer);
 
@@ -202,7 +193,7 @@ pub async fn login(options: LoginOptions, config_path: &Path) -> Result<LoginRep
         });
 
         if !options.no_verify
-            && let Err(err) = verify(&server, &membership, &token).await
+            && let Err(err) = verify(&server, &membership, &token, options.verify_timeout).await
         {
             return Err(rollback(&cp, minted, err).await);
         }
@@ -438,7 +429,12 @@ fn resolve_server(options: &LoginOptions, membership: &Membership) -> Result<Str
 /// travels the exact path a real query will — same client, same
 /// `Skardi-Workspace` header — because a login that reports success while its
 /// first query would 403 is the failure this step exists to remove.
-async fn verify(server: &str, membership: &Membership, token: &Minted) -> Result<()> {
+async fn verify(
+    server: &str,
+    membership: &Membership,
+    token: &Minted,
+    timeout: std::time::Duration,
+) -> Result<()> {
     let probe = config::ClientConfig {
         server: server.to_string(),
         token: Some(token.token.clone()),
@@ -450,16 +446,27 @@ async fn verify(server: &str, membership: &Membership, token: &Minted) -> Result
         }),
     };
     let client = ApiClient::new(&probe)?;
-    client
-        .post("/query", &serde_json::json!({"sql": "select 1"}))
-        .await
-        .map_err(|err| {
-            anyhow!(
-                "the new credential for workspace '{}' could not query {server}: {err} — the context was not written (pass --no-verify to skip this check)",
-                membership.tenant_slug
-            )
-        })?;
-    Ok(())
+    let statement = serde_json::json!({"sql": "select 1"});
+    let probe_request = client.post("/query", &statement);
+
+    // BOUNDED here rather than on `ApiClient` itself: the same client runs
+    // `skardi query`, where a statement legitimately takes minutes, so a
+    // client-wide total timeout would cap real work. A gateway that accepts
+    // the connection and then never answers must not hang the flow — this is
+    // the one point past which a PAT exists and no context does, so the saga
+    // has to be reachable (§6.5).
+    match tokio::time::timeout(timeout, probe_request).await {
+        Ok(Ok(_)) => Ok(()),
+        Ok(Err(err)) => Err(anyhow!(
+            "the new credential for workspace '{}' could not query {server}: {err} — the context was not written (pass --no-verify to skip this check)",
+            membership.tenant_slug
+        )),
+        Err(_) => Err(anyhow!(
+            "the new credential for workspace '{}' got no answer from {server} within {}s — the context was not written (pass --no-verify to skip this check)",
+            membership.tenant_slug,
+            timeout.as_secs()
+        )),
+    }
 }
 
 /// The context name for a membership: `--context` when given, else

--- a/crates/cli/src/login/mod.rs
+++ b/crates/cli/src/login/mod.rs
@@ -82,6 +82,13 @@ pub struct LoginOptions {
     /// `$SKARDI_GATEWAY_URL`, the second step.
     pub env_gateway_url: Option<String>,
     pub endpoints: oauth::Endpoints,
+    /// How the authorization URL reaches a browser.
+    ///
+    /// A plain `fn` pointer rather than a closure: nothing here needs to
+    /// capture state, so this keeps `LoginOptions` free of type parameters
+    /// while letting a test play the user agent — which is what makes the
+    /// browser path covered rather than argued.
+    pub open_browser: fn(&str) -> std::io::Result<()>,
     pub callback_timeout: std::time::Duration,
     /// The PAT's name at the control plane, `cli@<hostname>`.
     pub token_name: String,
@@ -148,7 +155,12 @@ pub async fn login(options: LoginOptions, config_path: &Path) -> Result<LoginRep
         }
     }
 
-    let selected = select_memberships(&options.selection, active, &report.skipped)?;
+    let selected = select_memberships(
+        &options.selection,
+        active,
+        &report.skipped,
+        &mut std::io::stdin().lock(),
+    )?;
     if options.context_name.is_some() && selected.len() > 1 {
         bail!(
             "--context names ONE context, but {} workspaces were selected — drop it, or select a single workspace with --workspace",
@@ -243,7 +255,7 @@ async fn acquire_bearer(http: &reqwest::Client, options: &LoginOptions) -> Resul
         client_id,
         options.no_browser,
         options.callback_timeout,
-        &oauth::open_in_browser,
+        &options.open_browser,
     )
     .await
 }
@@ -297,6 +309,9 @@ fn select_memberships(
     selection: &Selection,
     active: Vec<Membership>,
     skipped: &[(String, String)],
+    // Where the picker reads its answer. A parameter, not `stdin`, so the
+    // interactive branch is exercised by tests rather than only by hand.
+    input: &mut dyn std::io::BufRead,
 ) -> Result<Vec<Membership>> {
     if active.is_empty() {
         // The skip list is the explanation when it is the reason.
@@ -335,7 +350,7 @@ fn select_memberships(
         }
         Selection::Auto if active.len() == 1 => Ok(active),
         Selection::Auto => {
-            let chosen = prompt_for_workspace(&active)?;
+            let chosen = prompt_for_workspace(&active, input)?;
             Ok(vec![chosen])
         }
     }
@@ -344,29 +359,17 @@ fn select_memberships(
 /// Ask which workspace to use. On EOF — a pipe, a CI job, a `< /dev/null` —
 /// this is a non-interactive run, so it names the flags that do the same job
 /// rather than looping on an input that will never come.
-fn prompt_for_workspace(active: &[Membership]) -> Result<Membership> {
+fn prompt_for_workspace(
+    active: &[Membership],
+    input: &mut dyn std::io::BufRead,
+) -> Result<Membership> {
     use std::io::Write as _;
 
-    eprintln!("this identity has {} active workspaces:", active.len());
-    for (index, membership) in active.iter().enumerate() {
-        let display = membership
-            .display_name
-            .as_deref()
-            .filter(|name| !name.is_empty())
-            .map(|name| format!(" — {name}"))
-            .unwrap_or_default();
-        eprintln!(
-            "  {}) {}{display} (role: {})",
-            index + 1,
-            membership.context_name(),
-            membership.role
-        );
-    }
-    eprint!("select one [1-{}]: ", active.len());
+    eprint!("{}", render_workspace_menu(active));
     let _ = std::io::stderr().flush();
 
     let mut line = String::new();
-    let read = std::io::stdin()
+    let read = input
         .read_line(&mut line)
         .context("read the workspace selection")?;
     if read == 0 {
@@ -381,6 +384,32 @@ fn prompt_for_workspace(active: &[Membership]) -> Result<Membership> {
         .filter(|n| (1..=active.len()).contains(n))
         .ok_or_else(|| anyhow!("'{}' is not one of 1-{}", line.trim(), active.len()))?;
     Ok(active[choice - 1].clone())
+}
+
+/// The picker's menu, as its own function so the text — including the
+/// `display_name` a control plane may or may not send — is asserted rather
+/// than eyeballed.
+fn render_workspace_menu(active: &[Membership]) -> String {
+    use std::fmt::Write as _;
+
+    let mut out = format!("this identity has {} active workspaces:\n", active.len());
+    for (index, membership) in active.iter().enumerate() {
+        let display = membership
+            .display_name
+            .as_deref()
+            .filter(|name| !name.is_empty())
+            .map(|name| format!(" — {name}"))
+            .unwrap_or_default();
+        let _ = writeln!(
+            out,
+            "  {}) {}{display} (role: {})",
+            index + 1,
+            membership.context_name(),
+            membership.role
+        );
+    }
+    let _ = write!(out, "select one [1-{}]: ", active.len());
+    out
 }
 
 /// §6.2: `--server` > `$SKARDI_GATEWAY_URL` > the membership's `gateway_url` >

--- a/crates/cli/src/login/mod.rs
+++ b/crates/cli/src/login/mod.rs
@@ -1,0 +1,603 @@
+//! `skardi login`: turn a browser sign-in (or a dev bearer) into one
+//! workspace-scoped PAT per workspace, verified against the gateway before
+//! anything is written (§6).
+//!
+//! The flow is a SAGA, not a loop (§6.5). Each mint commits independently at
+//! the control plane, so a failure partway through `--all-workspaces` would
+//! otherwise leave live PATs whose ids die with the process — credentials
+//! nobody knows exist. Every `{token_id, workspace}` is retained in memory,
+//! contexts are written only after all selected mints succeed, and any failure
+//! (including the config write) revokes everything this run created before
+//! reporting the original cause.
+//!
+//! Everything that talks to a network is reachable through a parameter — the
+//! control-plane URL, both OAuth endpoints, the identity acquirer — so the
+//! whole flow runs in tests against `wiremock` with no browser and no Google.
+
+#[cfg(test)]
+mod tests;
+
+pub mod control_plane;
+pub mod loopback;
+pub mod oauth;
+pub mod pkce;
+
+use crate::client::ApiClient;
+use crate::config::{self, Context, ContextMode, ContextsFile, SelectedContext};
+use anyhow::{Context as _, Result, anyhow, bail};
+use chrono::{DateTime, Duration, Utc};
+use control_plane::{ControlPlane, CpError, Membership, Minted};
+use std::path::Path;
+
+/// Default PAT lifetime (§6.1 step 5), as `--expires` spells it. A string so
+/// clap's default and this documented value are the same token, parsed by the
+/// same function a user-supplied one goes through.
+pub const DEFAULT_EXPIRES: &str = "90d";
+
+/// Which memberships to mint for.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Selection {
+    /// A lone membership is used automatically; several prompt (§6.1 step 5).
+    Auto,
+    /// `--workspace SLUG`.
+    Named(String),
+    /// `--all-workspaces`.
+    All,
+}
+
+/// Everything `login` needs, with every network endpoint injectable.
+pub struct LoginOptions {
+    pub control_plane: String,
+    /// The OAuth client id. Required for the browser path, unused with
+    /// `--identity`.
+    pub client_id: Option<String>,
+    /// `dev:<external-id>[:<email>]` (§6.3), which skips the browser.
+    pub identity: Option<String>,
+    /// `--i-know-this-is-dev-auth`, the only way `--identity` is allowed
+    /// against a non-loopback control plane.
+    pub allow_dev_auth_off_loopback: bool,
+    pub selection: Selection,
+    /// `--context NAME`, overriding the `<org>/<workspace>` default. Only
+    /// legal for a single-workspace login: several contexts cannot share a
+    /// name.
+    pub context_name: Option<String>,
+    pub expires: Duration,
+    pub no_browser: bool,
+    pub no_verify: bool,
+    pub keep_old_token: bool,
+    /// `--server`, the top of §6.2's precedence.
+    pub server_override: Option<String>,
+    /// `$SKARDI_GATEWAY_URL`, the second step.
+    pub env_gateway_url: Option<String>,
+    pub endpoints: oauth::Endpoints,
+    pub callback_timeout: std::time::Duration,
+    /// The PAT's name at the control plane, `cli@<hostname>`.
+    pub token_name: String,
+    /// Injected so the expiry a test asserts is not the wall clock.
+    pub now: DateTime<Utc>,
+}
+
+/// One context this run wrote.
+#[derive(Debug)]
+pub struct WrittenContext {
+    pub name: String,
+    pub server: String,
+    pub workspace: String,
+    pub role: String,
+    pub expires_at: Option<String>,
+}
+
+/// What happened, for the caller to print.
+///
+/// `Debug`-able because it carries NO token values — only names, ids, and
+/// expiry stamps — so a report can be printed by a test or a future `--json`
+/// without a redaction step.
+#[derive(Debug, Default)]
+pub struct LoginReport {
+    pub written: Vec<WrittenContext>,
+    /// `(context name, provisioning_state)` for every non-`active` workspace.
+    pub skipped: Vec<(String, String)>,
+    pub current_context: Option<String>,
+    /// Token ids of replaced credentials that were revoked.
+    pub replaced_revoked: Vec<String>,
+    /// Token ids retained because of `--keep-old-token`.
+    pub replaced_kept: Vec<String>,
+    /// `(token id, reason)` for a replacement revocation that failed. Reported
+    /// but not fatal: the new context is already good (§6.5).
+    pub revoke_failures: Vec<(String, String)>,
+}
+
+/// A PAT this run created, retained so the saga can revoke it.
+struct MintedRef {
+    workspace: String,
+    token_id: String,
+}
+
+/// Run the whole flow. `config_path` is a parameter so tests write to a temp
+/// directory instead of the developer's own config.
+pub async fn login(options: LoginOptions, config_path: &Path) -> Result<LoginReport> {
+    let http = reqwest::Client::builder().no_proxy().build()?;
+    let bearer = acquire_bearer(&http, &options).await?;
+    let cp = ControlPlane::new(http.clone(), &options.control_plane, bearer);
+
+    let memberships = cp.memberships().await.map_err(describe_cp_failure)?;
+    let mut report = LoginReport::default();
+    let mut active = Vec::new();
+    for membership in memberships {
+        if membership.is_active() {
+            active.push(membership);
+        } else {
+            report
+                .skipped
+                .push((membership.context_name(), membership.provisioning_state));
+        }
+    }
+
+    let selected = select_memberships(&options.selection, active, &report.skipped)?;
+    if options.context_name.is_some() && selected.len() > 1 {
+        bail!(
+            "--context names ONE context, but {} workspaces were selected — drop it, or select a single workspace with --workspace",
+            selected.len()
+        );
+    }
+
+    // §6.5: mint, then verify, retaining every id. Any failure past the first
+    // mint rolls the whole run back before reporting.
+    let expires_at = (options.now + options.expires).to_rfc3339();
+    let mut minted: Vec<MintedRef> = Vec::new();
+    let mut pending: Vec<(Membership, Minted, String)> = Vec::new();
+    for membership in selected {
+        let server = match resolve_server(&options, &membership) {
+            Ok(server) => server,
+            Err(err) => return Err(rollback(&cp, minted, err).await),
+        };
+        let token = match cp
+            .mint(
+                &options.token_name,
+                &membership.tenant_slug,
+                &membership.role,
+                &expires_at,
+            )
+            .await
+        {
+            Ok(token) => token,
+            Err(err) => {
+                let err = describe_cp_failure(err).context(format!(
+                    "minting a credential for workspace '{}' failed",
+                    membership.tenant_slug
+                ));
+                return Err(rollback(&cp, minted, err).await);
+            }
+        };
+        minted.push(MintedRef {
+            workspace: membership.tenant_slug.clone(),
+            token_id: token.token_id.clone(),
+        });
+
+        if !options.no_verify
+            && let Err(err) = verify(&server, &membership, &token).await
+        {
+            return Err(rollback(&cp, minted, err).await);
+        }
+        pending.push((membership, token, server));
+    }
+
+    match write_contexts(config_path, &options, &pending) {
+        Ok(replaced) => {
+            report.written = pending
+                .iter()
+                .map(|(membership, token, server)| WrittenContext {
+                    name: context_name(&options, membership),
+                    server: server.clone(),
+                    workspace: membership.tenant_slug.clone(),
+                    role: membership.role.clone(),
+                    expires_at: token.expires_at.clone(),
+                })
+                .collect();
+            report.current_context = report.written.first().map(|w| w.name.clone());
+            revoke_replaced(&cp, replaced, &options, &mut report).await;
+            Ok(report)
+        }
+        Err(err) => Err(rollback(&cp, minted, err).await),
+    }
+}
+
+/// Step 1-3: the credential presented to the control plane.
+async fn acquire_bearer(http: &reqwest::Client, options: &LoginOptions) -> Result<String> {
+    if let Some(identity) = &options.identity {
+        check_dev_identity(
+            identity,
+            &options.control_plane,
+            options.allow_dev_auth_off_loopback,
+        )?;
+        return Ok(identity.clone());
+    }
+
+    let client_id = options
+        .client_id
+        .as_deref()
+        .filter(|id| !id.trim().is_empty());
+    let Some(client_id) = client_id else {
+        bail!(
+            "no OAuth client id: pass --client-id, set $SKARDI_OAUTH_CLIENT_ID, or use --identity dev:<id> against a loopback control plane"
+        )
+    };
+    oauth::acquire_id_token(
+        http,
+        &options.endpoints,
+        client_id,
+        options.no_browser,
+        options.callback_timeout,
+        &oauth::open_in_browser,
+    )
+    .await
+}
+
+/// §6.3's guard on the dev-auth path, shared by `login` and
+/// `logout --revoke` so neither can drift into accepting more than the other.
+///
+/// Loopback ONLY, deliberately not loopback-or-private: a `dev:<external-id>`
+/// bearer is unauthenticated impersonation of any user against a control plane
+/// with `SKARDI_GLOBAL_DEV_AUTH=1`, and RFC1918 is exactly where a shared
+/// internal staging cluster lives. It is also the simpler predicate, with no
+/// CIDR table to get wrong.
+pub fn check_dev_identity(
+    identity: &str,
+    control_plane: &str,
+    allow_off_loopback: bool,
+) -> Result<()> {
+    if !identity.starts_with("dev:") {
+        bail!("--identity must be a 'dev:<external-id>[:<email>]' bearer, not '{identity}'");
+    }
+    if !is_loopback_url(control_plane)? && !allow_off_loopback {
+        bail!(
+            "--identity is a dev-auth bearer and {control_plane} is not a loopback address — pass --i-know-this-is-dev-auth to use it against a remote control plane"
+        );
+    }
+    // Printed on every run, naming the control plane it authenticated against:
+    // the decision to trust an unverified claim should be visible in the
+    // terminal that made it.
+    eprintln!(
+        "warning: authenticating with a dev-auth identity against {control_plane} — this presents an unverified identity claim, not a signed sign-in"
+    );
+    Ok(())
+}
+
+/// Whether `url`'s host is a loopback address. `localhost` counts: it is the
+/// NAME for loopback, and it is what a compose stack and a dev README use.
+fn is_loopback_url(url: &str) -> Result<bool> {
+    let parsed = reqwest::Url::parse(url)
+        .with_context(|| format!("'{url}' is not a valid control-plane URL"))?;
+    let host = parsed.host_str().unwrap_or_default();
+    // `host_str` brackets an IPv6 literal, which `IpAddr` will not parse.
+    let host = host.trim_start_matches('[').trim_end_matches(']');
+    Ok(host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|addr| addr.is_loopback()))
+}
+
+/// §6.1 step 5's selection rule.
+fn select_memberships(
+    selection: &Selection,
+    active: Vec<Membership>,
+    skipped: &[(String, String)],
+) -> Result<Vec<Membership>> {
+    if active.is_empty() {
+        // The skip list is the explanation when it is the reason.
+        if skipped.is_empty() {
+            bail!("this identity has no workspace memberships at the control plane");
+        }
+        let states = skipped
+            .iter()
+            .map(|(name, state)| format!("{name} ({state})"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        bail!(
+            "no active workspace to log in to — every membership is still provisioning: {states}"
+        );
+    }
+
+    match selection {
+        Selection::All => Ok(active),
+        Selection::Named(slug) => {
+            let matched: Vec<Membership> = active
+                .iter()
+                .filter(|m| &m.tenant_slug == slug)
+                .cloned()
+                .collect();
+            if matched.is_empty() {
+                bail!(
+                    "no active workspace named '{slug}' — available: {}",
+                    active
+                        .iter()
+                        .map(|m| m.tenant_slug.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+            }
+            Ok(matched)
+        }
+        Selection::Auto if active.len() == 1 => Ok(active),
+        Selection::Auto => {
+            let chosen = prompt_for_workspace(&active)?;
+            Ok(vec![chosen])
+        }
+    }
+}
+
+/// Ask which workspace to use. On EOF — a pipe, a CI job, a `< /dev/null` —
+/// this is a non-interactive run, so it names the flags that do the same job
+/// rather than looping on an input that will never come.
+fn prompt_for_workspace(active: &[Membership]) -> Result<Membership> {
+    use std::io::Write as _;
+
+    eprintln!("this identity has {} active workspaces:", active.len());
+    for (index, membership) in active.iter().enumerate() {
+        let display = membership
+            .display_name
+            .as_deref()
+            .filter(|name| !name.is_empty())
+            .map(|name| format!(" — {name}"))
+            .unwrap_or_default();
+        eprintln!(
+            "  {}) {}{display} (role: {})",
+            index + 1,
+            membership.context_name(),
+            membership.role
+        );
+    }
+    eprint!("select one [1-{}]: ", active.len());
+    let _ = std::io::stderr().flush();
+
+    let mut line = String::new();
+    let read = std::io::stdin()
+        .read_line(&mut line)
+        .context("read the workspace selection")?;
+    if read == 0 {
+        bail!(
+            "several workspaces are available and there is no terminal to ask — pass --workspace <slug> or --all-workspaces"
+        );
+    }
+    let choice: usize = line
+        .trim()
+        .parse()
+        .ok()
+        .filter(|n| (1..=active.len()).contains(n))
+        .ok_or_else(|| anyhow!("'{}' is not one of 1-{}", line.trim(), active.len()))?;
+    Ok(active[choice - 1].clone())
+}
+
+/// §6.2: `--server` > `$SKARDI_GATEWAY_URL` > the membership's `gateway_url` >
+/// hard error. Deliberately no built-in default and no fall-through to
+/// `http://127.0.0.1:8080` — writing a context that points at a local port
+/// would fail later and further from the cause.
+fn resolve_server(options: &LoginOptions, membership: &Membership) -> Result<String> {
+    let candidate = options
+        .server_override
+        .as_deref()
+        .or(options.env_gateway_url.as_deref())
+        .or(membership.gateway_url.as_deref())
+        .map(str::trim)
+        .filter(|url| !url.is_empty());
+    let Some(server) = candidate else {
+        bail!(
+            "the control plane did not say which gateway serves workspace '{}' — pass --server <URL>, set $SKARDI_GATEWAY_URL, or configure gateway_url for the org",
+            membership.tenant_slug
+        )
+    };
+    Ok(server.to_string())
+}
+
+/// §6.1 step 6: one authenticated probe at the resolved gateway before the
+/// context is written. `select 1` is the cheapest governed round trip, and it
+/// travels the exact path a real query will — same client, same
+/// `Skardi-Workspace` header — because a login that reports success while its
+/// first query would 403 is the failure this step exists to remove.
+async fn verify(server: &str, membership: &Membership, token: &Minted) -> Result<()> {
+    let probe = config::ClientConfig {
+        server: server.to_string(),
+        token: Some(token.token.clone()),
+        context: Some(SelectedContext {
+            name: membership.context_name(),
+            mode: ContextMode::Cloud,
+            workspace: Some(membership.tenant_slug.clone()),
+            token_expires_at: token.expires_at.clone(),
+        }),
+    };
+    let client = ApiClient::new(&probe)?;
+    client
+        .post("/query", &serde_json::json!({"sql": "select 1"}))
+        .await
+        .map_err(|err| {
+            anyhow!(
+                "the new credential for workspace '{}' could not query {server}: {err} — the context was not written (pass --no-verify to skip this check)",
+                membership.tenant_slug
+            )
+        })?;
+    Ok(())
+}
+
+/// The context name for a membership: `--context` when given, else
+/// `<org_slug>/<tenant_slug>` (§6.1 step 7).
+fn context_name(options: &LoginOptions, membership: &Membership) -> String {
+    options
+        .context_name
+        .clone()
+        .unwrap_or_else(|| membership.context_name())
+}
+
+/// Write every verified context and point `current-context` at the first.
+///
+/// Returns the token ids of credentials this write REPLACED, for §6.5's
+/// replacement revocation. The whole file is written once, so a partial set of
+/// contexts cannot land.
+fn write_contexts(
+    path: &Path,
+    options: &LoginOptions,
+    pending: &[(Membership, Minted, String)],
+) -> Result<Vec<String>> {
+    let mut file: ContextsFile = config::load_for_mutation(path)?;
+    file.promote_legacy_spec();
+    let mut replaced = Vec::new();
+
+    for (membership, token, server) in pending {
+        let name = context_name(options, membership);
+        let existing = file.contexts.iter().position(|c| c.name == name);
+        if let Some(index) = existing {
+            // Retained BEFORE the overwrite: after it, the id is gone.
+            if let Some(token_id) = file.contexts[index].token_id.clone() {
+                replaced.push(token_id);
+            }
+        }
+        let index = existing.unwrap_or_else(|| {
+            file.contexts.push(Context {
+                name: name.clone(),
+                ..Context::default()
+            });
+            file.contexts.len() - 1
+        });
+        let context = &mut file.contexts[index];
+        context.server = Some(server.clone());
+        context.mode = ContextMode::Cloud;
+        context.workspace = Some(membership.tenant_slug.clone());
+        context.token = Some(token.token.clone());
+        context.token_id = Some(token.token_id.clone());
+        context.token_expires_at = token.expires_at.clone();
+    }
+
+    if let Some((membership, _, _)) = pending.first() {
+        file.current_context = Some(context_name(options, membership));
+    }
+    // Recorded so a later `login` with no --control-plane reaches the same
+    // control plane this one did.
+    file.control_plane = Some(options.control_plane.clone());
+    config::save(path, &file)?;
+    Ok(replaced)
+}
+
+/// §6.5's rollback: revoke everything this run minted, then report the ORIGINAL
+/// failure. A rollback that itself fails escalates — the ids it could not
+/// revoke are printed, because silence there would leave live credentials
+/// nobody knows exist.
+async fn rollback(
+    cp: &ControlPlane,
+    minted: Vec<MintedRef>,
+    cause: anyhow::Error,
+) -> anyhow::Error {
+    if minted.is_empty() {
+        return cause;
+    }
+    let mut stranded = Vec::new();
+    for reference in minted.iter().rev() {
+        if let Err(err) = cp.revoke(&reference.token_id).await {
+            stranded.push(format!(
+                "  {} (workspace '{}'): {err}",
+                reference.token_id, reference.workspace
+            ));
+        }
+    }
+    if stranded.is_empty() {
+        eprintln!(
+            "rolled back {} credential(s) minted by this login",
+            minted.len()
+        );
+        return cause;
+    }
+    cause.context(format!(
+        "LOGIN ROLLBACK INCOMPLETE — these credentials are live and are not in any context. Revoke them in the console:\n{}",
+        stranded.join("\n")
+    ))
+}
+
+/// §6.5's replacement rule: a re-login over an existing context revokes the
+/// token it replaced, unless `--keep-old-token` retains it for an agent that
+/// is mid-task. A failure here is reported, not fatal — the new context is
+/// already good.
+async fn revoke_replaced(
+    cp: &ControlPlane,
+    replaced: Vec<String>,
+    options: &LoginOptions,
+    report: &mut LoginReport,
+) {
+    for token_id in replaced {
+        if options.keep_old_token {
+            report.replaced_kept.push(token_id);
+            continue;
+        }
+        match cp.revoke(&token_id).await {
+            Ok(()) => report.replaced_revoked.push(token_id),
+            Err(err) => report.revoke_failures.push((token_id, format!("{err}"))),
+        }
+    }
+}
+
+/// §6.4: `POST /v1/me/tokens` answers `400 org_ambiguous` for an identity in
+/// more than one org, and v1 takes no org selector. Print the org list and the
+/// escape hatch rather than the raw code.
+fn describe_cp_failure(err: anyhow::Error) -> anyhow::Error {
+    let Some(cp_error) = err.downcast_ref::<CpError>() else {
+        return err;
+    };
+    if cp_error.code.as_deref() != Some("org_ambiguous") {
+        return err;
+    }
+    let orgs = if cp_error.orgs.is_empty() {
+        "(the control plane returned no org list)".to_string()
+    } else {
+        cp_error.orgs.join(", ")
+    };
+    anyhow!(
+        "this identity belongs to more than one organization ({orgs}), and minting for multi-org identities is not available in v1. Mint a token in the console, then run: skardi config set-context <name> --mode cloud --server <URL> --workspace <SLUG> --token-stdin"
+    )
+}
+
+/// The PAT's name at the control plane: `cli@<hostname>`, so a token list
+/// says which machine holds it.
+pub fn default_token_name() -> String {
+    format!("cli@{}", hostname())
+}
+
+/// The machine's name, best effort. `$HOSTNAME` is not exported by every
+/// shell, so `hostname(1)` is the fallback, and an unnamed host still logs in.
+fn hostname() -> String {
+    if let Ok(name) = std::env::var("HOSTNAME") {
+        let name = name.trim();
+        if !name.is_empty() {
+            return name.to_string();
+        }
+    }
+    std::process::Command::new("hostname")
+        .output()
+        .ok()
+        .and_then(|out| String::from_utf8(out.stdout).ok())
+        .map(|name| name.trim().to_string())
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| "unknown-host".to_string())
+}
+
+/// Parse `--expires`: `90d`, `12h`, or a bare number of days.
+///
+/// Days and hours only. `m` would be read as minutes by one person and months
+/// by the next, and a PAT lifetime is not a place for that ambiguity.
+pub fn parse_expires(raw: &str) -> Result<Duration> {
+    let trimmed = raw.trim();
+    let (digits, unit) = match trimmed.strip_suffix(['d', 'D']) {
+        Some(digits) => (digits, 'd'),
+        None => match trimmed.strip_suffix(['h', 'H']) {
+            Some(digits) => (digits, 'h'),
+            None => (trimmed, 'd'),
+        },
+    };
+    let amount: i64 = digits.trim().parse().map_err(|_| {
+        anyhow!("--expires takes a number of days or hours, like '90d' or '12h', not '{raw}'")
+    })?;
+    if amount <= 0 {
+        bail!("--expires must be positive, not '{raw}'");
+    }
+    let duration = match unit {
+        'h' => Duration::try_hours(amount),
+        _ => Duration::try_days(amount),
+    };
+    duration.ok_or_else(|| anyhow!("--expires '{raw}' is longer than any usable credential"))
+}

--- a/crates/cli/src/login/mod.rs
+++ b/crates/cli/src/login/mod.rs
@@ -54,6 +54,10 @@ pub enum Selection {
 }
 
 /// Everything `login` needs, with every network endpoint injectable.
+///
+/// No `Debug`, deliberately: it carries `identity` (a bearer presented to the
+/// control plane) and would be the natural place for a future field to hold
+/// something worse. Nothing needs to print it, so nothing can.
 pub struct LoginOptions {
     pub control_plane: String,
     /// The OAuth client id. Required for the browser path, unused with

--- a/crates/cli/src/login/mod.rs
+++ b/crates/cli/src/login/mod.rs
@@ -161,7 +161,16 @@ pub async fn login(options: LoginOptions, config_path: &Path) -> Result<LoginRep
 
     // §6.5: mint, then verify, retaining every id. Any failure past the first
     // mint rolls the whole run back before reporting.
-    let expires_at = (options.now + options.expires).to_rfc3339();
+    // `DateTime + TimeDelta` PANICS on overflow, and `parse_expires` cannot
+    // catch every case: it bounds the value by `TimeDelta`'s range (~1.07e11
+    // days) while `DateTime`'s is far smaller (year 262143, ~9.5e7 days), so
+    // `--expires 100000000d` parses and then aborts. The real ceiling is a
+    // function of `now`, so it is enforced here, where `now` is known.
+    let expires_at = options
+        .now
+        .checked_add_signed(options.expires)
+        .ok_or_else(|| anyhow!("--expires is longer than any usable credential"))?
+        .to_rfc3339();
     let mut minted: Vec<MintedRef> = Vec::new();
     let mut pending: Vec<(Membership, Minted, String)> = Vec::new();
     for membership in selected {
@@ -408,13 +417,21 @@ fn render_workspace_menu(active: &[Membership]) -> String {
 /// `http://127.0.0.1:8080` — writing a context that points at a local port
 /// would fail later and further from the cause.
 fn resolve_server(options: &LoginOptions, membership: &Membership) -> Result<String> {
-    let candidate = options
-        .server_override
-        .as_deref()
-        .or(options.env_gateway_url.as_deref())
-        .or(membership.gateway_url.as_deref())
-        .map(str::trim)
-        .filter(|url| !url.is_empty());
+    // Flatten-then-find, NOT `or`: `Option::or` short-circuits on the first
+    // `Some` and the trim would then apply only to that winner, so an
+    // exported-empty `SKARDI_GATEWAY_URL` (or `--server ""`) would SHADOW the
+    // control plane's answer and produce an error blaming the control plane
+    // for a silence that came from the variable the message names.
+    // `resolve_control_plane` has always had this shape; this one did not.
+    let candidate = [
+        options.server_override.as_deref(),
+        options.env_gateway_url.as_deref(),
+        membership.gateway_url.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    .map(str::trim)
+    .find(|url| !url.is_empty());
     let Some(server) = candidate else {
         bail!(
             "the control plane did not say which gateway serves workspace '{}' — pass --server <URL>, set $SKARDI_GATEWAY_URL, or configure gateway_url for the org",
@@ -457,10 +474,20 @@ async fn verify(
     // has to be reachable (§6.5).
     match tokio::time::timeout(timeout, probe_request).await {
         Ok(Ok(_)) => Ok(()),
-        Ok(Err(err)) => Err(anyhow!(
-            "the new credential for workspace '{}' could not query {server}: {err} — the context was not written (pass --no-verify to skip this check)",
-            membership.tenant_slug
-        )),
+        Ok(Err(err)) => {
+            // Through §8's translation, not raw: `ApiError`'s own 401 message
+            // says "set SKARDI_API_TOKEN or 'token' in ~/.skardi/config.yaml",
+            // which resolution REFUSES for a cloud context — and it is more
+            // wrong here than at query time, since the credential was minted
+            // seconds ago and no context exists to point `skardi login` at.
+            // `probe` is already a full cloud config, so the mapping is free.
+            let diagnosed =
+                crate::cloud::diagnose(err.into(), crate::cloud::Capability::Query, &probe);
+            Err(anyhow!(
+                "the new credential for workspace '{}' could not query {server}: {diagnosed:#} — the context was not written (pass --no-verify to skip this check)",
+                membership.tenant_slug
+            ))
+        }
         Err(_) => Err(anyhow!(
             "the new credential for workspace '{}' got no answer from {server} within {}s — the context was not written (pass --no-verify to skip this check)",
             membership.tenant_slug,

--- a/crates/cli/src/login/mod.rs
+++ b/crates/cli/src/login/mod.rs
@@ -29,6 +29,14 @@ use chrono::{DateTime, Duration, Utc};
 use control_plane::{ControlPlane, CpError, Membership, Minted};
 use std::path::Path;
 
+/// Per-request ceiling on control-plane and token-endpoint calls.
+///
+/// Bounded because of the ROLLBACK, not the happy path: a revoke that hangs
+/// forever leaves the operator watching a silent terminal while a live
+/// credential goes unreported, which is precisely the outcome §6.5 exists to
+/// prevent. Generous enough that a cold control plane still answers.
+const CONTROL_PLANE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// Default PAT lifetime (§6.1 step 5), as `--expires` spells it. A string so
 /// clap's default and this documented value are the same token, parsed by the
 /// same function a user-supplied one goes through.
@@ -116,7 +124,10 @@ struct MintedRef {
 /// Run the whole flow. `config_path` is a parameter so tests write to a temp
 /// directory instead of the developer's own config.
 pub async fn login(options: LoginOptions, config_path: &Path) -> Result<LoginReport> {
-    let http = reqwest::Client::builder().no_proxy().build()?;
+    let http = reqwest::Client::builder()
+        .no_proxy()
+        .timeout(CONTROL_PLANE_TIMEOUT)
+        .build()?;
     let bearer = acquire_bearer(&http, &options).await?;
     let cp = ControlPlane::new(http.clone(), &options.control_plane, bearer);
 

--- a/crates/cli/src/login/mod.rs
+++ b/crates/cli/src/login/mod.rs
@@ -434,7 +434,7 @@ fn resolve_server(options: &LoginOptions, membership: &Membership) -> Result<Str
     .find(|url| !url.is_empty());
     let Some(server) = candidate else {
         bail!(
-            "the control plane did not say which gateway serves workspace '{}' — pass --server <URL>, set $SKARDI_GATEWAY_URL, or configure gateway_url for the org",
+            "the control plane did not say which gateway serves workspace '{}' — pass --server <URL>, set $SKARDI_GATEWAY_URL, or set SKARDI_GLOBAL_GATEWAY_URL (helm: skardiGlobal.gatewayUrl) on the control plane",
             membership.tenant_slug
         )
     };

--- a/crates/cli/src/login/oauth.rs
+++ b/crates/cli/src/login/oauth.rs
@@ -1,0 +1,561 @@
+//! The browser half of `login` (§6.1 steps 2-3): build the authorization URL,
+//! wait for the redirect, check `state`, and exchange the code for an ID token
+//! that is **held in memory only**.
+//!
+//! No refresh token is requested and nothing the provider returns is written
+//! to disk (§9.1): the only credential that reaches the config file is the
+//! workspace-scoped PAT the control plane mints later. A stolen config
+//! therefore yields expiring, single-workspace PATs rather than a re-loginable
+//! identity.
+//!
+//! The two endpoint URLs are fields with production defaults rather than
+//! constants, so tests drive the whole flow against a stub token endpoint.
+
+use super::loopback::Loopback;
+use super::pkce::{Pkce, random_urlsafe};
+use anyhow::{Context, Result, bail};
+use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
+use serde::Deserialize;
+use std::time::Duration;
+
+/// Google's OAuth 2.0 endpoints, the identity provider skardi-cloud verifies
+/// (`SKARDI_GLOBAL_OIDC_ISSUER=accounts.google.com`).
+pub const GOOGLE_AUTHORIZATION_URL: &str = "https://accounts.google.com/o/oauth2/v2/auth";
+pub const GOOGLE_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
+
+/// The claims the control plane needs: `openid` for an ID token at all, `email`
+/// because memberships are keyed on the identity's email, `profile` for the
+/// display name `/v1/me/profile` returns. Nothing more — the CLI reads no
+/// provider API.
+const SCOPE: &str = "openid email profile";
+
+/// How long to wait for the user to finish in the browser (§6.1 step 2).
+pub const CALLBACK_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Where the browser flow talks. Defaults are production; tests override.
+#[derive(Debug, Clone)]
+pub struct Endpoints {
+    pub authorization_url: String,
+    pub token_url: String,
+}
+
+impl Default for Endpoints {
+    fn default() -> Endpoints {
+        Endpoints {
+            authorization_url: GOOGLE_AUTHORIZATION_URL.to_string(),
+            token_url: GOOGLE_TOKEN_URL.to_string(),
+        }
+    }
+}
+
+/// Run the browser flow and return the ID token.
+///
+/// `no_browser` prints the URL instead of opening it, for a remote shell or a
+/// machine with no browser at all.
+///
+/// `open` is a parameter, not a call to [`open_in_browser`], for one reason:
+/// it makes the composition below — bind, build, wait, exchange — testable end
+/// to end with a closure that plays the browser. Production passes
+/// `&open_in_browser`.
+pub async fn acquire_id_token(
+    http: &reqwest::Client,
+    endpoints: &Endpoints,
+    client_id: &str,
+    no_browser: bool,
+    timeout: Duration,
+    open: &dyn Fn(&str) -> std::io::Result<()>,
+) -> Result<String> {
+    let pkce = Pkce::generate()?;
+    let state = random_urlsafe()?;
+    let loopback = Loopback::bind().await?;
+    let redirect_uri = loopback.redirect_uri();
+    let url = authorization_url(
+        &endpoints.authorization_url,
+        client_id,
+        &redirect_uri,
+        &pkce.challenge,
+        &state,
+    );
+
+    if no_browser {
+        eprintln!("open this URL to sign in:\n\n  {url}\n");
+    } else {
+        match open(&url) {
+            Ok(()) => eprintln!("waiting for the browser to complete sign-in…"),
+            // Not fatal: printing the URL is exactly what --no-browser does,
+            // so a headless machine still completes the login.
+            Err(err) => eprintln!(
+                "could not open a browser ({err}); open this URL to sign in:\n\n  {url}\n"
+            ),
+        }
+    }
+
+    let code = await_code(loopback, &state, timeout).await?;
+    exchange_code(
+        http,
+        &endpoints.token_url,
+        client_id,
+        &code,
+        &pkce.verifier,
+        &redirect_uri,
+    )
+    .await
+}
+
+/// Build the authorization request URL.
+///
+/// `prompt=select_account` is deliberate: the CLI is minting a credential, and
+/// silently reusing whichever account the browser happens to be signed into is
+/// how someone ends up with a PAT for the wrong identity.
+pub fn authorization_url(
+    authorization_url: &str,
+    client_id: &str,
+    redirect_uri: &str,
+    challenge: &str,
+    state: &str,
+) -> String {
+    let q = |value: &str| utf8_percent_encode(value, NON_ALPHANUMERIC).to_string();
+    format!(
+        "{authorization_url}?response_type=code&client_id={}&redirect_uri={}&scope={}\
+         &code_challenge={}&code_challenge_method=S256&state={}&prompt=select_account",
+        q(client_id),
+        q(redirect_uri),
+        q(SCOPE),
+        q(challenge),
+        q(state),
+    )
+}
+
+/// Wait for the redirect and return the authorization code, refusing anything
+/// that does not match `expected_state`.
+pub async fn await_code(
+    loopback: Loopback,
+    expected_state: &str,
+    timeout: Duration,
+) -> Result<String> {
+    let callback = loopback.wait(timeout).await?;
+
+    if let Some(error) = callback.error {
+        let detail = callback
+            .error_description
+            .map(|d| format!(": {d}"))
+            .unwrap_or_default();
+        bail!("the identity provider refused the sign-in ({error}{detail})");
+    }
+    // Checked before the code is even read: a callback whose `state` does not
+    // match was not produced by this process's authorization request, and
+    // redeeming its code would be redeeming someone else's (§9.1).
+    match callback.state.as_deref() {
+        Some(state) if state == expected_state => {}
+        _ => bail!(
+            "the login callback carried the wrong 'state' value — it did not come from this sign-in request, so it was ignored"
+        ),
+    }
+    callback
+        .code
+        .filter(|code| !code.is_empty())
+        .context("the login callback carried no authorization code")
+}
+
+/// Redeem the code for an ID token. A public client with PKCE, so no client
+/// secret is sent — there is nowhere in a distributed CLI to keep one.
+pub async fn exchange_code(
+    http: &reqwest::Client,
+    token_url: &str,
+    client_id: &str,
+    code: &str,
+    verifier: &str,
+    redirect_uri: &str,
+) -> Result<String> {
+    let response = http
+        .post(token_url)
+        .form(&[
+            ("grant_type", "authorization_code"),
+            ("client_id", client_id),
+            ("code", code),
+            ("code_verifier", verifier),
+            ("redirect_uri", redirect_uri),
+        ])
+        .send()
+        .await
+        .with_context(|| format!("POST {token_url}"))?;
+
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .context("read the token endpoint's response")?;
+
+    if !status.is_success() {
+        // The provider's own error naming, without the body: a token-endpoint
+        // response can carry the code that was just redeemed.
+        let parsed: Option<TokenError> = serde_json::from_str(&body).ok();
+        let described = parsed
+            .map(|e| match e.error_description {
+                Some(description) => format!("{}: {description}", e.error),
+                None => e.error,
+            })
+            .unwrap_or_else(|| format!("HTTP {status}"));
+        bail!("the identity provider rejected the authorization code ({described})");
+    }
+
+    let parsed: TokenResponse = serde_json::from_str(&body)
+        .context("the token endpoint's response was not the expected JSON")?;
+    if parsed.id_token.trim().is_empty() {
+        bail!("the token endpoint returned no id_token — the client id may not be an OIDC client");
+    }
+    Ok(parsed.id_token)
+}
+
+/// Only `id_token` is read. `access_token` is deliberately ignored (the CLI
+/// calls no provider API) and no refresh token is requested at all.
+#[derive(Deserialize)]
+struct TokenResponse {
+    #[serde(default)]
+    id_token: String,
+}
+
+#[derive(Deserialize)]
+struct TokenError {
+    error: String,
+    #[serde(default)]
+    error_description: Option<String>,
+}
+
+/// Hand the URL to the platform opener. `Command`, not a crate: this is one
+/// argv per platform, and the URL is one we just built.
+pub fn open_in_browser(url: &str) -> std::io::Result<()> {
+    let (program, args): (&str, &[&str]) = if cfg!(target_os = "macos") {
+        ("open", &[])
+    } else if cfg!(target_os = "windows") {
+        ("cmd", &["/C", "start", ""])
+    } else {
+        ("xdg-open", &[])
+    };
+    let status = std::process::Command::new(program)
+        .args(args)
+        .arg(url)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(format!(
+            "{program} exited with {status}"
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Endpoints, authorization_url, await_code, exchange_code};
+    use crate::login::loopback::Loopback;
+    use serde_json::json;
+    use std::time::Duration;
+    use wiremock::matchers::{body_string_contains, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn the_authorization_url_carries_pkce_s256_and_the_loopback_redirect() {
+        let url = authorization_url(
+            "https://accounts.example/auth",
+            "client-123.apps.googleusercontent.com",
+            "http://127.0.0.1:54321/callback",
+            "the-challenge",
+            "the-state",
+        );
+        assert!(url.starts_with("https://accounts.example/auth?"), "{url}");
+        for expected in [
+            "response_type=code",
+            "code_challenge=the%2Dchallenge",
+            "code_challenge_method=S256",
+            "state=the%2Dstate",
+            "client_id=client%2D123%2Eapps%2Egoogleusercontent%2Ecom",
+            "redirect_uri=http%3A%2F%2F127%2E0%2E0%2E1%3A54321%2Fcallback",
+            "scope=openid%20email%20profile",
+            "prompt=select_account",
+        ] {
+            assert!(url.contains(expected), "missing {expected} in {url}");
+        }
+        // A public client sends no secret, and asks for no refresh token.
+        assert!(!url.contains("client_secret"), "{url}");
+        assert!(!url.contains("access_type=offline"), "{url}");
+    }
+
+    /// §9.1's `state` check: a callback that did not come from this request is
+    /// refused BEFORE its code is read, so a code planted by anything else is
+    /// never redeemed.
+    #[tokio::test]
+    async fn a_state_mismatch_refuses_the_callback() {
+        let loopback = Loopback::bind().await.unwrap();
+        let uri = loopback.redirect_uri();
+
+        let waiter = tokio::spawn(async move {
+            await_code(loopback, "the-real-state", Duration::from_secs(5)).await
+        });
+        let _ = reqwest::get(format!("{uri}?code=planted&state=someone-elses")).await;
+
+        let err = waiter.await.unwrap().unwrap_err().to_string();
+        assert!(err.contains("wrong 'state' value"), "{err}");
+        assert!(
+            !err.contains("planted"),
+            "the code must not be echoed: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_matching_state_yields_the_code() {
+        let loopback = Loopback::bind().await.unwrap();
+        let uri = loopback.redirect_uri();
+
+        let waiter = tokio::spawn(async move {
+            await_code(loopback, "the-real-state", Duration::from_secs(5)).await
+        });
+        let _ = reqwest::get(format!("{uri}?code=good-code&state=the-real-state")).await;
+
+        assert_eq!(waiter.await.unwrap().unwrap(), "good-code");
+    }
+
+    #[tokio::test]
+    async fn a_refused_sign_in_names_the_providers_reason() {
+        let loopback = Loopback::bind().await.unwrap();
+        let uri = loopback.redirect_uri();
+
+        let waiter = tokio::spawn(async move {
+            await_code(loopback, "the-real-state", Duration::from_secs(5)).await
+        });
+        let _ = reqwest::get(format!("{uri}?error=access_denied&error_description=nope")).await;
+
+        let err = waiter.await.unwrap().unwrap_err().to_string();
+        assert!(err.contains("access_denied"), "{err}");
+        assert!(err.contains("nope"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn the_exchange_sends_the_verifier_and_returns_only_the_id_token() {
+        let provider = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .and(body_string_contains("grant_type=authorization_code"))
+            .and(body_string_contains("code_verifier=the-verifier"))
+            .and(body_string_contains("code=the-code"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id_token": "the-id-token",
+                "access_token": "an-access-token",
+                "expires_in": 3599,
+            })))
+            .expect(1)
+            .mount(&provider)
+            .await;
+
+        let endpoints = Endpoints {
+            authorization_url: format!("{}/auth", provider.uri()),
+            token_url: format!("{}/token", provider.uri()),
+        };
+        let id_token = exchange_code(
+            &reqwest::Client::new(),
+            &endpoints.token_url,
+            "client-123",
+            "the-code",
+            "the-verifier",
+            "http://127.0.0.1:1/callback",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(id_token, "the-id-token");
+        // No client secret is sent — there is nowhere in a shipped CLI to keep
+        // one, which is why PKCE is doing this job.
+        let sent = &provider.received_requests().await.unwrap()[0];
+        let body = String::from_utf8_lossy(&sent.body);
+        assert!(!body.contains("client_secret"), "{body}");
+    }
+
+    #[tokio::test]
+    async fn a_rejected_code_reports_the_provider_error_without_the_body() {
+        let provider = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+                "error": "invalid_grant",
+                "error_description": "Code was already redeemed.",
+                "code": "the-secret-code",
+            })))
+            .mount(&provider)
+            .await;
+
+        let err = exchange_code(
+            &reqwest::Client::new(),
+            &format!("{}/token", provider.uri()),
+            "client-123",
+            "the-secret-code",
+            "the-verifier",
+            "http://127.0.0.1:1/callback",
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("invalid_grant"), "{err}");
+        assert!(err.contains("Code was already redeemed."), "{err}");
+    }
+
+    /// A non-OIDC client id gets an access token and no `id_token`. Failing
+    /// here names the cause; passing the empty string on would 401 at the
+    /// control plane instead.
+    #[tokio::test]
+    async fn a_response_without_an_id_token_is_refused_by_name() {
+        let provider = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({"access_token": "only-this"})),
+            )
+            .mount(&provider)
+            .await;
+
+        let err = exchange_code(
+            &reqwest::Client::new(),
+            &format!("{}/token", provider.uri()),
+            "client-123",
+            "the-code",
+            "the-verifier",
+            "http://127.0.0.1:1/callback",
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("no id_token"), "{err}");
+    }
+}
+
+#[cfg(test)]
+mod browser_path_tests {
+    use super::{CALLBACK_TIMEOUT, Endpoints, acquire_id_token};
+    use serde_json::json;
+    use std::time::Duration;
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// One query parameter out of a URL, percent-decoded.
+    fn param(url: &str, key: &str) -> String {
+        let query = url.split_once('?').expect("a query").1;
+        let raw = query
+            .split('&')
+            .find_map(|pair| pair.strip_prefix(&format!("{key}=")))
+            .unwrap_or_else(|| panic!("no {key} in {url}"));
+        percent_encoding::percent_decode_str(raw)
+            .decode_utf8_lossy()
+            .to_string()
+    }
+
+    /// The whole browser path, with a closure standing in for the browser: it
+    /// reads the authorization URL exactly as a user agent would, follows the
+    /// redirect back with the `state` it was given, and the flow completes.
+    #[tokio::test]
+    async fn the_browser_path_composes_bind_authorize_callback_and_exchange() {
+        let provider = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({"id_token": "issued-token"})),
+            )
+            .expect(1)
+            .mount(&provider)
+            .await;
+        let endpoints = Endpoints {
+            authorization_url: format!("{}/auth", provider.uri()),
+            token_url: format!("{}/token", provider.uri()),
+        };
+
+        let browser = |url: &str| {
+            let redirect = param(url, "redirect_uri");
+            let state = param(url, "state");
+            assert_eq!(param(url, "code_challenge_method"), "S256");
+            tokio::spawn(async move {
+                let _ = reqwest::get(format!("{redirect}?code=browser-code&state={state}")).await;
+            });
+            Ok(())
+        };
+
+        let token = acquire_id_token(
+            &reqwest::Client::new(),
+            &endpoints,
+            "client-123",
+            false,
+            Duration::from_secs(5),
+            &browser,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(token, "issued-token");
+        // The verifier that reached the token endpoint is the one whose
+        // challenge went out in the authorization URL — proven by the flow
+        // completing against a provider that requires both.
+        let sent = &provider.received_requests().await.unwrap()[0];
+        let body = String::from_utf8_lossy(&sent.body);
+        assert!(body.contains("code=browser-code"), "{body}");
+        assert!(body.contains("code_verifier="), "{body}");
+    }
+
+    /// A browser that cannot be opened is not fatal: the URL is printed and
+    /// the wait continues, which is what makes a headless machine work.
+    #[tokio::test]
+    async fn a_browser_that_will_not_open_still_completes_the_login() {
+        let provider = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"id_token": "issued"})))
+            .mount(&provider)
+            .await;
+        let endpoints = Endpoints {
+            authorization_url: format!("{}/auth", provider.uri()),
+            token_url: format!("{}/token", provider.uri()),
+        };
+
+        // Fails to "open", but still reads the URL — as a human would from the
+        // printed line — and follows it.
+        let browser = |url: &str| {
+            let redirect = param(url, "redirect_uri");
+            let state = param(url, "state");
+            tokio::spawn(async move {
+                let _ = reqwest::get(format!("{redirect}?code=c&state={state}")).await;
+            });
+            Err(std::io::Error::other("no display"))
+        };
+
+        let token = acquire_id_token(
+            &reqwest::Client::new(),
+            &endpoints,
+            "client-123",
+            false,
+            Duration::from_secs(5),
+            &browser,
+        )
+        .await
+        .unwrap();
+        assert_eq!(token, "issued");
+    }
+
+    /// The production timeout is the design's 120 seconds, and a browser that
+    /// never answers fails on it rather than hanging.
+    #[tokio::test]
+    async fn an_unanswered_authorization_times_out() {
+        assert_eq!(CALLBACK_TIMEOUT, Duration::from_secs(120));
+
+        let endpoints = Endpoints {
+            authorization_url: "http://127.0.0.1:1/auth".to_string(),
+            token_url: "http://127.0.0.1:1/token".to_string(),
+        };
+        let err = acquire_id_token(
+            &reqwest::Client::new(),
+            &endpoints,
+            "client-123",
+            true,
+            Duration::from_millis(50),
+            &|_url| Ok(()),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("no authorization response within"), "{err}");
+    }
+}

--- a/crates/cli/src/login/oauth.rs
+++ b/crates/cli/src/login/oauth.rs
@@ -222,16 +222,27 @@ struct TokenError {
     error_description: Option<String>,
 }
 
-/// Hand the URL to the platform opener. `Command`, not a crate: this is one
-/// argv per platform, and the URL is one we just built.
-pub fn open_in_browser(url: &str) -> std::io::Result<()> {
-    let (program, args): (&str, &[&str]) = if cfg!(target_os = "macos") {
+/// The platform's URL opener, as argv. Split out from [`open_in_browser`] so
+/// the per-platform choice is a tested value rather than a branch nothing can
+/// reach without launching a real browser.
+///
+/// The empty string after `start` is load-bearing on Windows: `start` reads its
+/// first quoted argument as the new window's TITLE, so a URL passed without it
+/// becomes a title and no browser opens.
+fn browser_command() -> (&'static str, &'static [&'static str]) {
+    if cfg!(target_os = "macos") {
         ("open", &[])
     } else if cfg!(target_os = "windows") {
         ("cmd", &["/C", "start", ""])
     } else {
         ("xdg-open", &[])
-    };
+    }
+}
+
+/// Hand the URL to the platform opener. `Command`, not a crate: this is one
+/// argv per platform, and the URL is one we just built.
+pub fn open_in_browser(url: &str) -> std::io::Result<()> {
+    let (program, args) = browser_command();
     let status = std::process::Command::new(program)
         .args(args)
         .arg(url)
@@ -398,6 +409,76 @@ mod tests {
 
         assert!(err.contains("invalid_grant"), "{err}");
         assert!(err.contains("Code was already redeemed."), "{err}");
+    }
+
+    /// An error body that is not the provider's JSON — a proxy page, an empty
+    /// 500 — still names the status instead of rendering an empty reason.
+    #[tokio::test]
+    async fn a_non_json_error_body_falls_back_to_the_status() {
+        let provider = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(
+                ResponseTemplate::new(502).set_body_string("<html>upstream-detail-abc123</html>"),
+            )
+            .mount(&provider)
+            .await;
+
+        let err = exchange_code(
+            &reqwest::Client::new(),
+            &format!("{}/token", provider.uri()),
+            "client-123",
+            "the-code",
+            "the-verifier",
+            "http://127.0.0.1:1/callback",
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+        // The status, including its reason phrase, and nothing from the body:
+        // a token-endpoint response can carry the code that was redeemed.
+        assert!(err.contains("HTTP 502"), "{err}");
+        assert!(!err.contains("upstream-detail-abc123"), "{err}");
+    }
+
+    /// An error body with a code and no description reads as just the code.
+    #[tokio::test]
+    async fn an_error_without_a_description_names_the_code_alone() {
+        let provider = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(
+                ResponseTemplate::new(400).set_body_json(json!({"error": "invalid_client"})),
+            )
+            .mount(&provider)
+            .await;
+
+        let err = exchange_code(
+            &reqwest::Client::new(),
+            &format!("{}/token", provider.uri()),
+            "client-123",
+            "the-code",
+            "the-verifier",
+            "http://127.0.0.1:1/callback",
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("(invalid_client)"), "{err}");
+    }
+
+    /// The opener's argv per platform. `open_in_browser` itself cannot be
+    /// tested without launching a browser; this is the part that can be wrong.
+    #[test]
+    fn the_browser_command_is_the_platforms_own_opener() {
+        let (program, args) = super::browser_command();
+        if cfg!(target_os = "macos") {
+            assert_eq!((program, args), ("open", &[] as &[&str]));
+        } else if cfg!(target_os = "windows") {
+            // The empty title argument must survive: without it `start` reads
+            // the URL as the window title and opens nothing.
+            assert_eq!((program, args), ("cmd", &["/C", "start", ""] as &[&str]));
+        } else {
+            assert_eq!((program, args), ("xdg-open", &[] as &[&str]));
+        }
     }
 
     /// A non-OIDC client id gets an access token and no `id_token`. Failing

--- a/crates/cli/src/login/oauth.rs
+++ b/crates/cli/src/login/oauth.rs
@@ -50,8 +50,14 @@ impl Default for Endpoints {
 
 /// Run the browser flow and return the ID token.
 ///
-/// `no_browser` prints the URL instead of opening it, for a remote shell or a
-/// machine with no browser at all.
+/// `no_browser` prints the URL instead of opening it, for a host with no
+/// browser of its own or none this process can launch.
+///
+/// It does NOT by itself make a remote shell work. The redirect target is
+/// `127.0.0.1:<port>` on THIS host, so whatever opens the URL must be able to
+/// reach that port here — over SSH that means forwarding it (`ssh -L`), and
+/// the port is fresh per run. A headless flow that needs no local listener is
+/// the device-code grant, which the design defers (§12).
 ///
 /// `open` is a parameter, not a call to [`open_in_browser`], for one reason:
 /// it makes the composition below — bind, build, wait, exchange — testable end
@@ -126,14 +132,19 @@ pub fn authorization_url(
     )
 }
 
-/// Wait for the redirect and return the authorization code, refusing anything
-/// that does not match `expected_state`.
+/// Wait for the redirect and return the authorization code.
+///
+/// `state` is enforced by the listener, which surfaces only a callback that
+/// carries `expected_state` (§9.1) — so everything below is known to belong to
+/// this sign-in request, and a refusal reported here really is the provider's.
+/// That ordering matters: were the error read first, any request that reached
+/// the port could end the login with a bare `?error=…`.
 pub async fn await_code(
     loopback: Loopback,
     expected_state: &str,
     timeout: Duration,
 ) -> Result<String> {
-    let callback = loopback.wait(timeout).await?;
+    let callback = loopback.wait(timeout, expected_state).await?;
 
     if let Some(error) = callback.error {
         let detail = callback
@@ -141,15 +152,6 @@ pub async fn await_code(
             .map(|d| format!(": {d}"))
             .unwrap_or_default();
         bail!("the identity provider refused the sign-in ({error}{detail})");
-    }
-    // Checked before the code is even read: a callback whose `state` does not
-    // match was not produced by this process's authorization request, and
-    // redeeming its code would be redeeming someone else's (§9.1).
-    match callback.state.as_deref() {
-        Some(state) if state == expected_state => {}
-        _ => bail!(
-            "the login callback carried the wrong 'state' value — it did not come from this sign-in request, so it was ignored"
-        ),
     }
     callback
         .code
@@ -294,25 +296,42 @@ mod tests {
         assert!(!url.contains("access_type=offline"), "{url}");
     }
 
-    /// §9.1's `state` check: a callback that did not come from this request is
-    /// refused BEFORE its code is read, so a code planted by anything else is
-    /// never redeemed.
+    /// §9.1's `state` check, from the caller's side: a planted code is never
+    /// returned to be redeemed, and the failure echoes neither it nor the
+    /// state that was guessed.
     #[tokio::test]
-    async fn a_state_mismatch_refuses_the_callback() {
+    async fn a_planted_callback_never_yields_a_code() {
+        let loopback = Loopback::bind().await.unwrap();
+        let uri = loopback.redirect_uri();
+
+        let waiter = tokio::spawn(async move {
+            await_code(loopback, "the-real-state", Duration::from_millis(300)).await
+        });
+        let _ = reqwest::get(format!("{uri}?code=planted&state=someone-elses")).await;
+
+        let err = waiter.await.unwrap().unwrap_err().to_string();
+        assert!(err.contains("did not issue"), "{err}");
+        assert!(
+            !err.contains("planted"),
+            "the code must not be echoed: {err}"
+        );
+        assert!(!err.contains("someone-elses"), "{err}");
+    }
+
+    /// A refusal carrying no `state` cannot masquerade as the provider's: it is
+    /// ignored, so the login is still there to complete.
+    #[tokio::test]
+    async fn a_stateless_error_is_not_reported_as_a_provider_refusal() {
         let loopback = Loopback::bind().await.unwrap();
         let uri = loopback.redirect_uri();
 
         let waiter = tokio::spawn(async move {
             await_code(loopback, "the-real-state", Duration::from_secs(5)).await
         });
-        let _ = reqwest::get(format!("{uri}?code=planted&state=someone-elses")).await;
+        let _ = reqwest::get(format!("{uri}?error=access_denied")).await;
+        let _ = reqwest::get(format!("{uri}?code=good&state=the-real-state")).await;
 
-        let err = waiter.await.unwrap().unwrap_err().to_string();
-        assert!(err.contains("wrong 'state' value"), "{err}");
-        assert!(
-            !err.contains("planted"),
-            "the code must not be echoed: {err}"
-        );
+        assert_eq!(waiter.await.unwrap().unwrap(), "good");
     }
 
     #[tokio::test]
@@ -336,7 +355,12 @@ mod tests {
         let waiter = tokio::spawn(async move {
             await_code(loopback, "the-real-state", Duration::from_secs(5)).await
         });
-        let _ = reqwest::get(format!("{uri}?error=access_denied&error_description=nope")).await;
+        // With the correct state, as a real provider echoes it (RFC 6749
+        // §4.1.2.1), so this is the provider's refusal and not a stray request.
+        let _ = reqwest::get(format!(
+            "{uri}?error=access_denied&error_description=nope&state=the-real-state"
+        ))
+        .await;
 
         let err = waiter.await.unwrap().unwrap_err().to_string();
         assert!(err.contains("access_denied"), "{err}");

--- a/crates/cli/src/login/pkce.rs
+++ b/crates/cli/src/login/pkce.rs
@@ -1,0 +1,93 @@
+//! PKCE S256 and the `state` nonce (§6.1 step 2, §9.1).
+//!
+//! Both values exist to bind the authorization response to THIS process: the
+//! verifier proves the code was requested by whoever redeems it, and `state`
+//! proves the callback belongs to the request we made. Both therefore come
+//! from the OS CSPRNG directly — `getrandom` and nothing more, with no PRNG
+//! state to seed, fork-safety to reason about, or reseeding policy to get
+//! wrong.
+
+use anyhow::{Result, anyhow};
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use sha2::{Digest, Sha256};
+
+/// Bytes of entropy behind the verifier and `state`. 32 bytes is 256 bits and
+/// encodes to 43 unreserved characters, which is also RFC 7636's floor for a
+/// verifier (43..=128 characters).
+const ENTROPY_BYTES: usize = 32;
+
+/// A PKCE pair: the secret kept in memory and the challenge that goes over the
+/// wire.
+pub struct Pkce {
+    /// Sent only to the token endpoint, in the exchange that redeems the code.
+    pub verifier: String,
+    /// `base64url(sha256(verifier))`, sent to the authorization endpoint.
+    pub challenge: String,
+}
+
+impl Pkce {
+    pub fn generate() -> Result<Pkce> {
+        let verifier = random_urlsafe()?;
+        let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
+        Ok(Pkce {
+            verifier,
+            challenge,
+        })
+    }
+}
+
+/// A fresh unreserved-character random string, used for the verifier and for
+/// `state`.
+///
+/// base64url WITHOUT padding on purpose: every character is in RFC 3986's
+/// unreserved set, so the value survives a URL, a query string, and a
+/// redirect without encoding — and `=` would not.
+pub fn random_urlsafe() -> Result<String> {
+    let mut bytes = [0u8; ENTROPY_BYTES];
+    getrandom::getrandom(&mut bytes)
+        .map_err(|err| anyhow!("read random bytes from the operating system: {err}"))?;
+    Ok(URL_SAFE_NO_PAD.encode(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Pkce, URL_SAFE_NO_PAD, random_urlsafe};
+    use base64::Engine as _;
+    use sha2::{Digest, Sha256};
+
+    /// RFC 7636 appendix B's worked example, so the transform is pinned to the
+    /// spec rather than to itself.
+    #[test]
+    fn s256_matches_rfc_7636_appendix_b() {
+        let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+        let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
+        assert_eq!(challenge, "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM");
+    }
+
+    #[test]
+    fn generated_pairs_are_unreserved_fresh_and_self_consistent() {
+        let first = Pkce::generate().unwrap();
+        let second = Pkce::generate().unwrap();
+
+        assert_ne!(first.verifier, second.verifier, "verifier must not repeat");
+        assert_ne!(first.challenge, second.challenge);
+        assert_eq!(first.verifier.len(), 43, "RFC 7636 requires 43..=128");
+        assert_eq!(
+            first.challenge,
+            URL_SAFE_NO_PAD.encode(Sha256::digest(first.verifier.as_bytes()))
+        );
+        for value in [
+            &first.verifier,
+            &first.challenge,
+            &random_urlsafe().unwrap(),
+        ] {
+            assert!(
+                value
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b"-._~".contains(&b)),
+                "not URL-safe: {value}"
+            );
+        }
+    }
+}

--- a/crates/cli/src/login/pkce.rs
+++ b/crates/cli/src/login/pkce.rs
@@ -28,12 +28,20 @@ pub struct Pkce {
 
 impl Pkce {
     pub fn generate() -> Result<Pkce> {
-        let verifier = random_urlsafe()?;
+        Ok(Pkce::from_verifier(random_urlsafe()?))
+    }
+
+    /// The S256 transform on its own, split out from [`Self::generate`] so a
+    /// KNOWN verifier can go through the production code path. With the
+    /// verifier random, every assertion about the pair is true by construction
+    /// — a switch to standard base64, or to SHA-1, would leave a
+    /// self-consistency test passing and only fail against a real provider.
+    fn from_verifier(verifier: String) -> Pkce {
         let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
-        Ok(Pkce {
+        Pkce {
             verifier,
             challenge,
-        })
+        }
     }
 }
 
@@ -52,31 +60,33 @@ pub fn random_urlsafe() -> Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Pkce, URL_SAFE_NO_PAD, random_urlsafe};
-    use base64::Engine as _;
-    use sha2::{Digest, Sha256};
+    use super::{Pkce, random_urlsafe};
 
-    /// RFC 7636 appendix B's worked example, so the transform is pinned to the
-    /// spec rather than to itself.
+    /// RFC 7636 appendix B's worked example, run THROUGH the production
+    /// transform — so this pins `Pkce`'s algorithm choice (S256, base64url
+    /// unpadded), not `sha2` and `base64`. Recomputing the expected value
+    /// inline would pass for SHA-1 too.
     #[test]
     fn s256_matches_rfc_7636_appendix_b() {
-        let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
-        let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
-        assert_eq!(challenge, "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM");
+        let pkce = Pkce::from_verifier("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk".to_string());
+        assert_eq!(
+            pkce.challenge,
+            "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+        );
     }
 
+    /// What `generate` adds over the transform: fresh, correctly sized, and
+    /// URL-safe. Deliberately no challenge/verifier comparison here — with a
+    /// random verifier that assertion is a tautology, and the vector above is
+    /// what actually pins the algorithm.
     #[test]
-    fn generated_pairs_are_unreserved_fresh_and_self_consistent() {
+    fn generated_pairs_are_unreserved_and_fresh() {
         let first = Pkce::generate().unwrap();
         let second = Pkce::generate().unwrap();
 
         assert_ne!(first.verifier, second.verifier, "verifier must not repeat");
         assert_ne!(first.challenge, second.challenge);
         assert_eq!(first.verifier.len(), 43, "RFC 7636 requires 43..=128");
-        assert_eq!(
-            first.challenge,
-            URL_SAFE_NO_PAD.encode(Sha256::digest(first.verifier.as_bytes()))
-        );
         for value in [
             &first.verifier,
             &first.challenge,

--- a/crates/cli/src/login/tests.rs
+++ b/crates/cli/src/login/tests.rs
@@ -7,7 +7,9 @@
 //! plane records every request, so "the first PAT was revoked" is an
 //! assertion rather than an inference.
 
-use super::{LoginOptions, Selection, login, oauth, parse_expires};
+use super::{
+    LoginOptions, Selection, login, oauth, parse_expires, render_workspace_menu, select_memberships,
+};
 use chrono::{DateTime, Duration, Utc};
 use serde_json::{Value, json};
 use std::path::{Path, PathBuf};
@@ -116,6 +118,7 @@ fn options(control_plane: &str, server_override: Option<&str>) -> LoginOptions {
         server_override: server_override.map(str::to_string),
         env_gateway_url: None,
         endpoints: oauth::Endpoints::default(),
+        open_browser: oauth::open_in_browser,
         callback_timeout: std::time::Duration::from_millis(50),
         token_name: "cli@test-host".to_string(),
         now: at("2026-08-24T12:00:00Z"),
@@ -703,4 +706,260 @@ fn expires_accepts_days_and_hours_and_refuses_the_rest() {
     for bad in ["0d", "-5d", "abc", "", "90m", "90 days"] {
         assert!(parse_expires(bad).is_err(), "'{bad}' must be refused");
     }
+}
+
+/// One membership, deserialized through the same path the flow uses, so these
+/// tests cannot drift from the wire shape.
+fn parsed(org: &str, workspace: &str, display: Option<&str>) -> super::control_plane::Membership {
+    let mut value = membership(org, workspace, "active", None);
+    match display {
+        Some(name) => value["display_name"] = json!(name),
+        None => {
+            value.as_object_mut().unwrap().remove("display_name");
+        }
+    }
+    serde_json::from_value(value).unwrap()
+}
+
+/// §6.1 step 5: "a lone membership is used automatically; several trigger a
+/// picker". The picker reads its answer from a parameter, so all three of its
+/// outcomes are exercised here rather than by hand.
+#[test]
+fn the_picker_resolves_a_valid_choice() {
+    let active = vec![parsed("acme", "one", None), parsed("acme", "two", None)];
+    let chosen = select_memberships(&Selection::Auto, active, &[], &mut &b"2\n"[..]).unwrap();
+    assert_eq!(chosen.len(), 1);
+    assert_eq!(chosen[0].tenant_slug, "two");
+}
+
+/// EOF is a non-interactive run — a pipe, a CI job, `< /dev/null`. Looping on
+/// an answer that will never come would hang the command, so it names the
+/// flags that do the same job.
+#[test]
+fn the_picker_treats_eof_as_non_interactive_and_names_the_flags() {
+    let active = vec![parsed("acme", "one", None), parsed("acme", "two", None)];
+    let err = select_memberships(&Selection::Auto, active, &[], &mut &b""[..])
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("--workspace <slug>"), "{err}");
+    assert!(err.contains("--all-workspaces"), "{err}");
+}
+
+#[test]
+fn the_picker_refuses_an_answer_outside_the_range() {
+    let active = vec![parsed("acme", "one", None), parsed("acme", "two", None)];
+    for answer in ["0\n", "3\n", "two\n", "\n"] {
+        let err = select_memberships(
+            &Selection::Auto,
+            active.clone(),
+            &[],
+            &mut answer.as_bytes(),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("is not one of 1-2"), "{answer:?}: {err}");
+    }
+}
+
+/// A lone membership never reaches the picker, so a non-interactive `login`
+/// with one workspace works with stdin closed.
+#[test]
+fn a_lone_membership_skips_the_picker_entirely() {
+    let chosen = select_memberships(
+        &Selection::Auto,
+        vec![parsed("acme", "only", None)],
+        &[],
+        &mut &b""[..],
+    )
+    .unwrap();
+    assert_eq!(chosen[0].tenant_slug, "only");
+}
+
+/// The menu names the workspace, the role, and the control plane's
+/// `display_name` when it sent one — and reads cleanly when it did not.
+#[test]
+fn the_menu_names_each_workspace_with_its_role() {
+    let menu = render_workspace_menu(&[
+        parsed("acme", "one", Some("Production")),
+        parsed("acme", "two", None),
+        parsed("acme", "three", Some("")),
+    ]);
+    assert_eq!(
+        menu,
+        "this identity has 3 active workspaces:\n\
+         \x20 1) acme/one — Production (role: admin)\n\
+         \x20 2) acme/two (role: admin)\n\
+         \x20 3) acme/three (role: admin)\n\
+         select one [1-3]: "
+    );
+}
+
+/// The browser path through the WHOLE flow, with a `fn` playing the user
+/// agent: it reads the authorization URL as a browser would and follows the
+/// redirect. What this pins beyond the oauth-level test is the handoff — the
+/// control plane is presented the **ID token**, never a PAT.
+#[tokio::test]
+async fn the_browser_path_presents_the_id_token_to_the_control_plane() {
+    let gw = gateway(200).await;
+    let cp = control_plane_with(vec![membership(
+        "acme",
+        "acme-prod",
+        "active",
+        Some(&gw.uri()),
+    )])
+    .await;
+    mint_ok(&cp, "acme-prod", "tok-1").await;
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"id_token": "the-id-token"})))
+        .mount(&cp)
+        .await;
+
+    let home = TempDir::new().unwrap();
+    let path = config_in(&home);
+    let mut options = options(&cp.uri(), None);
+    options.identity = None;
+    options.client_id = Some("client-123.apps.googleusercontent.com".to_string());
+    options.endpoints = oauth::Endpoints {
+        authorization_url: format!("{}/auth", cp.uri()),
+        token_url: format!("{}/token", cp.uri()),
+    };
+    options.callback_timeout = std::time::Duration::from_secs(5);
+    // The shared helper sets `no_browser`, which prints the URL instead of
+    // opening it; this test is specifically about the opening path.
+    options.no_browser = false;
+    // Stands in for the browser: no captures needed, which is why the field is
+    // a plain `fn`.
+    options.open_browser = |url: &str| {
+        let query = url.split_once('?').expect("a query").1;
+        let value = |key: &str| {
+            let raw = query
+                .split('&')
+                .find_map(|pair| pair.strip_prefix(&format!("{key}=")))
+                .unwrap_or_default();
+            percent_encoding::percent_decode_str(raw)
+                .decode_utf8_lossy()
+                .to_string()
+        };
+        let (redirect, state) = (value("redirect_uri"), value("state"));
+        tokio::spawn(async move {
+            let _ = reqwest::get(format!("{redirect}?code=browser-code&state={state}")).await;
+        });
+        Ok(())
+    };
+
+    let report = login(options, &path).await.unwrap();
+    assert_eq!(report.written.len(), 1);
+
+    let requests = cp.received_requests().await.unwrap();
+    let discovery = requests
+        .iter()
+        .find(|r| r.url.path() == "/v1/me/workspaces")
+        .expect("discovery happened");
+    assert_eq!(
+        discovery.headers.get("Authorization").unwrap(),
+        "Bearer the-id-token",
+        "the control plane is presented the ID token, not a PAT"
+    );
+    // And the ID token never reaches disk (§9.1).
+    let written = std::fs::read_to_string(&path).unwrap();
+    assert!(!written.contains("the-id-token"), "{written}");
+    assert!(written.contains("skardi_pat_tok-1"), "{written}");
+}
+
+#[test]
+fn an_identity_with_no_memberships_at_all_says_so() {
+    let err = select_memberships(&Selection::Auto, vec![], &[], &mut &b""[..])
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("no workspace memberships"), "{err}");
+}
+
+/// §6.5: "A revocation failure during replacement is reported but does not
+/// fail the login — the new context is already good."
+#[tokio::test]
+async fn a_replacement_whose_old_token_cannot_be_revoked_still_succeeds() {
+    let gw = gateway(200).await;
+    let cp = control_plane_with(vec![membership(
+        "acme",
+        "acme-prod",
+        "active",
+        Some(&gw.uri()),
+    )])
+    .await;
+    mint_ok(&cp, "acme-prod", "tok-new").await;
+    revoke_answers(&cp, 500).await;
+
+    let home = TempDir::new().unwrap();
+    let path = config_in(&home);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &path,
+        "contexts:\n\
+         \x20 - name: acme/acme-prod\n\
+         \x20   mode: cloud\n\
+         \x20   server: http://old.example\n\
+         \x20   workspace: acme-prod\n\
+         \x20   token: skardi_pat_old\n\
+         \x20   token-id: tok-old\n",
+    )
+    .unwrap();
+
+    let report = login(options(&cp.uri(), None), &path).await.unwrap();
+
+    assert_eq!(report.written.len(), 1, "the login itself succeeded");
+    assert!(report.replaced_revoked.is_empty());
+    assert_eq!(report.revoke_failures.len(), 1);
+    assert_eq!(report.revoke_failures[0].0, "tok-old");
+    assert_eq!(read_yaml(&path)["contexts"][0]["token-id"], "tok-new");
+}
+
+/// `org_ambiguous` without the org list still explains itself rather than
+/// rendering an empty parenthesis.
+#[tokio::test]
+async fn a_multi_org_failure_without_the_list_still_explains_itself() {
+    let gw = gateway(200).await;
+    let cp = control_plane_with(vec![membership(
+        "acme",
+        "acme-prod",
+        "active",
+        Some(&gw.uri()),
+    )])
+    .await;
+    mint_fails(
+        &cp,
+        "acme-prod",
+        400,
+        json!({"error": {"code": "org_ambiguous", "message": "several orgs"}}),
+    )
+    .await;
+
+    let home = TempDir::new().unwrap();
+    let err = login(options(&cp.uri(), None), &config_in(&home))
+        .await
+        .unwrap_err();
+    let rendered = format!("{err:#}");
+    assert!(rendered.contains("no org list"), "{rendered}");
+    assert!(rendered.contains("config set-context"), "{rendered}");
+}
+
+/// The control-plane body cap is defence-in-depth: a runaway endpoint must
+/// fail cleanly rather than being buffered.
+#[tokio::test]
+async fn an_oversized_control_plane_response_is_refused_rather_than_buffered() {
+    let cp = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/me/workspaces"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("x".repeat(1_100_000)))
+        .mount(&cp)
+        .await;
+
+    let home = TempDir::new().unwrap();
+    let err = login(options(&cp.uri(), None), &config_in(&home))
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err:#}").contains("refusing to buffer it"),
+        "{err:#}"
+    );
 }

--- a/crates/cli/src/login/tests.rs
+++ b/crates/cli/src/login/tests.rs
@@ -1013,3 +1013,119 @@ async fn a_gateway_that_never_answers_still_reaches_the_rollback() {
     );
     assert!(!path.exists());
 }
+
+/// A blank value must FALL THROUGH, not shadow: `Option::or` picks the first
+/// `Some` and would trim only the winner, so an exported-empty
+/// `SKARDI_GATEWAY_URL` blamed the control plane for a silence it did not
+/// cause. `resolve_control_plane` has always had the right shape; this side
+/// only ever saw populated values.
+#[tokio::test]
+async fn a_blank_flag_or_env_does_not_shadow_the_control_planes_gateway_url() {
+    for (server_override, env) in [
+        (Some(String::new()), None),
+        (Some("   ".to_string()), None),
+        (None, Some(String::new())),
+        (Some(String::new()), Some("  ".to_string())),
+    ] {
+        let gw = gateway(200).await;
+        let cp = control_plane_with(vec![membership(
+            "acme",
+            "acme-prod",
+            "active",
+            Some(&gw.uri()),
+        )])
+        .await;
+        mint_ok(&cp, "acme-prod", "tok-1").await;
+
+        let home = TempDir::new().unwrap();
+        let path = config_in(&home);
+        let mut options = options(&cp.uri(), server_override.as_deref());
+        options.env_gateway_url = env.clone();
+        login(options, &path).await.unwrap();
+
+        assert_eq!(
+            read_yaml(&path)["contexts"][0]["server"].as_str().unwrap(),
+            gw.uri(),
+            "blank override {server_override:?}/{env:?} shadowed the membership"
+        );
+    }
+}
+
+/// `--expires` bounded by `TimeDelta`'s range still overflowed `DateTime`'s,
+/// and `DateTime + TimeDelta` PANICS. The refusal must be typed, and must land
+/// before anything is minted.
+#[tokio::test]
+async fn an_expiry_past_the_end_of_time_is_refused_not_a_panic() {
+    let gw = gateway(200).await;
+    let cp = control_plane_with(vec![membership(
+        "acme",
+        "acme-prod",
+        "active",
+        Some(&gw.uri()),
+    )])
+    .await;
+    mint_ok(&cp, "acme-prod", "tok-1").await;
+
+    let home = TempDir::new().unwrap();
+    let path = config_in(&home);
+    let mut options = options(&cp.uri(), None);
+    // Accepted by `parse_expires` (TimeDelta's range is ~1.07e11 days) and far
+    // past `NaiveDate::MAX` (~9.5e7 days from now).
+    options.expires = parse_expires("100000000d").unwrap();
+
+    let err = login(options, &path).await.unwrap_err().to_string();
+
+    assert!(err.contains("longer than any usable credential"), "{err}");
+    assert!(!path.exists());
+    assert!(
+        mint_bodies(&cp.received_requests().await.unwrap()).is_empty(),
+        "the refusal must precede the mint"
+    );
+}
+
+/// The probe's failure goes through §8's translation: `ApiError`'s own 401
+/// tells the caller to set `SKARDI_API_TOKEN`, which resolution REFUSES for a
+/// cloud context — and it is worse advice here than at query time, since there
+/// is not yet a context for `skardi login` to point at.
+#[tokio::test]
+async fn a_rejected_probe_does_not_advise_the_env_var_it_refuses() {
+    let gw = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/query"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+            "success": false,
+            "error": "invalid token",
+            "error_type": "unauthorized",
+        })))
+        .mount(&gw)
+        .await;
+    let cp = control_plane_with(vec![membership(
+        "acme",
+        "acme-prod",
+        "active",
+        Some(&gw.uri()),
+    )])
+    .await;
+    mint_ok(&cp, "acme-prod", "tok-1").await;
+    revoke_answers(&cp, 204).await;
+
+    let home = TempDir::new().unwrap();
+    let path = config_in(&home);
+    let err = login(options(&cp.uri(), None), &path)
+        .await
+        .unwrap_err()
+        .to_string();
+
+    assert!(err.contains("could not query"), "{err}");
+    assert!(!err.contains("SKARDI_API_TOKEN"), "{err}");
+    assert!(
+        err.contains("skardi login"),
+        "the actionable half survives: {err}"
+    );
+    // Still the saga: revoked, and nothing written.
+    assert_eq!(
+        revoked_ids(&cp.received_requests().await.unwrap()),
+        ["tok-1"]
+    );
+    assert!(!path.exists());
+}

--- a/crates/cli/src/login/tests.rs
+++ b/crates/cli/src/login/tests.rs
@@ -251,9 +251,16 @@ async fn every_membership_only_provisioning_is_a_typed_failure_naming_the_states
     assert!(!config_in(&home).exists(), "nothing may be written");
 }
 
-/// §7.1's per-org `gateway_url`: two orgs, two hosts, one login.
+/// §7.1's `gateway_url` is read per MEMBERSHIP, so two memberships naming
+/// different hosts produce two contexts pointing at them.
+///
+/// The first control-plane release projects ONE deployment-wide URL onto every
+/// membership, so this case does not arise there — which is exactly why it is
+/// pinned: when workspace runtimes start supplying their own endpoints through
+/// the same field, the CLI must already honour them rather than collapse them
+/// to the first one it saw.
 #[tokio::test]
-async fn each_context_points_at_its_own_orgs_gateway() {
+async fn each_context_points_at_the_gateway_its_own_membership_names() {
     let first = gateway(200).await;
     let second = gateway(200).await;
     let cp = control_plane_with(vec![

--- a/crates/cli/src/login/tests.rs
+++ b/crates/cli/src/login/tests.rs
@@ -119,6 +119,7 @@ fn options(control_plane: &str, server_override: Option<&str>) -> LoginOptions {
         env_gateway_url: None,
         endpoints: oauth::Endpoints::default(),
         open_browser: oauth::open_in_browser,
+        verify_timeout: std::time::Duration::from_millis(200),
         callback_timeout: std::time::Duration::from_millis(50),
         token_name: "cli@test-host".to_string(),
         now: at("2026-08-24T12:00:00Z"),
@@ -962,4 +963,53 @@ async fn an_oversized_control_plane_response_is_refused_rather_than_buffered() {
         format!("{err:#}").contains("refusing to buffer it"),
         "{err:#}"
     );
+}
+
+/// A gateway that accepts the connection and never answers must not hang the
+/// flow: the probe is the last point past which a PAT exists and no context
+/// does, so the saga has to stay reachable (round-7 P1).
+#[tokio::test]
+async fn a_gateway_that_never_answers_still_reaches_the_rollback() {
+    let stalled = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/query"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(json!({"success": true}))
+                .set_delay(std::time::Duration::from_secs(30)),
+        )
+        .mount(&stalled)
+        .await;
+
+    let cp = control_plane_with(vec![membership(
+        "acme",
+        "acme-prod",
+        "active",
+        Some(&stalled.uri()),
+    )])
+    .await;
+    mint_ok(&cp, "acme-prod", "tok-1").await;
+    revoke_answers(&cp, 204).await;
+
+    let home = TempDir::new().unwrap();
+    let path = config_in(&home);
+    let started = std::time::Instant::now();
+    let err = login(options(&cp.uri(), None), &path)
+        .await
+        .unwrap_err()
+        .to_string();
+
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(10),
+        "the probe must be bounded, not wait out the gateway"
+    );
+    assert!(err.contains("got no answer from"), "{err}");
+    assert!(err.contains("--no-verify"), "{err}");
+    // The saga ran: the PAT this login minted is revoked, and no context was
+    // written to point at it.
+    assert_eq!(
+        revoked_ids(&cp.received_requests().await.unwrap()),
+        ["tok-1"]
+    );
+    assert!(!path.exists());
 }

--- a/crates/cli/src/login/tests.rs
+++ b/crates/cli/src/login/tests.rs
@@ -1,0 +1,706 @@
+//! §10's `login` test list, driven in-process against a `wiremock` control
+//! plane and a `wiremock` gateway.
+//!
+//! In-process rather than through the binary on purpose: the saga's whole
+//! point is what happens to credentials on a FAILURE path, and a subprocess
+//! can only be observed through its exit code and stderr. Here the control
+//! plane records every request, so "the first PAT was revoked" is an
+//! assertion rather than an inference.
+
+use super::{LoginOptions, Selection, login, oauth, parse_expires};
+use chrono::{DateTime, Duration, Utc};
+use serde_json::{Value, json};
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+use wiremock::matchers::{body_string_contains, method, path, path_regex};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+fn at(rfc3339: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(rfc3339)
+        .unwrap()
+        .with_timezone(&Utc)
+}
+
+/// One membership as `/v1/me/workspaces` renders it, with `gateway_url`
+/// present or absent (§7.1 is M4, so absence is the state today).
+fn membership(org: &str, workspace: &str, state: &str, gateway_url: Option<&str>) -> Value {
+    let mut value = json!({
+        "org_slug": org,
+        "tenant_slug": workspace,
+        "display_name": workspace,
+        "role": "admin",
+        "provisioning_state": state,
+    });
+    if let Some(url) = gateway_url {
+        value["gateway_url"] = json!(url);
+    }
+    value
+}
+
+async fn control_plane_with(memberships: Vec<Value>) -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/me/workspaces"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"workspaces": memberships})))
+        .mount(&server)
+        .await;
+    server
+}
+
+/// Mint `token_id` for any request naming `workspace`.
+async fn mint_ok(server: &MockServer, workspace: &str, token_id: &str) {
+    Mock::given(method("POST"))
+        .and(path("/v1/me/tokens"))
+        .and(body_string_contains(format!("\"{workspace}\"")))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "token": format!("skardi_pat_{token_id}"),
+            "pat": {
+                "token_id": token_id,
+                "name": "cli@test-host",
+                "expires_at": "2026-11-22T12:00:00Z",
+            },
+        })))
+        .mount(server)
+        .await;
+}
+
+async fn mint_fails(server: &MockServer, workspace: &str, status: u16, body: Value) {
+    Mock::given(method("POST"))
+        .and(path("/v1/me/tokens"))
+        .and(body_string_contains(format!("\"{workspace}\"")))
+        .respond_with(ResponseTemplate::new(status).set_body_json(body))
+        .mount(server)
+        .await;
+}
+
+async fn revoke_answers(server: &MockServer, status: u16) {
+    Mock::given(method("DELETE"))
+        .and(path_regex(r"^/v1/me/tokens/.+$"))
+        .respond_with(ResponseTemplate::new(status))
+        .mount(server)
+        .await;
+}
+
+/// A gateway that answers the `select 1` probe with `status`.
+async fn gateway(status: u16) -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/query"))
+        .respond_with(ResponseTemplate::new(status).set_body_json(json!({
+            "success": status == 200,
+            "columns": ["n"],
+            "rows": [[1]],
+            "error": "forbidden",
+            "error_type": "forbidden",
+        })))
+        .mount(&server)
+        .await;
+    server
+}
+
+fn options(control_plane: &str, server_override: Option<&str>) -> LoginOptions {
+    LoginOptions {
+        control_plane: control_plane.to_string(),
+        client_id: None,
+        // The dev path (§6.3) is how the flow under test is the real one minus
+        // the browser; the control plane is a loopback wiremock, so the guard
+        // is satisfied honestly rather than bypassed.
+        identity: Some("dev:alice".to_string()),
+        allow_dev_auth_off_loopback: false,
+        selection: Selection::Auto,
+        context_name: None,
+        expires: Duration::try_days(90).unwrap(),
+        no_browser: true,
+        no_verify: false,
+        keep_old_token: false,
+        server_override: server_override.map(str::to_string),
+        env_gateway_url: None,
+        endpoints: oauth::Endpoints::default(),
+        callback_timeout: std::time::Duration::from_millis(50),
+        token_name: "cli@test-host".to_string(),
+        now: at("2026-08-24T12:00:00Z"),
+    }
+}
+
+fn config_in(dir: &TempDir) -> PathBuf {
+    dir.path().join(".skardi").join("config.yaml")
+}
+
+fn read_yaml(path: &Path) -> serde_yaml::Value {
+    serde_yaml::from_str(&std::fs::read_to_string(path).unwrap()).unwrap()
+}
+
+/// Every DELETE the control plane saw, as the token id in its path.
+fn revoked_ids(requests: &[Request]) -> Vec<String> {
+    requests
+        .iter()
+        .filter(|r| r.method == wiremock::http::Method::DELETE)
+        .map(|r| r.url.path().rsplit('/').next().unwrap_or("").to_string())
+        .collect()
+}
+
+fn mint_bodies(requests: &[Request]) -> Vec<Value> {
+    requests
+        .iter()
+        .filter(|r| r.method == wiremock::http::Method::POST && r.url.path() == "/v1/me/tokens")
+        .map(|r| serde_json::from_slice(&r.body).unwrap())
+        .collect()
+}
+
+#[tokio::test]
+async fn a_lone_membership_mints_a_scoped_pat_verifies_it_and_writes_the_context() {
+    let gw = gateway(200).await;
+    let cp = control_plane_with(vec![membership(
+        "acme",
+        "acme-prod",
+        "active",
+        Some(&gw.uri()),
+    )])
+    .await;
+    mint_ok(&cp, "acme-prod", "tok-1").await;
+
+    let home = TempDir::new().unwrap();
+    let path = config_in(&home);
+    let report = login(options(&cp.uri(), None), &path).await.unwrap();
+
+    // §6.1 step 5: one workspace, the membership's role, the requested expiry.
+    let minted = mint_bodies(&cp.received_requests().await.unwrap());
+    assert_eq!(minted.len(), 1);
+    assert_eq!(minted[0]["name"], json!("cli@test-host"));
+    assert_eq!(
+        minted[0]["scope"],
+        json!({"workspaces": ["acme-prod"], "max_role": "admin"})
+    );
+    assert!(
+        minted[0]["expires_at"]
+            .as_str()
+            .unwrap()
+            .starts_with("2026-11-22"),
+        "90 days after 2026-08-24: {}",
+        minted[0]["expires_at"]
+    );
+
+    // §6.1 step 6: the probe went to the resolved gateway, with the selector.
+    let probes = gw.received_requests().await.unwrap();
+    assert_eq!(probes.len(), 1);
+    assert_eq!(
+        probes[0].headers.get("Skardi-Workspace").unwrap(),
+        "acme-prod"
+    );
+    assert_eq!(
+        probes[0].headers.get("Authorization").unwrap(),
+        "Bearer skardi_pat_tok-1"
+    );
+
+    // §6.1 step 7: one context, named <org>/<workspace>, made current.
+    assert_eq!(report.written.len(), 1);
+    assert_eq!(report.current_context.as_deref(), Some("acme/acme-prod"));
+    let file = read_yaml(&path);
+    assert_eq!(file["current-context"], "acme/acme-prod");
+    assert_eq!(file["control-plane"].as_str().unwrap(), cp.uri());
+    let context = &file["contexts"][0];
+    assert_eq!(context["name"], "acme/acme-prod");
+    assert_eq!(context["mode"], "cloud");
+    assert_eq!(context["server"].as_str().unwrap(), gw.uri());
+    assert_eq!(context["workspace"], "acme-prod");
+    assert_eq!(context["token"], "skardi_pat_tok-1");
+    assert_eq!(context["token-id"], "tok-1");
+    assert_eq!(context["token-expires-at"], "2026-11-22T12:00:00Z");
+    // Nothing was revoked: this was a first login, not a replacement.
+    assert!(revoked_ids(&cp.received_requests().await.unwrap()).is_empty());
+}
+
+#[tokio::test]
+async fn a_workspace_that_is_not_active_is_skipped_with_its_state_named() {
+    let gw = gateway(200).await;
+    let cp = control_plane_with(vec![
+        membership("acme", "acme-prod", "active", Some(&gw.uri())),
+        membership("acme", "acme-staging", "provisioning", Some(&gw.uri())),
+    ])
+    .await;
+    mint_ok(&cp, "acme-prod", "tok-1").await;
+
+    let home = TempDir::new().unwrap();
+    let mut options = options(&cp.uri(), None);
+    options.selection = Selection::All;
+    let report = login(options, &config_in(&home)).await.unwrap();
+
+    assert_eq!(
+        report.skipped,
+        vec![("acme/acme-staging".to_string(), "provisioning".to_string())]
+    );
+    assert_eq!(report.written.len(), 1);
+    // Only the active workspace was minted for.
+    assert_eq!(mint_bodies(&cp.received_requests().await.unwrap()).len(), 1);
+}
+
+#[tokio::test]
+async fn every_membership_only_provisioning_is_a_typed_failure_naming_the_states() {
+    let cp = control_plane_with(vec![membership("acme", "acme-prod", "provisioning", None)]).await;
+    let home = TempDir::new().unwrap();
+
+    let err = login(options(&cp.uri(), None), &config_in(&home))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("acme/acme-prod (provisioning)"), "{err}");
+    assert!(!config_in(&home).exists(), "nothing may be written");
+}
+
+/// §7.1's per-org `gateway_url`: two orgs, two hosts, one login.
+#[tokio::test]
+async fn each_context_points_at_its_own_orgs_gateway() {
+    let first = gateway(200).await;
+    let second = gateway(200).await;
+    let cp = control_plane_with(vec![
+        membership("acme", "acme-prod", "active", Some(&first.uri())),
+        membership("globex", "globex-prod", "active", Some(&second.uri())),
+    ])
+    .await;
+    mint_ok(&cp, "acme-prod", "tok-1").await;
+    mint_ok(&cp, "globex-prod", "tok-2").await;
+
+    let home = TempDir::new().unwrap();
+    let path = config_in(&home);
+    let mut options = options(&cp.uri(), None);
+    options.selection = Selection::All;
+    let report = login(options, &path).await.unwrap();
+
+    assert_eq!(report.written.len(), 2);
+    let file = read_yaml(&path);
+    let servers: Vec<String> = file["contexts"]
+        .as_sequence()
+        .unwrap()
+        .iter()
+        .map(|c| c["server"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(servers, vec![first.uri(), second.uri()]);
+    // Each probe reached its own host, so a per-org URL is not just written
+    // but actually used for verification.
+    assert_eq!(first.received_requests().await.unwrap().len(), 1);
+    assert_eq!(second.received_requests().await.unwrap().len(), 1);
+}
+
+/// §6.2's precedence, including the step that must NOT exist: no source at all
+/// is a typed error, never a fall-through to a local port.
+#[tokio::test]
+async fn the_gateway_url_comes_from_the_flag_then_the_env_then_the_membership() {
+    let flagged = gateway(200).await;
+    let from_env = gateway(200).await;
+    let from_membership = gateway(200).await;
+
+    for (server_override, env, expected) in [
+        (Some(flagged.uri()), Some(from_env.uri()), flagged.uri()),
+        (None, Some(from_env.uri()), from_env.uri()),
+        (None, None, from_membership.uri()),
+    ] {
+        let cp = control_plane_with(vec![membership(
+            "acme",
+            "acme-prod",
+            "active",
+            Some(&from_membership.uri()),
+        )])
+        .await;
+        mint_ok(&cp, "acme-prod", "tok-1").await;
+
+        let home = TempDir::new().unwrap();
+        let path = config_in(&home);
+        let mut options = options(&cp.uri(), server_override.as_deref());
+        options.env_gateway_url = env;
+        login(options, &path).await.unwrap();
+
+        assert_eq!(read_yaml(&path)["contexts"][0]["server"], expected);
+    }
+}
+
+#[tokio::test]
+async fn no_gateway_url_anywhere_names_server_and_writes_nothing() {
+    let cp = control_plane_with(vec![membership("acme", "acme-prod", "active", None)]).await;
+    let home = TempDir::new().unwrap();
+    let path = config_in(&home);
+
+    let err = login(options(&cp.uri(), None), &path)
+        .await
+        .unwrap_err()
+        .to_string();
+
+    assert!(err.contains("--server"), "{err}");
+    assert!(err.contains("SKARDI_GATEWAY_URL"), "{err}");
+    assert!(
+        !err.contains("127.0.0.1:8080"),
+        "there is deliberately no local fallback: {err}"
+    );
+    assert!(!path.exists(), "no context may be written");
+    // The failure precedes the mint, so there is nothing to roll back.
+    assert!(mint_bodies(&cp.received_requests().await.unwrap()).is_empty());
+}
+
+/// §6.1 step 6: "A context that cannot answer it is not written and its PAT is
+/// revoked."
+#[tokio::test]
+async fn a_credential_that_cannot_query_is_revoked_and_no_context_is_written() {
+    let gw = gateway(403).await;
+    let cp = control_plane_with(vec![membership(
+        "acme",
+        "acme-prod",
+        "active",
+        Some(&gw.uri()),
+    )])
+    .await;
+    mint_ok(&cp, "acme-prod", "tok-1").await;
+    revoke_answers(&cp, 204).await;
+
+    let home = TempDir::new().unwrap();
+    let path = config_in(&home);
+    let err = login(options(&cp.uri(), None), &path)
+        .await
+        .unwrap_err()
+        .to_string();
+
+    assert!(err.contains("could not query"), "{err}");
+    assert!(
+        err.contains("--no-verify"),
+        "the escape hatch is named: {err}"
+    );
+    assert!(!path.exists(), "no context may be written");
+    assert_eq!(
+        revoked_ids(&cp.received_requests().await.unwrap()),
+        ["tok-1"]
+    );
+}
+
+#[tokio::test]
+async fn no_verify_skips_the_probe_entirely() {
+    let gw = gateway(403).await;
+    let cp = control_plane_with(vec![membership(
+        "acme",
+        "acme-prod",
+        "active",
+        Some(&gw.uri()),
+    )])
+    .await;
+    mint_ok(&cp, "acme-prod", "tok-1").await;
+
+    let home = TempDir::new().unwrap();
+    let path = config_in(&home);
+    let mut options = options(&cp.uri(), None);
+    options.no_verify = true;
+    login(options, &path).await.unwrap();
+
+    assert!(gw.received_requests().await.unwrap().is_empty());
+    assert_eq!(read_yaml(&path)["contexts"][0]["token-id"], "tok-1");
+}
+
+/// §6.5: "If a later mint fails … `login` revokes every retained token."
+#[tokio::test]
+async fn a_failure_on_the_second_mint_revokes_the_first() {
+    let gw = gateway(200).await;
+    let cp = control_plane_with(vec![
+        membership("acme", "one", "active", Some(&gw.uri())),
+        membership("acme", "two", "active", Some(&gw.uri())),
+        membership("acme", "three", "active", Some(&gw.uri())),
+    ])
+    .await;
+    mint_ok(&cp, "one", "tok-1").await;
+    mint_fails(
+        &cp,
+        "two",
+        500,
+        json!({"error": {"code": "internal", "message": "internal error"}}),
+    )
+    .await;
+    mint_ok(&cp, "three", "tok-3").await;
+    revoke_answers(&cp, 204).await;
+
+    let home = TempDir::new().unwrap();
+    let path = config_in(&home);
+    let mut options = options(&cp.uri(), None);
+    options.selection = Selection::All;
+    let err = login(options, &path).await.unwrap_err();
+    let rendered = format!("{err:#}");
+
+    assert!(rendered.contains("workspace 'two'"), "{rendered}");
+    assert!(
+        rendered.contains("internal error"),
+        "the original cause survives the rollback: {rendered}"
+    );
+    let requests = cp.received_requests().await.unwrap();
+    assert_eq!(revoked_ids(&requests), ["tok-1"]);
+    // The third workspace is never minted for: the saga stops at the failure.
+    assert_eq!(mint_bodies(&requests).len(), 2);
+    assert!(!path.exists());
+}
+
+/// §6.5: "or the config write fails, `login` revokes every retained token".
+#[tokio::test]
+async fn a_config_write_failure_revokes_everything_minted() {
+    let gw = gateway(200).await;
+    let cp = control_plane_with(vec![
+        membership("acme", "one", "active", Some(&gw.uri())),
+        membership("acme", "two", "active", Some(&gw.uri())),
+    ])
+    .await;
+    mint_ok(&cp, "one", "tok-1").await;
+    mint_ok(&cp, "two", "tok-2").await;
+    revoke_answers(&cp, 204).await;
+
+    // A regular FILE where the config directory must be, so `save` cannot
+    // create the parent — a write failure that needs no permission games.
+    let home = TempDir::new().unwrap();
+    let blocked = home.path().join(".skardi");
+    std::fs::write(&blocked, b"not a directory").unwrap();
+
+    let mut options = options(&cp.uri(), None);
+    options.selection = Selection::All;
+    let err = login(options, &blocked.join("config.yaml"))
+        .await
+        .unwrap_err();
+
+    assert!(format!("{err:#}").contains("config"), "{err:#}");
+    let mut revoked = revoked_ids(&cp.received_requests().await.unwrap());
+    revoked.sort();
+    assert_eq!(revoked, ["tok-1", "tok-2"]);
+}
+
+/// §6.5: "If rollback itself partially fails, the command exits non-zero and
+/// prints the token ids … Silence here would leave credentials nobody knows
+/// exist."
+#[tokio::test]
+async fn a_rollback_that_fails_reports_the_surviving_token_ids() {
+    let gw = gateway(403).await;
+    let cp = control_plane_with(vec![membership(
+        "acme",
+        "acme-prod",
+        "active",
+        Some(&gw.uri()),
+    )])
+    .await;
+    mint_ok(&cp, "acme-prod", "tok-1").await;
+    revoke_answers(&cp, 500).await;
+
+    let home = TempDir::new().unwrap();
+    let err = login(options(&cp.uri(), None), &config_in(&home))
+        .await
+        .unwrap_err();
+    let rendered = format!("{err:#}");
+
+    assert!(rendered.contains("LOGIN ROLLBACK INCOMPLETE"), "{rendered}");
+    assert!(rendered.contains("tok-1"), "{rendered}");
+    assert!(rendered.contains("acme-prod"), "{rendered}");
+    assert!(
+        rendered.contains("could not query"),
+        "the original cause is still reported: {rendered}"
+    );
+}
+
+/// §6.5: "Re-login over an existing context replaces it and revokes the token
+/// it replaced", and `--keep-old-token` retains it.
+#[tokio::test]
+async fn a_relogin_replaces_the_context_and_revokes_or_keeps_the_old_token() {
+    for keep_old in [false, true] {
+        let gw = gateway(200).await;
+        let cp = control_plane_with(vec![membership(
+            "acme",
+            "acme-prod",
+            "active",
+            Some(&gw.uri()),
+        )])
+        .await;
+        mint_ok(&cp, "acme-prod", "tok-new").await;
+        revoke_answers(&cp, 204).await;
+
+        let home = TempDir::new().unwrap();
+        let path = config_in(&home);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            "current-context: acme/acme-prod\n\
+             contexts:\n\
+             \x20 - name: acme/acme-prod\n\
+             \x20   mode: cloud\n\
+             \x20   server: http://old.example\n\
+             \x20   workspace: acme-prod\n\
+             \x20   token: skardi_pat_old\n\
+             \x20   token-id: tok-old\n",
+        )
+        .unwrap();
+
+        let mut options = options(&cp.uri(), None);
+        options.keep_old_token = keep_old;
+        let report = login(options, &path).await.unwrap();
+
+        let file = read_yaml(&path);
+        assert_eq!(
+            file["contexts"].as_sequence().unwrap().len(),
+            1,
+            "replaced, not duplicated"
+        );
+        assert_eq!(file["contexts"][0]["token-id"], "tok-new");
+        assert_eq!(file["contexts"][0]["server"].as_str().unwrap(), gw.uri());
+
+        let revoked = revoked_ids(&cp.received_requests().await.unwrap());
+        if keep_old {
+            assert!(revoked.is_empty(), "--keep-old-token must retain it");
+            assert_eq!(report.replaced_kept, ["tok-old"]);
+        } else {
+            assert_eq!(revoked, ["tok-old"]);
+            assert_eq!(report.replaced_revoked, ["tok-old"]);
+        }
+    }
+}
+
+/// §6.4: a multi-org identity cannot mint in v1, and the message has to say
+/// what to do instead.
+#[tokio::test]
+async fn a_multi_org_identity_gets_the_org_list_and_the_escape_hatch() {
+    let gw = gateway(200).await;
+    let cp = control_plane_with(vec![membership(
+        "acme",
+        "acme-prod",
+        "active",
+        Some(&gw.uri()),
+    )])
+    .await;
+    mint_fails(
+        &cp,
+        "acme-prod",
+        400,
+        json!({"error": {
+            "code": "org_ambiguous",
+            "message": "caller belongs to multiple orgs; minting for multi-org identities is not available in v1",
+            "orgs": [
+                {"org_slug": "acme", "org_role": "owner"},
+                {"org_slug": "globex", "org_role": "member"},
+            ],
+        }}),
+    )
+    .await;
+
+    let home = TempDir::new().unwrap();
+    let err = login(options(&cp.uri(), None), &config_in(&home))
+        .await
+        .unwrap_err();
+    let rendered = format!("{err:#}");
+
+    assert!(rendered.contains("acme, globex"), "{rendered}");
+    assert!(rendered.contains("config set-context"), "{rendered}");
+    assert!(rendered.contains("--token-stdin"), "{rendered}");
+}
+
+/// §6.3's guard. RFC1918 is included deliberately: that is where a shared
+/// internal staging cluster lives, and a `dev:` bearer there is impersonation.
+#[tokio::test]
+async fn the_dev_identity_path_refuses_a_non_loopback_control_plane() {
+    let home = TempDir::new().unwrap();
+    for url in [
+        "https://global.example.com",
+        "http://10.0.0.5:8090",
+        "http://192.168.1.10:8090",
+        "http://172.16.4.4:8090",
+    ] {
+        let err = login(options(url, Some("http://gw.example")), &config_in(&home))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("--i-know-this-is-dev-auth"), "{url}: {err}");
+    }
+
+    // Loopback in all three spellings is allowed without the flag. These fail
+    // LATER (nothing is listening), which is exactly the point: the guard
+    // passed.
+    for url in ["http://127.0.0.1:1", "http://localhost:1", "http://[::1]:1"] {
+        let err = login(options(url, Some("http://gw.example")), &config_in(&home))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(!err.contains("--i-know-this-is-dev-auth"), "{url}: {err}");
+    }
+}
+
+#[tokio::test]
+async fn a_non_dev_identity_bearer_is_refused_by_shape() {
+    let home = TempDir::new().unwrap();
+    let mut options = options("http://127.0.0.1:1", Some("http://gw.example"));
+    options.identity = Some("eyJhbGciOi.a-real-looking-jwt".to_string());
+    let err = login(options, &config_in(&home))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("must be a 'dev:"), "{err}");
+}
+
+#[tokio::test]
+async fn the_browser_path_needs_a_client_id_and_says_so() {
+    let home = TempDir::new().unwrap();
+    let mut options = options("http://127.0.0.1:1", Some("http://gw.example"));
+    options.identity = None;
+    options.client_id = Some("   ".to_string());
+    let err = login(options, &config_in(&home))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("--client-id"), "{err}");
+    assert!(err.contains("SKARDI_OAUTH_CLIENT_ID"), "{err}");
+}
+
+#[tokio::test]
+async fn naming_one_context_for_several_workspaces_is_refused() {
+    let gw = gateway(200).await;
+    let cp = control_plane_with(vec![
+        membership("acme", "one", "active", Some(&gw.uri())),
+        membership("acme", "two", "active", Some(&gw.uri())),
+    ])
+    .await;
+    let home = TempDir::new().unwrap();
+    let mut options = options(&cp.uri(), None);
+    options.selection = Selection::All;
+    options.context_name = Some("just-one".to_string());
+
+    let err = login(options, &config_in(&home))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("--context names ONE context"), "{err}");
+    // Refused before any mint: nothing to roll back.
+    assert!(mint_bodies(&cp.received_requests().await.unwrap()).is_empty());
+}
+
+#[tokio::test]
+async fn selecting_a_workspace_by_slug_lists_the_alternatives_when_it_is_wrong() {
+    let gw = gateway(200).await;
+    let cp = control_plane_with(vec![
+        membership("acme", "one", "active", Some(&gw.uri())),
+        membership("acme", "two", "active", Some(&gw.uri())),
+    ])
+    .await;
+    let home = TempDir::new().unwrap();
+    let mut options = options(&cp.uri(), None);
+    options.selection = Selection::Named("three".to_string());
+
+    let err = login(options, &config_in(&home))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("no active workspace named 'three'"), "{err}");
+    assert!(err.contains("one, two"), "{err}");
+}
+
+#[test]
+fn expires_accepts_days_and_hours_and_refuses_the_rest() {
+    assert_eq!(
+        parse_expires("90d").unwrap(),
+        Duration::try_days(90).unwrap()
+    );
+    assert_eq!(
+        parse_expires(" 90 ").unwrap(),
+        Duration::try_days(90).unwrap()
+    );
+    assert_eq!(
+        parse_expires("12h").unwrap(),
+        Duration::try_hours(12).unwrap()
+    );
+    assert_eq!(parse_expires("7D").unwrap(), Duration::try_days(7).unwrap());
+    for bad in ["0d", "-5d", "abc", "", "90m", "90 days"] {
+        assert!(parse_expires(bad).is_err(), "'{bad}' must be refused");
+    }
+}

--- a/crates/cli/src/login/tests.rs
+++ b/crates/cli/src/login/tests.rs
@@ -292,6 +292,63 @@ async fn each_context_points_at_the_gateway_its_own_membership_names() {
     assert_eq!(second.received_requests().await.unwrap().len(), 1);
 }
 
+/// The shape the first control-plane release actually returns (skardi-cloud
+/// #355): one deployment-global URL copied onto every membership. §10 names it
+/// alongside the per-membership case, because it is the one production hits —
+/// several workspaces, one front door, and every context written pointing at it.
+///
+/// Same org deliberately: a multi-org identity cannot mint at all in v1
+/// (`org_ambiguous`, §6.4), so the realistic shared case is several workspaces
+/// within one org.
+#[tokio::test]
+async fn a_deployment_wide_gateway_url_is_used_by_every_context_it_names() {
+    let shared = gateway(200).await;
+    let cp = control_plane_with(vec![
+        membership("acme", "acme-prod", "active", Some(&shared.uri())),
+        membership("acme", "acme-staging", "active", Some(&shared.uri())),
+    ])
+    .await;
+    mint_ok(&cp, "acme-prod", "tok-prod").await;
+    mint_ok(&cp, "acme-staging", "tok-staging").await;
+
+    let home = TempDir::new().unwrap();
+    let path = config_in(&home);
+    let mut options = options(&cp.uri(), None);
+    options.selection = Selection::All;
+    let report = login(options, &path).await.unwrap();
+
+    assert_eq!(report.written.len(), 2);
+    let file = read_yaml(&path);
+    let contexts = file["contexts"].as_sequence().unwrap();
+    assert_eq!(contexts.len(), 2);
+    for context in contexts {
+        assert_eq!(context["server"].as_str().unwrap(), shared.uri());
+        assert_eq!(context["mode"], "cloud");
+    }
+    // Distinct workspaces and distinct credentials on one host — the selector
+    // is what separates them, which is the whole premise of §7.3.
+    assert_eq!(contexts[0]["workspace"], "acme-prod");
+    assert_eq!(contexts[1]["workspace"], "acme-staging");
+    assert_eq!(contexts[0]["token-id"], "tok-prod");
+    assert_eq!(contexts[1]["token-id"], "tok-staging");
+    // Both probes went to the shared host, each naming its own workspace.
+    let probed: Vec<String> = shared
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .map(|r| {
+            r.headers
+                .get("Skardi-Workspace")
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string()
+        })
+        .collect();
+    assert_eq!(probed, ["acme-prod", "acme-staging"]);
+}
+
 /// §6.2's precedence, including the step that must NOT exist: no source at all
 /// is a typed error, never a fall-through to a local port.
 #[tokio::test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -11,6 +11,7 @@ use client::{ApiClient, ApiError};
 use cloud::Capability;
 use commands::config::ConfigCmd;
 use commands::jobs::JobCmd;
+use commands::login::{LoginArgs, LogoutArgs};
 use commands::pipeline::PipelineCmd;
 use config::ClientConfig;
 use std::path::PathBuf;
@@ -20,6 +21,7 @@ mod client;
 mod cloud;
 mod commands;
 mod config;
+mod login;
 mod output;
 mod params;
 mod session;
@@ -45,6 +47,30 @@ struct Cli {
     command: Commands,
 }
 
+/// `login`'s long help. Two GLOBAL flags mean something different under it, and
+/// a third is refused, so the subcommand has to say so where the user looks.
+const LOGIN_LONG_ABOUT: &str = "\
+Sign in to skardi-cloud and write a context per workspace.
+
+Two of the global flags mean something different here:
+
+  --server <URL>    the GATEWAY url written into every context this run creates,
+                    ahead of $SKARDI_GATEWAY_URL and the control plane's answer
+  --context <NAME>  the NAME to write instead of <org>/<workspace>; only valid
+                    when a single workspace is selected
+
+--token is not accepted: login mints the credential. To store one by hand, use
+'skardi config set-context <name> --token-stdin'.";
+
+/// `logout`'s long help, for the same reason.
+const LOGOUT_LONG_ABOUT: &str = "\
+Drop the local credential, and optionally revoke it at the control plane.
+
+  --context <NAME>  which context to clear (default: the current one)
+
+--server and --token are not accepted: logout reads the credential it removes
+from ~/.skardi/config.yaml.";
+
 /// Subcommands supported by the CLI.
 #[derive(Subcommand, Debug)]
 enum Commands {
@@ -53,6 +79,15 @@ enum Commands {
         #[command(subcommand)]
         cmd: ConfigCmd,
     },
+
+    /// Sign in to skardi-cloud and write a context per workspace.
+    #[command(long_about = LOGIN_LONG_ABOUT)]
+    Login(LoginArgs),
+
+    /// Drop the local credential, and optionally revoke it at the control
+    /// plane.
+    #[command(long_about = LOGOUT_LONG_ABOUT)]
+    Logout(LogoutArgs),
 
     /// Run ad-hoc SQL against the server and print the result.
     Query {
@@ -165,8 +200,31 @@ async fn main() -> ExitCode {
 /// succeeding. Handling it here rather than short-circuiting in `main` keeps
 /// one dispatch point and leaves no structurally unreachable arm behind.
 async fn dispatch(cli: Cli) -> anyhow::Result<()> {
-    if let Commands::Config { cmd } = cli.command {
-        return commands::config::run(cmd, cli.context);
+    // These three edit the very file resolution reads, so they run BEFORE it:
+    // `login` writes a context that does not exist yet, and `logout` must work
+    // on a context whose credential has already expired.
+    match cli.command {
+        Commands::Config { cmd } => return commands::config::run(cmd, cli.context),
+        Commands::Login(args) => {
+            // Refused rather than ignored: `login` mints the credential, so a
+            // `--token` here is a misunderstanding worth naming, and silently
+            // dropping a flag someone typed is how they conclude it worked.
+            if cli.token.is_some() {
+                anyhow::bail!(
+                    "--token is not accepted by 'login': login mints the credential. To store one by hand, use 'skardi config set-context <name> --token-stdin'"
+                );
+            }
+            return commands::login::run(args, cli.context, cli.server).await;
+        }
+        Commands::Logout(args) => {
+            if cli.token.is_some() || cli.server.is_some() {
+                anyhow::bail!(
+                    "--server and --token are not accepted by 'logout': it reads the credential it removes from ~/.skardi/config.yaml"
+                );
+            }
+            return commands::logout::run(args, cli.context).await;
+        }
+        _ => {}
     }
 
     let config = ClientConfig::resolve(cli.server, cli.token, cli.context)?;
@@ -209,7 +267,7 @@ async fn dispatch(cli: Cli) -> anyhow::Result<()> {
         Commands::Health { name } => commands::health::run(&client, name.as_deref()).await,
 
         // Returned above, before resolution.
-        Commands::Config { .. } => Ok(()),
+        Commands::Config { .. } | Commands::Login(_) | Commands::Logout(_) => Ok(()),
     };
 
     outcome.map_err(|err| cloud::diagnose(err, capability, &config))
@@ -226,6 +284,7 @@ fn capability_of(command: &Commands) -> Option<Capability> {
         Commands::Pipeline { .. } => Some(Capability::Pipeline),
         Commands::Job { .. } => Some(Capability::Job),
         Commands::Health { .. } => Some(Capability::Health),
-        Commands::Config { .. } => None,
+        // Local, and returned before resolution: no capability to gate.
+        Commands::Config { .. } | Commands::Login(_) | Commands::Logout(_) => None,
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -8,6 +8,7 @@
 use clap::error::ErrorKind;
 use clap::{Parser, Subcommand};
 use client::{ApiClient, ApiError};
+use cloud::Capability;
 use commands::config::ConfigCmd;
 use commands::jobs::JobCmd;
 use commands::pipeline::PipelineCmd;
@@ -16,6 +17,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 mod client;
+mod cloud;
 mod commands;
 mod config;
 mod output;
@@ -168,9 +170,21 @@ async fn dispatch(cli: Cli) -> anyhow::Result<()> {
     }
 
     let config = ClientConfig::resolve(cli.server, cli.token, cli.context)?;
+    let capability = match capability_of(&cli.command) {
+        Some(capability) => capability,
+        // Unreachable: `Config` is the only capability-less command and it
+        // returned above. Refusing beats defaulting — a remote command added
+        // without an entry must fail loudly rather than quietly skip the
+        // cloud gating in `cloud::ensure_available`.
+        None => anyhow::bail!("internal error: command has no capability entry"),
+    };
+    // Both checks precede `ApiClient::new`, so a gated command and an expired
+    // credential issue no request at all (§8).
+    cloud::ensure_available(capability, &config)?;
+    cloud::ensure_credential_fresh(&config, chrono::Utc::now())?;
     let client = ApiClient::new(&config)?;
 
-    match cli.command {
+    let outcome = match cli.command {
         Commands::Query {
             sql,
             file,
@@ -196,5 +210,22 @@ async fn dispatch(cli: Cli) -> anyhow::Result<()> {
 
         // Returned above, before resolution.
         Commands::Config { .. } => Ok(()),
+    };
+
+    outcome.map_err(|err| cloud::diagnose(err, capability, &config))
+}
+
+/// The [`Capability`] a command exercises, or `None` for the purely local
+/// `config` command. Kept as one table so gating and the route-specific error
+/// mapping cannot disagree about what a command is.
+fn capability_of(command: &Commands) -> Option<Capability> {
+    match command {
+        Commands::Query { .. } => Some(Capability::Query),
+        Commands::Schema => Some(Capability::Schema),
+        Commands::Run { .. } => Some(Capability::Run),
+        Commands::Pipeline { .. } => Some(Capability::Pipeline),
+        Commands::Job { .. } => Some(Capability::Job),
+        Commands::Health { .. } => Some(Capability::Health),
+        Commands::Config { .. } => None,
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -288,3 +288,99 @@ fn capability_of(command: &Commands) -> Option<Capability> {
         Commands::Config { .. } | Commands::Login(_) | Commands::Logout(_) => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{Capability, Commands, capability_of};
+    use clap::Parser as _;
+
+    /// The table gating and the route-specific error mapping both read. A
+    /// remote command with no entry would silently skip cloud gating, so the
+    /// pairing is asserted rather than assumed.
+    #[test]
+    fn every_remote_command_names_its_capability() {
+        let cases: Vec<(&[&str], Capability)> = vec![
+            (&["skardi", "query", "-e", "select 1"], Capability::Query),
+            (&["skardi", "schema"], Capability::Schema),
+            (&["skardi", "run", "a-pipeline"], Capability::Run),
+            (&["skardi", "pipeline", "list"], Capability::Pipeline),
+            (&["skardi", "job", "list"], Capability::Job),
+            (&["skardi", "health"], Capability::Health),
+        ];
+        for (argv, expected) in cases {
+            let cli = super::Cli::try_parse_from(argv).expect("parses");
+            assert_eq!(
+                capability_of(&cli.command),
+                Some(expected),
+                "argv: {argv:?}"
+            );
+        }
+    }
+
+    /// The three local commands have no capability: they are answered before
+    /// resolution, so there is nothing to gate.
+    #[test]
+    fn the_local_commands_have_no_capability() {
+        for argv in [
+            vec!["skardi", "config", "get-contexts"],
+            vec!["skardi", "login"],
+            vec!["skardi", "logout"],
+        ] {
+            let cli = super::Cli::try_parse_from(&argv).expect("parses");
+            assert_eq!(capability_of(&cli.command), None, "argv: {argv:?}");
+        }
+    }
+
+    /// `--help` and `--version` exit 0 through `main`'s own arm; a usage error
+    /// must exit 1, because 2 is reserved for "cannot reach the server".
+    #[test]
+    fn clap_failures_are_classified_by_kind() {
+        use clap::error::ErrorKind;
+        assert_eq!(
+            super::Cli::try_parse_from(["skardi", "--help"])
+                .unwrap_err()
+                .kind(),
+            ErrorKind::DisplayHelp
+        );
+        assert_eq!(
+            super::Cli::try_parse_from(["skardi", "--version"])
+                .unwrap_err()
+                .kind(),
+            ErrorKind::DisplayVersion
+        );
+        assert!(super::Cli::try_parse_from(["skardi", "not-a-command"]).is_err());
+        // Mutually exclusive selection flags are refused by clap, not by the
+        // flow, so a wrong pair never reaches a mint.
+        assert!(
+            super::Cli::try_parse_from([
+                "skardi",
+                "login",
+                "--workspace",
+                "one",
+                "--all-workspaces"
+            ])
+            .is_err()
+        );
+    }
+
+    /// `Commands` is matched exhaustively in two places; this fails to compile
+    /// if a variant is added without visiting both.
+    #[test]
+    fn the_command_set_is_covered_exhaustively() {
+        fn assert_total(command: &Commands) -> bool {
+            match command {
+                Commands::Config { .. }
+                | Commands::Login(_)
+                | Commands::Logout(_)
+                | Commands::Query { .. }
+                | Commands::Run { .. }
+                | Commands::Pipeline { .. }
+                | Commands::Job { .. }
+                | Commands::Schema
+                | Commands::Health { .. } => true,
+            }
+        }
+        let cli = super::Cli::try_parse_from(["skardi", "schema"]).unwrap();
+        assert!(assert_total(&cli.command));
+    }
+}

--- a/crates/cli/tests/cloud_gating.rs
+++ b/crates/cli/tests/cloud_gating.rs
@@ -1,0 +1,176 @@
+//! §8 end to end: what a `mode: cloud` context refuses, and what it sends.
+//!
+//! Driving the REAL binary against a mock gateway is the only way to assert
+//! the half of the contract that is about ABSENCE — a gated command and an
+//! expired credential must issue no request at all, and only a process with a
+//! server in front of it can demonstrate that. The message wording and the
+//! (capability, mode) matrix are unit-tested in `cloud.rs`; these are the
+//! wiring tests.
+
+#![cfg(unix)]
+
+use std::path::Path;
+use std::process::{Command, Output};
+use tempfile::TempDir;
+use wiremock::matchers::{method, path as path_matcher};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn skardi(home: &Path, args: &[&str]) -> Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_skardi"));
+    cmd.env("HOME", home)
+        .env_remove("SKARDI_SERVER_URL")
+        .env_remove("SKARDI_API_TOKEN")
+        .env_remove("SKARDI_CONTEXT")
+        .args(args);
+    cmd.output().expect("spawn skardi")
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).to_string()
+}
+
+/// Write a single cloud context pointing at `server`, at mode 0600 so the
+/// binary's loose-permission warning stays out of the assertions.
+fn write_cloud_context(home: &Path, server: &str, token_expires_at: Option<&str>) {
+    use std::os::unix::fs::PermissionsExt as _;
+    let dir = home.join(".skardi");
+    std::fs::create_dir_all(&dir).unwrap();
+    let expiry = match token_expires_at {
+        Some(stamp) => format!("    token-expires-at: {stamp}\n"),
+        None => String::new(),
+    };
+    let path = dir.join("config.yaml");
+    std::fs::write(
+        &path,
+        format!(
+            "current-context: acme/prod\n\
+             contexts:\n\
+             \x20 - name: acme/prod\n\
+             \x20   mode: cloud\n\
+             \x20   server: {server}\n\
+             \x20   workspace: acme-prod\n\
+             \x20   token: pat-value\n\
+             {expiry}"
+        ),
+    )
+    .unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+}
+
+#[tokio::test]
+async fn a_gated_command_refuses_before_issuing_any_request() {
+    let gateway = MockServer::start().await;
+    // A catch-all that would answer anything: if the CLI dialed at all, the
+    // request would be recorded below.
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+        .mount(&gateway)
+        .await;
+
+    let home = TempDir::new().unwrap();
+    write_cloud_context(home.path(), &gateway.uri(), None);
+
+    let out = skardi(home.path(), &["job", "list"]);
+
+    assert_eq!(out.status.code(), Some(1), "{}", stderr(&out));
+    assert!(
+        stderr(&out).contains(
+            "'job' is not available in a cloud context (acme/prod). Available: query, schema."
+        ),
+        "stderr was: {}",
+        stderr(&out)
+    );
+    assert!(
+        gateway.received_requests().await.unwrap().is_empty(),
+        "a gated command must not reach the gateway"
+    );
+}
+
+#[tokio::test]
+async fn an_expired_credential_refuses_before_issuing_any_request() {
+    let gateway = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"rows": []})))
+        .mount(&gateway)
+        .await;
+
+    let home = TempDir::new().unwrap();
+    write_cloud_context(home.path(), &gateway.uri(), Some("2020-01-01T00:00:00Z"));
+
+    let out = skardi(home.path(), &["query", "-e", "select 1"]);
+
+    assert_eq!(out.status.code(), Some(1), "{}", stderr(&out));
+    assert!(
+        stderr(&out).contains("expired at 2020-01-01T00:00:00Z. Run 'skardi login'."),
+        "stderr was: {}",
+        stderr(&out)
+    );
+    assert!(
+        gateway.received_requests().await.unwrap().is_empty(),
+        "an expired credential must not spend a round trip"
+    );
+}
+
+#[tokio::test]
+async fn an_allowed_command_names_its_workspace_to_the_gateway() {
+    let gateway = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path_matcher("/query"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "success": true,
+            "columns": ["n"],
+            "rows": [[1]],
+            "row_count": 1,
+        })))
+        .expect(1)
+        .mount(&gateway)
+        .await;
+
+    let home = TempDir::new().unwrap();
+    write_cloud_context(home.path(), &gateway.uri(), None);
+
+    let out = skardi(home.path(), &["query", "-e", "select 1"]);
+    assert!(out.status.success(), "{}", stderr(&out));
+
+    let requests = gateway.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].headers.get("Skardi-Workspace").unwrap(),
+        "acme-prod"
+    );
+    assert_eq!(
+        requests[0].headers.get("Authorization").unwrap(),
+        "Bearer pat-value"
+    );
+}
+
+/// The gateway's 401 must not send a cloud user to `SKARDI_API_TOKEN`, which
+/// resolution refuses for a cloud context.
+#[tokio::test]
+async fn a_rejected_credential_points_at_login_not_at_the_env_var() {
+    let gateway = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path_matcher("/query"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+            "success": false,
+            "error": "invalid token",
+            "error_type": "unauthorized",
+        })))
+        .mount(&gateway)
+        .await;
+
+    let home = TempDir::new().unwrap();
+    write_cloud_context(home.path(), &gateway.uri(), None);
+
+    let out = skardi(home.path(), &["query", "-e", "select 1"]);
+    let stderr = stderr(&out);
+
+    assert_eq!(out.status.code(), Some(1), "{stderr}");
+    assert!(
+        stderr.contains(
+            "credential for context 'acme/prod' was rejected — it may be expired or revoked. Run 'skardi login'."
+        ),
+        "stderr was: {stderr}"
+    );
+    assert!(!stderr.contains("SKARDI_API_TOKEN"), "stderr was: {stderr}");
+}

--- a/crates/cli/tests/login_e2e.rs
+++ b/crates/cli/tests/login_e2e.rs
@@ -182,6 +182,46 @@ fn the_dev_identity_path_refuses_a_remote_control_plane() {
     assert!(!config_path(home.path()).exists());
 }
 
+/// The control-plane leg carries the ID token up and the raw PAT back, so a
+/// plain-http non-loopback control plane is warned about — before the browser
+/// opens, and on `logout --revoke` too. A warning rather than a refusal, as
+/// with `ApiClient`: TLS may terminate at a proxy the CLI cannot see.
+#[test]
+fn a_cleartext_control_plane_is_warned_about_before_anything_is_sent() {
+    let home = TempDir::new().unwrap();
+    // `--identity` against a non-loopback host is refused, which is what makes
+    // this fast: the warning is printed during resolution, before the refusal.
+    let output = skardi(
+        home.path(),
+        &[
+            "login",
+            "--control-plane",
+            "http://global.example.com",
+            "--identity",
+            "dev:alice",
+        ],
+    );
+    let stderr = err(&output);
+
+    assert!(
+        stderr.contains("plain http to a non-loopback host"),
+        "stderr was: {stderr}"
+    );
+    assert!(stderr.contains("in the clear"), "stderr was: {stderr}");
+    // Loopback and https are silent.
+    for quiet in ["http://127.0.0.1:1", "https://global.example.com"] {
+        let output = skardi(
+            home.path(),
+            &["login", "--control-plane", quiet, "--identity", "dev:alice"],
+        );
+        assert!(
+            !err(&output).contains("plain http"),
+            "{quiet} should not warn: {}",
+            err(&output)
+        );
+    }
+}
+
 /// With no `--control-plane`, no environment, and no `control-plane:` in the
 /// file, the failure names all three rather than dialing a guess.
 #[test]

--- a/crates/cli/tests/login_e2e.rs
+++ b/crates/cli/tests/login_e2e.rs
@@ -1,0 +1,225 @@
+//! `login` → `query` → `logout` through the REAL binary, against a mock
+//! control plane and a mock gateway.
+//!
+//! This is the automated form of M2's acceptance check ("smoke-tested on the
+//! preview compose via `--identity`): the flow under test is the real one
+//! minus the browser, and what it proves is the handoff the unit tests cannot
+//! — that a context `login` wrote is one `query` then resolves, sends the
+//! workspace selector for, and `logout` can undo.
+
+#![cfg(unix)]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn skardi(home: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_skardi"))
+        .env("HOME", home)
+        .env_remove("SKARDI_SERVER_URL")
+        .env_remove("SKARDI_API_TOKEN")
+        .env_remove("SKARDI_CONTEXT")
+        .env_remove("SKARDI_CONTROL_PLANE_URL")
+        .env_remove("SKARDI_GATEWAY_URL")
+        .env_remove("SKARDI_OAUTH_CLIENT_ID")
+        .env_remove("SKARDI_DEV_IDENTITY")
+        .args(args)
+        .output()
+        .expect("spawn skardi")
+}
+
+fn out(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+fn err(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).to_string()
+}
+
+fn config_path(home: &Path) -> PathBuf {
+    home.join(".skardi").join("config.yaml")
+}
+
+fn mode_of(path: &Path) -> u32 {
+    use std::os::unix::fs::PermissionsExt as _;
+    std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+}
+
+#[tokio::test]
+async fn login_writes_a_context_that_query_then_uses_and_logout_clears() {
+    let gateway = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/query"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "success": true,
+            "columns": ["n"],
+            "rows": [[1]],
+            "row_count": 1,
+        })))
+        .mount(&gateway)
+        .await;
+
+    let control_plane = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/me/workspaces"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "workspaces": [{
+                "org_slug": "acme",
+                "tenant_slug": "acme-prod",
+                "display_name": "Production",
+                "role": "admin",
+                "provisioning_state": "active",
+                "gateway_url": gateway.uri(),
+            }],
+        })))
+        .mount(&control_plane)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v1/me/tokens"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "token": "skardi_pat_e2e",
+            "pat": {"token_id": "tok-e2e", "expires_at": "2026-11-22T12:00:00Z"},
+        })))
+        .mount(&control_plane)
+        .await;
+
+    let home = TempDir::new().unwrap();
+    let home = home.path();
+
+    // 1. login, with the dev acquirer against a loopback control plane.
+    let login = skardi(
+        home,
+        &[
+            "login",
+            "--control-plane",
+            &control_plane.uri(),
+            "--identity",
+            "dev:alice",
+        ],
+    );
+    assert!(login.status.success(), "{}", err(&login));
+    assert!(
+        out(&login).contains(&format!("wrote context acme/acme-prod → {}", gateway.uri())),
+        "stdout was: {}",
+        out(&login)
+    );
+    assert!(out(&login).contains("current context is now acme/acme-prod"));
+    assert!(out(&login).contains("workspace acme-prod, role admin"));
+    // The dev path announces itself, every run, naming what it authenticated
+    // against.
+    assert!(
+        err(&login).contains("warning: authenticating with a dev-auth identity"),
+        "stderr was: {}",
+        err(&login)
+    );
+    // The raw PAT is never printed, on either stream.
+    assert!(!out(&login).contains("skardi_pat_e2e"));
+    assert!(!err(&login).contains("skardi_pat_e2e"));
+    assert_eq!(mode_of(&config_path(home)), 0o600);
+
+    // 2. query, with no flags at all: the context login wrote is the one
+    //    resolution picks, and it carries the selector.
+    let query = skardi(home, &["query", "-e", "select 1"]);
+    assert!(query.status.success(), "{}", err(&query));
+    let probes = gateway.received_requests().await.unwrap();
+    // One from login's verification probe, one from the query.
+    assert_eq!(probes.len(), 2);
+    for request in &probes {
+        assert_eq!(
+            request.headers.get("Skardi-Workspace").unwrap(),
+            "acme-prod"
+        );
+        assert_eq!(
+            request.headers.get("Authorization").unwrap(),
+            "Bearer skardi_pat_e2e"
+        );
+    }
+
+    // 3. a gated command is still refused, in a context that now really works.
+    let jobs = skardi(home, &["job", "list"]);
+    assert_eq!(jobs.status.code(), Some(1));
+    assert!(err(&jobs).contains("not available in a cloud context (acme/acme-prod)"));
+
+    // 4. logout drops the credential and is explicit that the PAT lives on.
+    let logout = skardi(home, &["logout"]);
+    assert!(logout.status.success(), "{}", err(&logout));
+    assert!(out(&logout).contains("cleared the credential in context acme/acme-prod"));
+    assert!(
+        out(&logout).contains("stays VALID"),
+        "stdout was: {}",
+        out(&logout)
+    );
+    let written = std::fs::read_to_string(config_path(home)).unwrap();
+    assert!(!written.contains("skardi_pat_e2e"), "{written}");
+    assert!(written.contains("workspace: acme-prod"), "{written}");
+}
+
+/// `--identity` against a non-loopback control plane is refused before any
+/// request, so a dev bearer cannot be presented to a shared cluster by
+/// accident.
+#[test]
+fn the_dev_identity_path_refuses_a_remote_control_plane() {
+    let home = TempDir::new().unwrap();
+    let output = skardi(
+        home.path(),
+        &[
+            "login",
+            "--control-plane",
+            "https://global.example.com",
+            "--identity",
+            "dev:alice",
+        ],
+    );
+
+    assert_eq!(output.status.code(), Some(1), "{}", err(&output));
+    assert!(
+        err(&output).contains("--i-know-this-is-dev-auth"),
+        "stderr was: {}",
+        err(&output)
+    );
+    assert!(!config_path(home.path()).exists());
+}
+
+/// With no `--control-plane`, no environment, and no `control-plane:` in the
+/// file, the failure names all three rather than dialing a guess.
+#[test]
+fn no_control_plane_anywhere_names_the_three_inputs() {
+    let home = TempDir::new().unwrap();
+    let output = skardi(home.path(), &["login"]);
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = err(&output);
+    assert!(stderr.contains("--control-plane"), "{stderr}");
+    assert!(stderr.contains("SKARDI_CONTROL_PLANE_URL"), "{stderr}");
+    assert!(stderr.contains("control-plane:"), "{stderr}");
+}
+
+/// The global `--token`/`--server` flags mean nothing to these two commands,
+/// and a typed flag that is silently dropped reads as one that worked.
+#[test]
+fn flags_these_commands_cannot_honour_are_refused_by_name() {
+    let home = TempDir::new().unwrap();
+    let home = home.path();
+
+    let login = skardi(home, &["--token", "skardi_pat_x", "login"]);
+    assert_eq!(login.status.code(), Some(1));
+    assert!(
+        err(&login).contains("--token is not accepted by 'login'"),
+        "stderr was: {}",
+        err(&login)
+    );
+
+    for flag in [["--server", "http://127.0.0.1:9"], ["--token", "t"]] {
+        let logout = skardi(home, &[flag[0], flag[1], "logout"]);
+        assert_eq!(logout.status.code(), Some(1));
+        assert!(
+            err(&logout).contains("not accepted by 'logout'"),
+            "stderr was: {}",
+            err(&logout)
+        );
+    }
+    // Refused before anything is read or written.
+    assert!(!config_path(home).exists());
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -193,7 +193,9 @@ plane is recorded in the config file and later runs need no flag for it.
 What it does, in order:
 
 1. Resolves the control plane, as above. With none of the three sources, it
-   stops and says so rather than guessing a host.
+   stops and says so rather than guessing a host. A plain-`http://`
+   non-loopback control plane is warned about here, before the browser opens:
+   this leg carries the sign-in assertion up and the minted credential back.
 2. Opens a browser against the identity provider, with PKCE (S256) and a
    `state` nonce, redirecting to a single-use listener on `127.0.0.1:<random
    port>`. It waits 120 seconds, then gives up and releases the port. A
@@ -257,7 +259,7 @@ available in v1: `login` prints the organizations and the way round it
 ### Signing out
 
 ```bash
-# Clear the current context's credential
+# Clear the current context's credential (cloud contexts only)
 skardi logout
 
 # Clear every cloud context's credential
@@ -272,6 +274,11 @@ Plain `logout` is a local edit: the credential leaves this machine but stays
 itself, so `--revoke` signs in again to call the control plane. The context
 itself (server, workspace, mode) is kept either way, so a later `login`
 refills it; removing the context entirely is `skardi config delete-context`.
+
+`logout` only touches **cloud** contexts — the ones `login` can mint again. A
+server-mode context's token was configured by hand and nothing can restore it,
+so clearing it is refused, with a pointer at `config delete-context` (or
+editing the file); `--all` skips those for the same reason.
 
 The local delete happens first, so an unreachable control plane still gets the
 credential off the machine. That means the token id — which lives only in the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -237,7 +237,7 @@ For a loopback control plane (a local or compose stack), `--identity` skips the
 browser entirely — see [Working against a local stack](#working-against-a-local-stack).
 
 The gateway URL comes from `--server` > `$SKARDI_GATEWAY_URL` > the control
-plane's answer for that org. There is deliberately no built-in default and no
+`gateway_url` on that workspace's membership. There is deliberately no built-in default and no
 fall back to `http://127.0.0.1:8080`: a context pointing at a local port
 would fail later and further from the cause.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -150,6 +150,125 @@ line is not echoed.
 When a token is resolved (from any source), every request carries
 `Authorization: Bearer <token>`.
 
+A `mode: cloud` context also sends `Skardi-Workspace: <workspace>` on every
+request. The gateway needs the workspace per request to resolve the
+credential, and the header sits deliberately outside the reserved
+`x-skardi-*` namespace, which the gateway strips from client-supplied
+headers before forwarding upstream.
+
+## Signing in to skardi-cloud — `login` / `logout`
+
+`skardi login` turns a browser sign-in into one workspace-scoped token per
+workspace and writes a context for each, so nothing is copied by hand:
+
+```bash
+# Sign in; a lone workspace is used automatically, several prompt
+skardi login --control-plane https://global.skardi.ai
+
+# Non-interactive selection
+skardi login --workspace acme-prod
+skardi login --all-workspaces
+
+# Print the sign-in URL instead of opening a browser (remote shells)
+skardi login --no-browser
+
+# Shorter-lived credential (default: 90d; `12h` also works)
+skardi login --expires 30d
+```
+
+What it does, in order:
+
+1. Resolves the control plane: `--control-plane` >
+   `$SKARDI_CONTROL_PLANE_URL` > `control-plane:` in the config file. With
+   none of the three, it stops and says so rather than guessing a host.
+2. Opens a browser against the identity provider, with PKCE (S256) and a
+   `state` nonce, redirecting to a single-use listener on `127.0.0.1:<random
+   port>`. It waits 120 seconds, then gives up and releases the port.
+3. Exchanges the code for an ID token that is **held in memory only**. No
+   refresh token is requested, and nothing the provider returns is written to
+   disk.
+4. Reads your workspaces from the control plane. Anything not yet `active` is
+   listed and skipped, with its state named.
+5. Mints one token per selected workspace, scoped to that workspace at your
+   role there — never an unscoped credential.
+6. Verifies each one with a `select 1` against the gateway it will actually
+   use. A credential that cannot answer is **not written**, and it is revoked.
+   `--no-verify` skips this.
+7. Writes one context per verified token, named `<org>/<workspace>`, points
+   `current-context` at the first, and prints a summary with no token values
+   in it.
+
+The gateway URL comes from `--server` > `$SKARDI_GATEWAY_URL` > the control
+plane's answer for that org. There is deliberately no built-in default and no
+fall back to `http://127.0.0.1:8080`: a context pointing at a local port
+would fail later and further from the cause.
+
+Minting is a **saga**. Each token commits independently at the control plane,
+so if a later mint fails — or the config write fails — every token this run
+created is revoked before the original failure is reported, and no context is
+written. If a rollback cannot complete, the surviving token ids are printed
+with a non-zero exit, because a live credential nobody knows about is worse
+than a loud failure.
+
+Running `login` again over an existing context replaces it and revokes the
+token it replaced. `--keep-old-token` retains the old one — for an agent
+that is mid-task — and says so.
+
+If your identity belongs to more than one organization, minting is not
+available in v1: `login` prints the organizations and the way round it
+(mint in the console, then `skardi config set-context … --token-stdin`).
+
+### Signing out
+
+```bash
+# Clear the current context's credential
+skardi logout
+
+# Clear every cloud context's credential
+skardi logout --all
+
+# Also revoke it at the control plane (re-authenticates first)
+skardi logout --revoke
+```
+
+Plain `logout` is a local edit: the credential leaves this machine but stays
+**valid until it expires**, and the output says so. A token cannot revoke
+itself, so `--revoke` signs in again to call the control plane. The context
+itself (server, workspace, mode) is kept either way, so a later `login`
+refills it; removing the context entirely is `skardi config delete-context`.
+
+### What a cloud context cannot do
+
+A skardi-cloud gateway serves `query` and `schema`. `run`, `pipeline`, `job`,
+and `health` are engine-local surfaces it does not mount, so they fail
+immediately, naming the context, with no request issued:
+
+```
+error: 'job' is not available in a cloud context (acme/acme-prod). Available: query, schema.
+```
+
+Two credential failures are reported in the context's own terms rather than
+the transport's: a rejected token points at `skardi login` (not at
+`SKARDI_API_TOKEN`, which a cloud context refuses anyway), and a
+`token-expires-at` already in the past is reported without spending a round
+trip.
+
+### Working against a local stack
+
+A control plane in dev mode accepts an unverified identity claim instead of a
+signed sign-in, which is how the flow is tested without a browser:
+
+```bash
+skardi login --control-plane http://localhost:18090 --identity dev:alice
+```
+
+This is refused unless the control plane is a **loopback** address — not
+"loopback or private", because a shared internal staging cluster lives on an
+RFC1918 address and a `dev:` bearer there is impersonation. A remote dev box
+needs `--i-know-this-is-dev-auth`, so the decision is visible in the command
+that made it. Every run prints a warning naming what it authenticated
+against.
+
 ## Ad-hoc SQL — `query`
 
 `skardi query` sends one SQL statement to `POST /query` on the server and

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -163,7 +163,13 @@ workspace and writes a context for each, so nothing is copied by hand:
 
 ```bash
 # Sign in; a lone workspace is used automatically, several prompt
-skardi login --control-plane https://global.skardi.ai
+skardi login --control-plane https://global.skardi.ai \
+  --client-id <your-deployment's-oauth-client-id>
+
+# With both pinned in the environment, the flags go away
+export SKARDI_CONTROL_PLANE_URL=https://global.skardi.ai
+export SKARDI_OAUTH_CLIENT_ID=<client-id>
+skardi login
 
 # Non-interactive selection
 skardi login --workspace acme-prod
@@ -176,11 +182,18 @@ skardi login --no-browser
 skardi login --expires 30d
 ```
 
+Two inputs have no built-in default, and both fail by name rather than
+guessing: the **control plane** (`--control-plane` >
+`$SKARDI_CONTROL_PLANE_URL` > `control-plane:` in the config file) and the
+**OAuth client id** (`--client-id` > `$SKARDI_OAUTH_CLIENT_ID`). The client id
+is per deployment — it is the same value the deployment gives its console — so
+there is nothing correct to hardcode. Once a `login` succeeds, the control
+plane is recorded in the config file and later runs need no flag for it.
+
 What it does, in order:
 
-1. Resolves the control plane: `--control-plane` >
-   `$SKARDI_CONTROL_PLANE_URL` > `control-plane:` in the config file. With
-   none of the three, it stops and says so rather than guessing a host.
+1. Resolves the control plane, as above. With none of the three sources, it
+   stops and says so rather than guessing a host.
 2. Opens a browser against the identity provider, with PKCE (S256) and a
    `state` nonce, redirecting to a single-use listener on `127.0.0.1:<random
    port>`. It waits 120 seconds, then gives up and releases the port.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -175,7 +175,7 @@ skardi login
 skardi login --workspace acme-prod
 skardi login --all-workspaces
 
-# Print the sign-in URL instead of opening a browser (remote shells)
+# Print the sign-in URL instead of opening a browser
 skardi login --no-browser
 
 # Shorter-lived credential (default: 90d; `12h` also works)
@@ -196,7 +196,10 @@ What it does, in order:
    stops and says so rather than guessing a host.
 2. Opens a browser against the identity provider, with PKCE (S256) and a
    `state` nonce, redirecting to a single-use listener on `127.0.0.1:<random
-   port>`. It waits 120 seconds, then gives up and releases the port.
+   port>`. It waits 120 seconds, then gives up and releases the port. A
+   response carrying a `state` this run did not issue is answered and ignored
+   rather than ending the wait, so nothing else that can reach the port can
+   interrupt a sign-in.
 3. Exchanges the code for an ID token that is **held in memory only**. No
    refresh token is requested, and nothing the provider returns is written to
    disk.
@@ -212,6 +215,24 @@ What it does, in order:
 7. Writes one context per verified token, named `<org>/<workspace>`, points
    `current-context` at the first, and prints a summary with no token values
    in it.
+
+### `--no-browser` and remote shells
+
+`--no-browser` prints the URL instead of launching a browser, for a host that
+has none or none the CLI can start. It does **not** on its own make `login`
+work over SSH: the redirect goes to `127.0.0.1:<port>` on the machine running
+`skardi`, so opening that URL on your laptop sends the callback to your
+laptop's port, where nothing is listening.
+
+To sign in against a remote host, the browser must reach that host's loopback
+port. Either run a browser there, or forward the port the printed URL names —
+it is fresh per run, so with OpenSSH add the forward mid-session (`~C` then
+`-L <port>:127.0.0.1:<port>`), or use `ssh -L` on a connection opened after
+the URL is shown. A headless flow needing no local listener is the device-code
+grant, which is deliberately out of scope for this milestone.
+
+For a loopback control plane (a local or compose stack), `--identity` skips the
+browser entirely — see [Working against a local stack](#working-against-a-local-stack).
 
 The gateway URL comes from `--server` > `$SKARDI_GATEWAY_URL` > the control
 plane's answer for that org. There is deliberately no built-in default and no

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -206,7 +206,9 @@ What it does, in order:
    role there — never an unscoped credential.
 6. Verifies each one with a `select 1` against the gateway it will actually
    use. A credential that cannot answer is **not written**, and it is revoked.
-   `--no-verify` skips this.
+   The probe is bounded (30s), so a gateway that accepts the connection and
+   then goes quiet cannot strand a freshly minted token. `--no-verify` skips
+   this.
 7. Writes one context per verified token, named `<org>/<workspace>`, points
    `current-context` at the first, and prints a summary with no token values
    in it.
@@ -249,6 +251,13 @@ Plain `logout` is a local edit: the credential leaves this machine but stays
 itself, so `--revoke` signs in again to call the control plane. The context
 itself (server, workspace, mode) is kept either way, so a later `login`
 refills it; removing the context entirely is `skardi config delete-context`.
+
+The local delete happens first, so an unreachable control plane still gets the
+credential off the machine. That means the token id — which lives only in the
+config file — is gone by the time a revocation can fail, so **every failure
+after that point prints the ids it could not revoke**, with the context each
+came from, for the console. A context written by `config set-context` has no
+recorded id at all, and `--revoke` names it rather than skipping it quietly.
 
 ### What a cloud context cannot do
 


### PR DESCRIPTION
Milestone 2 of `docs/superpowers/specs/2026-08-20-skardi-cli-contexts-and-login-design.md`
(the design lives in skardi-cloud; §11 assigns M1 and M2 to this repo).
Stacked on #224, now rebased onto `main`.

M2's scope, per §11: `login`/`logout` including the §6.5 saga, §6.2's URL
precedence, §6.3's `--identity` dev path, the `Skardi-Workspace` header,
capability gating and §8's error messages.

## What shipped, per module

### `client.rs` — the workspace selector, and a header bug it exposed

A `mode: cloud` context now sends `Skardi-Workspace: <slug>` on every request
(§7.3), keyed off `mode` rather than off the field being populated, so a stray
`workspace:` on a server-mode context cannot start selecting anything. It sits
outside the reserved `x-skardi-*` prefix deliberately: #288's invariant strips
client-supplied headers in that namespace before the gateway forwards
upstream, so a selector wearing it would be silently dropped.

Writing it surfaced a real defect in the existing client.
`RequestBuilder::header` **appends**, so a per-call header of the same name
produced *two* values on the wire and left the choice to the peer's parser.
For an authorization-relevant selector that is a spoofing surface, and the
same was already true of `Authorization`. Both names are now `insert`ed on a
built `Request`, and both values are built once in `ApiClient::new` — so an
unsendable token is a config error with one clear message instead of a failure
at every request, and the bearer is marked sensitive as `bearer_auth` did.
Pinned by a test that passes a forged pair through `post_with_headers` and
asserts exactly one value of each, with the client's own winning.

### `cloud.rs` (new) — §8, as pure functions

Three cloud-only behaviours, all pre/post-processing around an unchanged
request path (`mode` never selects a URL):

- **Capability gating.** The gateway mounts `query` and `schema`; `run`,
  `pipeline`, `job`, and `health` refuse before a request is built, because a
  404 from a route that was never served reads as a broken server rather than
  as a context that cannot do that. The "Available:" list is derived from the
  same table the gate reads, so the two cannot drift.
- **Credential expiry**, checked against `token-expires-at` with no round
  trip. An unparsable stamp is deliberately not fatal: it is an optional field
  in a hand-editable file, and refusing every command over a malformed
  annotation is worse than one authoritative request. Comparison is by
  instant, not by text, so a legal non-UTC offset resolves correctly.
- **Error translation.** 401 is *replaced* — the transport message's advice
  (set `SKARDI_API_TOKEN`) is refused by resolution for a cloud context and
  actively misleads. A workspace-boundary 403 is *annotated*, keeping the
  gateway's own sentence, which is what distinguishes "not a member" from "no
  matching workspace"; `identity_required` and `identity_unresolved` also
  mention "workspace" and are excluded by `error_type`, so a message-only rule
  cannot misclassify them. A 503 is the schema-read limiter only **with**
  `Retry-After` and only on `schema` — `ApiError::Http` now carries
  `retry_after` for exactly that distinction.

### `login/` (new) — §6

- `pkce.rs` — S256 and the `state` nonce, both straight from the OS CSPRNG.
- `loopback.rs` — a single-use listener on `127.0.0.1:0`, never `0.0.0.0` and
  never a fixed port. Single-use is about the *callback*: a favicon or a port
  probe gets a 404 and the wait continues (bounded), so it cannot consume the
  one authorization response. The page never echoes a query value.
- `oauth.rs` — authorization URL, `state` check *before* the code is read,
  code exchange. The ID token is held in memory only; no refresh token is
  requested and nothing the provider returns is written to disk (§9.1). Both
  endpoint URLs and the browser opener are parameters with production
  defaults, which is what makes the whole path testable.
- `control_plane.rs` — `GET /v1/me/workspaces`, `POST /v1/me/tokens`,
  `DELETE /v1/me/tokens/{id}`. Deliberately **not** `ApiClient`: the control
  plane's error envelope is nested (`{"error": {"code", "message", …}}`) while
  the engine's is flat, the credential is an ID token rather than the PAT, and
  `org_ambiguous` carries an org list one client cannot read without guessing.
- `mod.rs` — the flow, and the saga.

### `commands/login.rs`, `commands/logout.rs` (new)

`logout` is deliberately two things. Plain, it is a local edit that says the
PAT stays **valid** until it expires; a token cannot manage tokens, so
`--revoke` re-authenticates. The local edit happens first, so an unreachable
control plane still leaves the credential off this disk. `--all` covers cloud
contexts only: a server-mode token was configured by hand and there is no
`login` to put it back. A cleared context with no `token-id` is *named*, not
skipped — clearing it quietly would read as a revocation that happened.

## Design decisions worth reviewing

**Minting is a saga, not a loop (§6.5).** Each mint commits independently at
the control plane, so every `{token_id, workspace}` is retained in memory,
contexts are written only after all selected mints succeed, and any failure —
a later mint, a failed verification probe, the config write — revokes
everything this run created before reporting the original cause. A rollback
that cannot complete exits non-zero and prints the surviving ids, because a
live credential nobody knows about is worse than a loud failure. Control-plane
calls carry a 30s timeout for the rollback's sake specifically: a revoke that
hangs forever is a silent terminal in front of an unreported credential.

**Verification is the real path (§6.1 step 6).** The probe is a `select 1`
through the same `ApiClient` a query will use, so it carries the same
`Skardi-Workspace` header and the same bearer. A credential that cannot answer
is revoked and its context is never written — a login that reports success
while its first query would 403 is the failure this step exists to remove.

**`--identity` is loopback-only (§6.3),** not loopback-or-private: RFC1918 is
exactly where a shared internal staging cluster lives, and a `dev:` bearer
there is impersonation of any user. `--i-know-this-is-dev-auth` is the visible
opt-out, and the guard is one function shared with `logout --revoke` so the
two cannot drift. Every dev-path run warns, naming what it authenticated
against.

**Wire shapes are pinned against skardi-global's handlers, not prose:**
`{"workspaces": [MembershipView…]}` and `201 {"token": …, "pat": {"token_id":
…}}`. `gateway_url` is `Option` because §7.1 is M4's work — a control plane
that predates it omits the key, and §6.2's precedence then decides.

**The global flags mean something different here.** `--server` under `login`
is the *gateway* URL written into contexts, `--context` is the *name* to
write, and `--token` means nothing at all. Both subcommands carry long help
saying which, and the flags they cannot honour are refused by name rather than
silently dropped.

## Two deliberate deviations from the design's text

Both because the text would ship as false:

1. **§6.1 step 1 ends its chain in a "built-in default" control plane, and the
   browser path implies a built-in OAuth client id. Neither value exists.**
   The only committed control-plane URL is a commented `https://global.skardi.ai`
   example and localhost; the client id is per deployment (skardi-cloud feeds
   it from `$SKARDI_GOOGLE_CLIENT_ID`, and §7.2 makes the audience a set
   precisely so the CLI can have its own). A hostname that answers nothing
   would fail at DNS without mentioning the real inputs, so both chains end
   the way §6.2's deliberately does: a typed error naming
   `--control-plane`/`$SKARDI_CONTROL_PLANE_URL`/`control-plane:` and
   `--client-id`/`$SKARDI_OAUTH_CLIENT_ID`. One constant each replaces this
   when the hosted values exist.
2. **Wording.** The refusal names `'job'`, the subcommand this CLI has (§8's
   example wrote `'jobs'`), and the pre-flight expiry message states what was
   observed ("expired at \<stamp\>") instead of reusing the 401's "was
   rejected" — nothing rejected anything, and no request was sent.

## Verification

```
cargo test -p skardi-cli          # 211 passing, 2 ignored (need a live server)
cargo clippy -p skardi-cli --all-targets   # clean
cargo fmt -p skardi-cli --check             # clean
```

211 passing on this branch against 109 on `main` — **102 new tests** (94 unit,
8 integration). No new crate versions enter `Cargo.lock`: `chrono`, `sha2`,
`base64`, and `getrandom` are all already in the tree at the versions sibling
crates pin.

Coverage on the files this PR adds or touches, measured with the same tool CI
uses (`cargo llvm-cov -p skardi-cli --all-targets`): 96.87% lines overall
(from 94.80%), with `login/mod.rs` at 97.68%, `client.rs` 98.20%,
`control_plane.rs` 98.87%, `loopback.rs` 99.55%, `cloud.rs` 99.17%,
`commands/login.rs` 99.20%, `commands/logout.rs` 96.79%.

Three things stay uncovered because they are uncoverable, not untested:
`open_in_browser`'s `Command` invocation (a test would launch a real browser —
so the per-platform argv is split into `browser_command()` and tested
separately), `dispatch`'s per-command arms (they need a resolved config and a
live server; the integration tests do exercise them, but `cargo llvm-cov
nextest` does not instrument the spawned binary), and `logout --revoke`'s
browser re-authentication.

What the tests actually pin, beyond counts:

- **The saga was mutation-checked.** Disabling the rollback loop
  (`.iter().rev().take(0)`) failed exactly the four tests that assert it —
  second-mint failure revokes the first, a config-write failure revokes all, a
  failed verification revokes and writes nothing, and a failed rollback prints
  the surviving ids. A guard that cannot be shown to bite is a guard that
  quietly stops guarding.
- **The browser path is covered end to end**, with a closure standing in for
  the user agent: it reads the authorization URL as a browser would, follows
  the redirect with the `state` it was given, and the flow completes against a
  stub token endpoint. That opener is a parameter *because* of this test.
- **RFC 7636's own appendix B vector** pins S256 to the spec rather than to
  itself. A `state` mismatch is refused without the planted code appearing in
  the error. A timeout releases the port, proven by rebinding it.
- **§10's `login` list runs in-process** against a mock control plane and
  gateway, which is what makes "the first PAT was revoked" an assertion rather
  than an inference: minted scope and name, per-org gateway URLs, the full
  §6.2 precedence including the no-source error, non-`active` skips,
  `org_ambiguous`, re-login replacement, `--keep-old-token`.
- **Two integration tests assert absence** — a gated command and an expired
  credential record *zero* requests at the server, which no unit test can show.
- **One integration test drives the real binary** through login → query →
  gated refusal → logout, proving the context `login` writes is the one
  resolution then picks and sends the selector for, that the config lands at
  `0600`, and that the raw PAT appears on neither stream.

### Not machine-verified

§11's acceptance line for M2 is "smoke-tested on the preview compose via
`--identity`". The end-to-end test above is that same flow against a mock
control plane and gateway; running it against the live preview compose needs
an environment this branch cannot reach, and is the one check still owed
before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
