### PR TITLE
feat(sources): Google Drive source pack (milestone 5.9) — files, drives, file_permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ agents; deploy it next to your data, behind your usual auth.
 | InfluxDB 3 | Read | No | Time series over Arrow Flight SQL | [docs](docs/influxdb/) |
 | S3 / GCS / Azure | Read | No | CSV, Parquet, Lance in object stores | [docs](docs/S3_USAGE.md) |
 | CSV / Parquet | Read | No | Local or remote files | [docs](docs/server.md) |
-| SaaS via Open Connector | Read | Yes | GitHub, Slack, Notion, Feishu, Gmail, Discord, Outlook, OneDrive packs as stable SQL tables; pushdown + TTL cache | [docs](docs/open-connector.md) |
+| SaaS via Open Connector | Read | Yes | GitHub, Slack, Notion, Feishu, Gmail, Discord, Outlook, OneDrive, Google Drive packs as stable SQL tables; pushdown + TTL cache | [docs](docs/open-connector.md) |
 | Documents | Read | No | PDF/Office/ODF/image → per-page Markdown, tables, images | [docs](docs/documents.md) |
 | RSS / Atom | Read | Yes | Feeds as `feeds` + `items`; per-feed TTL cache, fault isolation, un-sandboxed fetch egress | [docs](docs/rss.md) |
 | Graph (Apache AGE) | Read | Yes | Read-only openCypher over Postgres; YAML views as catalog tables, `cypher_query` UDTF | [docs](docs/graph.md) |

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/google_drive/contracts/drives.list.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/google_drive/contracts/drives.list.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "drives": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of the shared drive."
+          },
+          "kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The type of the resource."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the shared drive."
+          },
+          "hidden": {
+            "type": "boolean",
+            "description": "Whether the shared drive is hidden from the default view."
+          },
+          "colorRgb": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The color of the shared drive as an RGB hex string."
+          },
+          "createdTime": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The time at which the shared drive was created (RFC 3339 date-time)."
+          },
+          "orgUnitId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The organizational unit ID of the shared drive."
+          },
+          "themeId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The ID of the theme from which the background image and color are set."
+          },
+          "backgroundImageLink": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "A short-lived link to this shared drive's background image."
+          },
+          "capabilities": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": {},
+            "description": "Capabilities the current user has on this shared drive."
+          },
+          "restrictions": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": {},
+            "description": "A set of restrictions that apply to this shared drive or items inside this shared drive."
+          }
+        },
+        "required": [
+          "id",
+          "kind",
+          "name",
+          "colorRgb",
+          "createdTime",
+          "orgUnitId",
+          "themeId",
+          "backgroundImageLink"
+        ],
+        "additionalProperties": false
+      },
+      "description": "The list of shared drives."
+    },
+    "nextPageToken": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "The page token for the next page of results, if any."
+    }
+  },
+  "required": [
+    "drives",
+    "nextPageToken"
+  ],
+  "additionalProperties": false
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/google_drive/contracts/files.list.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/google_drive/contracts/files.list.json
@@ -1,0 +1,190 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of the file."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the file."
+          },
+          "mimeType": {
+            "type": "string",
+            "description": "The MIME type of the file."
+          },
+          "webViewLink": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "A link for opening the file in a relevant Google editor or viewer in a browser."
+          },
+          "createdTime": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The time at which the file was created (RFC 3339 date-time)."
+          },
+          "modifiedTime": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The last time the file was modified by anyone (RFC 3339 date-time)."
+          },
+          "sizeBytes": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The size of the file's content in bytes."
+          },
+          "driveId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The ID of the shared drive the file belongs to."
+          },
+          "parents": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The IDs of the parent folders containing the file."
+          },
+          "owners": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "displayName": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "The display name of the owner."
+                },
+                "emailAddress": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "The email address of the owner."
+                },
+                "permissionId": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "The permission ID of the owner."
+                },
+                "photoLink": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "A link to the owner's profile photo."
+                }
+              },
+              "required": [
+                "displayName",
+                "emailAddress",
+                "permissionId",
+                "photoLink"
+              ],
+              "additionalProperties": false
+            },
+            "description": "The owners of the file."
+          },
+          "shared": {
+            "type": "boolean",
+            "description": "Whether the file has been shared."
+          },
+          "starred": {
+            "type": "boolean",
+            "description": "Whether the user has starred the file."
+          },
+          "trashed": {
+            "type": "boolean",
+            "description": "Whether the file has been trashed."
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "mimeType",
+          "webViewLink",
+          "createdTime",
+          "modifiedTime",
+          "sizeBytes",
+          "driveId"
+        ],
+        "additionalProperties": false
+      },
+      "description": "The list of files matching the search query."
+    },
+    "nextPageToken": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "The page token for the next page of results, if any."
+    }
+  },
+  "required": [
+    "files",
+    "nextPageToken"
+  ],
+  "additionalProperties": false
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/google_drive/contracts/inputs/drives.list.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/google_drive/contracts/inputs/drives.list.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "q": {
+      "type": "string",
+      "description": "A query string to filter the shared drives."
+    },
+    "pageSize": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 100,
+      "description": "The maximum number of shared drives to return per page (1–100)."
+    },
+    "pageToken": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The token for continuing a previous list request on the next page."
+    },
+    "useDomainAdminAccess": {
+      "type": "boolean",
+      "description": "Issue the request as a domain administrator."
+    }
+  },
+  "additionalProperties": false
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/google_drive/contracts/inputs/files.list.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/google_drive/contracts/inputs/files.list.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "corpora": {
+      "type": "string",
+      "description": "Bodies of items to which the query applies."
+    },
+    "corpus": {
+      "type": "string",
+      "description": "The source of files to list."
+    },
+    "driveId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "ID of the shared drive to search."
+    },
+    "includeItemsFromAllDrives": {
+      "type": "boolean",
+      "description": "Whether both My Drive and shared drive items should be included in results."
+    },
+    "includeLabels": {
+      "type": "string",
+      "description": "A comma-separated list of label IDs to include in labelInfo."
+    },
+    "includePermissionsForView": {
+      "type": "string",
+      "description": "Specifies which additional view's permissions to include in the response."
+    },
+    "orderBy": {
+      "type": "string",
+      "description": "A comma-separated list of sort keys."
+    },
+    "pageSize": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 1000,
+      "description": "The maximum number of files to return per page."
+    },
+    "pageToken": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The token for continuing a previous list request."
+    },
+    "q": {
+      "type": "string",
+      "description": "A Google Drive query string for filtering files."
+    },
+    "spaces": {
+      "type": "string",
+      "description": "A comma-separated list of spaces to query."
+    },
+    "supportsAllDrives": {
+      "type": "boolean",
+      "description": "Whether the request supports both My Drives and shared drives."
+    },
+    "teamDriveId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Deprecated Team Drive ID."
+    }
+  },
+  "additionalProperties": false
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/google_drive/contracts/inputs/permissions.list.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/google_drive/contracts/inputs/permissions.list.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "fileId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The ID of the file."
+    },
+    "fields": {
+      "type": "string",
+      "description": "The fields to include in the response."
+    },
+    "pageSize": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 100,
+      "description": "The maximum number of permissions to return per page (1–100)."
+    },
+    "pageToken": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The token for continuing a previous list request on the next page."
+    },
+    "supportsAllDrives": {
+      "type": "boolean",
+      "description": "Whether the request supports both My Drives and shared drives."
+    },
+    "useDomainAdminAccess": {
+      "type": "boolean",
+      "description": "Issue the request as a domain administrator."
+    },
+    "includePermissionsForView": {
+      "type": "string",
+      "const": "published",
+      "description": "Specifies which additional view's permissions to include in the response."
+    }
+  },
+  "additionalProperties": false
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/google_drive/contracts/permissions.list.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/google_drive/contracts/permissions.list.json
@@ -1,0 +1,199 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "permissions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of the permission."
+          },
+          "kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The type of the resource."
+          },
+          "role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The role granted by this permission (e.g. owner, writer, reader)."
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The type of grantee (user, group, domain, or anyone)."
+          },
+          "domain": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The domain to which this permission refers."
+          },
+          "deleted": {
+            "type": "boolean",
+            "description": "Whether the account associated with this permission has been deleted."
+          },
+          "photoLink": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "A link to the user's profile photo."
+          },
+          "displayName": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The display name of the user or group granted this permission."
+          },
+          "emailAddress": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The email address of the user or group granted this permission."
+          },
+          "pendingOwner": {
+            "type": "boolean",
+            "description": "Whether the account associated with this permission is a pending owner."
+          },
+          "expirationTime": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The time at which this permission will expire (RFC 3339 date-time)."
+          },
+          "allowFileDiscovery": {
+            "type": "boolean",
+            "description": "Whether the permission allows the file to be discovered through search."
+          },
+          "permissionDetails": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "role": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "The primary role for this user."
+                },
+                "inherited": {
+                  "type": "boolean",
+                  "description": "Whether this permission is inherited from a parent folder."
+                },
+                "inheritedFrom": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "The ID of the item from which this permission is inherited."
+                },
+                "permissionType": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "The permission type for this user."
+                }
+              },
+              "required": [
+                "role",
+                "inheritedFrom",
+                "permissionType"
+              ],
+              "additionalProperties": false
+            },
+            "description": "Details of whether the permission on the shared drive item is inherited or directly set."
+          }
+        },
+        "required": [
+          "id",
+          "kind",
+          "role",
+          "type",
+          "domain",
+          "photoLink",
+          "displayName",
+          "emailAddress",
+          "expirationTime"
+        ],
+        "additionalProperties": false
+      },
+      "description": "The list of permissions for the file or shared drive."
+    },
+    "nextPageToken": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "The page token for the next page of results, if any."
+    }
+  },
+  "required": [
+    "permissions",
+    "nextPageToken"
+  ],
+  "additionalProperties": false
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/google_drive/drives.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/google_drive/drives.json
@@ -1,0 +1,50 @@
+{
+  "drives": [
+    {
+      "id": "0ASyntheticDrivePVA",
+      "kind": "drive#drive",
+      "name": "example-shared-drive",
+      "hidden": false,
+      "colorRgb": "#e91e63",
+      "createdTime": "2026-08-25T12:37:02.745Z",
+      "orgUnitId": null,
+      "themeId": null,
+      "backgroundImageLink": "https://ssl.gstatic.com/team_drive_themes/clams_background.jpg",
+      "capabilities": {
+        "canAddChildren": true,
+        "canChangeCopyRequiresWriterPermissionRestriction": false,
+        "canChangeDomainUsersOnlyRestriction": false,
+        "canChangeDownloadRestriction": false,
+        "canChangeDriveBackground": true,
+        "canChangeDriveMembersOnlyRestriction": false,
+        "canChangeSharingFoldersRequiresOrganizerPermissionRestriction": false,
+        "canComment": true,
+        "canCopy": true,
+        "canDeleteChildren": true,
+        "canDeleteDrive": true,
+        "canDownload": true,
+        "canEdit": true,
+        "canListChildren": true,
+        "canManageMembers": true,
+        "canReadRevisions": true,
+        "canRename": true,
+        "canRenameDrive": true,
+        "canResetDriveRestrictions": true,
+        "canShare": true,
+        "canTrashChildren": true
+      },
+      "restrictions": {
+        "downloadRestriction": {
+          "restrictedForReaders": false,
+          "restrictedForWriters": false
+        },
+        "adminManagedRestrictions": false,
+        "copyRequiresWriterPermission": false,
+        "domainUsersOnly": false,
+        "driveMembersOnly": false,
+        "sharingFoldersRequiresOrganizerPermission": false
+      }
+    }
+  ],
+  "nextPageToken": null
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/google_drive/file_permissions.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/google_drive/file_permissions.json
@@ -1,0 +1,72 @@
+{
+  "permissions": [
+    {
+      "id": "anyoneWithLink",
+      "kind": "drive#permission",
+      "role": "reader",
+      "type": "anyone",
+      "domain": null,
+      "photoLink": null,
+      "displayName": null,
+      "emailAddress": null,
+      "expirationTime": null,
+      "allowFileDiscovery": false,
+      "permissionDetails": [
+        {
+          "role": "reader",
+          "inherited": false,
+          "inheritedFrom": null,
+          "permissionType": "file"
+        }
+      ]
+    },
+    {
+      "id": "00000000000000000002",
+      "kind": "drive#permission",
+      "role": "reader",
+      "type": "domain",
+      "domain": "example.com",
+      "photoLink": null,
+      "displayName": "Example Org",
+      "emailAddress": null,
+      "expirationTime": null,
+      "allowFileDiscovery": true,
+      "permissionDetails": [
+        {
+          "role": "reader",
+          "inherited": false,
+          "inheritedFrom": null,
+          "permissionType": "file"
+        }
+      ]
+    },
+    {
+      "id": "00000000000000000001",
+      "kind": "drive#permission",
+      "role": "owner",
+      "type": "user",
+      "domain": null,
+      "deleted": false,
+      "photoLink": "https://lh3.googleusercontent.com/a/SYNTHETIC=s64",
+      "displayName": "Example User",
+      "emailAddress": "user@example.com",
+      "pendingOwner": false,
+      "expirationTime": null,
+      "permissionDetails": [
+        {
+          "role": "writer",
+          "inherited": true,
+          "inheritedFrom": null,
+          "permissionType": "file"
+        },
+        {
+          "role": "owner",
+          "inherited": false,
+          "inheritedFrom": null,
+          "permissionType": "file"
+        }
+      ]
+    }
+  ],
+  "nextPageToken": null
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/google_drive/files.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/google_drive/files.json
@@ -1,0 +1,140 @@
+{
+  "files": [
+    {
+      "id": "1SyntheticNotesTxtBBBBBBBBBBBBBBB",
+      "name": "notes.txt",
+      "mimeType": "text/plain",
+      "webViewLink": "https://drive.google.com/file/d/1SyntheticNotesTxtBBBBBBBBBBBBBBB/view?usp=drivesdk",
+      "createdTime": "2026-08-25T12:32:32.420Z",
+      "modifiedTime": "2026-08-25T12:39:07.162Z",
+      "sizeBytes": 63,
+      "driveId": null,
+      "parents": [
+        "1SyntheticFolderAAAAAAAAAAAAAAAAA"
+      ],
+      "owners": [
+        {
+          "displayName": "Example User",
+          "emailAddress": "user@example.com",
+          "permissionId": "00000000000000000001",
+          "photoLink": "https://lh3.googleusercontent.com/a/SYNTHETIC=s64"
+        }
+      ],
+      "shared": true,
+      "starred": false,
+      "trashed": false
+    },
+    {
+      "id": "1SyntheticSharedFileEEEEEEEEEEEEE",
+      "name": "shared-drive-doc.txt",
+      "mimeType": "text/plain",
+      "webViewLink": "https://drive.google.com/file/d/1SyntheticSharedFileEEEEEEEEEEEEE/view?usp=drivesdk",
+      "createdTime": "2026-08-25T12:39:04.461Z",
+      "modifiedTime": "2026-08-25T12:39:04.461Z",
+      "sizeBytes": 27,
+      "driveId": "0ASyntheticDrivePVA",
+      "parents": [
+        "0ASyntheticDrivePVA"
+      ],
+      "starred": false,
+      "trashed": false
+    },
+    {
+      "id": "1SyntheticTrashedDDDDDDDDDDDDDDDD",
+      "name": "obsolete.txt",
+      "mimeType": "text/plain",
+      "webViewLink": "https://drive.google.com/file/d/1SyntheticTrashedDDDDDDDDDDDDDDDD/view?usp=drivesdk",
+      "createdTime": "2026-08-25T12:32:38.284Z",
+      "modifiedTime": "2026-08-25T12:32:38.284Z",
+      "sizeBytes": 14,
+      "driveId": null,
+      "parents": [
+        "0ASyntheticRootPVAA"
+      ],
+      "owners": [
+        {
+          "displayName": "Example User",
+          "emailAddress": "user@example.com",
+          "permissionId": "00000000000000000001",
+          "photoLink": "https://lh3.googleusercontent.com/a/SYNTHETIC=s64"
+        }
+      ],
+      "shared": false,
+      "starred": false,
+      "trashed": true
+    },
+    {
+      "id": "1SyntheticNativeDocFFFFFFFFFFFFFFFFFFFFFFFFF",
+      "name": "Design memo",
+      "mimeType": "application/vnd.google-apps.document",
+      "webViewLink": "https://docs.google.com/document/d/1SyntheticNativeDocFFFFFFFFFFFFFFFFFFFFFFFFF/edit?usp=drivesdk",
+      "createdTime": "2026-08-25T12:32:35.866Z",
+      "modifiedTime": "2026-08-25T12:32:36.598Z",
+      "sizeBytes": 1024,
+      "driveId": null,
+      "parents": [
+        "0ASyntheticRootPVAA"
+      ],
+      "owners": [
+        {
+          "displayName": "Example User",
+          "emailAddress": "user@example.com",
+          "permissionId": "00000000000000000001",
+          "photoLink": "https://lh3.googleusercontent.com/a/SYNTHETIC=s64"
+        }
+      ],
+      "shared": false,
+      "starred": false,
+      "trashed": false
+    },
+    {
+      "id": "1SyntheticCsvFileCCCCCCCCCCCCCCCC",
+      "name": "\u9884\u7b97\u8868.csv",
+      "mimeType": "text/csv",
+      "webViewLink": "https://drive.google.com/file/d/1SyntheticCsvFileCCCCCCCCCCCCCCCC/view?usp=drivesdk",
+      "createdTime": "2026-08-25T12:32:34.455Z",
+      "modifiedTime": "2026-08-25T12:32:34.455Z",
+      "sizeBytes": 24,
+      "driveId": null,
+      "parents": [
+        "1SyntheticFolderAAAAAAAAAAAAAAAAA"
+      ],
+      "owners": [
+        {
+          "displayName": "Example User",
+          "emailAddress": "user@example.com",
+          "permissionId": "00000000000000000001",
+          "photoLink": "https://lh3.googleusercontent.com/a/SYNTHETIC=s64"
+        }
+      ],
+      "shared": false,
+      "starred": true,
+      "trashed": false
+    },
+    {
+      "id": "1SyntheticFolderAAAAAAAAAAAAAAAAA",
+      "name": "corpus-folder",
+      "mimeType": "application/vnd.google-apps.folder",
+      "webViewLink": "https://drive.google.com/drive/folders/1SyntheticFolderAAAAAAAAAAAAAAAAA",
+      "createdTime": "2026-08-25T12:32:30.273Z",
+      "modifiedTime": "2026-08-25T12:32:30.273Z",
+      "sizeBytes": null,
+      "driveId": null,
+      "parents": [
+        "0ASyntheticRootPVAA"
+      ],
+      "owners": [
+        {
+          "displayName": "Example User",
+          "emailAddress": "user@example.com",
+          "permissionId": "00000000000000000001",
+          "photoLink": "https://lh3.googleusercontent.com/a/SYNTHETIC=s64"
+        }
+      ],
+      "shared": false,
+      "starred": false,
+      "trashed": false
+    }
+  ],
+  "nextPageToken": null
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/google_drive/files_type_mismatch.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/google_drive/files_type_mismatch.json
@@ -1,0 +1,15 @@
+{
+  "files": [
+    {
+      "id": "1SyntheticMismatchEEEEEEEEEEEEEEEEEEEEEEEEE",
+      "name": "wrong-types.bin",
+      "mimeType": "application/octet-stream",
+      "webViewLink": "https://drive.google.com/file/d/1SyntheticMismatchEEEEEEEEEEEEEEEEEEEEEEEEE/view",
+      "createdTime": "2026-07-01T09:15:00.000Z",
+      "modifiedTime": "2026-08-14T16:42:00.000Z",
+      "sizeBytes": "48213",
+      "driveId": null
+    }
+  ],
+  "nextPageToken": null
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/fixtures/google_drive/files_type_mismatch.json
+++ b/crates/skardi/src/sources/providers/open_connector/packs/fixtures/google_drive/files_type_mismatch.json
@@ -1,10 +1,10 @@
 {
   "files": [
     {
-      "id": "1SyntheticMismatchEEEEEEEEEEEEEEEEEEEEEEEEE",
+      "id": "1SyntheticMismatchEEEEEEEEEEEEEEE",
       "name": "wrong-types.bin",
       "mimeType": "application/octet-stream",
-      "webViewLink": "https://drive.google.com/file/d/1SyntheticMismatchEEEEEEEEEEEEEEEEEEEEEEEEE/view",
+      "webViewLink": "https://drive.google.com/file/d/1SyntheticMismatchEEEEEEEEEEEEEEE/view",
       "createdTime": "2026-07-01T09:15:00.000Z",
       "modifiedTime": "2026-08-14T16:42:00.000Z",
       "sizeBytes": "48213",

--- a/crates/skardi/src/sources/providers/open_connector/packs/google_drive.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/google_drive.rs
@@ -1575,6 +1575,47 @@ bindings:
     }
 
     #[tokio::test]
+    async fn drives_q_resource_forwards_verbatim() {
+        // `drives.list` has its own query language surface (`name` and
+        // `hidden`, rather than the files corpus fields). Pin the binding-to-
+        // wire path independently of `files.q`: the complete expression must
+        // survive verbatim alongside the action's page size and no other key.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return google_drive_discovery(&req.path);
+            }
+            if req.method == "POST" && req.path == "/v1/actions/googledrive.drives.list" {
+                return MockResponse::ok(&envelope_ok(
+                    &json!({"drives": [{"id": "d-1", "name": "Engineering"}],
+                            "nextPageToken": null})
+                    .to_string(),
+                ));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (gateway, ctx) = setup_with_gateway(
+            gateway,
+            "SKARDI_TEST_OC_GDRIVE_DRIVES_Q",
+            "drives",
+            "{q: \"name contains 'x'\"}",
+        )
+        .await;
+
+        let batches = collect(&ctx, "SELECT id FROM saas.gdrive.drives").await;
+        assert_eq!(column_values(&batches, "id"), vec!["d-1"]);
+
+        let inputs = execute_inputs(&gateway, "googledrive.drives.list");
+        assert_eq!(inputs.len(), 1);
+        assert_eq!(inputs[0]["q"], "name contains 'x'");
+        assert_eq!(inputs[0]["pageSize"], 100);
+        assert_eq!(input_keys(&inputs[0]), vec!["pageSize", "q"]);
+    }
+
+    #[tokio::test]
     async fn file_permissions_scan_forwards_its_required_file_id_on_every_page() {
         // The binding names the file, and the value rides EVERY request
         // including continuations — rows carry no file identity of their

--- a/crates/skardi/src/sources/providers/open_connector/packs/google_drive.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/google_drive.rs
@@ -209,13 +209,15 @@ mod tests {
         MockResponse::ok(&discovery_ok("{}", output_schema, true, None))
     }
 
-    // ── Contract tests. The row fixtures are SYNTHETIC (phase 3),
-    // provider-shaped key-for-key from the executors' normalizers: the
-    // always-present `?? null` keys appear in every row (null where no
-    // value), the conditionally-spread keys are genuinely absent where
-    // upstream would drop them, and identities/names are obviously
-    // synthetic. Phase 4 replaces them with redacted live captures and
-    // adds the default-deny redaction audit the one_drive pack carries. ──
+    // ── Contract tests. The row fixtures are REDACTED LIVE CAPTURES
+    // (phase 4, 2026-08-25), provider-shaped key-for-key: the
+    // always-present `?? null` keys carry explicit nulls, the
+    // conditionally-spread keys are absent exactly where upstream
+    // dropped them on the wire, and every identity, name and URL is
+    // synthetic — a property enforced by
+    // `fixtures_are_redacted_captures_under_a_default_deny_audit`
+    // rather than asserted by hand. The deliberately-broken
+    // mismatch fixture stays synthetic by design, and says so. ──
 
     fn convert_fixture(table: &SourcePackTable, fixture: &str) -> RecordBatch {
         let page: Value = serde_json::from_str(fixture).expect("fixture parses");
@@ -1766,7 +1768,8 @@ bindings:
         // an error. This is also the shape design record R1 warns about:
         // "empty and correct" and "empty because the account cannot see
         // shared drives at all" are indistinguishable from here, which
-        // is exactly why phase 4 needs an account that can see one.
+        // is exactly why phase 4 needed an account that could see one
+        // — R1, resolved: the phase-4 account created its own.
         let gateway = MockGateway::start(|req| {
             if req.method == "GET" && req.path == "/v1/health" {
                 return MockResponse::ok("{}");

--- a/crates/skardi/src/sources/providers/open_connector/packs/google_drive.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/google_drive.rs
@@ -1,0 +1,1967 @@
+//! Google Drive source pack: `files`, `drives` and `file_permissions`
+//! over Open Connector's `googledrive` service, reconciled against a
+//! live gateway (v1.3.4, open-connector at `2410fbe`, 2026-08-25).
+//! Design record:
+//! `docs/superpowers/specs/2026-08-25-open-connector-google-drive-pack-design.md`;
+//! user documentation: `docs/open-connector-google-drive.md`.
+//!
+//! **Status: phases 1–4 complete (live-verified 2026-08-25).** Phase 1
+//! reconciled the contract without provider credentials: action
+//! inventory, all six schema captures byte-exact from discovery, the
+//! input surfaces, the declared page-size bounds and the
+//! undeclared-key 400s (the gateway validates inputs before authz).
+//! Phase 4 then verified every load-bearing claim against a real
+//! Workspace account through a seeded corpus (6 files, 1 shared drive,
+//! 3 grants): the five `restrictions.*` spellings witnessed verbatim on
+//! a real drive row; the pinned page sizes real WIRE bounds (1000/100/
+//! 100 accepted; 1001/101/0 all 400); real multi-page walks at
+//! `pageSize: 1` with ~444-char cursors and terminal-page `null` on
+//! every table; the all-drives pin actually surfacing shared-drive
+//! rows; registration passing the fingerprint gate against LIVE
+//! discovery; a full three-table scan through skardi-server with LIMIT
+//! stopping real pagination one page early; and the row fixtures
+//! re-derived as redacted live captures under a default-deny audit.
+//! Three columns remain live-unwitnessed non-null, each key PRESENT
+//! (null) and correctly spelled on real rows, each structurally out of
+//! reach: `drives.org_unit_id` (reports only under Workspace org
+//! units), `drives.theme_id` (null even when a drive is CREATED with an
+//! explicit theme — the theme materializes as color + background link),
+//! and `file_permissions.expiration_time` (Google 403s expirations on
+//! domain/anyone grants and a user-grant expiration needs a second real
+//! account).
+//!
+//! Design decisions and their rationale. Each is held by a named test
+//! below unless marked as an upstream property no Skardi-side test can
+//! hold:
+//!
+//! - **The service is spelled `googledrive` and its action IDs carry
+//!   TWO dots** (`googledrive.files.list` — the upstream action name is
+//!   itself dotted). New to shipped packs, verified safe end to end in
+//!   phase 1: `validate_action_id` rejects only `/` and empty dot
+//!   segments, the URL path keeps dots verbatim, and the `rsplit('.')`
+//!   short-name lookups read TABLE ids (`google_drive.files`), never
+//!   action ids. Every e2e test below exercises the dotted id against
+//!   the mock gateway, and the drift/error tests pin that it survives
+//!   into error identity too.
+//! - **Rows are NORMALIZED, the opposite of `one_drive`.** Every
+//!   executor rebuilds rows through a `normalize*` function into a
+//!   fixed key set, the declared row objects are `additionalProperties:
+//!   false`, and each executor pins its own provider-side `fields`
+//!   projection — `files.list` does not even declare a `fields` input
+//!   (sending one 400s, probed live). So the wire keys are the
+//!   normalizer's (`sizeBytes`, not Google's string-typed `size`), the
+//!   declared contract is column truth to an unusual degree, and every
+//!   mapped path except the five `restrictions.*` flags resolves inside
+//!   the declared item schema
+//!   (`only_the_five_restriction_flags_escape_the_fingerprint_gate`).
+//! - **Two spellings of "no value", both modeled in the fixtures.** The
+//!   `?? null` normalizer fields are always present (explicit JSON
+//!   null); the conditionally-spread ones (`parents`/`owners`/`shared`/
+//!   `starred`/`trashed` on files, `hidden`/`capabilities`/
+//!   `restrictions` on drives, the three `optionalBoolean` flags on
+//!   permissions) vanish from the row entirely. Both convert to SQL
+//!   NULL; a present `false` stays `false`
+//!   (`file_permissions_fixture_converts_every_grant_shape`). The live
+//!   absence patterns are narrower than the declarations allow:
+//!   shared-drive file rows drop exactly `owners`+`shared` (keeping
+//!   `parents`/`starred`/`trashed`), non-user grants carry
+//!   `allowFileDiscovery` while user grants carry
+//!   `deleted`+`pendingOwner`, and every grant carries
+//!   `permissionDetails` — the fixtures pin these as captured.
+//! - **Three tables, scoped by the operator in phase 2.** `files` (the
+//!   corpus), `drives` (shared-drive inventory — legitimately empty on
+//!   an account with no shared-drive membership, design record R1), and
+//!   `file_permissions` (per-file sharing audit). Design record R1
+//!   resolved in phase 4: the account turned out to be Workspace and
+//!   able to CREATE a shared drive, so the drives table was verified on
+//!   real rows instead of deferred. Deferred at the
+//!   admission gate, recorded in the design record: `changes.list`
+//!   (its cursor must be bootstrapped by a second action,
+//!   `changes.getStartPageToken` — a pagination shape the engine has no
+//!   spelling for), plus the comments/replies/labels/accessproposals
+//!   surfaces (out of the requested scope; accessproposals is also
+//!   Workspace-approval-gated).
+//! - **The all-drives pin is the pack's one load-bearing fixed input.**
+//!   `files.list` forwards `supportsAllDrives` verbatim with NO default
+//!   — unlike `drives.list`/`permissions.list`, whose executors run
+//!   `resolveSupportsAllDrives` and default it TRUE — so an unpinned
+//!   `files` scan would inherit Google's own default and silently omit
+//!   every shared-drive file: the confidently-wrong-rows failure mode.
+//!   Both halves of the pair are pinned `true` (Google requires them
+//!   together). Phase 4 witnessed the pin doing its job: a seeded
+//!   shared-drive file came back through a live skardi-server scan with
+//!   `drive_id` carrying the real drive id.
+//! - **`q` is an optional RESOURCE, not a filter mapping,
+//!   structurally.** It is a whole query language (`name = 'x' and
+//!   trashed = false`); a FilterMapping sends a column's literal as the
+//!   input value, which is never a legal `q`. With no binding the scan
+//!   is the complete corpus, so no capability is lost. Trashed files
+//!   are deliberately IN (no `q: "trashed = false"` pin — it would
+//!   collide with the resource and silently narrow the table);
+//!   `trashed` is a column, so the filtering happens in SQL.
+//! - **`fileId` is a required resource on `file_permissions`, and the
+//!   enforcement boundary is narrow in exactly one_drive's `query`
+//!   way:** upstream's `required` array is EMPTY and `fileId` is merely
+//!   `minLength: 1`, so a missing fileId passes schema validation and
+//!   dies in the executor's own `resolveFileId` check. Declaring the
+//!   resource closes the missing case at registration; `""` dies at the
+//!   schema layer (400 `invalid_input`, probed live); whitespace-only
+//!   passes resource validation and fails at scan time. Loud all three
+//!   ways. Rows carry no file identity (and a resource value has no
+//!   path into a row), so the table means "the permissions of the file
+//!   this binding names" — the `notion.block_children` shape. Upstream
+//!   convenience worth knowing: `extractFileId` accepts a full Drive
+//!   URL as the `fileId` value.
+//! - **The five `restrictions.*` columns trade fingerprint coverage for
+//!   audit value, knowingly.** `restrictions` is declared as a bare
+//!   open object, so the five flags are outside the gate (an upstream
+//!   inner-key rename would be silent — the reviewed case-1 gap, pinned
+//!   by the coverage test). Phase 4 closed the spelling question the
+//!   gate cannot: a real drive row carried all five documented keys
+//!   verbatim (as present `false`s), plus a nested
+//!   `downloadRestriction` object the pack leaves unmapped. Their
+//!   per-caller
+//!   sibling `capabilities` stays unmapped: its values change with the
+//!   OAuth identity doing the scan, so the same table under two
+//!   bindings would disagree.
+//! - **In-band Google errors never reach the engine.** Every executor
+//!   runs `assertGoogleResponse` and throws into the gateway's failure
+//!   envelope, so no table declares `error_path`.
+//! - **Both halves of each contract are committed** (`contracts/` and
+//!   `contracts/inputs/`), gmail-style, because the fingerprint gate is
+//!   output-only. Note these captures carry a `$schema` key — the
+//!   sibling packs' do not — and the fingerprint hashes the WHOLE
+//!   schema, so the captures keep it verbatim.
+
+use std::sync::OnceLock;
+
+use crate::sources::providers::open_connector::error::OpenConnectorError;
+use crate::sources::providers::open_connector::source_pack::SourcePack;
+
+use super::loader;
+
+static PACK: OnceLock<Result<SourcePack, String>> = OnceLock::new();
+
+/// The Google Drive pack, parsed once from the embedded YAML asset.
+pub fn pack() -> Result<&'static SourcePack, OpenConnectorError> {
+    loader::builtin(
+        "google_drive.yaml",
+        include_str!("google_drive.yaml"),
+        &PACK,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sources::hierarchy::HierarchyLevel;
+    use crate::sources::providers::open_connector::action_registry::fingerprint_schema;
+    use crate::sources::providers::open_connector::json_to_arrow::RowConverter;
+    use crate::sources::providers::open_connector::pagination::PaginationStrategy;
+    use crate::sources::providers::open_connector::row_path::RowPath;
+    use crate::sources::providers::open_connector::source_pack::{FixedValue, SourcePackTable};
+    use crate::sources::providers::open_connector::testutil::{
+        EnvVarGuard, MockGateway, MockResponse, discovery_ok, envelope_err, envelope_ok,
+        fingerprint_uncovered_columns,
+    };
+    use crate::sources::providers::open_connector::{
+        OpenConnectorConfig, OpenConnectorGateways, register_open_connector_tables,
+        register_open_connector_udtfs,
+    };
+    use arrow::array::{
+        Array, BooleanArray, Int64Array, ListArray, StringArray, TimestampMillisecondArray,
+    };
+    use arrow::record_batch::RecordBatch;
+    use datafusion::prelude::SessionContext;
+    use serde_json::{Value, json};
+
+    /// Drive cursors are OPAQUE tokens (`pageToken`, `minLength: 1`) —
+    /// unlike one_drive's URI-shaped `nextLink`, there is no format to
+    /// round-trip and no per-action path allowlist to respect, so a
+    /// realistic token shape is all a mock cursor owes.
+    const FILES_PAGE2_TOKEN: &str = "~!!~AI9SyntheticFilesToken2";
+
+    /// Look up a table by short name; the assets are test-pinned to parse.
+    fn table(short: &str) -> &'static SourcePackTable {
+        pack()
+            .expect("embedded asset is test-pinned to parse")
+            .tables
+            .iter()
+            .find(|t| t.id.rsplit('.').next() == Some(short))
+            .unwrap_or_else(|| panic!("table {short}"))
+    }
+
+    /// Discovery serving the captured contracts, so every mock
+    /// registration exercises the fingerprint gate's pass side. The
+    /// dotted action ids are matched as full path suffixes — which is
+    /// itself part of what these tests exercise: a two-dot action id
+    /// travels the discovery URL verbatim.
+    fn google_drive_discovery(path: &str) -> MockResponse {
+        let output_schema = if path.ends_with("googledrive.files.list") {
+            include_str!("fixtures/google_drive/contracts/files.list.json")
+        } else if path.ends_with("googledrive.drives.list") {
+            include_str!("fixtures/google_drive/contracts/drives.list.json")
+        } else if path.ends_with("googledrive.permissions.list") {
+            include_str!("fixtures/google_drive/contracts/permissions.list.json")
+        } else {
+            r#"{"type": "object"}"#
+        };
+        MockResponse::ok(&discovery_ok("{}", output_schema, true, None))
+    }
+
+    // ── Contract tests. The row fixtures are SYNTHETIC (phase 3),
+    // provider-shaped key-for-key from the executors' normalizers: the
+    // always-present `?? null` keys appear in every row (null where no
+    // value), the conditionally-spread keys are genuinely absent where
+    // upstream would drop them, and identities/names are obviously
+    // synthetic. Phase 4 replaces them with redacted live captures and
+    // adds the default-deny redaction audit the one_drive pack carries. ──
+
+    fn convert_fixture(table: &SourcePackTable, fixture: &str) -> RecordBatch {
+        let page: Value = serde_json::from_str(fixture).expect("fixture parses");
+        convert_page(table, &page)
+    }
+
+    fn convert_page(table: &SourcePackTable, page: &Value) -> RecordBatch {
+        let rows = RowPath::parse(table.row_path)
+            .expect("row path")
+            .rows(page, 1)
+            .expect("row array");
+        RowConverter::new(table.fields)
+            .expect("converter")
+            .convert(rows, 1)
+            .expect("page converts")
+    }
+
+    fn utf8<'a>(batch: &'a RecordBatch, name: &str) -> &'a StringArray {
+        batch
+            .column_by_name(name)
+            .unwrap_or_else(|| panic!("column {name}"))
+            .as_any()
+            .downcast_ref()
+            .expect("Utf8 column")
+    }
+
+    fn int64<'a>(batch: &'a RecordBatch, name: &str) -> &'a Int64Array {
+        batch
+            .column_by_name(name)
+            .unwrap_or_else(|| panic!("column {name}"))
+            .as_any()
+            .downcast_ref()
+            .expect("Int64 column")
+    }
+
+    fn boolean<'a>(batch: &'a RecordBatch, name: &str) -> &'a BooleanArray {
+        batch
+            .column_by_name(name)
+            .unwrap_or_else(|| panic!("column {name}"))
+            .as_any()
+            .downcast_ref()
+            .expect("Boolean column")
+    }
+
+    fn timestamp<'a>(batch: &'a RecordBatch, name: &str) -> &'a TimestampMillisecondArray {
+        batch
+            .column_by_name(name)
+            .unwrap_or_else(|| panic!("column {name}"))
+            .as_any()
+            .downcast_ref()
+            .expect("Timestamp column")
+    }
+
+    fn utf8_list<'a>(batch: &'a RecordBatch, name: &str) -> &'a ListArray {
+        batch
+            .column_by_name(name)
+            .unwrap_or_else(|| panic!("column {name}"))
+            .as_any()
+            .downcast_ref()
+            .expect("List column")
+    }
+
+    /// One row of a string-list column, item nullability included — the
+    /// owner plucks need `Some`/`None` items, not just values.
+    fn list_items(lists: &ListArray, row: usize) -> Vec<Option<String>> {
+        let values = lists.value(row);
+        let values = values
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("Utf8 items");
+        (0..values.len())
+            .map(|i| values.is_valid(i).then(|| values.value(i).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn files_fixture_converts_every_row_shape() {
+        // The fixture is a REDACTED LIVE CAPTURE (2026-08-25; the
+        // redaction audit below is its enforcement): six rows spanning
+        // every shape the seeded phase-4 corpus produced — a shared
+        // My Drive file, a shared-drive file, a trashed file, a native
+        // Google Doc, a starred CJK-named file and a folder.
+        let batch = convert_fixture(
+            table("files"),
+            include_str!("fixtures/google_drive/files.json"),
+        );
+        assert_eq!(batch.num_rows(), 6);
+
+        // Row 0 — a shared My Drive file, fully populated: real byte
+        // size (the normalizer's `sizeBytes` NUMBER, not Google's
+        // string `size`), one parent, one owner whose four keys all
+        // carry values, all three boolean flags present. `driveId` is
+        // the explicit-null spelling: present on the wire, null in SQL
+        // (live, every My Drive row carries `driveId: null`).
+        assert_eq!(utf8(&batch, "name").value(0), "notes.txt");
+        assert_eq!(utf8(&batch, "mime_type").value(0), "text/plain");
+        assert_eq!(int64(&batch, "size_bytes").value(0), 63);
+        assert!(utf8(&batch, "drive_id").is_null(0));
+        assert!(
+            utf8(&batch, "web_view_link")
+                .value(0)
+                .starts_with("https://drive.google.com/file/d/")
+        );
+        assert!(timestamp(&batch, "created_time").is_valid(0));
+        assert!(timestamp(&batch, "modified_time").is_valid(0));
+        assert_eq!(
+            list_items(utf8_list(&batch, "parents"), 0),
+            vec![Some("1SyntheticFolderAAAAAAAAAAAAAAAAA".into())]
+        );
+        // The two columns plucked from ONE `owners` array.
+        assert_eq!(
+            list_items(utf8_list(&batch, "owner_display_names"), 0),
+            vec![Some("Example User".into())]
+        );
+        assert_eq!(
+            list_items(utf8_list(&batch, "owner_email_addresses"), 0),
+            vec![Some("user@example.com".into())]
+        );
+        assert!(boolean(&batch, "shared").value(0));
+        assert!(!boolean(&batch, "starred").value(0));
+        assert!(!boolean(&batch, "trashed").value(0));
+
+        // Row 1 — the shared-drive file: `driveId` non-null (the join
+        // key to `drives.id`) and the drive itself as the parent. The
+        // live absence pattern is NARROWER than phase 3 guessed:
+        // shared-drive rows drop exactly `owners` and `shared` (the
+        // drive owns its items) while `parents`/`starred`/`trashed`
+        // stay present. Absent key and explicit null land in the same
+        // SQL NULL.
+        assert_eq!(utf8(&batch, "name").value(1), "shared-drive-doc.txt");
+        assert_eq!(utf8(&batch, "drive_id").value(1), "0ASyntheticDrivePVA");
+        assert_eq!(
+            list_items(utf8_list(&batch, "parents"), 1),
+            vec![Some("0ASyntheticDrivePVA".into())]
+        );
+        assert!(utf8_list(&batch, "owner_display_names").is_null(1));
+        assert!(utf8_list(&batch, "owner_email_addresses").is_null(1));
+        assert!(boolean(&batch, "shared").is_null(1));
+        assert!(!boolean(&batch, "starred").value(1));
+        assert!(!boolean(&batch, "trashed").value(1));
+
+        // Row 2 — a trashed file, still a row: the yaml deliberately
+        // does not pin `q: "trashed = false"`, so the live wire really
+        // returns trash and the `trashed` column is how SQL filters it.
+        assert_eq!(utf8(&batch, "name").value(2), "obsolete.txt");
+        assert!(boolean(&batch, "trashed").value(2));
+
+        // Row 3 — a native Google Doc. Live correction to a phase-3
+        // guess: native docs DO report `sizeBytes` (Docs count against
+        // storage quota since 2021); the null-size row is the FOLDER
+        // below. The 44-char doc id (My Drive file ids are 33) and the
+        // docs.google.com link are the real shapes.
+        assert_eq!(utf8(&batch, "name").value(3), "Design memo");
+        assert_eq!(
+            utf8(&batch, "mime_type").value(3),
+            "application/vnd.google-apps.document"
+        );
+        assert_eq!(int64(&batch, "size_bytes").value(3), 1024);
+        assert_eq!(utf8(&batch, "id").value(3).len(), 44);
+        assert!(
+            utf8(&batch, "web_view_link")
+                .value(3)
+                .starts_with("https://docs.google.com/document/d/")
+        );
+
+        // Row 4 — CJK survives the capture, the redaction (`\u`
+        // escapes keep the fixture ASCII) and the conversion; `starred`
+        // carries a real true.
+        assert_eq!(utf8(&batch, "name").value(4), "预算表.csv");
+        assert!(boolean(&batch, "starred").value(4));
+
+        // Row 5 — the folder: `sizeBytes` is the EXPLICIT wire null
+        // (folders have no byte size of their own), and the mime type
+        // is the de-facto type discriminator.
+        assert_eq!(utf8(&batch, "name").value(5), "corpus-folder");
+        assert!(utf8(&batch, "mime_type").value(5).ends_with("apps.folder"));
+        assert!(int64(&batch, "size_bytes").is_null(5));
+
+        // Unmapped wire keys never become columns: `owners` maps to two
+        // pluck columns under its own names, and the per-owner
+        // `permissionId`/`photoLink` stay unmapped. `normalizeDriveFile`
+        // emits no `kind` at all — confirmed live on every row.
+        for absent in ["owners", "kind", "permission_id", "photo_link"] {
+            assert!(batch.column_by_name(absent).is_none(), "{absent}");
+        }
+    }
+
+    #[test]
+    fn drives_fixture_converts_including_the_restriction_flags() {
+        // REDACTED LIVE CAPTURE of the one shared drive the phase-4
+        // account created. It settles what phase 3 could not: the real
+        // `restrictions` object carries all five documented flag
+        // spellings verbatim (plus a nested `downloadRestriction`
+        // object the pack leaves unmapped), so the documentation-derived
+        // paths extract real values.
+        let batch = convert_fixture(
+            table("drives"),
+            include_str!("fixtures/google_drive/drives.json"),
+        );
+        assert_eq!(batch.num_rows(), 1);
+
+        assert_eq!(utf8(&batch, "id").value(0), "0ASyntheticDrivePVA");
+        assert_eq!(utf8(&batch, "name").value(0), "example-shared-drive");
+        assert!(!boolean(&batch, "hidden").value(0));
+        assert_eq!(utf8(&batch, "color_rgb").value(0), "#e91e63");
+        assert!(timestamp(&batch, "created_time").is_valid(0));
+        // The two live residual columns, keys present and null:
+        // `orgUnitId` reports only under Workspace org units, and
+        // `themeId` came back null even when a drive was CREATED with
+        // an explicit theme (the theme materializes as `colorRgb` +
+        // `backgroundImageLink` instead; probed live).
+        assert!(utf8(&batch, "org_unit_id").is_null(0));
+        assert!(utf8(&batch, "theme_id").is_null(0));
+        assert!(
+            utf8(&batch, "background_image_link")
+                .value(0)
+                .starts_with("https://ssl.gstatic.com/")
+        );
+        // A fresh drive reports all five restriction flags PRESENT and
+        // false — real extracted values, not NULLs. (Org policy blocked
+        // flipping any to true on the phase-4 tenant — admin-only — but
+        // a boolean's extraction path does not depend on which boolean
+        // it carries.)
+        for flag in [
+            "admin_managed_restrictions",
+            "copy_requires_writer_permission",
+            "domain_users_only",
+            "drive_members_only",
+            "sharing_folders_requires_organizer_permission",
+        ] {
+            assert!(boolean(&batch, flag).is_valid(0), "{flag}");
+            assert!(!boolean(&batch, flag).value(0), "{flag}");
+        }
+
+        // `kind` (constant), `capabilities` (a 21-flag per-caller view,
+        // live) and the raw `restrictions` object are on the wire and
+        // deliberately not columns.
+        for absent in ["kind", "capabilities", "restrictions"] {
+            assert!(batch.column_by_name(absent).is_none(), "{absent}");
+        }
+
+        // SYNTHETIC boundary page — shapes one live drive cannot show,
+        // held at the engine level. `hidden`/`capabilities`/
+        // `restrictions` are conditionally spread upstream, so a drive
+        // may omit them entirely (all five flags NULL — "unreported",
+        // never false), and a partially-populated `restrictions` object
+        // must yield one present false among four NULL siblings.
+        let page = json!({
+            "drives": [
+                {
+                    "id": "0ASyntheticMinimlPVA",
+                    "kind": "drive#drive",
+                    "name": "minimal",
+                    "colorRgb": null,
+                    "createdTime": null,
+                    "orgUnitId": null,
+                    "themeId": null,
+                    "backgroundImageLink": null
+                },
+                {
+                    "id": "0ASyntheticPartilPVA",
+                    "kind": "drive#drive",
+                    "name": "partial",
+                    "hidden": true,
+                    "colorRgb": null,
+                    "createdTime": null,
+                    "orgUnitId": null,
+                    "themeId": null,
+                    "backgroundImageLink": null,
+                    "restrictions": { "copyRequiresWriterPermission": false }
+                }
+            ],
+            "nextPageToken": null
+        });
+        let batch = convert_page(table("drives"), &page);
+        assert!(boolean(&batch, "hidden").is_null(0));
+        for flag in [
+            "admin_managed_restrictions",
+            "copy_requires_writer_permission",
+            "domain_users_only",
+            "drive_members_only",
+            "sharing_folders_requires_organizer_permission",
+        ] {
+            assert!(boolean(&batch, flag).is_null(0), "{flag}");
+        }
+        assert!(boolean(&batch, "hidden").value(1));
+        assert!(
+            boolean(&batch, "copy_requires_writer_permission").is_valid(1),
+            "present false is false, not NULL"
+        );
+        assert!(!boolean(&batch, "copy_requires_writer_permission").value(1));
+        for flag in [
+            "admin_managed_restrictions",
+            "domain_users_only",
+            "drive_members_only",
+            "sharing_folders_requires_organizer_permission",
+        ] {
+            assert!(boolean(&batch, flag).is_null(1), "{flag}");
+        }
+    }
+
+    #[test]
+    fn file_permissions_fixture_converts_every_grant_shape() {
+        // REDACTED LIVE CAPTURE of the seeded corpus file's grants: the
+        // `anyone` link-share, a `domain` grant, and the `user` owner.
+        // Live correction to a phase-3 guess: EVERY grant carries
+        // `permissionDetails` (not just shared-drive ones) — the
+        // conversion must simply ignore it on all three rows.
+        let batch = convert_fixture(
+            table("file_permissions"),
+            include_str!("fixtures/google_drive/file_permissions.json"),
+        );
+        assert_eq!(batch.num_rows(), 3);
+
+        // Row 0 — the `anyone` grant, the row a sharing audit exists to
+        // find: identity columns all null (nobody in particular holds
+        // it) and `allowFileDiscovery: false` PRESENT — a link-only
+        // share, distinguishable from "not reported" NULL only because
+        // false survives as false. The two user-shaped booleans are
+        // ABSENT on non-user grants → NULL.
+        assert_eq!(utf8(&batch, "id").value(0), "anyoneWithLink");
+        assert_eq!(utf8(&batch, "role").value(0), "reader");
+        assert_eq!(utf8(&batch, "type").value(0), "anyone");
+        assert!(utf8(&batch, "email_address").is_null(0));
+        assert!(utf8(&batch, "display_name").is_null(0));
+        assert!(utf8(&batch, "domain").is_null(0));
+        assert!(utf8(&batch, "photo_link").is_null(0));
+        assert!(boolean(&batch, "allow_file_discovery").is_valid(0));
+        assert!(!boolean(&batch, "allow_file_discovery").value(0));
+        assert!(boolean(&batch, "deleted").is_null(0));
+        assert!(boolean(&batch, "pending_owner").is_null(0));
+
+        // Row 1 — a `domain` grant: `domain` carries the meaning, the
+        // display name is the org's (not a person's), and the grant is
+        // search-discoverable — `allowFileDiscovery` carries both
+        // values across these two rows.
+        assert_eq!(utf8(&batch, "type").value(1), "domain");
+        assert_eq!(utf8(&batch, "domain").value(1), "example.com");
+        assert_eq!(utf8(&batch, "display_name").value(1), "Example Org");
+        assert!(utf8(&batch, "email_address").is_null(1));
+        assert!(boolean(&batch, "allow_file_discovery").value(1));
+
+        // Row 2 — the `user` owner: identity columns populated, the two
+        // reported booleans present-and-false, `allowFileDiscovery`
+        // ABSENT (meaningless for user grants) → NULL.
+        assert_eq!(utf8(&batch, "role").value(2), "owner");
+        assert_eq!(utf8(&batch, "type").value(2), "user");
+        assert_eq!(utf8(&batch, "email_address").value(2), "user@example.com");
+        assert_eq!(utf8(&batch, "display_name").value(2), "Example User");
+        assert!(utf8(&batch, "domain").is_null(2));
+        assert!(utf8(&batch, "photo_link").is_valid(2));
+        assert!(!boolean(&batch, "deleted").value(2));
+        assert!(!boolean(&batch, "pending_owner").value(2));
+        assert!(boolean(&batch, "allow_file_discovery").is_null(2));
+
+        // `expirationTime` is null on every live row and CANNOT be
+        // otherwise here: Google rejects expirations on domain/anyone
+        // grants outright (probed live — 403, "Expiration dates cannot
+        // be set on domain or anyone type permissions"), and setting
+        // one on a user grant needs a second real account. So the
+        // timestamp conversion is held by a SYNTHETIC user grant
+        // carrying the field's documented RFC 3339 shape instead.
+        for row in 0..3 {
+            assert!(timestamp(&batch, "expiration_time").is_null(row));
+        }
+        let page = json!({
+            "permissions": [{
+                "id": "00000000000000000003",
+                "kind": "drive#permission",
+                "role": "reader",
+                "type": "user",
+                "domain": null,
+                "deleted": false,
+                "photoLink": null,
+                "displayName": null,
+                "emailAddress": "user@example.com",
+                "pendingOwner": false,
+                "expirationTime": "2026-12-31T23:59:59.000Z"
+            }],
+            "nextPageToken": null
+        });
+        let synthetic = convert_page(table("file_permissions"), &page);
+        assert!(timestamp(&synthetic, "expiration_time").is_valid(0));
+
+        // `kind` (constant) and `permissionDetails` (a second table's
+        // worth of nested shape) are on the wire and deliberately not
+        // columns.
+        for absent in ["kind", "permission_details"] {
+            assert!(batch.column_by_name(absent).is_none(), "{absent}");
+        }
+    }
+
+    #[test]
+    fn wire_nulls_and_empty_strings_convert_without_failing_the_page() {
+        // The fixture rows model the wire the normalizers produce; this
+        // inline page models the boundary shapes regardless of whether
+        // today's upstream can produce them all — the engine's promise
+        // is per-declaration, not per-normalizer-version. A null in any
+        // nullable mapped position must reach SQL as NULL rather than
+        // failing the page, and `""` must survive as `""` (upstream's
+        // `String(x ?? "")` really produces it for id/name/mimeType).
+        let page = json!({
+            "files": [
+                {
+                    "id": "1SyntheticAllNull",
+                    "name": "n",
+                    "mimeType": "text/plain",
+                    "webViewLink": null,
+                    "createdTime": null,
+                    "modifiedTime": null,
+                    "sizeBytes": null,
+                    "driveId": null
+                },
+                {
+                    "id": "1SyntheticAllEmpty",
+                    "name": "",
+                    "mimeType": "",
+                    "webViewLink": "",
+                    "createdTime": null,
+                    "modifiedTime": null,
+                    "sizeBytes": 0,
+                    "driveId": "",
+                    "parents": [],
+                    "owners": []
+                },
+                {
+                    "id": "1SyntheticNullPluck",
+                    "name": "n",
+                    "mimeType": "text/plain",
+                    "webViewLink": null,
+                    "createdTime": null,
+                    "modifiedTime": null,
+                    "sizeBytes": null,
+                    "driveId": null,
+                    "owners": [
+                        { "displayName": null, "emailAddress": "user@example.com" }
+                    ]
+                }
+            ],
+            "nextPageToken": null
+        });
+        let batch = convert_page(table("files"), &page);
+        assert_eq!(batch.num_rows(), 3);
+
+        for column in ["web_view_link", "drive_id"] {
+            assert!(utf8(&batch, column).is_null(0), "{column} must be NULL");
+        }
+        assert!(int64(&batch, "size_bytes").is_null(0));
+        assert!(timestamp(&batch, "created_time").is_null(0));
+        assert!(timestamp(&batch, "modified_time").is_null(0));
+        for column in ["parents", "owner_display_names", "owner_email_addresses"] {
+            assert!(utf8_list(&batch, column).is_null(0), "{column}");
+        }
+
+        // Empty is NOT null, and size 0 is 0 — and an EMPTY
+        // `parents`/`owners` array is an empty list, not NULL (an
+        // orphaned file really has `parents: []`).
+        for column in ["name", "mime_type", "web_view_link", "drive_id"] {
+            let values = utf8(&batch, column);
+            assert!(values.is_valid(1), "{column}: empty is not null");
+            assert_eq!(values.value(1), "", "{column}");
+        }
+        assert_eq!(int64(&batch, "size_bytes").value(1), 0);
+        for column in ["parents", "owner_display_names", "owner_email_addresses"] {
+            assert!(utf8_list(&batch, column).is_valid(1), "{column}");
+            assert_eq!(list_items(utf8_list(&batch, column), 1), vec![], "{column}");
+        }
+
+        // An owner object with a null field: the pluck yields a null
+        // list ITEM — it neither fails the page nor drops the item, so
+        // the two plucked columns stay index-aligned.
+        assert_eq!(
+            list_items(utf8_list(&batch, "owner_display_names"), 2),
+            vec![None]
+        );
+        assert_eq!(
+            list_items(utf8_list(&batch, "owner_email_addresses"), 2),
+            vec![Some("user@example.com".into())]
+        );
+    }
+
+    #[test]
+    fn fixtures_are_redacted_captures_under_a_default_deny_audit() {
+        // The row fixtures are REDACTED LIVE CAPTURES (2026-08-25), and
+        // this audit is the redaction's enforcement: every string leaf
+        // must satisfy an allowlist FOR ITS KEY, default-deny, or the
+        // test fails. The scheme it pins: `1Synthetic…`/`0ASynthetic…`
+        // ids with the live LENGTHS preserved (33- and 44-char file
+        // ids, 19-char drive ids), all-zero-prefixed 20-digit
+        // permission ids, placeholder identities under example.com, one
+        // synthetic avatar URL, and Google URL shapes rebuilt around
+        // the synthetic ids. Structural constants (kinds, mime types,
+        // role/type enums, Google's own theme-asset URL) and timestamps
+        // stay verbatim; CJK travels as `\u` escapes so the fixtures
+        // stay ASCII and the redaction stays auditable by eye. The
+        // deliberately-broken mismatch fixture is SYNTHETIC by design
+        // (the admission gate wants it that way) and is audited under
+        // the same arms.
+        fn synthetic_id(s: &str) -> bool {
+            s.starts_with("1Synthetic")
+                || s.starts_with("0ASynthetic")
+                || s == "anyoneWithLink"
+                || (s.len() == 20 && s.starts_with("0000000000000000000"))
+        }
+        fn rfc3339(s: &str) -> bool {
+            s.len() == 24
+                && s.ends_with('Z')
+                && s.bytes()
+                    .all(|b| b.is_ascii_digit() || b"-:T.Z".contains(&b))
+        }
+        // A URL is only as redacted as its parts: known Google prefix,
+        // then a SYNTHETIC id, then a known structural tail — anything
+        // else (a real id, a title-bearing slug, an extra query) fails.
+        fn synthetic_url(s: &str) -> bool {
+            for prefix in [
+                "https://drive.google.com/file/d/",
+                "https://drive.google.com/drive/folders/",
+                "https://docs.google.com/document/d/",
+            ] {
+                if let Some(rest) = s.strip_prefix(prefix) {
+                    let (id, tail) = rest.split_once('/').unwrap_or((rest, ""));
+                    return synthetic_id(id)
+                        && ["", "view", "view?usp=drivesdk", "edit?usp=drivesdk"].contains(&tail);
+                }
+            }
+            false
+        }
+        // No shape can vouch for a name, so the set is explicit — a
+        // real one fails. These are the names the phase-4 corpus was
+        // SEEDED with (authored for the test, carrying no tenant data);
+        // the CJK one keeps the capture's non-ASCII coverage honest.
+        const REDACTED_NAMES: &[&str] = &[
+            "notes.txt",
+            "shared-drive-doc.txt",
+            "obsolete.txt",
+            "Design memo",
+            "预算表.csv",
+            "corpus-folder",
+            "example-shared-drive",
+            "wrong-types.bin",
+        ];
+        fn audit(fixture: &str, key: &str, value: &Value) {
+            match value {
+                Value::String(s) => {
+                    let allowed = match key {
+                        "id" | "driveId" | "parents" | "inheritedFrom" | "permissionId" => {
+                            synthetic_id(s)
+                        }
+                        "name" => REDACTED_NAMES.contains(&s.as_str()),
+                        "displayName" => s == "Example User" || s == "Example Org",
+                        "emailAddress" => s == "user@example.com",
+                        "domain" => s == "example.com",
+                        "photoLink" => s == "https://lh3.googleusercontent.com/a/SYNTHETIC=s64",
+                        "backgroundImageLink" => {
+                            s == "https://ssl.gstatic.com/team_drive_themes/clams_background.jpg"
+                        }
+                        "webViewLink" => synthetic_url(s),
+                        "mimeType" => [
+                            "text/plain",
+                            "text/csv",
+                            "application/vnd.google-apps.document",
+                            "application/vnd.google-apps.folder",
+                            "application/octet-stream",
+                        ]
+                        .contains(&s.as_str()),
+                        "createdTime" | "modifiedTime" | "expirationTime" => rfc3339(s),
+                        "kind" => s == "drive#drive" || s == "drive#permission",
+                        "role" => ["owner", "reader", "writer"].contains(&s.as_str()),
+                        "type" | "permissionType" => {
+                            ["anyone", "domain", "user", "file"].contains(&s.as_str())
+                        }
+                        "colorRgb" => {
+                            s.len() == 7
+                                && s.starts_with('#')
+                                && s[1..].bytes().all(|b| b.is_ascii_hexdigit())
+                        }
+                        // The mismatch fixture's broken `sizeBytes` is a
+                        // bare digit string — synthetic, carrying nothing.
+                        "sizeBytes" => !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit()),
+                        _ => false,
+                    };
+                    assert!(
+                        allowed,
+                        "{fixture}: unredacted string at key `{key}`: {s:?}"
+                    );
+                }
+                Value::Array(items) => {
+                    for item in items {
+                        audit(fixture, key, item);
+                    }
+                }
+                Value::Object(map) => {
+                    for (k, v) in map {
+                        audit(fixture, k, v);
+                    }
+                }
+                _ => {}
+            }
+        }
+        for (fixture, content) in [
+            ("files", include_str!("fixtures/google_drive/files.json")),
+            ("drives", include_str!("fixtures/google_drive/drives.json")),
+            (
+                "file_permissions",
+                include_str!("fixtures/google_drive/file_permissions.json"),
+            ),
+            (
+                "files_type_mismatch",
+                include_str!("fixtures/google_drive/files_type_mismatch.json"),
+            ),
+        ] {
+            let page: Value = serde_json::from_str(content).expect("fixture parses");
+            audit(fixture, "$", &page);
+        }
+    }
+
+    #[test]
+    fn empty_page_keeps_schema_stable() {
+        // An empty first page must still produce the full declared
+        // schema, or a first-page-empty scan would change shape. The
+        // widths are this pack's column counts: 14 / 13 / 11.
+        for (short, row_key, columns) in [
+            ("files", "files", 14),
+            ("drives", "drives", 13),
+            ("file_permissions", "permissions", 11),
+        ] {
+            let t = table(short);
+            let batch = convert_page(t, &json!({row_key: [], "nextPageToken": null}));
+            assert_eq!(batch.num_rows(), 0, "{short}");
+            assert_eq!(
+                batch.num_columns(),
+                columns,
+                "{short} keeps its declared schema"
+            );
+            assert!(batch.column_by_name("id").is_some(), "{short}");
+        }
+    }
+
+    #[test]
+    fn type_mismatch_fixture_fails_with_the_targeted_error() {
+        // Admission-gate schema-mismatch fixture, and not a hypothetical
+        // one: Google's own REST API returns `size` as a decimal STRING;
+        // the normalized wire is a number only because the executor's
+        // `parseSizeBytes` converts it. If that ever regressed toward
+        // passthrough, this is the loud failure it must produce — full
+        // row-scoped identity and the JSON kind, never a silent NULL and
+        // never the offending value.
+        let t = table("files");
+        let page: Value = serde_json::from_str(include_str!(
+            "fixtures/google_drive/files_type_mismatch.json"
+        ))
+        .expect("fixture parses");
+        let rows = RowPath::parse(t.row_path)
+            .expect("row path")
+            .rows(&page, 1)
+            .expect("row array");
+        let err = RowConverter::new(t.fields)
+            .expect("converter")
+            .convert(rows, 1)
+            .expect_err("a string in an int64 column must fail the page");
+        match err {
+            OpenConnectorError::ConversionFailed {
+                ref path,
+                ref column,
+                page,
+                row,
+                ref expected,
+                ref found,
+            } => {
+                assert_eq!(column, "size_bytes");
+                assert_eq!(path, "$.sizeBytes");
+                assert_eq!(page, 1);
+                assert_eq!(row, 0, "the fixture's only row is the failing one");
+                assert_eq!(expected, "integer");
+                assert_eq!(found, "a string");
+                assert!(
+                    !err.to_string().contains("48213"),
+                    "row values never appear in errors"
+                );
+            }
+            other => panic!("expected ConversionFailed, got {other}"),
+        }
+    }
+
+    #[test]
+    fn a_row_without_an_id_fails_the_page_rather_than_yielding_a_null_key() {
+        // `id` is the one non-nullable column on every table. Unlike
+        // one_drive (whose item schema has no `required` array), an
+        // id-less row here is contract-ILLEGAL — declared `required`
+        // plus `String(x ?? "")` upstream — so this arm is defense in
+        // depth: even a gateway violating its own contract cannot hand
+        // SQL a NULL join key. The page fails, naming the column.
+        let t = table("files");
+        let mut page: Value =
+            serde_json::from_str(include_str!("fixtures/google_drive/files.json"))
+                .expect("fixture parses");
+        page["files"][1]
+            .as_object_mut()
+            .expect("row is an object")
+            .remove("id");
+        let rows = RowPath::parse(t.row_path)
+            .expect("row path")
+            .rows(&page, 3)
+            .expect("row array");
+        let err = RowConverter::new(t.fields)
+            .expect("converter")
+            .convert(rows, 3)
+            .expect_err("a missing id must fail the page");
+        match err {
+            OpenConnectorError::ConversionFailed {
+                ref column,
+                page,
+                row,
+                ref found,
+                ..
+            } => {
+                assert_eq!(column, "id");
+                assert_eq!(page, 3, "the page number travels with the error");
+                assert_eq!(row, 1, "the row index is named");
+                assert_eq!(found, "missing key");
+            }
+            other => panic!("expected ConversionFailed, got {other}"),
+        }
+    }
+
+    #[test]
+    fn pinned_fingerprints_match_the_reconciled_contracts() {
+        for (short, contract) in [
+            (
+                "files",
+                include_str!("fixtures/google_drive/contracts/files.list.json"),
+            ),
+            (
+                "drives",
+                include_str!("fixtures/google_drive/contracts/drives.list.json"),
+            ),
+            (
+                "file_permissions",
+                include_str!("fixtures/google_drive/contracts/permissions.list.json"),
+            ),
+        ] {
+            let t = table(short);
+            let schema: Value = serde_json::from_str(contract).expect("contract fixture parses");
+            let actual = fingerprint_schema(Some(&schema));
+            assert_eq!(
+                t.expected_fingerprint,
+                Some(actual.as_str()),
+                "{}: pinned {:?}, contract fixture hashes to {actual}",
+                t.id,
+                t.expected_fingerprint
+            );
+        }
+    }
+
+    #[test]
+    fn only_the_five_restriction_flags_escape_the_fingerprint_gate() {
+        // The pack's coverage ledger, both directions. `files` and
+        // `file_permissions` are fully inside the gate: upstream
+        // renaming any mapped key changes the hash and fails
+        // registration. On `drives`, exactly the five `restrictions.*`
+        // flags are outside it — `restrictions` is declared as a bare
+        // open object, so an upstream INNER-key rename is silent (hash
+        // unchanged, column quietly all-NULL): the reviewed case-1 gap
+        // this pin makes deliberate. If this list grows, a mapped path
+        // left the declared surface; if it shrinks, upstream started
+        // declaring the flags and the yaml's rationale is stale — either
+        // way the change must be conscious.
+        for (short, contract) in [
+            (
+                "files",
+                include_str!("fixtures/google_drive/contracts/files.list.json"),
+            ),
+            (
+                "file_permissions",
+                include_str!("fixtures/google_drive/contracts/permissions.list.json"),
+            ),
+        ] {
+            let t = table(short);
+            assert_eq!(
+                fingerprint_uncovered_columns(contract, t.row_path, t.fields),
+                &[] as &[&str],
+                "{short}: every column must stay inside the fingerprint gate"
+            );
+        }
+        let drives = table("drives");
+        assert_eq!(
+            fingerprint_uncovered_columns(
+                include_str!("fixtures/google_drive/contracts/drives.list.json"),
+                drives.row_path,
+                drives.fields
+            ),
+            [
+                "admin_managed_restrictions",
+                "copy_requires_writer_permission",
+                "domain_users_only",
+                "drive_members_only",
+                "sharing_folders_requires_organizer_permission",
+            ],
+            "drives: exactly the five restriction flags trade coverage for audit value"
+        );
+    }
+
+    #[test]
+    fn every_table_declares_terminating_cursor_pagination() {
+        // One pagination grammar across all three actions: opaque
+        // `pageToken` in, top-level `nextPageToken` out — declared
+        // `anyOf [string, null]` AND required, so the key is always
+        // present and null exactly on the final page. No executor
+        // filters rows after paginating, so null-cursor termination is
+        // complete; Google publishes no has-more flag, so no override.
+        for (short, row_path, page_size) in [
+            ("files", "$.files", 1000),
+            ("drives", "$.drives", 100),
+            ("file_permissions", "$.permissions", 100),
+        ] {
+            let t = table(short);
+            match t.pagination {
+                PaginationStrategy::Cursor {
+                    cursor_param,
+                    next_cursor_path,
+                    page_size_param,
+                    page_size: declared,
+                    has_more_path,
+                } => {
+                    assert_eq!(cursor_param, "pageToken", "{short}");
+                    assert_eq!(next_cursor_path, "$.nextPageToken", "{short}");
+                    assert_eq!(page_size_param, Some("pageSize"), "{short}");
+                    // The declared ceilings, confirmed WIRE bounds in
+                    // phase 4 (1000/100/100 each 200 with real
+                    // credentials; 1001/101/0 each 400).
+                    assert_eq!(declared, page_size, "{short}");
+                    assert!(has_more_path.is_none(), "{short}");
+                }
+                other => panic!("{short} must paginate by cursor, got {other:?}"),
+            }
+            assert_eq!(t.row_path, row_path, "{short}");
+            // In-band Google errors are consumed by `assertGoogleResponse`
+            // upstream into the failure envelope; nothing to forward.
+            assert!(t.error_path.is_none(), "{short}");
+        }
+    }
+
+    #[test]
+    fn resources_and_fixed_inputs_are_exactly_as_designed() {
+        // `files`: the two all-drives pins (BTreeMap order — the loader
+        // sorts fixed inputs alphabetically) plus two composable optional
+        // scopes; no exclusive group, because `driveId` and `q` compose
+        // (a query within one drive is meaningful) — and the deprecated
+        // `teamDriveId` alias that WOULD have needed one is simply not
+        // declared as a resource.
+        let files = table("files");
+        assert_eq!(
+            files.fixed_inputs,
+            &[
+                ("includeItemsFromAllDrives", FixedValue::Bool(true)),
+                ("supportsAllDrives", FixedValue::Bool(true)),
+            ]
+        );
+        assert!(files.required_resources.is_empty());
+        assert_eq!(files.optional_resources, &["driveId", "q"]);
+        assert!(files.exclusive_resources.is_empty());
+
+        // `drives`: `q` only; `useDomainAdminAccess` never becomes a
+        // knob (Workspace-admin-only, 403s for everyone else).
+        let drives = table("drives");
+        assert!(drives.fixed_inputs.is_empty());
+        assert!(drives.required_resources.is_empty());
+        assert_eq!(drives.optional_resources, &["q"]);
+
+        // `file_permissions`: the binding names the file; nothing else.
+        // No `supportsAllDrives` pin needed — THIS executor (unlike
+        // files.list) defaults it true upstream.
+        let permissions = table("file_permissions");
+        assert!(permissions.fixed_inputs.is_empty());
+        assert_eq!(permissions.required_resources, &["fileId"]);
+        assert!(permissions.optional_resources.is_empty());
+
+        // No table maps a filter: `q` is a query LANGUAGE, so pushdown
+        // is structurally impossible (a column-op-value literal is
+        // never a legal `q`) — a resource, not a FilterMapping.
+        for short in ["files", "drives", "file_permissions"] {
+            assert!(table(short).filters.is_empty(), "{short}");
+        }
+    }
+
+    #[test]
+    fn generated_inputs_are_accepted_by_the_captured_input_contracts() {
+        // The fingerprint gate is OUTPUT-only, so the input half lives
+        // in committed captures, gmail-style: every key this pack can
+        // put on the wire must be declared, every declared bound must
+        // contain the pinned page size, and the negative space — both
+        // the undeclared keys that 400ed live and the declared keys the
+        // yaml promises never to send — is pinned per action. Compares
+        // committed artifacts, not the live gateway: its value is on
+        // RE-CAPTURE after an upstream bump.
+        for (short, contract, declared_never_sent) in [
+            (
+                "files",
+                include_str!("fixtures/google_drive/contracts/inputs/files.list.json"),
+                // Superseded by the all-drives pins (`corpora`, the
+                // deprecated `corpus`), the deprecated `driveId` alias
+                // (`teamDriveId` — the silent-precedence trap), the
+                // default space (`spaces`), a reorder of a fully-read
+                // scan (`orderBy`), and two structural no-ops — the
+                // executor's pinned `fields` projection carries neither
+                // `labelInfo` nor `permissions` back out
+                // (`includeLabels`, `includePermissionsForView`).
+                vec![
+                    "corpora",
+                    "corpus",
+                    "spaces",
+                    "teamDriveId",
+                    "orderBy",
+                    "includeLabels",
+                    "includePermissionsForView",
+                ],
+            ),
+            (
+                "drives",
+                include_str!("fixtures/google_drive/contracts/inputs/drives.list.json"),
+                // Workspace-admin-only; 403s for everyone else.
+                vec!["useDomainAdminAccess"],
+            ),
+            (
+                "file_permissions",
+                include_str!("fixtures/google_drive/contracts/inputs/permissions.list.json"),
+                // `fields` would REPLACE the executor's projection and
+                // can only narrow the normalized surface; the published
+                // view and the admin knob are out of scope; and
+                // `supportsAllDrives` already defaults true upstream in
+                // THIS executor.
+                vec![
+                    "fields",
+                    "includePermissionsForView",
+                    "useDomainAdminAccess",
+                    "supportsAllDrives",
+                ],
+            ),
+        ] {
+            let schema: Value =
+                serde_json::from_str(contract).expect("input contract fixture parses");
+            let properties = &schema["properties"];
+            let t = table(short);
+
+            // Strictness is the premise: a lenient action would ignore
+            // an undeclared key instead of 400ing on it.
+            assert_eq!(
+                schema["additionalProperties"],
+                json!(false),
+                "{short}: the action's input schema is strict"
+            );
+
+            // Every key this table can put on the wire must be declared.
+            let mut generated: Vec<&str> = t
+                .required_resources
+                .iter()
+                .chain(t.optional_resources)
+                .copied()
+                .collect();
+            generated.extend(t.fixed_inputs.iter().map(|(key, _)| *key));
+            if let PaginationStrategy::Cursor {
+                cursor_param,
+                page_size_param,
+                ..
+            } = t.pagination
+            {
+                generated.push(cursor_param);
+                generated.extend(page_size_param);
+            }
+            for key in &generated {
+                assert!(
+                    !properties[*key].is_null(),
+                    "{short}: `{key}` is not declared by the action's input schema"
+                );
+            }
+
+            // …and anything the action requires must be among them. All
+            // three actions declare NO `required` array today — which is
+            // why `fileId` needs the resource-level requirement (see
+            // below); a re-captured contract growing one breaks here.
+            if let Some(required) = schema["required"].as_array() {
+                for entry in required {
+                    let entry = entry.as_str().expect("required entries are strings");
+                    assert!(
+                        generated.contains(&entry),
+                        "{short}: the action requires `{entry}`, which this table never sends"
+                    );
+                }
+            }
+
+            // The pinned page size sits inside the declared bounds — at
+            // the ceiling exactly (1–1000 / 1–100 / 1–100).
+            if let PaginationStrategy::Cursor {
+                page_size_param: Some(param),
+                page_size,
+                ..
+            } = t.pagination
+            {
+                let declared = &properties[param];
+                assert_eq!(
+                    u64::from(page_size),
+                    declared["maximum"].as_u64().expect("declared maximum"),
+                    "{short}: the pinned size is the declared ceiling"
+                );
+                assert!(
+                    u64::from(page_size) >= declared["minimum"].as_u64().expect("declared minimum")
+                );
+            }
+
+            // The cursor is an OPAQUE token, not one_drive's URI: no
+            // format, just non-empty — the engine never sends an empty
+            // cursor, so `minLength: 1` costs nothing.
+            assert_eq!(
+                properties["pageToken"]["minLength"],
+                json!(1),
+                "{short}: the cursor is a non-empty opaque token"
+            );
+
+            // Negative space, undeclared side: each of these 400ed live
+            // as `invalid_input` (probed 2026-08-25 — inputs are
+            // validated before credentials). `fields` is in this list
+            // for files.list ONLY: the sibling actions declare it.
+            let undeclared: &[&str] = if short == "files" {
+                &[
+                    "fields",
+                    "filter",
+                    "orderby",
+                    "maxResults",
+                    "cursor",
+                    "page",
+                    "perPage",
+                    "limit",
+                ]
+            } else {
+                &[
+                    "filter",
+                    "orderby",
+                    "maxResults",
+                    "cursor",
+                    "page",
+                    "perPage",
+                    "limit",
+                ]
+            };
+            for absent in undeclared {
+                assert!(
+                    properties[*absent].is_null(),
+                    "{short}: `{absent}` is not part of this action's input surface"
+                );
+            }
+
+            // Negative space, declared side: the yaml's "never sent
+            // though declared" claims stay honest — each key really is
+            // declared (so the omission is a choice, not fiction) and
+            // really is outside the generated set.
+            for key in declared_never_sent {
+                assert!(
+                    !properties[key].is_null(),
+                    "{short}: `{key}` should be declared upstream"
+                );
+                assert!(
+                    !generated.contains(&key),
+                    "{short}: `{key}` must never be generated"
+                );
+            }
+        }
+
+        // The `fileId` enforcement boundary, pinned the way one_drive
+        // pins `query`: declared `minLength: 1` (so `""` is a
+        // schema-layer 400) but absent from any `required` array (so a
+        // MISSING fileId would pass validation and die in the executor's
+        // own `resolveFileId` check). The resource-level requirement
+        // closes the missing case at registration. This pins an upstream
+        // DEFECT — if a re-captured contract grows `required:
+        // ["fileId"]`, upstream fixed the gap: update this assertion and
+        // the yaml rationale.
+        let permissions: Value = serde_json::from_str(include_str!(
+            "fixtures/google_drive/contracts/inputs/permissions.list.json"
+        ))
+        .expect("input contract fixture parses");
+        assert_eq!(permissions["properties"]["fileId"]["minLength"], json!(1));
+        assert!(
+            permissions["required"].is_null(),
+            "upstream now declares a `required` array ({}) — if it contains \
+             `fileId`, the executor-layer gap this pack works around is fixed; \
+             update this assertion and the `fileId` rationale in the yaml",
+            permissions["required"]
+        );
+        assert_eq!(table("file_permissions").required_resources, &["fileId"]);
+    }
+
+    // ── Integration: the pack against a mock gateway, end to end. ───────
+
+    fn google_drive_config(token_env: &str, tables: &str, resource: &str) -> OpenConnectorConfig {
+        let resource_line = if resource.is_empty() {
+            String::new()
+        } else {
+            format!("resource: {resource}")
+        };
+        serde_yaml::from_str(&format!(
+            r#"
+runtime_token_env: {token_env}
+bindings:
+  - name: gdrive
+    source_pack: google_drive
+    {resource_line}
+    tables: [{tables}]
+"#
+        ))
+        .expect("config parses")
+    }
+
+    async fn setup_with_gateway(
+        gateway: MockGateway,
+        token_env: &'static str,
+        tables: &str,
+        resource: &str,
+    ) -> (MockGateway, SessionContext) {
+        let _token = EnvVarGuard::set(token_env, "test-token");
+        let gateways = OpenConnectorGateways::default();
+        let mut ctx = SessionContext::new();
+        register_open_connector_tables(
+            &mut ctx,
+            "saas",
+            &gateway.url,
+            Some(&google_drive_config(token_env, tables, resource)),
+            false,
+            HierarchyLevel::Catalog,
+            Some(&gateways),
+        )
+        .await
+        .expect("gateway registration succeeds");
+        register_open_connector_udtfs(&ctx, gateways).expect("UDTF registration succeeds");
+        (gateway, ctx)
+    }
+
+    async fn collect(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch> {
+        ctx.sql(sql)
+            .await
+            .expect("plan")
+            .collect()
+            .await
+            .expect("collect")
+    }
+
+    fn column_values(batches: &[RecordBatch], name: &str) -> Vec<String> {
+        batches
+            .iter()
+            .flat_map(|batch| {
+                let values = batch
+                    .column_by_name(name)
+                    .unwrap_or_else(|| panic!("column {name}"))
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .expect("Utf8 column")
+                    .clone();
+                (0..values.len()).map(move |i| values.value(i).to_string())
+            })
+            .collect()
+    }
+
+    fn execute_inputs(gateway: &MockGateway, action_path: &str) -> Vec<Value> {
+        gateway
+            .requests()
+            .into_iter()
+            .filter(|r| r.method == "POST" && r.path.ends_with(action_path))
+            .map(|r| {
+                serde_json::from_str::<Value>(&r.body).expect("request body is JSON")["input"]
+                    .clone()
+            })
+            .collect()
+    }
+
+    fn input_keys(input: &Value) -> Vec<&str> {
+        let mut keys: Vec<&str> = input
+            .as_object()
+            .expect("input object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        keys.sort_unstable();
+        keys
+    }
+
+    /// A minimal normalized file row: identity plus enough to prove the
+    /// row travelled, deliberately not a full driveFile.
+    fn file_row(id: &str) -> Value {
+        json!({
+            "id": id,
+            "name": format!("{id}.txt"),
+            "mimeType": "text/plain",
+            "sizeBytes": 12
+        })
+    }
+
+    #[tokio::test]
+    async fn files_cursor_scan_pages_with_the_pinned_all_drives_inputs() {
+        // Two-page cursor scan pinning the wire declaration: the two
+        // all-drives pins and `pageSize` on EVERY request (continuations
+        // included), the opaque cursor verbatim on page 2, explicit null
+        // termination, row identity across pages, and exact key sets —
+        // no `q`, `fields`, `corpora` or `orderBy` ever.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return google_drive_discovery(&req.path);
+            }
+            if req.method == "POST" && req.path == "/v1/actions/googledrive.files.list" {
+                let body: Value = serde_json::from_str(&req.body).unwrap_or_default();
+                let page = match body["input"].get("pageToken").and_then(Value::as_str) {
+                    None => json!({"files": [file_row("f-1"), file_row("f-2")],
+                                    "nextPageToken": FILES_PAGE2_TOKEN}),
+                    Some(token) if token == FILES_PAGE2_TOKEN => {
+                        json!({"files": [file_row("f-3")], "nextPageToken": null})
+                    }
+                    Some(other) => return MockResponse::new(400, format!("bad cursor {other}")),
+                };
+                return MockResponse::ok(&envelope_ok(&page.to_string()));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (gateway, ctx) =
+            setup_with_gateway(gateway, "SKARDI_TEST_OC_GDRIVE_FILES", "files", "").await;
+
+        let batches = collect(&ctx, "SELECT id FROM saas.gdrive.files ORDER BY id").await;
+        assert_eq!(column_values(&batches, "id"), vec!["f-1", "f-2", "f-3"]);
+
+        let inputs = execute_inputs(&gateway, "googledrive.files.list");
+        assert_eq!(inputs.len(), 2, "two cursor pages");
+        assert_eq!(
+            inputs[1]["pageToken"], FILES_PAGE2_TOKEN,
+            "the opaque cursor verbatim"
+        );
+        for (page, (input, expected_keys)) in inputs
+            .iter()
+            .zip([
+                vec!["includeItemsFromAllDrives", "pageSize", "supportsAllDrives"],
+                vec![
+                    "includeItemsFromAllDrives",
+                    "pageSize",
+                    "pageToken",
+                    "supportsAllDrives",
+                ],
+            ])
+            .enumerate()
+        {
+            assert_eq!(input["pageSize"], 1000, "declared ceiling: {input}");
+            assert_eq!(input["supportsAllDrives"], true, "{input}");
+            assert_eq!(input["includeItemsFromAllDrives"], true, "{input}");
+            assert_eq!(input_keys(input), expected_keys, "page {} keys", page + 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn optional_resources_forward_verbatim_and_compose() {
+        // `driveId` and `q` on one binding: both reach the wire
+        // byte-for-byte alongside the pins — the two scopes COMPOSE (a
+        // query within one shared drive), which is why the yaml declares
+        // no exclusive group. The `q` value is a whole Drive
+        // query-language expression: exactly the shape a filter mapping
+        // could never generate.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return google_drive_discovery(&req.path);
+            }
+            if req.method == "POST" && req.path == "/v1/actions/googledrive.files.list" {
+                return MockResponse::ok(&envelope_ok(
+                    &json!({"files": [file_row("f-1")], "nextPageToken": null}).to_string(),
+                ));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (gateway, ctx) = setup_with_gateway(
+            gateway,
+            "SKARDI_TEST_OC_GDRIVE_SCOPES",
+            "files",
+            "{driveId: 0ASyntheticSharedDriveUk9PVA, q: \"mimeType != 'application/vnd.google-apps.folder' and trashed = false\"}",
+        )
+        .await;
+
+        let batches = collect(&ctx, "SELECT id FROM saas.gdrive.files").await;
+        assert_eq!(column_values(&batches, "id"), vec!["f-1"]);
+
+        let inputs = execute_inputs(&gateway, "googledrive.files.list");
+        assert_eq!(inputs.len(), 1);
+        assert_eq!(inputs[0]["driveId"], "0ASyntheticSharedDriveUk9PVA");
+        assert_eq!(
+            inputs[0]["q"],
+            "mimeType != 'application/vnd.google-apps.folder' and trashed = false"
+        );
+        assert_eq!(
+            input_keys(&inputs[0]),
+            vec![
+                "driveId",
+                "includeItemsFromAllDrives",
+                "pageSize",
+                "q",
+                "supportsAllDrives"
+            ],
+            "both scopes ride alongside the pins: {}",
+            inputs[0]
+        );
+    }
+
+    #[tokio::test]
+    async fn drives_scan_sends_only_its_page_size_and_terminates_on_null() {
+        // The leanest wire in the pack: an unbound `drives` scan is
+        // `{"pageSize": 100}` and nothing else — no all-drives pins
+        // (drives ARE the shared drives), no `useDomainAdminAccess`.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return google_drive_discovery(&req.path);
+            }
+            if req.method == "POST" && req.path == "/v1/actions/googledrive.drives.list" {
+                let body: Value = serde_json::from_str(&req.body).unwrap_or_default();
+                let page = match body["input"].get("pageToken").and_then(Value::as_str) {
+                    None => json!({"drives": [{"id": "d-1", "name": "Engineering"}],
+                                    "nextPageToken": "drives-page-2"}),
+                    Some("drives-page-2") => {
+                        json!({"drives": [{"id": "d-2", "name": "Legal"}],
+                               "nextPageToken": null})
+                    }
+                    Some(other) => return MockResponse::new(400, format!("bad cursor {other}")),
+                };
+                return MockResponse::ok(&envelope_ok(&page.to_string()));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (gateway, ctx) =
+            setup_with_gateway(gateway, "SKARDI_TEST_OC_GDRIVE_DRIVES", "drives", "").await;
+
+        let batches = collect(&ctx, "SELECT id, name FROM saas.gdrive.drives ORDER BY id").await;
+        assert_eq!(column_values(&batches, "id"), vec!["d-1", "d-2"]);
+
+        let inputs = execute_inputs(&gateway, "googledrive.drives.list");
+        assert_eq!(inputs.len(), 2, "two cursor pages");
+        assert_eq!(input_keys(&inputs[0]), vec!["pageSize"]);
+        assert_eq!(
+            inputs[0]["pageSize"], 100,
+            "declared ceiling: {}",
+            inputs[0]
+        );
+        assert_eq!(input_keys(&inputs[1]), vec!["pageSize", "pageToken"]);
+    }
+
+    #[tokio::test]
+    async fn file_permissions_scan_forwards_its_required_file_id_on_every_page() {
+        // The binding names the file, and the value rides EVERY request
+        // including continuations — rows carry no file identity of their
+        // own, so the binding is the only place the file is named.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return google_drive_discovery(&req.path);
+            }
+            if req.method == "POST" && req.path == "/v1/actions/googledrive.permissions.list" {
+                let body: Value = serde_json::from_str(&req.body).unwrap_or_default();
+                let page = match body["input"].get("pageToken").and_then(Value::as_str) {
+                    None => json!({"permissions": [{"id": "p-1", "role": "owner"}],
+                                    "nextPageToken": "perms-page-2"}),
+                    Some("perms-page-2") => {
+                        json!({"permissions": [{"id": "p-2", "role": "reader"}],
+                               "nextPageToken": null})
+                    }
+                    Some(other) => return MockResponse::new(400, format!("bad cursor {other}")),
+                };
+                return MockResponse::ok(&envelope_ok(&page.to_string()));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (gateway, ctx) = setup_with_gateway(
+            gateway,
+            "SKARDI_TEST_OC_GDRIVE_PERMS",
+            "file_permissions",
+            "{fileId: 1SyntheticMyDriveDocAAAAAAAAAAAAAAAAAAAAAAA}",
+        )
+        .await;
+
+        let batches = collect(
+            &ctx,
+            "SELECT id, role FROM saas.gdrive.file_permissions ORDER BY id",
+        )
+        .await;
+        assert_eq!(column_values(&batches, "id"), vec!["p-1", "p-2"]);
+
+        let inputs = execute_inputs(&gateway, "googledrive.permissions.list");
+        assert_eq!(inputs.len(), 2, "two cursor pages");
+        for (page, (input, expected_keys)) in inputs
+            .iter()
+            .zip([
+                vec!["fileId", "pageSize"],
+                vec!["fileId", "pageSize", "pageToken"],
+            ])
+            .enumerate()
+        {
+            assert_eq!(
+                input["fileId"], "1SyntheticMyDriveDocAAAAAAAAAAAAAAAAAAAAAAA",
+                "the bound file on every page: {input}"
+            );
+            assert_eq!(input["pageSize"], 100, "declared ceiling: {input}");
+            assert_eq!(input_keys(input), expected_keys, "page {} keys", page + 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn a_permissions_binding_without_a_file_id_fails_before_any_http() {
+        // The failing arm of the required resource. Upstream, a missing
+        // fileId passes schema validation (empty `required` array) and
+        // dies in the executor — declaring the resource is what refuses
+        // the binding at REGISTRATION instead, before discovery: the
+        // gateway sees nothing but the health probe.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return google_drive_discovery(&req.path);
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let _token = EnvVarGuard::set("SKARDI_TEST_OC_GDRIVE_NO_FILE", "test-token");
+        let mut ctx = SessionContext::new();
+        let gateways = OpenConnectorGateways::default();
+        let err = register_open_connector_tables(
+            &mut ctx,
+            "saas",
+            &gateway.url,
+            Some(&google_drive_config(
+                "SKARDI_TEST_OC_GDRIVE_NO_FILE",
+                "file_permissions",
+                "",
+            )),
+            false,
+            HierarchyLevel::Catalog,
+            Some(&gateways),
+        )
+        .await
+        .expect_err("a permissions binding with no fileId must fail registration");
+        assert!(
+            err.to_string().contains("fileId"),
+            "the missing resource is named: {err}"
+        );
+        assert!(
+            gateway.requests().iter().all(|r| r.path == "/v1/health"),
+            "resource enforcement precedes discovery"
+        );
+    }
+
+    #[tokio::test]
+    async fn predicates_stay_local_against_a_provider_that_cannot_narrow() {
+        // No filter mapping exists (see the resources test), so every
+        // predicate runs in DataFusion after the bounded fetch and the
+        // wire request is identical to an unfiltered one — in particular
+        // no `q` invented from the SQL, even though a human could write
+        // this WHERE clause as one.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return google_drive_discovery(&req.path);
+            }
+            if req.method == "POST" && req.path == "/v1/actions/googledrive.files.list" {
+                return MockResponse::ok(&envelope_ok(
+                    &json!({"files": [file_row("keep"), file_row("drop")],
+                            "nextPageToken": null})
+                    .to_string(),
+                ));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (gateway, ctx) =
+            setup_with_gateway(gateway, "SKARDI_TEST_OC_GDRIVE_FILTER", "files", "").await;
+
+        let batches = collect(&ctx, "SELECT id FROM saas.gdrive.files WHERE id = 'keep'").await;
+        assert_eq!(column_values(&batches, "id"), vec!["keep"]);
+
+        let inputs = execute_inputs(&gateway, "googledrive.files.list");
+        assert_eq!(inputs.len(), 1);
+        assert_eq!(
+            input_keys(&inputs[0]),
+            vec!["includeItemsFromAllDrives", "pageSize", "supportsAllDrives"],
+            "a WHERE clause must not invent a wire input: {}",
+            inputs[0]
+        );
+    }
+
+    #[tokio::test]
+    async fn limit_stops_cursor_pagination_early() {
+        // LIMIT must stop the walk rather than drain the corpus: one
+        // page fetched, the cursor never followed — and the page size
+        // stays the declared ceiling, because `pageSize` bounds
+        // REQUESTS, not bytes (a LIMIT 1 still transfers a full page).
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return google_drive_discovery(&req.path);
+            }
+            if req.method == "POST" && req.path == "/v1/actions/googledrive.files.list" {
+                return MockResponse::ok(&envelope_ok(
+                    &json!({"files": [file_row("f-1"), file_row("f-2")],
+                            "nextPageToken": FILES_PAGE2_TOKEN})
+                    .to_string(),
+                ));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (gateway, ctx) =
+            setup_with_gateway(gateway, "SKARDI_TEST_OC_GDRIVE_LIMIT", "files", "").await;
+
+        // Cardinality, not identity: WHICH row a LIMIT keeps without an
+        // ORDER BY is not something SQL promises.
+        let batches = collect(&ctx, "SELECT id FROM saas.gdrive.files LIMIT 1").await;
+        assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 1);
+        let inputs = execute_inputs(&gateway, "googledrive.files.list");
+        assert_eq!(inputs.len(), 1, "LIMIT stops before following the cursor");
+        assert_eq!(
+            inputs[0]["pageSize"], 1000,
+            "a full page still crosses the wire: {}",
+            inputs[0]
+        );
+    }
+
+    #[tokio::test]
+    async fn scan_of_an_account_with_no_shared_drives_is_clean() {
+        // `drives` lists SHARED drives only — My Drive is not a drive
+        // resource — so on an account with no shared-drive membership
+        // the table is legitimately empty: a successful empty scan, not
+        // an error. This is also the shape design record R1 warns about:
+        // "empty and correct" and "empty because the account cannot see
+        // shared drives at all" are indistinguishable from here, which
+        // is exactly why phase 4 needs an account that can see one.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return google_drive_discovery(&req.path);
+            }
+            if req.method == "POST" && req.path == "/v1/actions/googledrive.drives.list" {
+                return MockResponse::ok(&envelope_ok(
+                    &json!({"drives": [], "nextPageToken": null}).to_string(),
+                ));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (gateway, ctx) =
+            setup_with_gateway(gateway, "SKARDI_TEST_OC_GDRIVE_EMPTY", "drives", "").await;
+
+        let batches = collect(&ctx, "SELECT id, name FROM saas.gdrive.drives").await;
+        assert_eq!(
+            batches.iter().map(RecordBatch::num_rows).sum::<usize>(),
+            0,
+            "an empty collection is an empty result set, not an error"
+        );
+        assert_eq!(
+            execute_inputs(&gateway, "googledrive.drives.list").len(),
+            1,
+            "an empty page still costs exactly one request"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_repeated_cursor_fails_as_a_pagination_loop() {
+        // A gateway that hands back the cursor it was given must fail
+        // loudly instead of spinning: incomplete is never success.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return google_drive_discovery(&req.path);
+            }
+            if req.method == "POST" && req.path == "/v1/actions/googledrive.files.list" {
+                return MockResponse::ok(&envelope_ok(
+                    &json!({"files": [file_row("f-1")], "nextPageToken": FILES_PAGE2_TOKEN})
+                        .to_string(),
+                ));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (_gateway, ctx) =
+            setup_with_gateway(gateway, "SKARDI_TEST_OC_GDRIVE_LOOP", "files", "").await;
+
+        let err = ctx
+            .sql("SELECT id FROM saas.gdrive.files")
+            .await
+            .expect("plan")
+            .collect()
+            .await
+            .expect_err("a repeated cursor must fail the scan");
+        let message = err.to_string();
+        assert!(
+            message.contains("pagination loop") && message.contains(FILES_PAGE2_TOKEN),
+            "the loop names the cursor the gateway would not advance: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_errors_surface_through_the_gateway_failure_envelope() {
+        // In-band Google errors are consumed upstream, so the pack sees
+        // them as a failure envelope — the exact surface the phase-1
+        // no-credential calibration witnessed live (403
+        // `authorization_failed` on a valid input with no connection).
+        // The assertion also pins that the TWO-DOT action id survives
+        // intact into error identity.
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return google_drive_discovery(&req.path);
+            }
+            if req.method == "POST" && req.path == "/v1/actions/googledrive.files.list" {
+                return MockResponse::new(
+                    403,
+                    envelope_err(
+                        "authorization_failed",
+                        "Connect googledrive with OAuth first.",
+                    ),
+                );
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (_gateway, ctx) =
+            setup_with_gateway(gateway, "SKARDI_TEST_OC_GDRIVE_AUTHZ", "files", "").await;
+
+        let err = ctx
+            .sql("SELECT id FROM saas.gdrive.files")
+            .await
+            .expect("plan")
+            .collect()
+            .await
+            .expect_err("a failure envelope must fail the scan");
+        let message = err.to_string();
+        assert!(
+            message.contains("authorization_failed") && message.contains("googledrive.files.list"),
+            "the gateway's error code and the dotted action id are named: {message}"
+        );
+        assert!(
+            !message.contains("row path"),
+            "never the misleading row-path error: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn udtf_parity_for_files() {
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return google_drive_discovery(&req.path);
+            }
+            if req.method == "POST" && req.path == "/v1/actions/googledrive.files.list" {
+                return MockResponse::ok(&envelope_ok(
+                    &json!({"files": [file_row("f-1")], "nextPageToken": null}).to_string(),
+                ));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let (_gateway, ctx) =
+            setup_with_gateway(gateway, "SKARDI_TEST_OC_GDRIVE_UDTF", "files", "").await;
+
+        let from_table = collect(&ctx, "SELECT id, name, mime_type FROM saas.gdrive.files").await;
+        let from_udtf = collect(
+            &ctx,
+            "SELECT id, name, mime_type \
+             FROM open_connector_query('saas', 'google_drive.files', '{}')",
+        )
+        .await;
+        assert_eq!(from_table[0].schema(), from_udtf[0].schema());
+        assert_eq!(
+            arrow::util::pretty::pretty_format_batches(&from_table)
+                .unwrap()
+                .to_string(),
+            arrow::util::pretty::pretty_format_batches(&from_udtf)
+                .unwrap()
+                .to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn drifted_contract_fails_registration_not_the_scan() {
+        // The pin's refusal side: a gateway whose discovered output
+        // schema differs from the captured contract is refused at
+        // REGISTRATION, table and action named — the dotted action id
+        // again travelling the error intact. (Every other e2e proves the
+        // pass side via google_drive_discovery's captured contracts.)
+        let gateway = MockGateway::start(|req| {
+            if req.method == "GET" && req.path == "/v1/health" {
+                return MockResponse::ok("{}");
+            }
+            if req.method == "GET" && req.path.starts_with("/v1/actions/") {
+                return MockResponse::ok(&discovery_ok("{}", r#"{"type": "object"}"#, true, None));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+        let _token = EnvVarGuard::set("SKARDI_TEST_OC_GDRIVE_DRIFT", "test-token");
+        let mut ctx = SessionContext::new();
+        let gateways = OpenConnectorGateways::default();
+        let err = register_open_connector_tables(
+            &mut ctx,
+            "saas",
+            &gateway.url,
+            Some(&google_drive_config(
+                "SKARDI_TEST_OC_GDRIVE_DRIFT",
+                "files",
+                "",
+            )),
+            false,
+            HierarchyLevel::Catalog,
+            Some(&gateways),
+        )
+        .await
+        .expect_err("a drifted contract must fail registration");
+        let message = err.to_string();
+        assert!(
+            message.contains("google_drive.files")
+                && message.contains("googledrive.files.list")
+                && message.contains("fingerprint mismatch"),
+            "table, action, and cause are named: {message}"
+        );
+    }
+}

--- a/crates/skardi/src/sources/providers/open_connector/packs/google_drive.yaml
+++ b/crates/skardi/src/sources/providers/open_connector/packs/google_drive.yaml
@@ -102,9 +102,11 @@ tables:
     # excludes a whole class of the account's files is the
     # confidently-wrong-rows failure mode; Google requires the pair
     # together for shared-drive items to appear, so both are pinned.
-    # Phase 4 must verify the pin directly: accepted on the wire,
-    # shared-drive rows actually present, no bad interaction with a
-    # bound `driveId` (Google's `corpora` inference).
+    # Phase 4 verified the pin directly: accepted on the wire, a
+    # seeded shared-drive file really present in a live scan (its
+    # `drive_id` carrying the real drive id), and no bad interaction
+    # with a bound `driveId` (Google's `corpora` inference) — the two
+    # compose live.
     fixed_inputs:
       supportsAllDrives: true
       includeItemsFromAllDrives: true
@@ -155,16 +157,20 @@ tables:
       # A normalization win worth naming: Google's REST API returns
       # `size` as a decimal STRING; the executor's `parseSizeBytes`
       # emits a real number (or null for anything without a byte size of
-      # its own — folders and every native Docs/Sheets/Slides file), so
-      # this column is a true int64. An all-NULL `size_bytes` on a
-      # Docs-only corpus is expected, not the always-NULL defect.
+      # its own), so this column is a true int64. Which files have none
+      # is a live finding, not a guess: FOLDERS came back null, while
+      # native Docs/Sheets/Slides reported real sizes (Workspace files
+      # count against storage quota since 2021). So an all-NULL
+      # `size_bytes` over real files is the always-NULL defect, not an
+      # expected shape.
       - { name: size_bytes, path: sizeBytes, type: int64, nullable: true }
       # Null on My Drive items; the join key to `drives.id` for
       # shared-drive items.
       - { name: drive_id, path: driveId, type: utf8, nullable: true }
-      # Conditionally spread upstream (absent when Google omits it, e.g.
-      # some shared-drive rows), else an array of parent folder IDs —
-      # in practice at most one since Drive dropped multi-parenting.
+      # Conditionally spread upstream, so NULL where Google omits it
+      # — though live it was present on every row, shared-drive ones
+      # included; otherwise an array of parent folder IDs, in practice
+      # at most one since Drive dropped multi-parenting.
       - { name: parents, path: parents, type: utf8_list, nullable: true }
       # Two columns from ONE `owners` array under different pluck keys:
       # the engine deliberately has no scalar array indexing, so these

--- a/crates/skardi/src/sources/providers/open_connector/packs/google_drive.yaml
+++ b/crates/skardi/src/sources/providers/open_connector/packs/google_drive.yaml
@@ -1,0 +1,337 @@
+# Google Drive source pack. Wire contract reconciled against a live Open
+# Connector gateway (v1.3.4, open-connector at `2410fbe`, 2026-08-25):
+# the service is spelled `googledrive` upstream (one word), and its
+# action IDs carry TWO dots (`googledrive.files.list` — `service.name`
+# where the name itself is dotted). That shape is new to shipped packs
+# and already safe end to end: `validate_action_id` rejects only `/` and
+# bare dot segments, the client's percent-encode set keeps dots verbatim
+# in the URL path, and the `rsplit('.')` lookups elsewhere read TABLE
+# ids, not action ids.
+#
+# Rows are NORMALIZED upstream — the opposite of `one_drive`, and the
+# reason no column below uses Google's own REST field names. Every
+# executor rebuilds its rows through a `normalize*` function into a
+# fixed key set (`normalizeDriveFile`, `normalizeDrive`,
+# `normalizePermission`), every declared row object is
+# `additionalProperties: false`, and the executors pin their own
+# `fields` projection on the provider request — `files.list` does not
+# even declare a `fields` input (verified live: sending one 400s), so
+# the row shape is fully determined upstream and cannot be widened or
+# narrowed from here. Mapping Google's REST spellings
+# (`webContentLink`, string-typed `size`) would have shipped
+# always-NULL columns; the wire keys below are the normalizer's, read
+# from the executor source, and — with one deliberate exception on
+# `drives`, documented there — every mapped path resolves INSIDE the
+# declared item schema, so the fingerprint gate covers it.
+#
+# Key absence is not uniform, and fixtures model both spellings of
+# "no value": the `?? null` normalizer fields are ALWAYS present
+# (explicit JSON null on the wire), while the conditionally-spread ones
+# vanish from the row entirely when upstream omits them — on files:
+# `parents`, `owners`, `shared`, `starred`, `trashed`; on drives:
+# `hidden`, `capabilities`, `restrictions`; on permissions: `deleted`,
+# `pendingOwner`, `allowFileDiscovery` (their `optionalBoolean` result
+# is dropped at JSON serialization when undefined). Both spellings
+# extract as SQL NULL; the distinction matters only to fixtures and to
+# anyone reading raw wire captures.
+#
+# Pagination is uniform across all three actions: a `pageToken` input
+# (`minLength: 1`) against a top-level `nextPageToken` output declared
+# `anyOf: [string, null]` AND listed in the output schema's `required`
+# array — the key is always present, null exactly on the final page. No
+# executor filters rows after paginating (each is a bare
+# `payload.<key>.map(normalize…)`), so null-cursor termination is sound;
+# Google publishes no has-more flag and no total, so no override is
+# declared. In-band Google errors are consumed by the executor
+# (`assertGoogleResponse` throws on any non-2xx), so no table declares
+# `error_path`.
+#
+# Inputs are strict camelCase (`additionalProperties: false`). Verified
+# live on `files.list`: `fields`, `page`, `perPage`, `limit`,
+# lower-case `orderby`, `maxResults` and `cursor` each 400 as
+# `invalid_input`. Page-size bounds differ per action — 1–1000 on
+# `files.list`, 1–100 on `drives.list` and `permissions.list` — and each
+# pinned size below is the declared ceiling, verified to pass schema
+# validation live while `+1` and `0` both 400. A declared bound is not a
+# wire bound (feishu declared 100 and hard-failed above 50, PR #186);
+# phase 4 confirmed all three ceilings ARE wire bounds: 1000/100/100
+# each returned 200 live while 1001/101/0 each 400.
+#
+# No table declares a filter mapping, structurally: the one candidate
+# input (`q`) is a whole query LANGUAGE (`name = 'x' and trashed =
+# false`), and a FilterMapping sends a column's literal as the input's
+# value, which is never a legal `q`. It is an optional RESOURCE instead
+# (on `files` and `drives`): the binding pins the whole query string and
+# the table means "the rows matching this binding's query"; with no `q`
+# the table is the complete collection, so no capability is lost.
+#
+# Authz: all three actions declare `drive.readonly` +
+# `drive.metadata.readonly`, but the provider-level OAuth grant requests
+# the full read-write `https://www.googleapis.com/auth/drive` as well —
+# an upstream connection property a pack cannot narrow, documented as a
+# caveat in `docs/open-connector-google-drive.md`.
+kind: pack
+pack: google_drive
+version: 1
+
+tables:
+  files:
+    action: googledrive.files.list
+    row_path: "$.files"
+    fingerprint: 5da2805b9646b6e775d0126fe25917eb6cc84874e27c6e22a10fac4ad9b4c20f
+    pagination:
+      strategy: cursor
+      cursor_input: pageToken
+      next_cursor_path: "$.nextPageToken"
+      page_size_input: pageSize
+      # The declared ceiling (1–1000; 1001 and 0 both 400 live). It
+      # bounds REQUESTS, not bytes: `pageSize` is sent verbatim and never
+      # narrowed to the SQL LIMIT, so `LIMIT 10` costs one request but
+      # still transfers up to 1000 rows. Rows are small normalized
+      # metadata objects (the executor's own `fields` projection strips
+      # everything else), so a full page sits far under the client's
+      # 16 MiB response cap: measured live, a fully-populated My Drive
+      # row serializes to ~700 bytes, so 1000 rows is under 1 MiB.
+      page_size: 1000
+    # The pack's ONE load-bearing behaviour pin. `files.list` forwards
+    # `supportsAllDrives` verbatim with NO default
+    # (`optionalBoolean(input.supportsAllDrives)`) — unlike the sibling
+    # actions, which run `resolveSupportsAllDrives` and default it TRUE
+    # — so an unpinned scan inherits Google's own default and silently
+    # omits every shared-drive file. A table named `files` that quietly
+    # excludes a whole class of the account's files is the
+    # confidently-wrong-rows failure mode; Google requires the pair
+    # together for shared-drive items to appear, so both are pinned.
+    # Phase 4 must verify the pin directly: accepted on the wire,
+    # shared-drive rows actually present, no bad interaction with a
+    # bound `driveId` (Google's `corpora` inference).
+    fixed_inputs:
+      supportsAllDrives: true
+      includeItemsFromAllDrives: true
+    # `q` pins a Drive query-language string (see the header: a resource
+    # because it cannot be a filter mapping); absent, the scan is the
+    # whole corpus. `driveId` scopes the scan to one shared drive; the
+    # two COMPOSE (a query within one drive is meaningful), so there is
+    # no exclusive group. Deliberately NOT declared: `teamDriveId`, the
+    # deprecated alias of `driveId` — declaring both would create
+    # exactly the silent-precedence trap one_drive needed
+    # `exclusive_resources` for. Also never sent: `corpora` and the
+    # deprecated `corpus` (superseded by the pinned all-drives pair),
+    # `spaces` (the default space is the files corpus this table means),
+    # `orderBy` (reorders a set the scan reads in full), and
+    # `includeLabels` / `includePermissionsForView` — structural no-ops
+    # here, because the executor's pinned `fields` projection contains
+    # neither `labelInfo` nor `permissions`, so the requested data has
+    # no way back out of the wire.
+    #
+    # Trashed files are INCLUDED: Drive's listing does not exclude them
+    # by default and this pack does not pin `q: "trashed = false"` to
+    # make it do so — that would silently narrow the table's meaning
+    # (and collide with `q` as a resource; the loader refuses that
+    # spelling outright). `trashed` is a mapped column; the filtering
+    # belongs in SQL where the operator can see it.
+    resources:
+      optional: [driveId, q]
+    columns:
+      # Identity non-null, the rest nullable — the convention every pack
+      # follows (rationale recorded in gmail.yaml's messages table).
+      # Upstream `id`/`name`/`mimeType` are `String(x ?? "")` — never
+      # null on the wire, possibly empty — and the declared item schema
+      # lists them `required` with plain string types; only `id` claims
+      # non-null here, per the convention.
+      - { name: id, path: id, type: utf8, nullable: false }
+      - { name: name, path: name, type: utf8, nullable: true }
+      # The de-facto type discriminator: folders are
+      # `application/vnd.google-apps.folder`, native Workspace files are
+      # `application/vnd.google-apps.*`, everything else is an ordinary
+      # MIME type.
+      - { name: mime_type, path: mimeType, type: utf8, nullable: true }
+      - { name: web_view_link, path: webViewLink, type: utf8, nullable: true }
+      # RFC 3339 on the wire; `timestamp_ms_utc` names the Arrow storage
+      # — Timestamp(ms, UTC) — and its converter accepts RFC 3339 or
+      # epoch-millis alike (see gmail.yaml's message_timestamp).
+      - { name: created_time, path: createdTime, type: timestamp_ms_utc, nullable: true }
+      - { name: modified_time, path: modifiedTime, type: timestamp_ms_utc, nullable: true }
+      # A normalization win worth naming: Google's REST API returns
+      # `size` as a decimal STRING; the executor's `parseSizeBytes`
+      # emits a real number (or null for anything without a byte size of
+      # its own — folders and every native Docs/Sheets/Slides file), so
+      # this column is a true int64. An all-NULL `size_bytes` on a
+      # Docs-only corpus is expected, not the always-NULL defect.
+      - { name: size_bytes, path: sizeBytes, type: int64, nullable: true }
+      # Null on My Drive items; the join key to `drives.id` for
+      # shared-drive items.
+      - { name: drive_id, path: driveId, type: utf8, nullable: true }
+      # Conditionally spread upstream (absent when Google omits it, e.g.
+      # some shared-drive rows), else an array of parent folder IDs —
+      # in practice at most one since Drive dropped multi-parenting.
+      - { name: parents, path: parents, type: utf8_list, nullable: true }
+      # Two columns from ONE `owners` array under different pluck keys:
+      # the engine deliberately has no scalar array indexing, so these
+      # are lists rather than `owners[0].…` scalars. My Drive files
+      # carry exactly one owner; shared-drive items carry NONE (the
+      # drive owns them — the key is absent, so both columns are NULL
+      # there, which doubles as an ownership-model discriminator).
+      # Each owner object's four keys are always present (`?? null`
+      # normalizer), so the pluck never sees a missing key; a null
+      # displayName becomes a null LIST ITEM, not a failure. The
+      # `permissionId`/`photoLink` siblings stay unmapped: an opaque
+      # per-owner join id this pack cannot join, and an avatar URL.
+      - { name: owner_display_names, path: owners, type: utf8_list_from_object_key, key: displayName, nullable: true }
+      - { name: owner_email_addresses, path: owners, type: utf8_list_from_object_key, key: emailAddress, nullable: true }
+      # The three boolean flags are conditionally spread upstream:
+      # absent unless the provider sent a real boolean, so NULL here
+      # means "not reported", never false.
+      - { name: shared, path: shared, type: boolean, nullable: true }
+      - { name: starred, path: starred, type: boolean, nullable: true }
+      - { name: trashed, path: trashed, type: boolean, nullable: true }
+
+  drives:
+    action: googledrive.drives.list
+    row_path: "$.drives"
+    fingerprint: f85332b8ba49a7c3a36e70cfa5a04de0819ed4e8acadbdb74676c436a6212d81
+    pagination:
+      strategy: cursor
+      cursor_input: pageToken
+      next_cursor_path: "$.nextPageToken"
+      page_size_input: pageSize
+      # Declared ceiling 100 (101 and 0 both 400 live).
+      page_size: 100
+    # SHARED drives only — `My Drive` is not a drive resource and never
+    # appears as a row, so on an account with no shared-drive membership
+    # this table is legitimately empty (witnessed live: a clean
+    # zero-row scan before the phase-4 account created its own shared
+    # drive and resolved design record R1).
+    # `q` is the drives query language (`name contains 'x'`, `hidden =
+    # true`), a resource for the same structural reason as on `files`.
+    # `useDomainAdminAccess` is never sent: it requires a Workspace
+    # admin and 403s for everyone else, so pinning it would break the
+    # common case to serve the rare one.
+    resources:
+      optional: [q]
+    columns:
+      - { name: id, path: id, type: utf8, nullable: false }
+      - { name: name, path: name, type: utf8, nullable: true }
+      # Conditionally spread upstream: absent unless Google reports it.
+      - { name: hidden, path: hidden, type: boolean, nullable: true }
+      # Theme/branding surface: organizer-managed. Live: `colorRgb`
+      # and `backgroundImageLink` carried real values; `themeId` stayed
+      # null even when a drive was CREATED with an explicit theme (it
+      # materializes as the other two), and `orgUnitId` reports only
+      # under Workspace org units — both keys PRESENT and null.
+      - { name: color_rgb, path: colorRgb, type: utf8, nullable: true }
+      - { name: created_time, path: createdTime, type: timestamp_ms_utc, nullable: true }
+      # Workspace org unit; null outside domain-managed drives.
+      - { name: org_unit_id, path: orgUnitId, type: utf8, nullable: true }
+      - { name: theme_id, path: themeId, type: utf8, nullable: true }
+      - { name: background_image_link, path: backgroundImageLink, type: utf8, nullable: true }
+      # ── The five restriction flags: the ONLY columns in this pack
+      # outside the fingerprint gate, and the trade is taken knowingly.
+      # `restrictions` is declared as a bare open object
+      # (`properties: {}`, `additionalProperties: {}`), so the contract
+      # promises the key and says nothing about its contents. Three
+      # consequences, worst first: (1) these five key spellings appear
+      # in NO capture — they come from Google's Drive v3 documentation,
+      # exactly the source the reconciliation discipline warns about;
+      # the executor passes the object through raw
+      # (`asOptionalObject(payload.restrictions)`, no renaming), and
+      # phase 4 supplied the verification the captures cannot: a real
+      # drive row carried all five spellings verbatim as present
+      # `false`s (alongside a nested `downloadRestriction` object left
+      # unmapped), closing the Notion `archived`/`is_archived` risk for
+      # today's upstream — the gate still cannot see tomorrow's. (2) Upstream can
+      # rename an inner key at runtime without touching the declaration
+      # — hash unchanged, registration passes, column silently all-NULL;
+      # the coverage test pins all five as a reviewed case-1 gap.
+      # (3) `restrictions` is not in the item's `required` array and is
+      # conditionally spread, so a drive with no restrictions set may
+      # carry no key at all — all five are nullable, and NULL means
+      # "unreported", never false.
+      # Why ship them at all: `domain_users_only` / `drive_members_only`
+      # answer "how open is this drive", squarely the sharing-audit
+      # question `file_permissions` exists for. Its per-caller sibling
+      # `capabilities` stays unmapped — its values change with the OAuth
+      # identity doing the scan ("Capabilities the current user has"),
+      # so the same table under two bindings would disagree; that is a
+      # permission view, not drive data, and no declaration shape would
+      # make it a column.
+      - { name: admin_managed_restrictions, path: restrictions.adminManagedRestrictions, type: boolean, nullable: true }
+      - { name: copy_requires_writer_permission, path: restrictions.copyRequiresWriterPermission, type: boolean, nullable: true }
+      - { name: domain_users_only, path: restrictions.domainUsersOnly, type: boolean, nullable: true }
+      - { name: drive_members_only, path: restrictions.driveMembersOnly, type: boolean, nullable: true }
+      - { name: sharing_folders_requires_organizer_permission, path: restrictions.sharingFoldersRequiresOrganizerPermission, type: boolean, nullable: true }
+      # `kind` (the constant "drive#drive") stays unmapped here and on
+      # `file_permissions` ("drive#permission"): a per-resource constant
+      # carries no information. `files` has no such key to skip —
+      # `normalizeDriveFile` never emits one.
+
+  file_permissions:
+    action: googledrive.permissions.list
+    row_path: "$.permissions"
+    fingerprint: 5275c28c30a13cb262bc9c8650ed93efd163d2a749ab9b9e88668de0bbc7a3e9
+    pagination:
+      strategy: cursor
+      cursor_input: pageToken
+      next_cursor_path: "$.nextPageToken"
+      page_size_input: pageSize
+      # Declared ceiling 100 (101 and 0 both 400 live).
+      page_size: 100
+    # Who can reach ONE file — the binding names it, because the rows
+    # carry no file identity of their own (`permissions.list` rows have
+    # no `fileId` field, and a resource's value has no path into a row),
+    # so this table is "the permissions of the file this binding names",
+    # the `notion.block_children` shape. An operator auditing many files
+    # binds the pack once per file.
+    #
+    # `fileId` is REQUIRED, and the enforcement boundary is narrow in
+    # exactly the way one_drive's `query` is: the input schema's
+    # `required` array is EMPTY and `fileId` is merely `minLength: 1`,
+    # so a MISSING fileId passes schema validation and dies in the
+    # executor's own check (`resolveFileId` → 400 "fileId is required")
+    # — declaring it a required resource closes that case at
+    # registration, before any HTTP. `fileId: ""` is caught by the
+    # schema layer (400 `invalid_input`, verified live); a
+    # whitespace-only value passes resource validation
+    # (presence-and-non-null only) and fails at scan time on the
+    # upstream 400. Loud either way, never a silent empty table.
+    # One upstream convenience worth naming so it does not read as a
+    # bug: `resolveFileId` runs the value through `extractFileId`, which
+    # accepts a full Drive URL and pulls the ID out of it — a binding
+    # whose `fileId` is `https://drive.google.com/file/d/ABC/view`
+    # works.
+    #
+    # Never sent, though declared: `fields` (it would REPLACE the
+    # executor's default projection and can only narrow the normalized
+    # surface the columns below map), `includePermissionsForView`
+    # (adds `published` view entries the default projection then cannot
+    # widen into), `useDomainAdminAccess` (Workspace-admin-only, 403s
+    # otherwise), and `supportsAllDrives` — unlike `files.list`, this
+    # executor runs `resolveSupportsAllDrives`, which already defaults
+    # it TRUE upstream, so shared-drive files work with no pin.
+    resources:
+      required: [fileId]
+    columns:
+      - { name: id, path: id, type: utf8, nullable: false }
+      # owner / organizer / fileOrganizer / writer / commenter / reader.
+      - { name: role, path: role, type: utf8, nullable: true }
+      # user / group / domain / anyone — with `domain` and `anyone`, the
+      # identity columns below are null and `domain` / discoverability
+      # carry the meaning instead.
+      - { name: type, path: type, type: utf8, nullable: true }
+      - { name: email_address, path: emailAddress, type: utf8, nullable: true }
+      - { name: display_name, path: displayName, type: utf8, nullable: true }
+      - { name: domain, path: domain, type: utf8, nullable: true }
+      - { name: photo_link, path: photoLink, type: utf8, nullable: true }
+      # RFC 3339; set only on expiring grants.
+      - { name: expiration_time, path: expirationTime, type: timestamp_ms_utc, nullable: true }
+      # The three booleans are conditionally spread upstream (absent
+      # unless reported): NULL means "not reported", never false.
+      # `allow_file_discovery` is meaningful for `domain`/`anyone`
+      # grants — whether the link is findable by search.
+      - { name: allow_file_discovery, path: allowFileDiscovery, type: boolean, nullable: true }
+      - { name: deleted, path: deleted, type: boolean, nullable: true }
+      - { name: pending_owner, path: pendingOwner, type: boolean, nullable: true }
+      # `kind` (constant) and `permissionDetails` (an array of
+      # inherited-permission records — a second table's worth of shape,
+      # not a column; its useful content is per-entry role and
+      # inheritance source) stay unmapped.

--- a/crates/skardi/src/sources/providers/open_connector/packs/mod.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/mod.rs
@@ -6,6 +6,7 @@ pub mod discord;
 pub mod feishu;
 pub mod github;
 pub mod gmail;
+pub mod google_drive;
 pub mod mock;
 pub mod notion;
 pub mod one_drive;

--- a/crates/skardi/src/sources/providers/open_connector/source_pack.rs
+++ b/crates/skardi/src/sources/providers/open_connector/source_pack.rs
@@ -170,6 +170,7 @@ impl SourcePackRegistry {
             super::packs::discord::pack()?,
             super::packs::outlook::pack()?,
             super::packs::one_drive::pack()?,
+            super::packs::google_drive::pack()?,
         ] {
             packs.insert(pack.name, pack);
         }
@@ -292,6 +293,7 @@ mod tests {
                 "feishu",
                 "github",
                 "gmail",
+                "google_drive",
                 "mock",
                 "notion",
                 "one_drive",
@@ -370,6 +372,25 @@ mod tests {
     }
 
     #[test]
+    fn builtin_google_drive_pack_is_registered() {
+        let registry = SourcePackRegistry::builtins().expect("embedded assets parse");
+        let pack = registry.require("google_drive").unwrap();
+        assert_eq!(pack.name, "google_drive");
+        assert_eq!(pack.version, 1);
+        // BTreeMap order, not the yaml's authoring order: drives sorts
+        // ahead of the files table it exists to join against.
+        let ids: Vec<&str> = pack.tables.iter().map(|table| table.id).collect();
+        assert_eq!(
+            ids,
+            vec![
+                "google_drive.drives",
+                "google_drive.file_permissions",
+                "google_drive.files",
+            ]
+        );
+    }
+
+    #[test]
     fn unknown_table_is_a_targeted_error() {
         let registry = SourcePackRegistry::builtins().expect("embedded assets parse");
         let pack = registry.require("mock").unwrap();
@@ -433,6 +454,7 @@ mod tests {
             "discord",
             "outlook",
             "one_drive",
+            "google_drive",
         ] {
             let pack = registry.require(name).unwrap();
             let mut seen = std::collections::HashSet::new();

--- a/docs/open-connector-gmail.md
+++ b/docs/open-connector-gmail.md
@@ -5,6 +5,13 @@ messages, drafts, labels, and filters — as stable SQL tables through an
 [Open Connector gateway](open-connector.md). The Google OAuth credential
 lives in Open Connector; Skardi holds only the gateway runtime token.
 
+Google reaches Skardi as **one source pack per Open Connector service**:
+upstream splits Google into `gmail`, `googledrive` and others, each with
+its **own OAuth connection**, so authorizing Gmail does not authorize
+Drive. The Drive pack has its own guide: **[Google Drive source
+pack](open-connector-google-drive.md)** (`files`, `drives`,
+`file_permissions`).
+
 **The wire contract is Open Connector's, not the Gmail API's**: the
 gateway's gmail executors rebuild list rows the way the Slack ones do —
 camelCase identity (`threadId`/`messageId`), the `From`/`To`/`Subject`

--- a/docs/open-connector-google-drive.md
+++ b/docs/open-connector-google-drive.md
@@ -1,0 +1,356 @@
+# Google Drive Source Pack
+
+Google services reach Skardi as **one source pack per Open Connector
+service**: upstream splits Google into `gmail`, `googledrive` (and
+others), each with its **own OAuth connection** — and a Skardi binding
+carries exactly one connection alias, so authorizing Gmail does not
+authorize Drive or vice versa. This document covers the built-in
+**`google_drive` pack** — `files`, `drives` and `file_permissions` over
+the `googledrive` service. The `gmail` pack has
+[its own document](open-connector-gmail.md).
+
+Two upstream spellings worth knowing before anything else: the service
+is **`googledrive`** (one word), and its action IDs carry **two dots**
+(`googledrive.files.list` — the action name is itself dotted). The
+dotted IDs are handled end to end; the pack's table IDs stay the normal
+shape (`google_drive.files`).
+
+> **Status: live-verified.** The wire contract below is reconciled
+> against a live gateway (v1.3.4, open-connector at `2410fbe`) and
+> verified against real Google Drive data on 2026-08-25: a seeded
+> corpus (six files, one shared drive, three grants) scanned end to end
+> through skardi-server, every table's registration passing the
+> fingerprint gate against live discovery. The two load-bearing items
+> both closed: the five `restrictions.*` spellings were witnessed
+> verbatim on a real drive row, and the all-drives pin really surfaces
+> shared-drive rows. Three columns remain unwitnessed non-null for
+> structural reasons (their keys are present, correctly spelled, and
+> null on real rows): `drives.org_unit_id` (Workspace org units only),
+> `drives.theme_id` (null even when a drive is created with an explicit
+> theme — it materializes as `color_rgb` + `background_image_link`),
+> and `file_permissions.expiration_time` (Google rejects expirations on
+> domain/anyone grants, and a user-grant expiration needs a second real
+> account).
+
+**The wire contract is Open Connector's, not Google's REST API**: the
+gateway's googledrive executors rebuild every row **normalized**
+(Slack-style) into a fixed key set, declare the row objects
+`additionalProperties: false`, and pin their own `fields` projection on
+the provider request — `files.list` does not even declare a `fields`
+input (sending one is a hard 400). So the row shape is fully determined
+upstream, and the wire keys are the normalizer's, not Google's REST
+spellings: `size_bytes` is a real number here (Google's own `size` is a
+decimal *string*), and columns named from Google's docs
+(`webContentLink`, …) simply do not exist on this wire. Inputs are the
+gateway's camelCase strict schema (`pageSize`, `pageToken`, `driveId`,
+`q`, `fileId`; a wrong key is a hard 400).
+
+## Binding
+
+```yaml
+spec:
+  data_sources:
+    - name: saas
+      type: open_connector
+      connection_string: http://open-connector:3000
+      hierarchy_level: catalog
+      open_connector:
+        runtime_token_env: OPEN_CONNECTOR_TOKEN
+        bindings:
+          - name: gdrive                    # schema name in SQL
+            source_pack: google_drive
+            connection_alias: my-google-drive  # the gateway's googledrive OAuth connection
+            tables: [files, drives]         # no resource: files = the whole corpus
+
+          # `q` pins a Drive query-language string; the table then means
+          # "the files matching this query". It composes with `driveId`
+          # (a query within one shared drive is meaningful).
+          - name: gdrive_docs
+            source_pack: google_drive
+            connection_alias: my-google-drive
+            resource:
+              q: "mimeType = 'application/vnd.google-apps.document' and trashed = false"
+            tables: [files]
+
+          # One binding per audited file: `fileId` is required, and rows
+          # carry no file identity of their own — the binding is what
+          # names the file. A full Drive URL works as the value too
+          # (upstream extracts the ID from it).
+          - name: contract_acl
+            source_pack: google_drive
+            connection_alias: my-google-drive
+            resource:
+              fileId: "1AbCdEfGhIjKlMnOpQrStUvWxYz1234567890abcd"
+            tables: [file_permissions]
+```
+
+```sql
+-- Largest real files (native Docs/Sheets/Slides have no byte size):
+SELECT name, mime_type, size_bytes, modified_time
+FROM saas.gdrive.files
+WHERE size_bytes IS NOT NULL
+ORDER BY size_bytes DESC
+LIMIT 20;
+
+-- Shared-drive files join back to their drive:
+SELECT d.name AS drive, f.name, f.modified_time
+FROM saas.gdrive.files f
+JOIN saas.gdrive.drives d ON f.drive_id = d.id;
+
+-- Who can reach the audited file (schema = the binding name above):
+SELECT type, role, email_address, domain, allow_file_discovery
+FROM saas.contract_acl.file_permissions;
+```
+
+## Tables
+
+### `files`
+
+Action `googledrive.files.list` — the only action that sees the whole
+corpus. With no resource, the table is **every file the connected
+account can reach**. Fourteen columns:
+
+| column | wire path | type |
+|---|---|---|
+| `id` | `id` | utf8, non-null |
+| `name` | `name` | utf8 |
+| `mime_type` | `mimeType` | utf8 |
+| `web_view_link` | `webViewLink` | utf8 |
+| `created_time` | `createdTime` | timestamp(ms, UTC) |
+| `modified_time` | `modifiedTime` | timestamp(ms, UTC) |
+| `size_bytes` | `sizeBytes` | int64 |
+| `drive_id` | `driveId` | utf8 |
+| `parents` | `parents` | list of utf8 |
+| `owner_display_names` | `owners[].displayName` | list of utf8 |
+| `owner_email_addresses` | `owners[].emailAddress` | list of utf8 |
+| `shared` | `shared` | boolean |
+| `starred` | `starred` | boolean |
+| `trashed` | `trashed` | boolean |
+
+**`mime_type` is the de-facto type discriminator**: folders are
+`application/vnd.google-apps.folder`, native Workspace files are
+`application/vnd.google-apps.*`, everything else is an ordinary MIME
+type. **`size_bytes` is null for anything without a byte size of its
+own** — folders and every native Docs/Sheets/Slides file — so an
+all-NULL `size_bytes` on a Docs-only corpus is expected, not a defect.
+
+**Ownership doubles as a second discriminator.** My Drive files carry
+exactly one owner; **shared-drive items carry none** (the drive owns
+them), so both owner columns are NULL there while `drive_id` is set —
+the join key to `drives.id`. The two owner columns are plucked from one
+`owners` array; they are lists rather than scalars because the engine
+has no array indexing, not because multi-owner is expected.
+
+**A NULL boolean means "not reported", never false.** `shared`,
+`starred` and `trashed` are only present on the wire when upstream
+reports a real boolean.
+
+**Trashed files are included.** Drive's listing does not exclude them by
+default and the pack does not quietly pin a `q` to change that —
+`trashed` is a column; filter in SQL (`WHERE trashed IS NOT TRUE`).
+
+**The pack pins `supportsAllDrives: true` +
+`includeItemsFromAllDrives: true` on every request.** Unpinned, the
+action inherits Google's own default and **silently omits every
+shared-drive file** — a `files` table that quietly excludes a class of
+files is the failure mode the pin exists to prevent. (The sibling
+actions need no pin: their executors default it upstream.)
+
+Optional resources: `q` (a Drive
+[query-language](https://developers.google.com/drive/api/guides/search-files)
+string — see [why it is not a filter](#pagination)) and `driveId` (scope
+the scan to one shared drive). They compose. The deprecated
+`teamDriveId` alias is deliberately not exposed.
+
+### `drives`
+
+Action `googledrive.drives.list`. **Shared drives only** — My Drive is
+not a drive resource and never appears as a row, so on an account with
+no shared-drive membership this table is **legitimately empty** (a
+successful empty scan, not an error). Thirteen columns: `id` (non-null),
+`name`, `hidden` (boolean), `color_rgb`, `created_time`, `org_unit_id`,
+`theme_id`, `background_image_link`, plus five boolean flags from the
+drive's `restrictions` object:
+
+| column | meaning (Google Drive v3 docs) |
+|---|---|
+| `admin_managed_restrictions` | administrative privileges required to modify restrictions |
+| `copy_requires_writer_permission` | readers/commenters cannot copy, print, download |
+| `domain_users_only` | access limited to the drive's domain |
+| `drive_members_only` | access limited to drive members |
+| `sharing_folders_requires_organizer_permission` | only organizers can share folders |
+
+The restriction flags carry an explicit caveat: upstream declares
+`restrictions` as a **bare open object**, so these five key spellings
+are outside the fingerprint gate (a coverage test pins exactly these
+five as the pack's only uncovered columns) — an upstream inner-key
+rename would not change the pinned fingerprint. The live pass witnessed
+all five spellings verbatim on a real drive row (as present `false`s,
+alongside a nested `downloadRestriction` object the pack leaves
+unmapped), which verifies today's upstream; the gate still cannot see
+tomorrow's. NULL in any of them means "unreported", never false. The per-caller sibling
+`capabilities` ("capabilities the *current user* has") is deliberately
+unmapped: its values change with the OAuth identity doing the scan, so
+the same table under two connections would disagree.
+
+Optional resource: `q` (the drives query language, e.g.
+`name contains 'x'`). `useDomainAdminAccess` is never sent — it requires
+a Workspace admin and 403s for everyone else.
+
+### `file_permissions`
+
+Action `googledrive.permissions.list`. **Required resource: `fileId`.**
+The rows carry no file identity of their own, so the table is "the
+permissions of the file this binding names" — the same shape as Notion's
+`block_children`. Auditing many files means one binding per file. Eleven
+columns: `id` (non-null), `role` (owner / organizer / fileOrganizer /
+writer / commenter / reader), `type` (user / group / domain / anyone),
+`email_address`, `display_name`, `domain`, `photo_link`,
+`expiration_time` (timestamp; set only on expiring grants), and three
+booleans — `allow_file_discovery`, `deleted`, `pending_owner` (NULL =
+not reported, never false).
+
+The `type` column changes what identity means: for `domain` and `anyone`
+grants the identity columns are null and `domain` /
+`allow_file_discovery` carry the meaning — a `type = 'anyone'` row with
+`allow_file_discovery` false is a link-only share, the row a sharing
+audit usually exists to find.
+
+**A blank `fileId` fails at scan time, not at startup.** Omitting the
+key is refused at registration, naming the binding; but resource values
+are checked for presence, not content, so `fileId: ""` starts up and
+then 400s every scan (`invalid_input` at the gateway's schema layer),
+and a whitespace-only value dies on the executor's own check. Loud
+either way, never a silent empty table. Convenience: upstream runs the
+value through `extractFileId`, so a full
+`https://drive.google.com/file/d/…/view` URL works as the binding value.
+
+`permissionDetails` (inherited-permission records) and the constant
+`kind` are on the wire and deliberately unmapped.
+
+## Pagination
+
+Cursor pagination, uniform across all three actions: a `pageToken`
+input against a top-level `nextPageToken` output that is **always
+present and null exactly on the final page** (declared nullable *and*
+required). The cursor is an opaque token — unlike OneDrive's
+complete-URL `nextLink`, there is no shape to preserve and no per-action
+allowlist to trip. No executor filters rows after paginating, so
+null-cursor termination is complete.
+
+- Page sizes are pinned at each action's **declared ceiling**: `files`
+  1000, `drives` and `file_permissions` 100 — and the live pass
+  confirmed the ceilings are *wire* bounds, not just declared ones
+  (1000/100/100 each returned 200; 1001/101/0 each 400). Page size
+  bounds **requests, not bytes**: `LIMIT 10` on `files` costs one
+  request but still transfers up to 1000 rows (measured live, a fully
+  populated row is ~700 bytes).
+- At the default safety bounds, an unfiltered `files` scan fails (never
+  truncates) past `max_pages` × 1000 = 100 000 rows — exactly the
+  default `max_rows`, so the two ceilings coincide here. Raise them in
+  the `open_connector:` block or narrow with `LIMIT` — see
+  [the integration guide](open-connector.md#bounds-retries-and-errors).
+- **No filter is pushed down, structurally.** The one candidate input,
+  `q`, is a whole query *language* — Skardi's filter facility maps a
+  `column op value` comparison onto an input field, and a bare column
+  literal is never a legal `q`. So `q` is a **resource** (the binding
+  pins the whole query; the table means "the rows matching it") and
+  every SQL predicate runs locally after the bounded fetch.
+
+## Authorization
+
+`googledrive` is authorized separately from `gmail`. Until it is
+connected, a scan fails with the gateway's own
+`403 "Connect googledrive with OAuth first."`
+
+> **The OAuth consent is read-write even though this pack is read-only.**
+> All three actions declare only `drive.readonly` +
+> `drive.metadata.readonly`, but the provider-level grant requests the
+> full read-write `https://www.googleapis.com/auth/drive` as well,
+> because the same connection serves the service's upload, update and
+> delete actions. Skardi's tables stay read-only by construction, but
+> you are consenting to more than Skardi will use — an upstream
+> connection property a pack cannot narrow.
+
+Google throttles per project and per user (403/429 with backoff); the
+gateway surfaces that as a failure envelope rather than silently
+truncating. Observed quota behaviour is a live-pass item.
+
+## Fingerprints and drift
+
+Each table pins the BLAKE3 fingerprint of its action's declared output
+schema, compared against live discovery at **registration** — a changed
+upstream contract fails there, naming the table and action, instead of
+producing wrong rows later.
+
+Because rows are normalized and declared closed
+(`additionalProperties: false`), the declared contract is column truth
+to an unusual degree: on `files` and `file_permissions` **every** mapped
+path resolves inside the declared item schema, so the gate covers the
+whole table. The one exception is deliberate: the five `restrictions.*`
+flags on `drives` sit under a bare open object, outside the gate — an
+upstream rename of an *inner* key there would keep the hash unchanged
+and surface as a silently-NULL column, which is why a coverage test pins
+exactly those five and the live pass owes them real rows.
+
+The gate is **output-only**, so this pack also commits the input
+schemas (`packs/fixtures/google_drive/contracts/inputs/`), with a test
+checking every key, page size and cursor spelling it can send against
+them — including the negative space: the keys that 400ed live
+(`fields` on `files.list`, `filter`, `page`, `perPage`, `maxResults`,
+`cursor`, lowercase `orderby`) and the declared keys the pack promises
+never to send (`corpora`, `corpus`, `spaces`, `teamDriveId`, `orderBy`,
+`includeLabels`, `includePermissionsForView` on files; `fields`,
+`includePermissionsForView`, `useDomainAdminAccess`,
+`supportsAllDrives` on permissions; `useDomainAdminAccess` on drives).
+One capture detail: these schemas carry a `$schema` key (the sibling
+packs' captures do not), and the fingerprint hashes the whole schema, so
+the captures keep it verbatim.
+
+## Live verification
+
+The phase-4 pass ran 2026-08-25 against a real Workspace account with a
+seeded corpus (a folder, four files spanning every shape, one shared
+drive, one shared-drive file, and three grant types on one file). What
+it established, following the
+[design record](superpowers/specs/2026-08-25-open-connector-google-drive-pack-design.md):
+
+1. **R1 resolved in the best direction**: the account started with zero
+   shared drives (that clean empty scan was itself witnessed), then
+   turned out to be able to *create* one — so the `drives` columns were
+   verified on real rows instead of deferred. All five restriction
+   spellings came back verbatim as present `false`s; flipping any to
+   `true` is admin-gated on this tenant, which does not affect the
+   extraction path.
+2. Real rows under every mapped column on all three tables, through
+   end-to-end skardi-server scans registered against live discovery —
+   every column except the three structural residuals above extracted a
+   real non-NULL value somewhere.
+3. The all-drives pin surfaced the seeded shared-drive file with
+   `drive_id` carrying the real drive id, and shared-drive rows showed
+   their real absence pattern: exactly `owners` and `shared` drop
+   (NULL in SQL) while `parents`/`starred`/`trashed` stay.
+4. Wire bounds confirmed (1000/100/100 pass, 1001/101/0 all 400); real
+   multi-page walks at `pageSize: 1` on `files` (five pages) and
+   `file_permissions` (two pages) with ~444-char cursors and a real
+   terminal-page `null` each; through skardi-server with a small page
+   size, `LIMIT` stopped a three-page scan after two requests.
+5. Real `q` values filtered live (both as a direct input and through a
+   bound binding resource); the required `fileId` forwarded verbatim on
+   every page; a nonexistent `fileId` produced the documented gateway
+   failure envelope.
+6. Row fixtures re-derived as redacted live captures under a
+   default-deny redaction audit (one_drive-style). Live corrections the
+   captures folded in: native Google Docs DO report `sizeBytes` (the
+   null-size row is a folder), every grant carries `permissionDetails`
+   (not just shared-drive ones), and owner objects always carry four
+   keys.
+
+Deferred surfaces, recorded in the design record: `changes.list` (its
+cursor must be bootstrapped by a second action, a pagination shape the
+engine has no spelling for), and the comments / replies / revisions /
+labels / accessproposals actions (out of the first wave's scope;
+accessproposals is additionally Workspace-approval-gated).
+
+Provider API version: Google Drive `v3` (the executors pin it in every
+URL).

--- a/docs/open-connector-google-drive.md
+++ b/docs/open-connector-google-drive.md
@@ -85,7 +85,7 @@ spec:
 ```
 
 ```sql
--- Largest real files (native Docs/Sheets/Slides have no byte size):
+-- Largest files by stored bytes (folders have no size of their own):
 SELECT name, mime_type, size_bytes, modified_time
 FROM saas.gdrive.files
 WHERE size_bytes IS NOT NULL
@@ -131,8 +131,10 @@ account can reach**. Fourteen columns:
 `application/vnd.google-apps.folder`, native Workspace files are
 `application/vnd.google-apps.*`, everything else is an ordinary MIME
 type. **`size_bytes` is null for anything without a byte size of its
-own** — folders and every native Docs/Sheets/Slides file — so an
-all-NULL `size_bytes` on a Docs-only corpus is expected, not a defect.
+own** — live, that means folders. Native Docs/Sheets/Slides *do* report
+a size (Workspace files count against storage quota), so an all-NULL
+`size_bytes` over real files is a defect to chase, not an expected
+shape.
 
 **Ownership doubles as a second discriminator.** My Drive files carry
 exactly one owner; **shared-drive items carry none** (the drive owns
@@ -274,7 +276,9 @@ connected, a scan fails with the gateway's own
 
 Google throttles per project and per user (403/429 with backoff); the
 gateway surfaces that as a failure envelope rather than silently
-truncating. Observed quota behaviour is a live-pass item.
+truncating. The live pass never approached a throttle — its seeded
+corpus is a handful of files — so behaviour under real quota pressure
+is unobserved rather than characterized here.
 
 ## Fingerprints and drift
 

--- a/docs/open-connector-google-drive.md
+++ b/docs/open-connector-google-drive.md
@@ -190,7 +190,13 @@ rename would not change the pinned fingerprint. The live pass witnessed
 all five spellings verbatim on a real drive row (as present `false`s,
 alongside a nested `downloadRestriction` object the pack leaves
 unmapped), which verifies today's upstream; the gate still cannot see
-tomorrow's. NULL in any of them means "unreported", never false. The per-caller sibling
+tomorrow's. NULL in any of them means "unreported", never false. If all
+five ever read NULL on drives that plainly have restrictions set, the
+raw action scan is the check — it types every object as an opaque JSON
+column, so `SELECT id, restrictions FROM open_connector_scan(<gateway>,
+'googledrive.drives.list', '{}', '$.drives')` shows the spellings
+upstream currently emits (the action must be in the gateway's
+`raw_action_allowlist`). The per-caller sibling
 `capabilities` ("capabilities the *current user* has") is deliberately
 unmapped: its values change with the OAuth identity doing the scan, so
 the same table under two connections would disagree.

--- a/docs/open-connector.md
+++ b/docs/open-connector.md
@@ -33,12 +33,16 @@ gateway **runtime token**.
 > folders — live-verified against a real MSA mailbox; message bodies
 > deferred as on Gmail; the whole `excel` service is deferred at the
 > admission gate over incomplete pagination per the pack doc),
-> and [OneDrive](open-connector-one-drive.md) (drive items, drive item
+> [OneDrive](open-connector-one-drive.md) (drive items, drive item
 > search — live-verified against a real MSA drive; search rows are a
 > reduced projection and search continuations currently fail upstream
-> on personal drives, loudly, per the pack doc).
-> Further provider packs (Google Calendar,
-> Google Drive, Jira, …) ship one pack per release per the
+> on personal drives, loudly, per the pack doc),
+> and [Google Drive](open-connector-google-drive.md) (files, drives,
+> file permissions — live-verified against a real Workspace account,
+> shared-drive rows included; three structurally unreachable columns
+> stay documented as residuals per the pack doc).
+> Further provider packs (Google Calendar, Jira, …) ship one pack per
+> release per the
 > [design spec](superpowers/specs/2026-07-11-open-connector-integration-design.md);
 > a source is advertised as supported only once its pack passes the
 > admission gate there.

--- a/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
+++ b/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
@@ -601,6 +601,95 @@ event carrying the scan identity and error.
       (5 children rows, 3 search rows, both real-page composites);
       full-suite counts pending CI.
 
+- [ ] 5.9 Google Drive pack (OAuth user token, cursor pagination over
+      `pageToken`/`nextPageToken`, NORMALIZED rows — the opposite of 5.8):
+      `files`, `drives`, `file_permissions`. **Phases 1–4 done 2026-08-25.**
+      Design record risk R1 (whether the test account can see a shared
+      drive at all) resolved in phase 4's favor: the account started at
+      zero shared drives (that clean empty scan was itself witnessed),
+      then proved able to CREATE one, so `drives` was verified on real
+      rows instead of deferred. Recorded in
+      `docs/superpowers/specs/2026-08-25-open-connector-google-drive-pack-design.md`,
+      reconciled live 2026-08-25 against the same v1.3.4 / `2410fbe` pin as
+      5.7/5.8. The service is spelled `googledrive` upstream and its action
+      IDs carry TWO dots (`googledrive.files.list`) — verified engine-safe
+      end to end with no engine changes (this pack touches only `packs/`
+      plus the registration rosters). Rows are rebuilt by upstream
+      normalizers into closed key sets (`additionalProperties: false`) with
+      the executor pinning its own provider-side `fields` projection —
+      `files.list` does not even declare a `fields` input — so the declared
+      contract is column truth to an unusual degree: `files` (14 columns)
+      and `file_permissions` (11) sit entirely inside the fingerprint gate,
+      and `drives` (13) escapes it in exactly five columns — the
+      `restrictions.*` boolean flags under a bare-open-object declaration,
+      mapped KNOWINGLY (operator decision, phase 2): a coverage test pins
+      exactly those five as the pack's only uncovered columns, and phase
+      4 witnessed all five key spellings verbatim on a real drive row
+      (present `false`s, alongside an unmapped nested
+      `downloadRestriction`), closing the Notion `archived`/`is_archived`
+      defect class for today's upstream — the gate still cannot see
+      tomorrow's. The per-caller sibling
+      `capabilities` stays unmapped (its values change with the OAuth
+      identity doing the scan). One load-bearing fixed-input pair on
+      `files`: `supportsAllDrives` + `includeItemsFromAllDrives` pinned
+      true, because `files.list` forwards the former verbatim with NO
+      upstream default (unlike its siblings, which default it true via
+      `resolveSupportsAllDrives`) and an unpinned scan silently omits every
+      shared-drive file. `q` is an optional resource on `files`/`drives`
+      rather than a filter mapping, structurally: it is a whole query
+      language, and a column-op-value literal is never a legal `q`; the
+      deprecated `teamDriveId` alias is simply not exposed (avoiding the
+      silent-precedence trap 5.8 needed `exclusive_resources` for).
+      `fileId` is a required resource on `file_permissions` with the same
+      three-way enforcement boundary as 5.8's `query` (upstream declares NO
+      `required` array; missing → refused at registration, `""` →
+      schema-layer 400, whitespace → executor 400 at scan time). Page sizes
+      pinned at the declared ceilings (1000/100/100), confirmed live to be
+      WIRE bounds with real credentials, not just declared ones (each
+      ceiling 200; 1001/101/0 each 400). Both contract halves
+      committed for all three actions (`contracts/` + `contracts/inputs/`,
+      gmail-style) — these captures carry a `$schema` key the sibling
+      packs' do not, and the fingerprint hashes the whole schema. Trashed
+      files deliberately included (`trashed` is a column; filtering belongs
+      in SQL). Deferred with reasons in the design record: `changes.list`
+      (cursor bootstrapped by a second action — a pagination shape the
+      engine has no spelling for), comments/replies/revisions/labels/
+      accessproposals (second wave; accessproposals also
+      Workspace-approval-gated). Docs: `docs/open-connector-google-drive.md`
+      + the status note in `docs/open-connector.md`. Verification
+      (static counts; CI is the arbiter): 25 pack-module tests
+      (`cargo test -p skardi --lib sources::providers::open_connector::packs::google_drive`
+      — 13 contract/conversion: per-table fixture conversions across all
+      six admission-gate shapes (explicit null vs absent key vs empty
+      string/list, partial `restrictions`, null owner list items,
+      `sizeBytes`-as-string type mismatch with row-scoped error identity,
+      id-less row failing the page), the default-deny redaction audit
+      over every fixture string leaf, fingerprint pins for all three
+      contracts, the five-column coverage-gap pin, pagination/resource/
+      fixed-input declarations, and the captured-input-contract test
+      locking every sendable key plus the declared-but-never-sent negative
+      space per action; 12 e2e through MockGateway: per-table
+      wire-declaration scans with exact key sets and the all-drives pins on
+      every page, opaque-cursor continuation and null termination, a
+      fileId-less permissions binding refused before any HTTP, no-pushdown
+      row identity, LIMIT early-stop, empty shared-drive scan (the R1
+      shape), pagination-loop refusal, failure-envelope surfacing with the
+      dotted action id named, UDTF parity, drift-refusal at registration)
+      plus 1 registry test asserting the BTreeMap table order; row fixtures
+      are REDACTED LIVE CAPTURES (phase 4, 2026-08-25) under the
+      default-deny audit. Phase-4 live evidence, in brief: three-table
+      end-to-end skardi-server scans registered against LIVE discovery;
+      every mapped column non-NULL somewhere except three structural
+      residuals (`drives.org_unit_id`, `drives.theme_id`,
+      `file_permissions.expiration_time` — keys present-and-null on real
+      rows, each with a documented reason); real `pageSize: 1` multi-page
+      walks with ~444-char cursors and terminal nulls; LIMIT stopping a
+      real three-page scan after two requests; `q` live both as direct
+      input and as a bound binding resource; live corrections folded into
+      the fixtures (native Docs DO report `sizeBytes`; every grant
+      carries `permissionDetails`; shared-drive rows drop exactly
+      `owners`+`shared`).
+
 **Gate for each pack** (from the design spec): complete terminating pagination,
 deterministic schema, read-only allowlist, documented authz/rate limits,
 bounded safety defaults, null/empty/nested fixtures, docs.
@@ -609,17 +698,17 @@ bounded safety defaults, null/empty/nested fixtures, docs.
 
 ## Review notes
 
-- **Current PR**: milestone 5.8 (OneDrive pack — drive_items,
-  drive_item_search). Milestones 1–4 and 5.1–5.7 (GitHub, Slack, Notion,
-  Feishu, Gmail, Discord, Outlook packs) are merged; this PR adds the
-  second Microsoft 365 pack over raw Graph passthrough rows, with zero
-  engine changes — the pack-shaping decisions are the empty coverage gap
-  (no `select` pin needed, unlike outlook) and the shared driveItem
-  fingerprint across both tables. Live verification (phase 4) ran
-  2026-08-21 against a real MSA drive; its one pack-changing finding is
-  the search table's 14-column reduction (search rows carried no
-  `eTag`/`cTag` on the MSA drive probed; a business/SharePoint drive is
-  unprobed — design record R1).
+- **Current PR**: milestone 5.9 (Google Drive pack — files, drives,
+  file_permissions; PR #226). Milestones 1–4 and 5.1–5.8 (GitHub, Slack,
+  Notion, Feishu, Gmail, Discord, Outlook, OneDrive packs) are merged;
+  this PR adds the second Google pack over normalized rows, with zero
+  engine changes — the pack-shaping decisions are the two-dot action IDs
+  (`googledrive.files.list`, verified engine-safe), the load-bearing
+  all-drives fixed-input pair on `files`, and the five knowingly
+  outside-the-gate `restrictions.*` columns on `drives`. Live
+  verification (phase 4) is PENDING, gated first on design record R1
+  (an account that can see a shared drive); the five restriction
+  columns are documentation-derived until it runs.
 - **Invariants to hold in review**: no provider credentials in Skardi;
   read-only until explicitly designed otherwise; pure validation shared by
   CLI and server; no network I/O at query-planning time; no `.unwrap()` in

--- a/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
+++ b/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
@@ -599,7 +599,10 @@ event carrying the scan identity and error.
       self-trip probes are the leak classes the real captures actually
       contained); conversion tests run against the redacted live captures
       (5 children rows, 3 search rows, both real-page composites);
-      full-suite counts pending CI.
+      CI green on that PR's head `e12ec9c` (run 32729437184): 1981
+      workspace tests passed (`cargo llvm-cov --no-report nextest
+      --all-features`), plus 237 `--ignored` integration tests and 37
+      doc tests.
 
 - [x] 5.9 Google Drive pack (OAuth user token, cursor pagination over
       `pageToken`/`nextPageToken`, NORMALIZED rows — the opposite of 5.8):
@@ -656,8 +659,15 @@ event carrying the scan identity and error.
       engine has no spelling for), comments/replies/revisions/labels/
       accessproposals (second wave; accessproposals also
       Workspace-approval-gated). Docs: `docs/open-connector-google-drive.md`
-      + the status note in `docs/open-connector.md`. Verification
-      (static counts; CI is the arbiter): 25 pack-module tests
+      + the status note in `docs/open-connector.md`. Verification — CI
+      green on `f763ce8` (run 32854955874): 2125 workspace tests passed
+      (`cargo llvm-cov --no-report nextest --all-features`), plus 237
+      `--ignored` integration tests and 37 doc tests. CI runs the whole
+      workspace through nextest, not the per-module filters, so the two
+      filtered figures are static counts of test functions in the tree
+      (none `#[ignore]`d): 428 under
+      `sources::providers::open_connector`, 402 of them before this pack
+      — the 26 new ones being 25 pack-module tests
       (`cargo test -p skardi --lib sources::providers::open_connector::packs::google_drive`
       — 13 contract/conversion: per-table fixture conversions across all
       six admission-gate shapes (explicit null vs absent key vs empty

--- a/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
+++ b/docs/superpowers/specs/2026-07-11-open-connector-integration-tasks.md
@@ -601,7 +601,7 @@ event carrying the scan identity and error.
       (5 children rows, 3 search rows, both real-page composites);
       full-suite counts pending CI.
 
-- [ ] 5.9 Google Drive pack (OAuth user token, cursor pagination over
+- [x] 5.9 Google Drive pack (OAuth user token, cursor pagination over
       `pageToken`/`nextPageToken`, NORMALIZED rows — the opposite of 5.8):
       `files`, `drives`, `file_permissions`. **Phases 1–4 done 2026-08-25.**
       Design record risk R1 (whether the test account can see a shared
@@ -706,9 +706,18 @@ bounded safety defaults, null/empty/nested fixtures, docs.
   (`googledrive.files.list`, verified engine-safe), the load-bearing
   all-drives fixed-input pair on `files`, and the five knowingly
   outside-the-gate `restrictions.*` columns on `drives`. Live
-  verification (phase 4) is PENDING, gated first on design record R1
-  (an account that can see a shared drive); the five restriction
-  columns are documentation-derived until it runs.
+  verification (phase 4) ran 2026-08-25 against a real Workspace
+  account and closed both load-bearing items: design record R1
+  resolved in its favor (zero shared drives at first, then the account
+  proved able to CREATE one, so `drives` was verified on real rows and
+  all five restriction spellings came back verbatim), and the pinned
+  all-drives pair really surfaced a shared-drive file through a live
+  scan. Its pack-changing findings were all fixture-level corrections
+  (native Docs DO report `sizeBytes`; every grant carries
+  `permissionDetails`; shared-drive rows drop exactly
+  `owners`+`shared`), plus three columns recorded as structural
+  residuals (`drives.org_unit_id`, `drives.theme_id`,
+  `file_permissions.expiration_time`).
 - **Invariants to hold in review**: no provider credentials in Skardi;
   read-only until explicitly designed otherwise; pure validation shared by
   CLI and server; no network I/O at query-planning time; no `.unwrap()` in

--- a/docs/superpowers/specs/2026-08-25-open-connector-google-drive-pack-design.md
+++ b/docs/superpowers/specs/2026-08-25-open-connector-google-drive-pack-design.md
@@ -483,6 +483,49 @@ Mapping it as one `json` column was rejected: a blob no SQL predicate
 can reach without JSON functions is not a usable answer to "which
 drives are domain-restricted".
 
+**Adding a raw `restrictions` json column *alongside* the five booleans
+was weighed separately, and also declined.** The distinction matters
+because the paragraph above argues against json-*instead-of* and says
+nothing about json-*in-addition-to*; review of the 5.9 PR raised the
+additive form, correctly. Its mechanics check out: `path: restrictions`
+IS declared, so such a column would sit inside the fingerprint gate and
+would not enlarge the pinned uncovered set, and an inner-key rename
+would then surface as five NULLs beside a blob carrying the new
+spellings. Three grounds against it. (1) It detects nothing — no
+refusal, no event; it pays off only when a human looks, and a human who
+is looking already has the raw action scan below, so the column buys a
+skipped allowlist entry rather than a capability. (2) It moves the risk
+downstream: the five booleans keep the documentation-sourced spellings
+in ONE reviewed place with a coverage test pinning them, while a blob
+makes every caller re-derive `domainUsersOnly` from Google's docs inside
+a `LIKE` or a JSON function — unreviewed, unpinned, multiplied by the
+number of readers. (3) No pack maps a subtree as `json` while also
+typing scalars out of it; mapping one path into two columns has
+precedent (`owners` here), but this pairing would be a new shape rather
+than the reuse of an old one.
+
+**Where to look when the five come back all-NULL.** The silent case is
+narrower than the caveat first reads: it requires upstream to rename an
+inner key *while still declaring nothing* about the object. Should
+Google start declaring these properties, the declaration changes, the
+fingerprint changes, and registration refuses — loudly, by design. For
+the remaining case the diagnosis path exists today and needs no pack
+change, because a raw action scan types every object as an opaque JSON
+column:
+
+```sql
+SELECT id, restrictions
+FROM open_connector_scan(<gateway>, 'googledrive.drives.list', '{}', '$.drives')
+```
+
+with `googledrive.drives.list` added to the gateway's
+`raw_action_allowlist`. What would actually *close* the class is a
+column spelling that fails when a key is missing under a PRESENT parent
+— the engine already holds exactly that doctrine for object-list plucks
+(a dropped pluck key fails the page instead of yielding an all-null
+list) and has no scalar equivalent. Adding one is engine work for its
+own milestone, not a pack decision.
+
 `useDomainAdminAccess` is never sent: it requires a Workspace admin and
 403s for everyone else, so pinning it would break the common case to
 serve the rare one. `q` is an optional resource here too.

--- a/docs/superpowers/specs/2026-08-25-open-connector-google-drive-pack-design.md
+++ b/docs/superpowers/specs/2026-08-25-open-connector-google-drive-pack-design.md
@@ -310,8 +310,11 @@ follows (rationale recorded in gmail.yaml's messages table).
 it into a number, rejecting anything that is not a safe non-negative
 integer. So the column is a real `int64` rather than a string that
 looks like one — but it is null for every file with no byte size of its
-own, which includes folders and every native Docs/Sheets/Slides file.
-An all-null `size_bytes` on a Docs-only drive is expected, not a bug.
+own. Phase 2 expected that set to include native Docs/Sheets/Slides;
+**phase 4 corrected it** (see the phase-4 notes below): only FOLDERS
+came back null, because Workspace files count against storage quota. So
+an all-null `size_bytes` over real files is a defect to chase, not an
+expected shape.
 
 Two columns come from the same `owners` array under different pluck
 keys. Drive files normally have exactly one owner (shared-drive items

--- a/docs/superpowers/specs/2026-08-25-open-connector-google-drive-pack-design.md
+++ b/docs/superpowers/specs/2026-08-25-open-connector-google-drive-pack-design.md
@@ -1,0 +1,219 @@
+# Google Drive Source Pack
+
+Milestone 5.9. Phase-1 record for the `google_drive` source pack: the wire
+contract as reconciled against a **live** Open Connector gateway on
+2026-08-25 (gateway v1.3.4, open-connector `2410fbe` — the same upstream
+pin milestone 5.8 captured against). Table design (phase 2) and the
+implementation decisions (phase 3) are appended to this document as those
+phases run.
+
+Google Drive is the second Google service to get a pack. `gmail` went
+first as milestone 5.5 (PR #192); this is a separate Open Connector
+service with its own OAuth connection, so — exactly as Microsoft 365
+ships one pack per Graph service — it is one pack per Google service and
+a Skardi binding carries exactly one `connection_alias`.
+
+## Service landscape
+
+Upstream the service is spelled **`googledrive`** (one word, no
+underscore), unlike `one_drive`. It publishes **43 actions**, of which
+ten are list-shaped reads:
+
+| action | scope of one call | pageSize bound | requires |
+|---|---|---|---|
+| `googledrive.files.list` | the whole corpus, `q`-filterable | 1–1000 | — |
+| `googledrive.drives.list` | shared drives | 1–100 | — |
+| `googledrive.changes.list` | incremental change feed | 1–1000 | — |
+| `googledrive.permissions.list` | one file's permissions | 1–100 | `fileId` |
+| `googledrive.revisions.list` | one file's revisions | 1–1000 | `fileId` |
+| `googledrive.comments.list` | one file's comments | 1–100 | `fileId` |
+| `googledrive.replies.list` | one comment's replies | 1–100 | `fileId`, `commentId` |
+| `googledrive.files.listLabels` | one file's labels | 1–100 (`maxResults`) | `fileId` |
+| `googledrive.accessproposals.list` | one file's access proposals | 1–100 | `fileId` |
+| `googledrive.approvals.list` | one file's approvals | 1–100 | `fileId` |
+
+The other 33 are single-item reads (`files.get`, `drives.get`,
+`about.get`, `apps.get`, the four `*.get` collaboration reads,
+`changes.getStartPageToken`), an export (`files.export`), or writes —
+`files.create/copy/update/delete/emptyTrash/generateIds/modifyLabels`,
+`drives.create/update/delete/hide/unhide`, and the create/update/delete
+triples on comments, replies, permissions and revisions. None is a list,
+and the writes are outside a read-only pack by construction.
+
+## Wire contract (gateway v1.3.4, open-connector `2410fbe`)
+
+Verified live 2026-08-25. Every list action above declares
+`requiredAuthTypes: ["oauth2"]`, `needsCredential: true`,
+`noAuthRunnable: false`, `locallyExecutable: true`.
+
+### Action IDs carry two dots — and that is already safe
+
+`googledrive.files.list` is `service.name` where the *name* itself is
+dotted (`files.list`), so pack action IDs here have a shape no shipped
+pack has used. Checked on this base rather than assumed:
+
+- `config.rs#validate_action_id` rejects only `/` and the bare `.` / `..`
+  segments; an interior dot passes.
+- `client.rs#action_url` percent-encodes with `ACTION_ID_SET =
+  NON_ALPHANUMERIC.remove(b'.').remove(b'-').remove(b'_')`, so dots
+  survive verbatim into the path.
+- The `rsplit('.')` calls in `source_pack.rs` and the pack accessors
+  operate on **table** IDs, not action IDs, so nothing parses a service
+  prefix out of the action.
+- Live: `GET`/`POST /v1/actions/googledrive.files.list` both route.
+
+**No engine change is needed for the ID shape.**
+
+### Rows are NORMALIZED, not passthrough
+
+This is the single most consequential phase-1 finding and it is the
+opposite of `one_drive`. `executors.ts` rebuilds every row:
+
+```ts
+return {
+  files: files.map((file) => normalizeDriveFile(asObject(file))),
+  nextPageToken: optionalString(payload.nextPageToken) ?? null,
+}
+```
+
+`normalizeDriveFile` emits a **fixed key set** — `id`, `name`,
+`mimeType`, `webViewLink`, `createdTime`, `modifiedTime`, `sizeBytes`,
+`driveId`, plus conditionally `parents`, `owners`, `shared`, `starred`,
+`trashed` — and every declared row object is
+`additionalProperties: false`. Mapping Google's own field names
+(`webContentLink`, `size` as a string, `owners[].me`, …) would produce
+all-NULL columns, the Slack-pack lesson.
+
+Two consequences worth pinning now:
+
+- The executor **pins its own `fields` projection** for `files.list`,
+  `drives.list`, `changes.list` and `revisions.list`
+  (`fields: nextPageToken,files(id,name,mimeType,webViewLink,…)` — the
+  `driveFileFields` constant). There is no `fields` input on
+  `files.list` at all (verified: sending one 400s), so the row shape is
+  fully determined upstream and cannot be widened from Skardi.
+  `comments.list`, `replies.list` and `permissions.list` DO accept a
+  `fields` input that overrides their default projection — a lever this
+  pack will not pull, since overriding it can only narrow the declared
+  contract.
+- **Key absence vs null is not uniform.** `compactObject` (core/cast.ts)
+  drops only `undefined`, so the `?? null` fields are always present as
+  explicit nulls, while the conditionally-spread ones (`parents`,
+  `owners`, `shared`, `starred`, `trashed` on files; `hidden`,
+  `capabilities`, `restrictions` on drives; `file`, `removed` on
+  changes) are **absent** from the object entirely when upstream omits
+  them. Both extract as NULL in Skardi, but the fixtures must model
+  both shapes.
+
+`id` / `name` / `mimeType` are `String(payload.x ?? "")` — never null,
+so they are sound identity columns (an empty string is possible in
+principle and is a phase-4 question, not a nullability one).
+
+### In-band errors are consumed
+
+`runtime-shared.ts#assertGoogleResponse` throws `ProviderRequestError` on
+any non-2xx, so Google's `{"error": {...}}` envelope never reaches the
+row payload — it becomes the gateway's failure envelope. **No table
+declares `error_path`.**
+
+### Pagination
+
+Uniform across all ten actions: a `pageToken` input (`minLength: 1`)
+and a sibling top-level `nextPageToken` output declared
+`anyOf: [string, null]` **and listed in the output schema's `required`
+array**, so the key is always present and null exactly on the final
+page. Google publishes no has-more flag and no total count, so no
+`has_more_path` / `total_pages_path` override applies.
+
+No executor filters rows after paginating — every one is a bare
+`payload.<key>.map(normalize…)` — so **null-cursor termination is
+sound** for all ten. (The `.filter()`-after-paginate hazard that forced
+the `pageInfo.fetched` contribution upstream for GitHub issues does not
+exist here.)
+
+`changes.list` is the one exception to "a scan is a collection scan",
+and it is a semantic exception rather than a pagination one: when no
+`pageToken` is supplied the executor first calls
+`changes.getStartPageToken` and starts from **now**, so a fresh scan
+reads changes that happen *after* the scan begins — normally an
+immediately-terminating empty page. It is an incremental-sync feed, not
+a collection. Phase 2 decides whether it ships at all and, if so,
+whether `pageToken` becomes a required resource.
+
+### Inputs are strict camelCase
+
+Every list action declares `additionalProperties: false` and — this is
+worth stating precisely — an **empty/absent `required` array, even for
+the actions that cannot work without a `fileId`**. The same subtlety
+`one_drive.search_items`'s `query` had: enforcement lives in the
+executor's own check (`resolveFileId` → `ProviderRequestError(400,
+"fileId is required")`), not in the schema, so a missing `fileId` passes
+validation and dies at scan time. `fileId: ""` is the one case the
+schema does catch, via `minLength: 1`.
+
+Calibrated per the no-credential recipe (default connection, no alias,
+no action policy): a bad key answers **400 `invalid_input`**, a good one
+**403 `authorization_failed` — "Connect googledrive with OAuth first."**
+Two different responses, so the discrimination is valid. Probed live:
+
+| probe | result |
+|---|---|
+| `files.list` `pageSize` 1 / 1000 | 403 (accepted) |
+| `files.list` `pageSize` 0 / 1001 | 400 `invalid_input` |
+| `files.list` `pageToken: ""` | 400 (`minLength: 1`) |
+| `files.list` `q`+`orderBy`+`spaces`+`corpora`+`supportsAllDrives`+`includeItemsFromAllDrives` | 403 (all accepted) |
+| `files.list` `fields` / `page` / `perPage` / `limit` / `orderby` / `maxResults` / `cursor` | 400 each |
+| `drives.list` `pageSize` 100 / 101 | 403 / 400 |
+| `drives.list` `driveId` | 400 (not an input here) |
+| `revisions.list` `pageSize: 1000` | 403 (accepted) |
+| `files.listLabels` `maxResults: 100` | 403; `pageSize` → 400 |
+| `changes.list` `fileId` | 400 (not an input here) |
+| `comments.list` with / without `fileId` | 403 both — schema cannot see it |
+| `comments.list` `fileId: ""` | 400 |
+
+Note the per-action page-size asymmetry (`pageSize` 1–1000 on files,
+revisions and changes; 1–100 on drives, comments, replies, permissions,
+proposals and approvals; **`maxResults`**, not `pageSize`, on
+`files.listLabels`) and that `orderby` lower-case 400s where `orderBy`
+passes. A *declared* bound is not a *wire* bound (feishu declared 100
+and hard-failed above 50, skardi PR #186) — confirming the real ceiling
+is phase-4 work.
+
+### Coverage of the fingerprint gate
+
+Every declared row object is `additionalProperties: false` with all keys
+under a plain `properties` map; the scalars are `anyOf: [T, null]`
+wrappers, which `fingerprint_uncovered_columns` resolves fine (it fails
+only when a path *segment* is missing, or when descending *into* an
+`anyOf` branch — the gmail case). So mapped columns are expected to be
+**fully covered by the fingerprint**, like `one_drive` and unlike
+`outlook`: an upstream rename fails registration, an author's typo shows
+up as an uncovered column in CI. No `select`-style coverage pin is
+needed.
+
+## Authz and rate limits
+
+Every one of the ten list actions declares exactly
+`drive.readonly` + `drive.metadata.readonly`. But the **provider-level
+OAuth grant requests all three declared scopes**, including the full
+read-write `https://www.googleapis.com/auth/drive`
+(`providers/googledrive/scopes.ts`). An operator connecting Google Drive
+therefore grants write access that this pack never exercises; that is an
+upstream connection property, not something a Skardi pack can narrow,
+and it belongs in the pack docs as a caveat. Google Drive's own quota
+behaviour (per-project and per-user query limits, 403/429 with backoff)
+is a phase-4 observation, not something the gateway declares.
+
+## Contract captures
+
+Live discovery for all ten actions is captured (input and output halves)
+and will be committed under
+`packs/fixtures/google_drive/contracts/` — output as the fingerprint
+input, `contracts/inputs/` alongside — once phase 2 settles which
+actions ship, following gmail (5.5) and one_drive (5.8).
+
+**The captured output schema is fingerprint input, not column truth.**
+Rows here are normalized rather than passthrough, which makes the
+declared schema a much stronger predictor than it was for `one_drive` —
+but conditional key spreads mean a declared key can still be absent on
+every real row, so no column set is final until phase 4 scans real data.

--- a/docs/superpowers/specs/2026-08-25-open-connector-google-drive-pack-design.md
+++ b/docs/superpowers/specs/2026-08-25-open-connector-google-drive-pack-design.md
@@ -1,11 +1,31 @@
 # Google Drive Source Pack
 
-Milestone 5.9. Phase-1 record for the `google_drive` source pack: the wire
+Milestone 5.9. Design record for the `google_drive` source pack: the wire
 contract as reconciled against a **live** Open Connector gateway on
 2026-08-25 (gateway v1.3.4, open-connector `2410fbe` — the same upstream
 pin milestone 5.8 captured against). Table design (phase 2) and the
-implementation decisions (phase 3) are appended to this document as those
-phases run.
+implementation decisions (phase 3) are appended as those phases run.
+
+**Status: phases 1–4 done (2026-08-25); risk R1 resolved — see its
+section.** Phase 3 shipped `packs/google_drive.yaml` +
+`packs/google_drive.rs` (three tables: `files` 14 columns, `drives` 13,
+`file_permissions` 11), the six contract captures under
+`packs/fixtures/google_drive/contracts/` (output and input halves,
+`$schema` key kept verbatim — these captures carry one and the
+fingerprint hashes the whole schema), and the registry entries. Phase 4
+ran against a real Workspace account with a seeded corpus: every
+load-bearing claim verified live (restriction spellings witnessed
+verbatim, wire page-size bounds confirmed, real cursors and terminal
+nulls, the all-drives pin surfacing a real shared-drive row,
+three-table end-to-end skardi-server scans against live discovery,
+LIMIT stopping real pagination early), and the row fixtures are now
+redacted live captures under a default-deny redaction audit. Three
+columns remain unwitnessed non-null for structural reasons, keys
+present-and-null on real rows: `drives.org_unit_id` (Workspace org
+units only), `drives.theme_id` (null even when a drive is created with
+an explicit theme), `file_permissions.expiration_time` (Google 403s
+expirations on domain/anyone grants; a user-grant expiration needs a
+second real account).
 
 Google Drive is the second Google service to get a pack. `gmail` went
 first as milestone 5.5 (PR #192); this is a separate Open Connector
@@ -206,14 +226,446 @@ is a phase-4 observation, not something the gateway declares.
 
 ## Contract captures
 
-Live discovery for all ten actions is captured (input and output halves)
-and will be committed under
+Live discovery for all ten actions was captured (input and output
+halves); the three shipped actions' captures are committed under
 `packs/fixtures/google_drive/contracts/` — output as the fingerprint
-input, `contracts/inputs/` alongside — once phase 2 settles which
-actions ship, following gmail (5.5) and one_drive (5.8).
+input, `contracts/inputs/` alongside — following gmail (5.5) and
+one_drive (5.8).
 
 **The captured output schema is fingerprint input, not column truth.**
 Rows here are normalized rather than passthrough, which makes the
 declared schema a much stronger predictor than it was for `one_drive` —
 but conditional key spreads mean a declared key can still be absent on
 every real row, so no column set is final until phase 4 scans real data.
+
+---
+
+# Phase 2 — Table design
+
+Three tables in the first wave, the same count Slack (5.2) shipped. The
+shape of the choice: **two zero-resource tables that any account can
+scan end to end**, so phase 4 can verify them with no setup beyond the
+OAuth grant, plus **exactly one file-scoped table** to put the `fileId`
+resource shape through review before the six other file-scoped actions
+follow it mechanically.
+
+| table | action | row path | resources | page size |
+|---|---|---|---|---|
+| `files` | `googledrive.files.list` | `$.files` | optional `driveId`, `q` | 1000 |
+| `drives` | `googledrive.drives.list` | `$.drives` | optional `q` | 100 |
+| `file_permissions` | `googledrive.permissions.list` | `$.permissions` | **required** `fileId` | 100 |
+
+No table declares `error_path` (phase 1: in-band errors are consumed
+upstream), and no table needs an `exclusive_resources` group — unlike
+`one_drive`, no two inputs here are alternatives with a silent
+precedence. `driveId` and `q` compose.
+
+## Engine facilities this design needs — all of them already exist
+
+Verified on this base before designing around them:
+
+- `utf8_list` and `utf8_list_from_object_key` (+ `key`) for array
+  columns, the github precedent. **Scalar array indexing does not
+  exist and is deliberately out of scope**
+  (`json_to_arrow.rs`: "array indexing is out of scope for relational
+  mappings"), so `owners` becomes a list of display names and a list of
+  emails rather than `owners[0].displayName`.
+- `timestamp_ms_utc`, whose converter accepts RFC 3339 — which is what
+  Google emits — as well as epoch millis.
+- Optional resources, required resources, and the fixed-input surface.
+
+**No engine change is needed for this pack.** That is a deliberate goal,
+not a coincidence: it keeps the diff reviewable as one pack.
+
+## `files`
+
+The flagship. `files.list` is the only action that sees the whole
+corpus, and it needs no resource at all, so the default binding scans
+every file the connected account can reach.
+
+### Columns (14)
+
+| column | path | type | note |
+|---|---|---|---|
+| `id` | `id` | utf8, **non-null** | identity; upstream `String(x ?? "")`, never null |
+| `name` | `name` | utf8 | |
+| `mime_type` | `mimeType` | utf8 | the folder discriminator — `application/vnd.google-apps.folder` |
+| `web_view_link` | `webViewLink` | utf8 | |
+| `created_time` | `createdTime` | timestamp_ms_utc | RFC 3339 upstream |
+| `modified_time` | `modifiedTime` | timestamp_ms_utc | |
+| `size_bytes` | `sizeBytes` | int64 | see below |
+| `drive_id` | `driveId` | utf8 | null on My Drive items |
+| `parents` | `parents` | utf8_list | |
+| `owner_display_names` | `owners` | utf8_list_from_object_key, `key: displayName` | |
+| `owner_email_addresses` | `owners` | utf8_list_from_object_key, `key: emailAddress` | |
+| `shared` | `shared` | boolean | conditionally spread upstream |
+| `starred` | `starred` | boolean | conditionally spread upstream |
+| `trashed` | `trashed` | boolean | conditionally spread upstream |
+
+Identity non-null, everything else nullable — the convention every pack
+follows (rationale recorded in gmail.yaml's messages table).
+
+`size_bytes` is worth a note as a **normalization win**: Google returns
+`size` as a decimal *string*, and the executor's `parseSizeBytes` turns
+it into a number, rejecting anything that is not a safe non-negative
+integer. So the column is a real `int64` rather than a string that
+looks like one — but it is null for every file with no byte size of its
+own, which includes folders and every native Docs/Sheets/Slides file.
+An all-null `size_bytes` on a Docs-only drive is expected, not a bug.
+
+Two columns come from the same `owners` array under different pluck
+keys. Drive files normally have exactly one owner (shared-drive items
+have none — the drive owns them), so both lists are usually length 0 or
+1; they are lists rather than scalars because the engine has no scalar
+indexing, not because multi-owner is expected.
+
+`permissionId` and `photoLink` are declared on the owner objects and
+left unmapped: a per-owner opaque ID useful only for a join this pack
+cannot perform, and an avatar URL.
+
+### Inputs: `q` and `driveId` as optional resources, and why there is no filter pushdown
+
+**`q` cannot be a filter mapping, structurally.** The filter facility
+maps one `column <eq|gt|gt_eq> value` comparison onto one input field,
+sending the column's value as the input's value. Drive's `q` is a whole
+query *language* (`name = 'x' and trashed = false`), so the value the
+facility would send is never a legal `q`. It is therefore an **optional
+resource**: the binding pins the whole query string and the table means
+"the files matching this binding's query" — the `one_drive.search_items`
+and `notion.block_children` shape. With no `q`, the table is every file
+the account can see.
+
+`driveId` is the other optional resource: it scopes the scan to one
+shared drive. It composes with `q` rather than competing with it, so no
+exclusive group.
+
+Nothing is filter-mapped on any of the three tables. That is a
+structural fact about this service's inputs, not an omission.
+
+### Fixed inputs: `supportsAllDrives` and `includeItemsFromAllDrives`, both `true`
+
+The one place this pack pins behaviour, and the reasoning matters.
+`files.list` forwards `supportsAllDrives` verbatim with **no default**
+(`optionalBoolean(input.supportsAllDrives)`), unlike the sibling
+actions, where `resolveSupportsAllDrives` defaults it to `true`. So
+unpinned, the scan inherits Google's own default and **silently omits
+every shared-drive file**. A table named `files` that quietly excludes a
+whole class of the account's files is the confidently-wrong-rows failure
+mode, so both flags are pinned `true` (Google requires the pair
+together to return shared-drive items).
+
+This is the pack's most load-bearing assumption and phase 4 must check
+it directly: that the pinned pair is accepted, that shared-drive items
+actually appear, and that it does not conflict with a `driveId`
+resource, where Google's `corpora` rules interact.
+
+### Negative space — inputs deliberately never sent
+
+- `includeLabels` and `includePermissionsForView` are **structural
+  no-ops**: the executor pins its own `fields` projection
+  (`driveFileFields`) and that projection contains neither `labelInfo`
+  nor `permissions`, so the requested data has no way back out. Sending
+  them would cost a request parameter and change nothing.
+- `orderBy` would only reorder a set the scan reads in full.
+- `corpora` and the deprecated `corpus` are superseded by the pinned
+  all-drives pair.
+- `teamDriveId` is the deprecated alias of `driveId`; declaring both
+  would create exactly the silent-precedence trap `one_drive` needed
+  `exclusive_resources` for, so only `driveId` is declared.
+- `fields` is not an input on this action at all (verified live: 400).
+
+### Trashed files are included
+
+Drive's `files.list` does not exclude trashed files by default, and this
+pack does not pin `q: "trashed = false"` to make it do so — that would
+be a semantic narrowing the operator never asked for, and it would
+collide with `q` as a resource (the loader rejects a fixed input that
+collides with a declared resource). `trashed` is a mapped column, so
+the filtering belongs in SQL where the operator can see it.
+
+## `drives`
+
+Shared drives the account can reach — no required resource, and a
+natural join partner for `files.drive_id`.
+
+**Read what this table does and does not contain.** `drives.list`
+returns **shared drives** (formerly Team Drives) only; **`My Drive` is
+not a drive resource and never appears as a row.** Shared drives are a
+Google Workspace feature — a personal Gmail account cannot create one
+and sees rows here only when it has been invited into someone else's.
+
+That makes this table's verifiability account-dependent, and the first
+draft of this document got it wrong: it called the table "cheap, clean,
+any account can scan", which failed to apply the very standard used two
+sections down to defer `accessproposals` and `approvals` (do not ship a
+table whose every column is unverifiable).
+
+**The table is kept in this wave by the operator's decision; the
+account question (risk R1) resolved in phase 4's favor** — the account
+proved able to create a shared drive, and the columns were verified on
+its real rows. See R1 for the outcome detail.
+
+### Columns (13)
+
+Eight from the declared scalar surface — `id` (utf8, non-null), `name`,
+`color_rgb`, `created_time` (timestamp_ms_utc), `org_unit_id`,
+`theme_id`, `background_image_link`, `hidden` (boolean) — plus the five
+restriction flags:
+
+| column | path | type |
+|---|---|---|
+| `admin_managed_restrictions` | `restrictions.adminManagedRestrictions` | boolean |
+| `copy_requires_writer_permission` | `restrictions.copyRequiresWriterPermission` | boolean |
+| `domain_users_only` | `restrictions.domainUsersOnly` | boolean |
+| `drive_members_only` | `restrictions.driveMembersOnly` | boolean |
+| `sharing_folders_requires_organizer_permission` | `restrictions.sharingFoldersRequiresOrganizerPermission` | boolean |
+
+**These five are the only columns in the pack outside the fingerprint
+gate, and the reason deserves stating exactly.** `restrictions` is
+declared as a bare open object —
+`{"type":"object","properties":{},"additionalProperties":{}}` — so the
+contract promises the key exists and says *nothing whatsoever* about its
+contents. Three consequences, worst first:
+
+1. **The five key spellings above appear in no capture.** They come from
+   Google's own Drive v3 documentation, which is exactly the source this
+   skill's opening lesson warns about: plausible from the provider's
+   docs, wrong against the real gateway. `normalizeDrive` passes the
+   object through raw (`asOptionalObject(payload.restrictions)`, no
+   renaming), so Google's camelCase spelling is what arrives — which
+   makes the doc-derived names credible but **not verified**. Phase-4
+   real rows are the only thing standing between these five columns and
+   the Notion `archived`/`is_archived` defect.
+2. **Upstream drift stays silent here.** The fingerprint hashes the
+   whole output schema, so a change to the *declaration* fails
+   registration — but the inner keys are undeclared, so upstream can
+   rename one at runtime without touching the declaration: hash
+   unchanged, registration passes, column silently all-NULL.
+   `fingerprint_uncovered_columns` will report all five, and that is a
+   genuine case-1 gap, not the case-2 "declared but the walker cannot
+   descend an `anyOf`" that covers every gmail column.
+3. `restrictions` is **not** in the item's `required` array, and
+   upstream drops the key when absent (`asOptionalObject` → `undefined`
+   → dropped by `compactObject`), so a drive with no restrictions set
+   may carry no key at all. All five columns are nullable.
+
+The trade is taken deliberately: these five answer "how open is this
+drive" (`domain_users_only`, `drive_members_only`), squarely the same
+sharing-audit question `file_permissions` exists for. What buys it is
+that phase-4 real rows close the *authoring-error* class. Nothing closes
+the *future-drift* class, and the pack doc must say so rather than let
+the reader assume the fingerprint covers them.
+
+Left unmapped, with reasons:
+
+- `kind` — the constant `"drive#drive"` on every row. A per-resource
+  constant carries no information, the same reasoning that left
+  `one_drive`'s `driveType` unmapped. (It is also declared on comments,
+  replies, revisions and permissions rows, and unmapped there for the
+  same reason.)
+- `capabilities` — about 20-30 booleans (`canAddChildren`,
+  `canComment`, `canDeleteDrive`, `canManageMembers`, `canRename`,
+  `canShare`, …). Unmapped for a reason stronger than "it is a blob":
+  the values are **relative to the authenticated account**, so scanning
+  the same drive under a different OAuth identity yields different
+  values. It is a per-user permission view, not a property of the
+  drive, and putting it in a table that claims to describe drives would
+  mislead every reader of that column.
+`restrictions` is the counterpart that IS mapped — five boolean
+scalars, in the column table above. It is drive-owned configuration
+that does not vary by caller, so the argument against `capabilities`
+does not touch it; what it costs instead is fingerprint coverage, and
+that cost is spelled out at the column table rather than glossed.
+Mapping it as one `json` column was rejected: a blob no SQL predicate
+can reach without JSON functions is not a usable answer to "which
+drives are domain-restricted".
+
+`useDomainAdminAccess` is never sent: it requires a Workspace admin and
+403s for everyone else, so pinning it would break the common case to
+serve the rare one. `q` is an optional resource here too.
+
+## `file_permissions`
+
+Who can reach one file. The sharing-audit surface, and the table that
+establishes the file-scoped shape.
+
+### `fileId` is a required resource — and the enforcement boundary is narrow
+
+Same mechanism as `one_drive.search_items`'s `query`, and worth stating
+precisely because it is easy to over-read. The input schema's `required`
+array is **empty** and `fileId` is merely `minLength: 1`, so:
+
+- `fileId` **missing** → passes schema validation, dies in the
+  executor's own `resolveFileId` check (`400 "fileId is required"`).
+  Declaring it a required resource closes exactly this case, at
+  registration, before any HTTP.
+- `fileId: ""` → 400 `invalid_input` at the schema layer (verified
+  live).
+- `fileId: "   "` → resource validation is presence-plus-non-null only
+  (`contains_key` plus the config layer's null check), so it registers
+  cleanly and fails at **scan** time on the upstream 400. Loud either
+  way, never a silent empty table — but a scan-time failure, not a
+  config-time one. Trimming resource values would be an engine-wide
+  policy change, not a pack decision.
+
+One more upstream quirk to document rather than fight: `resolveFileId`
+runs the value through `extractFileId`, which accepts a **Drive URL**
+and pulls the ID out of it. So a binding whose `fileId` is
+`https://drive.google.com/file/d/ABC/view` works. Convenient, and worth
+naming so it does not read as a bug when someone tries it.
+
+### Columns (11)
+
+`id` (utf8, non-null), `role`, `type`, `email_address`,
+`display_name`, `domain`, `photo_link`, `expiration_time`
+(timestamp_ms_utc), `allow_file_discovery` (boolean), `deleted`
+(boolean), `pending_owner` (boolean).
+
+`kind` is unmapped (constant). `permissionDetails` is unmapped: an
+array of inherited-permission records whose useful content is a
+per-entry role and inheritance source — a second table's worth of shape,
+not a column.
+
+### The rows carry no file identity, and the engine cannot add one
+
+`permissions.list` rows have no `fileId` field, and **a resource's value
+cannot become a column** — the loader wires resources into the request,
+and there is no injection path into the row. So the table is
+"the permissions of the one file this binding names", exactly as
+`notion.block_children` is the children of one block. An operator
+wanting permissions across many files binds the pack once per file, and
+the binding name is what distinguishes the resulting schemas. This is a
+limitation to document in the pack doc, not to work around.
+
+## Deferred, with a reason each
+
+| action | why not in this wave |
+|---|---|
+| `changes.list` | **Semantically not a collection.** With no `pageToken` the executor first calls `changes.getStartPageToken` and starts from *now*, so a full scan reads changes occurring after it begins and terminates on an empty page. Shipping it would need `pageToken` as a required resource and a story for what a re-scan means — an incremental-sync design, not a table. |
+| `comments.list`, `revisions.list` | Fine actions, file-scoped exactly like `file_permissions`. Held for a second wave so the first carries one instance of the shape rather than three. `comments` additionally needs a decision on its nested `replies` array and its bare-object `quotedFileContent`. |
+| `replies.list` | Needs `fileId` **and** `commentId` — a two-level binding that only earns its place next to a comments table. |
+| `files.listLabels` | Workspace-only label taxonomy: empty on any non-Workspace account, so phase 4 could not witness a single non-NULL column. It also spells its page size **`maxResults`** rather than `pageSize`, the one pagination-input asymmetry in the service. |
+| `accessproposals.list`, `approvals.list` | Rare surfaces that are empty on ordinary accounts, so phase 4 cannot verify any column against real data. Shipping a table whose every column is unverifiable is the defect the live pass exists to prevent. |
+
+## Page sizes, and what phase 4 confirmed
+
+`files` pins 1000, `drives` and `file_permissions` pin 100 — each the
+declared ceiling. A declared bound is not a wire bound (feishu declared
+100 and hard-failed above 50, skardi PR #186), so phase 4 probed the
+real wire: **all three ceilings hold** (1000/100/100 each 200 with real
+credentials; 1001/101/0 each 400), and real multi-page walks at
+`pageSize: 1` returned ~444-char cursors with a terminal-page `null` on
+every table.
+
+Response size, measured from the live captures: a fully-populated
+My Drive row serializes to ~650–690 bytes (shared-drive rows are
+smaller), so the largest page (1000 files) is under 1 MiB — far below
+the client's 16 MiB cap.
+
+The other phase-4 items beyond the per-table scan, all witnessed: the
+pinned all-drives pair really surfaces shared-drive files (the seeded
+one came back with its real `drive_id` through skardi-server); it
+composes with a `driveId` resource and with `q` (both probed live, and
+`q` also verified through a bound binding resource); `size_bytes` is
+non-null on real files INCLUDING native Google Docs (a live correction:
+Docs report byte sizes; the null-size row is a folder); and `owners` is
+absent on shared-drive items exactly as expected — the live absence
+pattern is `owners`+`shared`, with `parents`/`starred`/`trashed`
+staying present.
+
+
+---
+
+## Decisions locked at the end of phase 2
+
+Settled with the operator; phase 3 implements exactly these and nothing
+wider.
+
+1. **Three tables** — `files`, `drives`, `file_permissions`. The six
+   other file-scoped list actions and `changes.list` stay deferred with
+   the reasons tabulated above.
+2. **`supportsAllDrives` and `includeItemsFromAllDrives` are pinned
+   `true`** as fixed inputs on `files`, so the table does not silently
+   omit shared-drive files. The pack's most load-bearing assumption;
+   phase 4 verifies it directly.
+3. **`q` is an optional resource** on `files` and on `drives`. It
+   cannot be a filter mapping (it is a query language, not a value), and
+   no table on this pack declares any filter mapping.
+4. **`capabilities` unmapped, `restrictions` mapped as five boolean
+   columns.** These were first treated as one decision, which hid that
+   their reasons differ in kind. `capabilities` is a *per-caller*
+   permission view ("Capabilities the current user has on this shared
+   drive") — its values change with the OAuth identity doing the scan,
+   so the same table under two bindings would disagree. That is not
+   data, and no amount of declaration would make it a column.
+   `restrictions` is drive-owned configuration answering a real
+   sharing-audit question, so it ships — at the price of being the
+   pack's only fingerprint-uncovered columns, a price paid explicitly
+   with phase-4 real rows closing the authoring-error class and the pack
+   doc stating plainly that nothing closes future drift.
+
+## Risk register
+
+### R1 — the phase-4 account may see no shared drive at all (RESOLVED 2026-08-25)
+
+**Outcome — a fourth path the three below did not anticipate.** The
+account began at the third outcome: `drives.list` returned zero rows
+(that clean empty scan was itself witnessed end to end). But
+`drives.create` succeeded — the account is a Workspace account able to
+create its own shared drive — converting the situation to the first
+outcome. The created drive's real row carried all five `restrictions.*`
+spellings verbatim (present `false`s, alongside an unmapped nested
+`downloadRestriction`), a file seeded into the drive came back through
+a live skardi-server scan with `drive_id` carrying the real drive id
+(closing decision 2's residual as well), and the shared-drive row
+absence pattern was captured (`owners`+`shared` drop; the rest stay).
+What could NOT be witnessed on this tenant: flipping any restriction to
+`true` (admin-gated, 403 `userCannotChangeDriveRestrictionsUnderOrg` —
+a value question, not an extraction-path question), `org_unit_id`
+(org-unit feature unused) and `theme_id` (null even when the drive was
+created with an explicit `themeId`; the theme materializes as
+`color_rgb` + `background_image_link`). The original analysis follows,
+kept for the record.
+
+`drives` ships in this wave, but whether the test account is a Google
+Workspace account, or a personal account invited into someone else's
+shared drive, is **unconfirmed**. If it is neither, `drives.list`
+returns zero rows and not one of the table's thirteen columns can be
+witnessed non-NULL — which is exactly the standard this document uses
+to defer `accessproposals`, `approvals` and `files.listLabels`.
+
+Being wrong here is quiet rather than loud: an empty scan is a
+*successful* scan. Registration passes (the fingerprint gate reads the
+declared contract, not rows), pagination terminates immediately and
+correctly on a null `nextPageToken`, and nothing anywhere fails. A
+reader would see a working table and an empty result and conclude the
+account has no shared drives — which is true, but says nothing about
+whether the thirteen column mappings are right.
+
+**Phase 4 must establish this FIRST, before the per-table scans**, and
+report the account type it actually observed. Three outcomes:
+
+- Shared drives visible → scan normally, verify all thirteen columns,
+  R1 closes.
+- Visible but the account is a non-organizer member → expect
+  `color_rgb`, `org_unit_id`, `theme_id` and `background_image_link` to
+  come back null (they are organizer-managed); record which columns
+  went unwitnessed and why, rather than reporting them as verified.
+- No shared drive at all → do NOT report `drives` as verified. Surface
+  it and let the operator choose between deferring the table (the
+  consistent call) and shipping it with the unverifiable-columns caveat
+  recorded here.
+
+**Mapping `restrictions` made R1 load-bearing rather than merely
+inconvenient.** Before that decision, a bad R1 outcome meant eight
+unwitnessed columns that the fingerprint gate still protected. Now it
+also means five columns that are *both* unwitnessed *and* unprotected —
+and those five carry key spellings taken from provider documentation
+that no capture can check. If R1 lands on the third outcome, the five
+restriction columns are the first thing to reconsider, ahead of the
+table as a whole.
+
+This also partly gates decision 2: the pinned all-drives pair cannot be
+shown to actually surface shared-drive files on an account with no
+shared drive. If R1 lands on the third outcome, the pin stays (it is
+still the right default) but its verification becomes a residual too.


### PR DESCRIPTION
Milestone 5.9: a source pack for Google Drive over Open Connector's `googledrive` service — three tables (`files`, `drives`, `file_permissions`), **live-verified end to end against a real Workspace account** on 2026-08-25. Contract reconciled against gateway v1.3.4 / open-connector `2410fbe` (the same pin as 5.7/5.8); on the provider side the executors pin Google Drive **`v3`** in every URL. No engine changes: the diff is `packs/` plus the registration rosters and docs.

Design record: `docs/superpowers/specs/2026-08-25-open-connector-google-drive-pack-design.md` (phases 1–4, risk R1 resolved). User docs: `docs/open-connector-google-drive.md`.

## What shipped

- `packs/google_drive.yaml` — the declarative pack: `files` (14 columns), `drives` (13), `file_permissions` (11), every design decision annotated inline with its rationale.
- `packs/google_drive.rs` — module doc (status, 11 design decisions, each held by a named test), OnceLock accessor, 25 tests.
- `packs/fixtures/google_drive/` — row fixtures as **redacted live captures** under a default-deny redaction audit, plus both halves of all three contracts (`contracts/` + `contracts/inputs/`, gmail-style).
- Registry entries in `packs/mod.rs` / `source_pack.rs` (+1 roster test), pack doc, status line in `docs/open-connector.md`, the README's source matrix, a cross-link from the Gmail guide — Google splits into one pack per service upstream, so a reader landing on Gmail now has a path to Drive — and the milestone entry in the tasks spec.

## Service shape

The service is spelled `googledrive` and its action IDs carry **two dots** (`googledrive.files.list`) — new to shipped packs, verified engine-safe end to end in phase 1 (`validate_action_id` rejects only `/` and empty dot segments; the URL path keeps dots verbatim; the `rsplit('.')` short-name lookups read table IDs, never action IDs).

Rows are **NORMALIZED** — the opposite of one_drive. Every executor rebuilds rows through a `normalize*` function into a closed key set (`additionalProperties: false`) and pins its own provider-side `fields` projection (`files.list` does not even declare a `fields` input; sending one 400s). So the declared contract is column truth to an unusual degree, and the wire keys are the normalizer's (`sizeBytes` as a number, not Google's string-typed `size`).

## Design decisions

- **The all-drives pin is the pack's one load-bearing fixed input.** `files.list` forwards `supportsAllDrives` verbatim with NO upstream default (unlike its siblings, which default it true), so an unpinned scan silently omits every shared-drive file — the confidently-wrong-rows failure mode. Both halves of the pair are pinned `true`.
- **`q` is an optional RESOURCE, not a filter mapping, structurally**: it is a whole query language, and a FilterMapping's column-op-value literal is never a legal `q`. Trashed files deliberately stay in (`trashed` is a column; filtering belongs in SQL — a `q` pin would collide with the resource and silently narrow the table).
- **`fileId` is a required resource on `file_permissions`** with a three-way enforcement boundary (upstream declares NO `required` array): missing → refused at registration, `""` → schema-layer 400, whitespace → executor 400 at scan time. Loud all three ways. The table means "the permissions of the file this binding names" — the `notion.block_children` shape.
- **The five `restrictions.*` columns trade fingerprint coverage for audit value, knowingly.** `restrictions` is a bare open object, so the five flags sit outside the gate; a coverage test pins exactly those five as the pack's only uncovered columns. Phase 4 supplied what no capture can: a real drive row carried all five spellings verbatim. The per-caller sibling `capabilities` stays unmapped (its values change with the OAuth identity doing the scan).
- Page sizes pinned at the declared ceilings (1000/100/100); the deprecated `teamDriveId` alias is not exposed (avoiding the silent-precedence trap 5.8 needed `exclusive_resources` for); no table declares `error_path` (executors consume in-band Google errors into the gateway failure envelope).
- **Deferred with reasons** (design record): `changes.list` (its cursor must be bootstrapped by a second action — an incremental-sync feed, not a collection), comments / replies / revisions / labels / accessproposals (second wave; the last is Workspace-approval-gated).

## Phase-4 live verification (real Workspace account, seeded corpus)

Seeded: a folder, four files spanning every shape, one shared drive, one shared-drive file, three grant types on one file.

- **Risk R1 resolved in the best direction.** The account started at zero shared drives — that clean empty scan was itself witnessed — then proved able to CREATE one, so `drives` was verified on real rows instead of deferred. All five `restrictions.*` spellings came back verbatim (present `false`s, alongside an unmapped nested `downloadRestriction`).
- **Three-table end-to-end skardi-server scans**, registration passing the fingerprint gate against LIVE discovery. Every mapped column extracted a real non-NULL value somewhere, except three structural residuals (below).
- **The all-drives pin does its job**: the seeded shared-drive file came back with its real `drive_id`. Live absence pattern captured: shared-drive rows drop exactly `owners`+`shared`; `parents`/`starred`/`trashed` stay.
- **Wire bounds confirmed**: 1000/100/100 each 200 with real credentials; 1001/101/0 each 400. Real `pageSize: 1` multi-page walks (~444-char cursors, true terminal `null` on every table). Through skardi-server with a small page size, `LIMIT` stopped a three-page scan after two requests.
- `q` verified live both as a direct input and as a bound binding resource; `fileId` forwarded verbatim on every page; a nonexistent `fileId` produced the documented gateway failure envelope.
- **Live corrections folded into the fixtures**: native Google Docs DO report `sizeBytes` (the null-size row is a folder); every grant carries `permissionDetails`, not just shared-drive ones; owner objects always carry four keys.

**Three columns remain unwitnessed non-null**, each key present-and-null on real rows, each structurally out of reach, each documented as a residual: `drives.org_unit_id` (Workspace org units only), `drives.theme_id` (null even when a drive is CREATED with an explicit theme — it materializes as `color_rgb` + `background_image_link`), `file_permissions.expiration_time` (Google 403s expirations on domain/anyone grants; a user-grant expiration needs a second real account).

## Verification

**CI green on `f763ce8`** ([run 32854955874](https://github.com/SkardiLabs/skardi/actions/runs/32854955874)): 2125 workspace tests passed via `cargo llvm-cov --no-report nextest --all-features`, plus 237 `--ignored` integration tests and 37 doc tests. CI runs the whole workspace through nextest rather than the per-module filter, so the per-pack figures are static counts of test functions in the tree (none `#[ignore]`d): 26 new — 25 in the pack module (`cargo test -p skardi --lib sources::providers::open_connector::packs::google_drive`) plus 1 registry test, taking `sources::providers::open_connector` from 402 to 428.

- 13 contract/conversion: per-table fixture conversions over the redacted live captures; boundary shapes one live tenant cannot produce (empty strings/arrays, partial `restrictions`, a non-null expiration) as inline synthetic pages, marked as such; the default-deny redaction audit over every fixture string leaf; `sizeBytes`-as-string type mismatch with row-scoped error identity; id-less row failing the page; fingerprint pins for all three contracts; the five-column coverage-gap pin; pagination / resource / fixed-input declarations; the captured-input-contract test locking every sendable key plus the declared-but-never-sent negative space per action.
- 12 e2e through MockGateway: per-table wire-declaration scans with exact key sets and the all-drives pins on every page, opaque-cursor continuation and null termination, a fileId-less permissions binding refused before any HTTP, no-pushdown predicates staying local, LIMIT early-stop, empty shared-drive scan, pagination-loop refusal, failure-envelope surfacing with the dotted action id named, UDTF parity, drift-refusal at registration.

## Phase-5 self-review

The review checklist plus the repo's own code-review pass found **no correctness defect in the pack**: all twelve findings were honesty and sync problems in the prose around it, fixed in the last commit. Two would have actively misled a reader. `size_bytes` was documented in three places as null for every native Docs/Sheets/Slides file, with an all-NULL column on a Docs corpus called expected — a phase-3 guess the phase-4 capture contradicts (the native Doc row carries `sizeBytes: 1024`; the null-size row is the folder), so as written it would have talked a future reader out of investigating exactly the always-NULL defect the live pass exists to catch. And the tasks spec's Review notes still announced phase 4 as PENDING — the first thing a reviewer reads, and the opposite of what the 5.9 entry says.

The checks with teeth came back clean, each verified against the code rather than the comments: `owners`' four inner keys are declared `required` under `additionalProperties: false`, so both pluck columns really are inside the fingerprint gate and "only the five `restrictions.*` flags escape it" holds; a missing pluck key fails the page loudly instead of dropping an item, so the two owner columns cannot silently misalign; the loader does refuse a fixed input colliding with a declared resource, as the yaml claims; `max_pages` × 1000 does equal the default `max_rows`; and `validate_action_id` rejects only `/` and a whole-id dot segment, so the two-dot action ids travel safely.

## Caveat carried in the docs

The provider-level OAuth grant requests all three declared scopes including read-write `auth/drive`, though every action this pack maps is read-only. A pack cannot narrow an upstream connection property; documented in the pack doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
