### PR TITLE
feat(cli): skardi mcp — MCP-over-stdio binding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7065,6 +7065,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7637,6 +7649,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "path_abs"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8013,6 +8031,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "process-wrap"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+dependencies = [
+ "futures",
+ "indexmap 2.14.0",
+ "nix",
+ "tokio",
+ "tracing",
+ "windows",
 ]
 
 [[package]]
@@ -8876,6 +8908,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a15bc53261a9dc37e105df006e4656c598379a8f9581f8950debb130f27a7cf"
+dependencies = [
+ "chrono",
+ "futures",
+ "indexmap 2.14.0",
+ "pastey",
+ "pin-project-lite",
+ "process-wrap",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9179,10 +9234,24 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9655,12 +9724,14 @@ dependencies = [
  "getrandom 0.2.17",
  "percent-encoding",
  "reqwest 0.12.28",
+ "rmcp",
  "serde",
  "serde_json",
  "serde_yaml",
  "sha2 0.10.9",
  "tempfile",
  "tokio",
+ "uuid",
  "wiremock",
 ]
 
@@ -11717,6 +11788,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11727,6 +11819,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -11756,6 +11859,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -11842,6 +11955,15 @@ dependencies = [
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ spec:
     GROUP BY plan ORDER BY cancels DESC
 ```
 
-**4 — The agent has a new tool.** One definition, both bindings — so the same
-promoted pipeline works in Claude Code, Cursor, your own loop, or any HTTP host,
-with no wrapper code to maintain.
+**4 — The agent has a new tool.** One definition, every binding — shell, REST,
+and MCP — so the same promoted pipeline works in Claude Code, Cursor, your own
+loop, or any HTTP host, with no wrapper code to maintain.
 
 ```bash
 # shell verb — any agent with a Bash tool, no MCP config
@@ -119,6 +119,8 @@ skardi run weekly-churn -p window='7 days'
 # same pipeline, served as REST
 curl -X POST localhost:8080/weekly-churn/execute \
   -H 'Content-Type: application/json' -d '{"window": "7 days"}'
+# same pipeline as an MCP tool — hosts without a shell (Claude Desktop, …)
+skardi mcp
 ```
 
 Promoting queries into pipelines is only the simplest form of **Act**. The same ledger supports

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -22,7 +22,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 # The MCP-over-stdio bridge (`skardi mcp`). default-features = false keeps
 # rmcp's HTTP stack (and any axum version skew) out of the dependency graph;
 # `transport-io` is the server-side stdio transport.
-rmcp = { version = "3.1.4", default-features = false, features = ["server", "transport-io"] }
+rmcp = { version = "=3.1.4", default-features = false, features = ["server", "transport-io"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
@@ -39,7 +39,7 @@ uuid = { workspace = true }
 [dev-dependencies]
 # Feature unification: these add the MCP *client* side (spawning the binary
 # as a child process) for the e2e tests only.
-rmcp = { version = "3.1.4", default-features = false, features = ["client", "transport-child-process"] }
+rmcp = { version = "=3.1.4", default-features = false, features = ["client", "transport-child-process"] }
 tempfile = { workspace = true }
 wiremock = "0.6"
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -19,6 +19,10 @@ clap = { version = "4.5", features = ["derive"] }
 dirs = "5.0"
 percent-encoding = "2.3"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+# The MCP-over-stdio bridge (`skardi mcp`). default-features = false keeps
+# rmcp's HTTP stack (and any axum version skew) out of the dependency graph;
+# `transport-io` is the server-side stdio transport.
+rmcp = { version = "3.1.4", default-features = false, features = ["server", "transport-io"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
@@ -29,8 +33,13 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "io-
 sha2 = "0.10"
 base64 = "0.22"
 getrandom = "0.2"
+# One v4 UUID per MCP connection: the ai_context session id.
+uuid = { workspace = true }
 
 [dev-dependencies]
+# Feature unification: these add the MCP *client* side (spawning the binary
+# as a child process) for the e2e tests only.
+rmcp = { version = "3.1.4", default-features = false, features = ["client", "transport-child-process"] }
 tempfile = { workspace = true }
 wiremock = "0.6"
 

--- a/crates/cli/src/cloud.rs
+++ b/crates/cli/src/cloud.rs
@@ -33,6 +33,7 @@ pub enum Capability {
     Pipeline,
     Job,
     Health,
+    Mcp,
 }
 
 impl Capability {
@@ -49,6 +50,7 @@ impl Capability {
             Capability::Pipeline => "pipeline",
             Capability::Job => "job",
             Capability::Health => "health",
+            Capability::Mcp => "mcp",
         }
     }
 
@@ -56,7 +58,9 @@ impl Capability {
     ///
     /// The gateway's route table is `POST /query` and `GET /data_source`
     /// (§7.4); everything else is an engine-local surface that only a
-    /// `mode: server` context reaches.
+    /// `mode: server` context reaches. `mcp` straddles both (its tools need
+    /// pipeline execution and `/pipelines`, which the gateway does not
+    /// mount), so it is refused as a whole rather than served half-broken.
     pub const fn served_by_gateway(self) -> bool {
         matches!(self, Capability::Query | Capability::Schema)
     }
@@ -65,13 +69,14 @@ impl Capability {
 /// Every capability, so the "Available:" list is DERIVED from
 /// [`Capability::served_by_gateway`] rather than restated next to it — a
 /// hand-written list is the kind that survives the table changing under it.
-const ALL_CAPABILITIES: [Capability; 6] = [
+const ALL_CAPABILITIES: [Capability; 7] = [
     Capability::Query,
     Capability::Schema,
     Capability::Run,
     Capability::Pipeline,
     Capability::Job,
     Capability::Health,
+    Capability::Mcp,
 ];
 
 /// The comma-separated commands a cloud context can run.

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -22,6 +22,7 @@ mod cloud;
 mod commands;
 mod config;
 mod login;
+mod mcp;
 mod output;
 mod params;
 mod session;
@@ -153,6 +154,13 @@ enum Commands {
         /// pipeline name (omit for overall server health)
         name: Option<String>,
     },
+
+    /// Serve MCP over stdio, proxying tools to the server (for MCP hosts).
+    ///
+    /// Spawned by an MCP host (Claude Desktop, Cursor, ...) as a long-lived
+    /// child process; speaks JSON-RPC on stdout, so it prints nothing else
+    /// there. Runs until the host closes stdin.
+    Mcp,
 }
 
 #[tokio::main]
@@ -266,6 +274,10 @@ async fn dispatch(cli: Cli) -> anyhow::Result<()> {
 
         Commands::Health { name } => commands::health::run(&client, name.as_deref()).await,
 
+        // Moves `client` by value: the bridge owns it for the process's
+        // lifetime (the host decides when that ends by closing stdin).
+        Commands::Mcp => mcp::run(client).await,
+
         // Returned above, before resolution.
         Commands::Config { .. } | Commands::Login(_) | Commands::Logout(_) => Ok(()),
     };
@@ -284,6 +296,7 @@ fn capability_of(command: &Commands) -> Option<Capability> {
         Commands::Pipeline { .. } => Some(Capability::Pipeline),
         Commands::Job { .. } => Some(Capability::Job),
         Commands::Health { .. } => Some(Capability::Health),
+        Commands::Mcp => Some(Capability::Mcp),
         // Local, and returned before resolution: no capability to gate.
         Commands::Config { .. } | Commands::Login(_) | Commands::Logout(_) => None,
     }
@@ -306,6 +319,7 @@ mod tests {
             (&["skardi", "pipeline", "list"], Capability::Pipeline),
             (&["skardi", "job", "list"], Capability::Job),
             (&["skardi", "health"], Capability::Health),
+            (&["skardi", "mcp"], Capability::Mcp),
         ];
         for (argv, expected) in cases {
             let cli = super::Cli::try_parse_from(argv).expect("parses");
@@ -377,7 +391,8 @@ mod tests {
                 | Commands::Pipeline { .. }
                 | Commands::Job { .. }
                 | Commands::Schema
-                | Commands::Health { .. } => true,
+                | Commands::Health { .. }
+                | Commands::Mcp => true,
             }
         }
         let cli = super::Cli::try_parse_from(["skardi", "schema"]).unwrap();

--- a/crates/cli/src/mcp/bridge.rs
+++ b/crates/cli/src/mcp/bridge.rs
@@ -1,0 +1,349 @@
+//! MCP ⇄ REST bridge: a manual `ServerHandler` whose tools come from the
+//! server's pipeline inventory at list time. All REST I/O goes through the
+//! CLI's `ApiClient`; stdout belongs to the JSON-RPC transport, so nothing
+//! here may print to it.
+//!
+//! The MCP trait methods are thin wrappers over inherent `do_*` methods:
+//! `RequestContext` is `#[non_exhaustive]` and cannot be constructed in
+//! tests, so the wiremock tests below drive the `do_*` methods directly and
+//! the spawned-binary e2e (`tests/mcp_e2e.rs`) covers the trait wiring.
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use rmcp::ServerHandler;
+use rmcp::model::{
+    CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ErrorData,
+    Implementation, JsonObject, ListToolsResult, PaginatedRequestParams, ServerCapabilities,
+    ServerInfo,
+};
+use rmcp::service::{RequestContext, RoleServer};
+use serde_json::Value;
+
+use crate::client::{ApiClient, ApiError, encode_component};
+use crate::mcp::projection;
+
+const INSTRUCTIONS: &str = "Skardi is a federated SQL data plane: operator-defined \
+pipelines plus an ad-hoc SQL engine over the configured data sources. Prefer the \
+pipeline tools for tasks they cover. Before writing ad-hoc SQL with `query`, call \
+`list_data_sources` to see tables, schemas, and their plain-English descriptions.";
+
+pub(crate) struct McpBridge {
+    client: ApiClient,
+    /// Tool name → original pipeline name; rebuilt on every tools/list, so a
+    /// host that re-lists (or reconnects) sees a re-configured server's fresh
+    /// inventory with no bridge restart.
+    tool_map: RwLock<HashMap<String, String>>,
+    /// One UUID per MCP connection, sent as `ai_context.session_id` whenever
+    /// the model provides a `purpose`. This is the v1 carrier of the
+    /// agent-identity passthrough seam.
+    session_id: String,
+}
+
+impl McpBridge {
+    pub(crate) fn new(client: ApiClient) -> Self {
+        McpBridge {
+            client,
+            tool_map: RwLock::new(HashMap::new()),
+            session_id: uuid::Uuid::new_v4().to_string(),
+        }
+    }
+
+    pub(crate) async fn do_list_tools(&self) -> Result<ListToolsResult, ErrorData> {
+        // Fetched on every call — no cache. Hosts list rarely (typically at
+        // connect time) and the hop is usually localhost.
+        let inventory = self
+            .client
+            .get("/pipelines")
+            .await
+            // ApiError::Connect's Display already names the resolved URL and
+            // the three ways to configure it.
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let (tools, map) = projection::project(&inventory);
+        *self.tool_map.write().expect("tool map lock") = map;
+        Ok(ListToolsResult::with_all_items(tools))
+    }
+
+    pub(crate) async fn do_call_tool(
+        &self,
+        name: &str,
+        args: Option<JsonObject>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let outcome = match name {
+            "query" => self.call_query(args).await,
+            "list_data_sources" => self.client.get("/data_source").await,
+            _ => {
+                let pipeline = self
+                    .tool_map
+                    .read()
+                    .expect("tool map lock")
+                    .get(name)
+                    .cloned();
+                match pipeline {
+                    Some(pipeline) => {
+                        // Arguments pass through as the flat execute body —
+                        // the server is the validator.
+                        let body = Value::Object(args.unwrap_or_default());
+                        let path = format!("/{}/execute", encode_component(&pipeline));
+                        self.client.post(&path, &body).await
+                    }
+                    None => {
+                        // Protocol-level: covers host bugs and a server
+                        // re-configured since the host last listed.
+                        return Err(ErrorData::invalid_params(
+                            format!(
+                                "unknown tool '{name}' — the pipeline inventory may have \
+                                 changed; re-issue tools/list to refresh it"
+                            ),
+                            None,
+                        ));
+                    }
+                }
+            }
+        };
+        Ok(match outcome {
+            // Success: the response JSON verbatim, no client-side reshaping.
+            Ok(value) => CallToolResult::success(vec![ContentBlock::text(value.to_string())]),
+            // Execution errors are for the model to see and react to (fix a
+            // parameter, pick another tool), not protocol errors. ApiError's
+            // Display carries the server's message and error_type.
+            Err(err) => CallToolResult::error(vec![ContentBlock::text(err.to_string())]),
+        })
+    }
+
+    /// The one choke-point that assembles the `/query` body; later versions
+    /// extend this to full identity injection without touching call sites.
+    async fn call_query(&self, args: Option<JsonObject>) -> Result<Value, ApiError> {
+        let args = args.unwrap_or_default();
+        let mut body = serde_json::Map::new();
+        for key in ["sql", "max_rows"] {
+            if let Some(value) = args.get(key) {
+                body.insert(key.to_string(), value.clone());
+            }
+        }
+        // When `purpose` is absent, ai_context is omitted entirely — the
+        // server rejects a partial object.
+        if let Some(purpose) = args.get("purpose").and_then(Value::as_str) {
+            let purpose = purpose.trim();
+            if !purpose.is_empty() {
+                body.insert(
+                    "ai_context".to_string(),
+                    serde_json::json!({"purpose": purpose, "session_id": self.session_id}),
+                );
+            }
+        }
+        self.client.post("/query", &Value::Object(body)).await
+    }
+}
+
+impl ServerHandler for McpBridge {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::new("skardi", env!("CARGO_PKG_VERSION")))
+            .with_instructions(INSTRUCTIONS)
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, ErrorData> {
+        self.do_list_tools().await
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResponse, ErrorData> {
+        self.do_call_tool(&request.name, request.arguments)
+            .await
+            .map(CallToolResponse::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ClientConfig;
+    use serde_json::json;
+    use wiremock::matchers::{body_json, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn test_config(server: &str) -> ClientConfig {
+        ClientConfig {
+            server: server.to_string(),
+            token: None,
+            context: None,
+        }
+    }
+
+    fn bridge_for(server: &MockServer) -> McpBridge {
+        McpBridge::new(ApiClient::new(&test_config(&server.uri())).unwrap())
+    }
+
+    fn inventory() -> Value {
+        json!({"success": true, "count": 1, "data_sources": 0,
+               "pipelines": [{"name": "product-search", "version": "1.0.0",
+                 "endpoint": "/product-search/execute",
+                 "description": "Filter products",
+                 "parameters": [{"name": "brand", "data_type": "Utf8",
+                                 "json_schema": {"type": ["string", "null"]}}]}]})
+    }
+
+    #[tokio::test]
+    async fn list_tools_projects_pipelines_and_builtins() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/pipelines"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(inventory()))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let bridge = bridge_for(&server);
+        let result = bridge.do_list_tools().await.unwrap();
+        let names: Vec<&str> = result.tools.iter().map(|t| t.name.as_ref()).collect();
+        assert!(names.contains(&"product-search"), "{names:?}");
+        assert!(names.contains(&"query"), "{names:?}");
+        assert!(names.contains(&"list_data_sources"), "{names:?}");
+    }
+
+    #[tokio::test]
+    async fn list_tools_maps_connect_failure_to_a_protocol_error() {
+        let bridge = McpBridge::new(ApiClient::new(&test_config("http://127.0.0.1:1")).unwrap());
+        let err = bridge.do_list_tools().await.unwrap_err();
+        assert!(
+            err.message.contains("cannot reach skardi-server"),
+            "{}",
+            err.message
+        );
+    }
+
+    #[tokio::test]
+    async fn pipeline_call_posts_flat_body_and_returns_verbatim_json() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/pipelines"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(inventory()))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/product-search/execute"))
+            .and(body_json(json!({"brand": "acme"})))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({"success": true, "data": [], "rows": 0})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let bridge = bridge_for(&server);
+        bridge.do_list_tools().await.unwrap(); // builds the dispatch map
+        let args = json!({"brand": "acme"}).as_object().cloned();
+        let result = bridge.do_call_tool("product-search", args).await.unwrap();
+        assert_eq!(result.is_error, Some(false));
+    }
+
+    #[tokio::test]
+    async fn unknown_tool_is_a_protocol_error_nudging_a_relist() {
+        let server = MockServer::start().await;
+        let bridge = bridge_for(&server);
+        let err = bridge.do_call_tool("nope", None).await.unwrap_err();
+        assert!(err.message.contains("unknown tool"), "{}", err.message);
+        assert!(err.message.contains("tools/list"), "{}", err.message);
+    }
+
+    #[tokio::test]
+    async fn query_with_purpose_sends_ai_context_with_a_stable_session_id() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/query"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({"success": true, "data": [], "rows": 0})),
+            )
+            .expect(2)
+            .mount(&server)
+            .await;
+        let bridge = bridge_for(&server);
+        for _ in 0..2 {
+            let args = json!({"sql": "select 1", "purpose": "why"})
+                .as_object()
+                .cloned();
+            let result = bridge.do_call_tool("query", args).await.unwrap();
+            assert_eq!(result.is_error, Some(false));
+        }
+        let requests = server.received_requests().await.unwrap();
+        let bodies: Vec<Value> = requests
+            .iter()
+            .map(|r| serde_json::from_slice(&r.body).unwrap())
+            .collect();
+        assert_eq!(bodies[0]["ai_context"]["purpose"], json!("why"));
+        let sid0 = bodies[0]["ai_context"]["session_id"].as_str().unwrap();
+        let sid1 = bodies[1]["ai_context"]["session_id"].as_str().unwrap();
+        assert_eq!(sid0, sid1, "session id must be stable per connection");
+        assert!(!sid0.is_empty());
+    }
+
+    #[tokio::test]
+    async fn query_without_purpose_omits_ai_context_entirely() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/query"))
+            .and(body_json(json!({"sql": "select 1", "max_rows": 5})))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({"success": true, "data": [], "rows": 0})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let bridge = bridge_for(&server);
+        let args = json!({"sql": "select 1", "max_rows": 5})
+            .as_object()
+            .cloned();
+        let result = bridge.do_call_tool("query", args).await.unwrap();
+        assert_eq!(result.is_error, Some(false));
+    }
+
+    #[tokio::test]
+    async fn server_error_becomes_is_error_tool_result_with_error_type() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/query"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+                "success": false,
+                "error": "Missing required parameters: brand",
+                "error_type": "parameter_validation_error"
+            })))
+            .mount(&server)
+            .await;
+        let bridge = bridge_for(&server);
+        let args = json!({"sql": "select 1"}).as_object().cloned();
+        let result = bridge.do_call_tool("query", args).await.unwrap();
+        assert_eq!(result.is_error, Some(true));
+        let text = serde_json::to_string(&result.content).unwrap();
+        assert!(text.contains("parameter_validation_error"), "{text}");
+        assert!(text.contains("Missing required parameters"), "{text}");
+    }
+
+    #[tokio::test]
+    async fn list_data_sources_proxies_get_data_source_verbatim() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/data_source"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({"success": true, "data": [], "count": 0})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let bridge = bridge_for(&server);
+        let result = bridge
+            .do_call_tool("list_data_sources", None)
+            .await
+            .unwrap();
+        assert_eq!(result.is_error, Some(false));
+    }
+}

--- a/crates/cli/src/mcp/bridge.rs
+++ b/crates/cli/src/mcp/bridge.rs
@@ -19,6 +19,7 @@ use rmcp::model::{
 };
 use rmcp::service::{RequestContext, RoleServer};
 use serde_json::Value;
+use uuid::Uuid;
 
 use crate::client::{ApiClient, ApiError, encode_component};
 use crate::mcp::projection;
@@ -45,7 +46,7 @@ impl McpBridge {
         McpBridge {
             client,
             tool_map: RwLock::new(HashMap::new()),
-            session_id: uuid::Uuid::new_v4().to_string(),
+            session_id: Uuid::new_v4().to_string(),
         }
     }
 
@@ -60,7 +61,7 @@ impl McpBridge {
             // the three ways to configure it.
             .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
         let (tools, map) = projection::project(&inventory);
-        *self.tool_map.write().expect("tool map lock") = map;
+        *self.tool_map.write().unwrap_or_else(|p| p.into_inner()) = map;
         Ok(ListToolsResult::with_all_items(tools))
     }
 
@@ -76,7 +77,7 @@ impl McpBridge {
                 let pipeline = self
                     .tool_map
                     .read()
-                    .expect("tool map lock")
+                    .unwrap_or_else(|p| p.into_inner())
                     .get(name)
                     .cloned();
                 match pipeline {

--- a/crates/cli/src/mcp/bridge.rs
+++ b/crates/cli/src/mcp/bridge.rs
@@ -71,8 +71,8 @@ impl McpBridge {
         args: Option<JsonObject>,
     ) -> Result<CallToolResult, ErrorData> {
         let outcome = match name {
-            "query" => self.call_query(args).await,
-            "list_data_sources" => self.client.get("/data_source").await,
+            projection::QUERY => self.call_query(args).await,
+            projection::LIST_DATA_SOURCES => self.client.get("/data_source").await,
             _ => {
                 let pipeline = self
                     .tool_map
@@ -83,10 +83,21 @@ impl McpBridge {
                 match pipeline {
                     Some(pipeline) => {
                         // Arguments pass through as the flat execute body —
-                        // the server is the validator.
+                        // the server is the validator. The session header
+                        // gives pipeline runs the same ledger attribution as
+                        // `query`'s ai_context.session_id (the server reads
+                        // it in execute_pipeline_by_name), so the surface the
+                        // INSTRUCTIONS steer the model toward is not the
+                        // unattributed one.
                         let body = Value::Object(args.unwrap_or_default());
                         let path = format!("/{}/execute", encode_component(&pipeline));
-                        self.client.post(&path, &body).await
+                        self.client
+                            .post_with_headers(
+                                &path,
+                                &body,
+                                &[("x-skardi-session-id", &self.session_id)],
+                            )
+                            .await
                     }
                     None => {
                         // Protocol-level: covers host bugs and a server
@@ -242,6 +253,35 @@ mod tests {
         bridge.do_list_tools().await.unwrap(); // builds the dispatch map
         let args = json!({"brand": "acme"}).as_object().cloned();
         let result = bridge.do_call_tool("product-search", args).await.unwrap();
+        assert_eq!(result.is_error, Some(false));
+    }
+
+    #[tokio::test]
+    async fn pipeline_call_carries_the_connection_session_id_header() {
+        // Ledger attribution parity: pipeline runs must land under the same
+        // session id that `query` sends in ai_context.session_id.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/pipelines"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(inventory()))
+            .mount(&server)
+            .await;
+        let bridge = bridge_for(&server);
+        Mock::given(method("POST"))
+            .and(path("/product-search/execute"))
+            .and(wiremock::matchers::header(
+                "x-skardi-session-id",
+                bridge.session_id.as_str(),
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"success": true})))
+            .expect(1)
+            .mount(&server)
+            .await;
+        bridge.do_list_tools().await.unwrap();
+        let result = bridge
+            .do_call_tool("product-search", json!({"brand": "x"}).as_object().cloned())
+            .await
+            .unwrap();
         assert_eq!(result.is_error, Some(false));
     }
 

--- a/crates/cli/src/mcp/mod.rs
+++ b/crates/cli/src/mcp/mod.rs
@@ -1,0 +1,24 @@
+//! `skardi mcp` — serve MCP over stdio, proxying every tool call to a
+//! running skardi-server over REST. The host (Claude Desktop, Cursor, ...)
+//! spawns this subcommand as a long-lived child process; stdout is the
+//! JSON-RPC channel, so nothing on this path may print to it.
+
+mod bridge;
+mod projection;
+
+use rmcp::ServiceExt;
+use rmcp::transport::stdio;
+
+use crate::client::ApiClient;
+
+pub async fn run(client: ApiClient) -> anyhow::Result<()> {
+    let service = bridge::McpBridge::new(client)
+        .serve(stdio())
+        .await
+        .map_err(|e| anyhow::anyhow!("MCP initialize handshake failed: {e}"))?;
+    // Runs until the host closes stdin (or cancels). In-flight request tasks
+    // die with the process — nobody is left to read their results. Falling
+    // through to Ok(()) is the decided "host closed → exit 0" behavior.
+    service.waiting().await?;
+    Ok(())
+}

--- a/crates/cli/src/mcp/projection.rs
+++ b/crates/cli/src/mcp/projection.rs
@@ -1,0 +1,291 @@
+//! Projection of the enriched pipeline inventory into MCP tool definitions.
+//! Pure functions — everything here is unit-testable without a server.
+
+use std::collections::{HashMap, HashSet};
+
+use rmcp::model::{JsonObject, Tool};
+use serde_json::{Value, json};
+
+/// Tool names claimed by the built-ins; a pipeline sanitizing to one of
+/// these is renamed with a `_pipeline` suffix.
+pub(crate) const RESERVED_NAMES: [&str; 2] = ["query", "list_data_sources"];
+
+/// MCP clients commonly enforce `^[a-zA-Z0-9_-]{1,64}$` for tool names.
+const MAX_TOOL_NAME: usize = 64;
+
+/// Replace every char outside `[a-zA-Z0-9_-]` with `_` and truncate to 64.
+/// Every kept char is ASCII, so char count == byte count downstream.
+fn sanitize(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .take(MAX_TOOL_NAME)
+        .collect()
+}
+
+/// Assign unique tool names in sorted order of ORIGINAL pipeline name.
+///
+/// The taken set starts with the reserved built-ins; a candidate equal to a
+/// reserved name is first renamed with `_pipeline` (stderr warning), then
+/// the collision pass appends `_2`, `_3`, ... re-truncating the base so
+/// base + suffix never exceeds 64, iterating until unique against every
+/// name already assigned (reserved and previously suffixed ones included).
+fn assign_tool_names(original_names: &[&str]) -> Vec<(String, String)> {
+    let mut sorted: Vec<&str> = original_names.to_vec();
+    sorted.sort_unstable();
+    let mut taken: HashSet<String> = RESERVED_NAMES.iter().map(|s| s.to_string()).collect();
+    let mut assigned = Vec::with_capacity(sorted.len());
+    for original in sorted {
+        let mut candidate = sanitize(original);
+        if RESERVED_NAMES.contains(&candidate.as_str()) {
+            eprintln!(
+                "warning: pipeline '{original}' collides with the built-in `{candidate}` tool; exposing it as `{candidate}_pipeline`"
+            );
+            candidate = format!("{candidate}_pipeline");
+            candidate.truncate(MAX_TOOL_NAME);
+        }
+        if taken.contains(&candidate) {
+            let mut n = 2usize;
+            loop {
+                let suffix = format!("_{n}");
+                let mut base = candidate.clone();
+                base.truncate(MAX_TOOL_NAME - suffix.len());
+                let renamed = format!("{base}{suffix}");
+                if !taken.contains(&renamed) {
+                    candidate = renamed;
+                    break;
+                }
+                n += 1;
+            }
+        }
+        taken.insert(candidate.clone());
+        assigned.push((candidate, original.to_string()));
+    }
+    assigned
+}
+
+fn object_schema(properties: Value, required: Vec<String>) -> JsonObject {
+    serde_json::from_value(json!({
+        "type": "object",
+        "properties": properties,
+        "required": required,
+        "additionalProperties": false
+    }))
+    .expect("assembled schema is a JSON object")
+}
+
+/// One pipeline entry from the enriched inventory → one MCP tool. Every
+/// parameter is required (key presence is the only thing the server
+/// validates; explicit JSON `null` is accepted per the null unions), and
+/// the object is closed because the server rejects unsupported keys.
+fn pipeline_tool(tool_name: &str, pipeline_name: &str, entry: &Value) -> Tool {
+    // The original pipeline name is echoed so the model can correlate with
+    // server-side errors even after sanitization/suffixing renamed the tool.
+    let description = match entry["description"].as_str() {
+        Some(d) if !d.trim().is_empty() => format!("{d} (pipeline `{pipeline_name}`)"),
+        _ => format!("Execute pipeline `{pipeline_name}`"),
+    };
+    let mut properties = serde_json::Map::new();
+    let mut required = Vec::new();
+    if let Some(params) = entry["parameters"].as_array() {
+        for param in params {
+            if let Some(name) = param["name"].as_str() {
+                properties.insert(name.to_string(), param["json_schema"].clone());
+                required.push(name.to_string());
+            }
+        }
+    }
+    Tool::new(
+        tool_name.to_string(),
+        description,
+        object_schema(Value::Object(properties), required),
+    )
+}
+
+pub(crate) fn builtin_tools() -> Vec<Tool> {
+    let query_schema = object_schema(
+        json!({
+            "sql": {"type": "string"},
+            "max_rows": {
+                "type": "integer",
+                "description": "Result row cap; server default 1000."
+            },
+            "purpose": {
+                "type": "string",
+                "description": "One line on why you are running this query; recorded in the query audit log."
+            }
+        }),
+        vec!["sql".to_string()],
+    );
+    let list_data_sources_schema = object_schema(json!({}), Vec::new());
+    vec![
+        Tool::new(
+            "query",
+            "Run ad-hoc SQL against Skardi's federated engine. DML is only accepted on \
+             data sources configured with access_mode: read_write; DDL is always \
+             rejected. Use list_data_sources first to see available tables.",
+            query_schema,
+        ),
+        Tool::new(
+            "list_data_sources",
+            "List Skardi's data sources: tables, column schemas, and plain-English \
+             semantic descriptions. Call this before writing ad-hoc SQL with `query`.",
+            list_data_sources_schema,
+        ),
+    ]
+}
+
+/// Project the enriched `GET /pipelines` body into (tools, tool → pipeline
+/// name map). The built-ins are appended after the pipeline tools; the map
+/// covers pipeline tools only.
+pub(crate) fn project(inventory: &Value) -> (Vec<Tool>, HashMap<String, String>) {
+    let entries: HashMap<&str, &Value> = inventory["pipelines"]
+        .as_array()
+        .map(|entries| {
+            entries
+                .iter()
+                .filter_map(|entry| entry["name"].as_str().map(|name| (name, entry)))
+                .collect()
+        })
+        .unwrap_or_default();
+    let originals: Vec<&str> = entries.keys().copied().collect();
+    let mut tools = Vec::new();
+    let mut map = HashMap::new();
+    for (tool_name, pipeline_name) in assign_tool_names(&originals) {
+        let entry = entries[pipeline_name.as_str()];
+        tools.push(pipeline_tool(&tool_name, &pipeline_name, entry));
+        map.insert(tool_name, pipeline_name);
+    }
+    tools.extend(builtin_tools());
+    (tools, map)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn inventory(pipelines: Value) -> Value {
+        json!({"success": true, "pipelines": pipelines, "count": 0})
+    }
+
+    #[test]
+    fn sanitizes_names_to_the_mcp_charset() {
+        assert_eq!(sanitize("product-search"), "product-search");
+        assert_eq!(sanitize("my.pipe/v2"), "my_pipe_v2");
+        // replacement is per-char: two hanzi + one space → three underscores
+        assert_eq!(sanitize("空 格"), "___");
+        assert_eq!(sanitize(&"x".repeat(80)).len(), 64);
+    }
+
+    #[test]
+    fn reserved_names_get_the_pipeline_suffix() {
+        let (tools, map) = project(&inventory(json!([
+            {"name": "query", "version": "1", "endpoint": "/query/execute",
+             "description": null, "parameters": []}
+        ])));
+        assert_eq!(map.get("query_pipeline").map(String::as_str), Some("query"));
+        assert!(tools.iter().any(|t| t.name.as_ref() == "query_pipeline"));
+        // the built-in `query` is still present and distinct
+        assert!(tools.iter().any(|t| t.name.as_ref() == "query"));
+    }
+
+    #[test]
+    fn collisions_suffix_in_sorted_original_name_order() {
+        let (_, map) = project(&inventory(json!([
+            {"name": "a.b", "version": "1", "endpoint": "/a.b/execute",
+             "description": null, "parameters": []},
+            {"name": "a_b", "version": "1", "endpoint": "/a_b/execute",
+             "description": null, "parameters": []},
+            {"name": "a_b_2", "version": "1", "endpoint": "/a_b_2/execute",
+             "description": null, "parameters": []}
+        ])));
+        // sorted originals: "a.b" < "a_b" < "a_b_2". "a.b" sanitizes to
+        // "a_b" and claims it first; the literal "a_b" collides and takes
+        // "_2"; the literal "a_b_2" then finds ITS candidate taken and
+        // suffixes that, landing on "a_b_2_2" — it must not silently merge.
+        assert_eq!(map.get("a_b").map(String::as_str), Some("a.b"));
+        assert_eq!(map.get("a_b_2").map(String::as_str), Some("a_b"));
+        assert_eq!(map.get("a_b_2_2").map(String::as_str), Some("a_b_2"));
+        assert_eq!(map.len(), 3);
+    }
+
+    #[test]
+    fn suffixes_never_push_past_64_chars() {
+        let long = "x".repeat(64);
+        let (_, map) = project(&inventory(json!([
+            {"name": long.clone(), "version": "1", "endpoint": "/x/execute",
+             "description": null, "parameters": []},
+            {"name": format!("{long}y"), "version": "1", "endpoint": "/xy/execute",
+             "description": null, "parameters": []}
+        ])));
+        assert!(map.keys().all(|k| k.len() <= 64), "keys: {:?}", map.keys());
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn description_falls_back_when_yaml_omits_it() {
+        let (tools, _) = project(&inventory(json!([
+            {"name": "p", "version": "1", "endpoint": "/p/execute",
+             "description": null, "parameters": []}
+        ])));
+        let tool = tools.iter().find(|t| t.name.as_ref() == "p").unwrap();
+        assert_eq!(tool.description.as_deref(), Some("Execute pipeline `p`"));
+    }
+
+    #[test]
+    fn input_schema_assembles_fragments_with_required_and_closed_object() {
+        let (tools, _) = project(&inventory(json!([
+            {"name": "p", "version": "1", "endpoint": "/p/execute",
+             "description": "Search products",
+             "parameters": [
+                {"name": "brand", "data_type": "Utf8",
+                 "json_schema": {"type": ["string", "null"]}},
+                {"name": "max_price", "data_type": "Float64",
+                 "json_schema": {"type": ["number", "null"]}}
+             ]}
+        ])));
+        let tool = tools.iter().find(|t| t.name.as_ref() == "p").unwrap();
+        let schema = serde_json::to_value(tool.input_schema.as_ref()).unwrap();
+        assert_eq!(
+            schema,
+            json!({
+                "type": "object",
+                "properties": {
+                    "brand": {"type": ["string", "null"]},
+                    "max_price": {"type": ["number", "null"]}
+                },
+                "required": ["brand", "max_price"],
+                "additionalProperties": false
+            })
+        );
+        // original pipeline name echoed for error correlation
+        assert_eq!(
+            tool.description.as_deref(),
+            Some("Search products (pipeline `p`)")
+        );
+    }
+
+    #[test]
+    fn builtins_have_the_specified_schemas() {
+        let tools = builtin_tools();
+        let query = tools.iter().find(|t| t.name.as_ref() == "query").unwrap();
+        let schema = serde_json::to_value(query.input_schema.as_ref()).unwrap();
+        assert_eq!(schema["required"], json!(["sql"]));
+        assert_eq!(schema["properties"]["sql"], json!({"type": "string"}));
+        assert_eq!(schema["properties"]["max_rows"]["type"], json!("integer"));
+        assert!(schema["properties"]["purpose"].is_object());
+        assert_eq!(schema["additionalProperties"], json!(false));
+        let lds = tools
+            .iter()
+            .find(|t| t.name.as_ref() == "list_data_sources")
+            .unwrap();
+        let schema = serde_json::to_value(lds.input_schema.as_ref()).unwrap();
+        assert_eq!(schema["type"], json!("object"));
+        assert_eq!(schema["additionalProperties"], json!(false));
+    }
+}

--- a/crates/cli/src/mcp/projection.rs
+++ b/crates/cli/src/mcp/projection.rs
@@ -122,6 +122,9 @@ pub(crate) fn builtin_tools() -> Vec<Tool> {
             "sql": {"type": "string"},
             "max_rows": {
                 "type": "integer",
+                // The server rejects 0 ("must be a positive integer") and a
+                // negative value fails its usize deserialization outright.
+                "minimum": 1,
                 "description": "Result row cap; server default 1000."
             },
             "purpose": {
@@ -303,6 +306,7 @@ mod tests {
         assert_eq!(schema["required"], json!(["sql"]));
         assert_eq!(schema["properties"]["sql"], json!({"type": "string"}));
         assert_eq!(schema["properties"]["max_rows"]["type"], json!("integer"));
+        assert_eq!(schema["properties"]["max_rows"]["minimum"], json!(1));
         assert!(schema["properties"]["purpose"].is_object());
         assert_eq!(schema["additionalProperties"], json!(false));
         let lds = tools

--- a/crates/cli/src/mcp/projection.rs
+++ b/crates/cli/src/mcp/projection.rs
@@ -30,11 +30,14 @@ fn sanitize(name: &str) -> String {
 
 /// Assign unique tool names in sorted order of ORIGINAL pipeline name.
 ///
-/// The taken set starts with the reserved built-ins; a candidate equal to a
-/// reserved name is first renamed with `_pipeline` (stderr warning), then
-/// the collision pass appends `_2`, `_3`, ... re-truncating the base so
-/// base + suffix never exceeds 64, iterating until unique against every
-/// name already assigned (reserved and previously suffixed ones included).
+/// The taken set starts with the reserved built-ins; an empty sanitized
+/// candidate (the server does not reject `name: ""` at load time) falls
+/// back to `pipeline` so the listing never carries a name below the
+/// 1-char MCP minimum; a candidate equal to a reserved name is renamed
+/// with `_pipeline` (stderr warning); then the collision pass appends
+/// `_2`, `_3`, ... re-truncating the base so base + suffix never exceeds
+/// 64, iterating until unique against every name already assigned
+/// (reserved and previously suffixed ones included).
 fn assign_tool_names(original_names: &[&str]) -> Vec<(String, String)> {
     let mut sorted: Vec<&str> = original_names.to_vec();
     sorted.sort_unstable();
@@ -42,6 +45,12 @@ fn assign_tool_names(original_names: &[&str]) -> Vec<(String, String)> {
     let mut assigned = Vec::with_capacity(sorted.len());
     for original in sorted {
         let mut candidate = sanitize(original);
+        if candidate.is_empty() {
+            eprintln!(
+                "warning: pipeline name '{original}' sanitizes to an empty MCP tool name; exposing it as `pipeline`"
+            );
+            candidate = "pipeline".to_string();
+        }
         if RESERVED_NAMES.contains(&candidate.as_str()) {
             eprintln!(
                 "warning: pipeline '{original}' collides with the built-in `{candidate}` tool; exposing it as `{candidate}_pipeline`"
@@ -212,6 +221,22 @@ mod tests {
         assert_eq!(map.get("a_b_2").map(String::as_str), Some("a_b"));
         assert_eq!(map.get("a_b_2_2").map(String::as_str), Some("a_b_2"));
         assert_eq!(map.len(), 3);
+    }
+
+    #[test]
+    fn empty_name_falls_back_and_still_collides_cleanly() {
+        // The server loads `name: ""` without complaint; the tool name must
+        // still satisfy the 1-char minimum. Sorted originals: "" < "pipeline",
+        // so the empty name claims the fallback and the literal one suffixes.
+        let (tools, map) = project(&inventory(json!([
+            {"name": "", "version": "1", "endpoint": "//execute",
+             "description": null, "parameters": []},
+            {"name": "pipeline", "version": "1", "endpoint": "/pipeline/execute",
+             "description": null, "parameters": []}
+        ])));
+        assert_eq!(map.get("pipeline").map(String::as_str), Some(""));
+        assert_eq!(map.get("pipeline_2").map(String::as_str), Some("pipeline"));
+        assert!(tools.iter().all(|t| !t.name.is_empty()));
     }
 
     #[test]

--- a/crates/cli/src/mcp/projection.rs
+++ b/crates/cli/src/mcp/projection.rs
@@ -6,9 +6,15 @@ use std::collections::{HashMap, HashSet};
 use rmcp::model::{JsonObject, Tool};
 use serde_json::{Value, json};
 
+/// The built-in tool names. `builtin_tools()` and the bridge's dispatch
+/// match use these same constants, and `RESERVED_NAMES` is built from them,
+/// so the three sites cannot drift apart.
+pub(crate) const QUERY: &str = "query";
+pub(crate) const LIST_DATA_SOURCES: &str = "list_data_sources";
+
 /// Tool names claimed by the built-ins; a pipeline sanitizing to one of
 /// these is renamed with a `_pipeline` suffix.
-pub(crate) const RESERVED_NAMES: [&str; 2] = ["query", "list_data_sources"];
+pub(crate) const RESERVED_NAMES: [&str; 2] = [QUERY, LIST_DATA_SOURCES];
 
 /// MCP clients commonly enforce `^[a-zA-Z0-9_-]{1,64}$` for tool names.
 const MAX_TOOL_NAME: usize = 64;
@@ -99,14 +105,39 @@ fn pipeline_tool(tool_name: &str, pipeline_name: &str, entry: &Value) -> Tool {
         Some(d) if !d.trim().is_empty() => format!("{d} (pipeline `{pipeline_name}`)"),
         _ => format!("Execute pipeline `{pipeline_name}`"),
     };
+    // No `parameters` key means a server predating the enriched inventory
+    // (the bridge may front a remote deployment, so version skew is a
+    // supported state). Publish an OPEN schema rather than a closed empty
+    // one: the model's attempt then reaches the server, whose error names
+    // the missing parameters — degraded but usable. A present-but-empty
+    // `parameters: []` is a real zero-parameter pipeline and keeps the
+    // closed empty schema below.
+    let Some(params) = entry.get("parameters").and_then(Value::as_array) else {
+        eprintln!(
+            "warning: pipeline '{pipeline_name}' carries no `parameters` in the inventory \
+             (skardi-server older than the CLI?); publishing an open input schema"
+        );
+        let open_schema = serde_json::from_value(json!({
+            "type": "object",
+            "additionalProperties": true
+        }))
+        .expect("open schema is a JSON object");
+        return Tool::new(tool_name.to_string(), description, open_schema);
+    };
     let mut properties = serde_json::Map::new();
     let mut required = Vec::new();
-    if let Some(params) = entry["parameters"].as_array() {
-        for param in params {
-            if let Some(name) = param["name"].as_str() {
-                properties.insert(name.to_string(), param["json_schema"].clone());
-                required.push(name.to_string());
-            }
+    for param in params {
+        if let Some(name) = param["name"].as_str() {
+            // Version-skew guard: a property's schema must be an object or
+            // boolean; anything else (Null from a missing key) would make
+            // the whole listing invalid for strict hosts. `{}` = accept
+            // anything, the server stays the validator.
+            let schema = match &param["json_schema"] {
+                v @ (Value::Object(_) | Value::Bool(_)) => v.clone(),
+                _ => json!({}),
+            };
+            properties.insert(name.to_string(), schema);
+            required.push(name.to_string());
         }
     }
     Tool::new(
@@ -137,14 +168,14 @@ pub(crate) fn builtin_tools() -> Vec<Tool> {
     let list_data_sources_schema = object_schema(json!({}), Vec::new());
     vec![
         Tool::new(
-            "query",
+            QUERY,
             "Run ad-hoc SQL against Skardi's federated engine. DML is only accepted on \
              data sources configured with access_mode: read_write; DDL is always \
              rejected. Use list_data_sources first to see available tables.",
             query_schema,
         ),
         Tool::new(
-            "list_data_sources",
+            LIST_DATA_SOURCES,
             "List Skardi's data sources: tables, column schemas, and plain-English \
              semantic descriptions. Call this before writing ad-hoc SQL with `query`.",
             list_data_sources_schema,
@@ -296,6 +327,59 @@ mod tests {
             tool.description.as_deref(),
             Some("Search products (pipeline `p`)")
         );
+    }
+
+    #[test]
+    fn missing_parameters_key_publishes_an_open_schema() {
+        // Version skew: a server predating the enriched inventory has no
+        // `parameters` key at all. A closed empty schema would make the tool
+        // silently unusable; the open schema lets attempts reach the server.
+        let (tools, _) = project(&inventory(json!([
+            {"name": "old", "version": "1", "endpoint": "/old/execute"}
+        ])));
+        let tool = tools.iter().find(|t| t.name.as_ref() == "old").unwrap();
+        let schema = serde_json::to_value(tool.input_schema.as_ref()).unwrap();
+        assert_eq!(
+            schema,
+            json!({"type": "object", "additionalProperties": true})
+        );
+        // an explicitly empty list is a real zero-parameter pipeline and
+        // keeps the closed empty schema
+        let (tools, _) = project(&inventory(json!([
+            {"name": "empty", "version": "1", "endpoint": "/empty/execute",
+             "description": null, "parameters": []}
+        ])));
+        let tool = tools.iter().find(|t| t.name.as_ref() == "empty").unwrap();
+        let schema = serde_json::to_value(tool.input_schema.as_ref()).unwrap();
+        assert_eq!(schema["additionalProperties"], json!(false));
+        assert_eq!(schema["required"], json!([]));
+    }
+
+    #[test]
+    fn missing_json_schema_falls_back_to_accept_anything() {
+        // `param["json_schema"]` on an entry without the key yields Null,
+        // which is not a legal property schema — strict hosts would reject
+        // the whole listing. It must degrade to `{}` instead.
+        let (tools, _) = project(&inventory(json!([
+            {"name": "p", "version": "1", "endpoint": "/p/execute",
+             "description": null,
+             "parameters": [{"name": "brand", "data_type": "Utf8"}]}
+        ])));
+        let tool = tools.iter().find(|t| t.name.as_ref() == "p").unwrap();
+        let schema = serde_json::to_value(tool.input_schema.as_ref()).unwrap();
+        assert_eq!(schema["properties"]["brand"], json!({}));
+        assert_eq!(schema["required"], json!(["brand"]));
+    }
+
+    #[test]
+    fn builtin_tool_names_match_the_reserved_set() {
+        // The reserved set seeds `taken` in assign_tool_names while project()
+        // appends builtin_tools() unconditionally — a built-in missing from
+        // RESERVED_NAMES would let a pipeline claim its name and the listing
+        // would carry duplicates. This pins the two sets to each other.
+        let tools = builtin_tools();
+        let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+        assert_eq!(names, RESERVED_NAMES);
     }
 
     #[test]

--- a/crates/cli/src/mcp/projection.rs
+++ b/crates/cli/src/mcp/projection.rs
@@ -117,7 +117,7 @@ fn pipeline_tool(tool_name: &str, pipeline_name: &str, entry: &Value) -> Tool {
             "warning: pipeline '{pipeline_name}' carries no `parameters` in the inventory \
              (skardi-server older than the CLI?); publishing an open input schema"
         );
-        let open_schema = serde_json::from_value(json!({
+        let open_schema: JsonObject = serde_json::from_value(json!({
             "type": "object",
             "additionalProperties": true
         }))

--- a/crates/cli/tests/cloud_gating.rs
+++ b/crates/cli/tests/cloud_gating.rs
@@ -86,6 +86,40 @@ async fn a_gated_command_refuses_before_issuing_any_request() {
     );
 }
 
+/// `mcp` straddles gateway-served (`query`) and engine-local (pipeline
+/// execution, `/pipelines`) surfaces, so a cloud context refuses it whole
+/// before the bridge ever starts speaking MCP on stdout.
+#[tokio::test]
+async fn mcp_is_gated_in_a_cloud_context_before_serving() {
+    let gateway = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+        .mount(&gateway)
+        .await;
+
+    let home = TempDir::new().unwrap();
+    write_cloud_context(home.path(), &gateway.uri(), None);
+
+    let out = skardi(home.path(), &["mcp"]);
+
+    assert_eq!(out.status.code(), Some(1), "{}", stderr(&out));
+    assert!(
+        stderr(&out).contains(
+            "'mcp' is not available in a cloud context (acme/prod). Available: query, schema."
+        ),
+        "stderr was: {}",
+        stderr(&out)
+    );
+    assert!(
+        out.stdout.is_empty(),
+        "a refused mcp must write nothing to stdout (the would-be protocol channel)"
+    );
+    assert!(
+        gateway.received_requests().await.unwrap().is_empty(),
+        "a gated command must not reach the gateway"
+    );
+}
+
 #[tokio::test]
 async fn an_expired_credential_refuses_before_issuing_any_request() {
     let gateway = MockServer::start().await;

--- a/crates/cli/tests/mcp_e2e.rs
+++ b/crates/cli/tests/mcp_e2e.rs
@@ -73,12 +73,13 @@ async fn initialize_list_and_call_round_trip() {
     assert!(names.contains(&"query"), "{names:?}");
     assert!(names.contains(&"list_data_sources"), "{names:?}");
 
+    // CallToolRequestParams is #[non_exhaustive]: construct via its builder.
+    let args = json!({"brand": "acme"})
+        .as_object()
+        .cloned()
+        .expect("literal is an object");
     let result = client
-        .call_tool(CallToolRequestParams {
-            name: "product-search".into(),
-            arguments: json!({"brand": "acme"}).as_object().cloned(),
-            ..Default::default()
-        })
+        .call_tool(CallToolRequestParams::new("product-search").with_arguments(args))
         .await
         .unwrap();
     assert_eq!(result.is_error, Some(false));

--- a/crates/cli/tests/mcp_e2e.rs
+++ b/crates/cli/tests/mcp_e2e.rs
@@ -1,0 +1,102 @@
+//! End-to-end: spawn the real `skardi mcp` binary and speak MCP to it over
+//! stdio with an rmcp client, against a wiremock "server". Also the
+//! permanent guard for the stdout-is-protocol-only invariant — any stray
+//! print to stdout corrupts the JSON-RPC framing and breaks the initialize
+//! handshake below.
+
+#![cfg(unix)]
+
+use rmcp::ServiceExt;
+use rmcp::model::CallToolRequestParams;
+use rmcp::transport::{ConfigureCommandExt, TokioChildProcess};
+use serde_json::json;
+use wiremock::matchers::{body_json, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn spawn_transport(server_url: &str, home: &std::path::Path) -> TokioChildProcess {
+    TokioChildProcess::new(
+        tokio::process::Command::new(env!("CARGO_BIN_EXE_skardi")).configure(|cmd| {
+            cmd.env("HOME", home)
+                .env_remove("SKARDI_SERVER_URL")
+                .env_remove("SKARDI_API_TOKEN")
+                .env_remove("SKARDI_CONTEXT")
+                .args(["mcp", "--server", server_url]);
+        }),
+    )
+    .expect("spawn skardi mcp")
+}
+
+fn inventory() -> serde_json::Value {
+    json!({"success": true, "count": 1, "data_sources": 0,
+           "pipelines": [{"name": "product-search", "version": "1.0.0",
+             "endpoint": "/product-search/execute",
+             "description": "Filter products by brand",
+             "parameters": [{"name": "brand", "data_type": "Utf8",
+                             "json_schema": {"type": ["string", "null"]}}]}]})
+}
+
+#[tokio::test]
+async fn initialize_list_and_call_round_trip() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/pipelines"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(inventory()))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/product-search/execute"))
+        .and(body_json(json!({"brand": "acme"})))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(json!({"success": true, "data": [{"id": 1}], "rows": 1})),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let home = tempfile::TempDir::new().unwrap();
+    let client = ()
+        .serve(spawn_transport(&server.uri(), home.path()))
+        .await
+        .expect("initialize handshake (fails on any stray stdout output)");
+
+    let info = client.peer_info().expect("server info");
+    assert!(info.capabilities.tools.is_some(), "tools capability");
+    assert!(
+        info.instructions.as_deref().is_some_and(|i| !i.is_empty()),
+        "instructions should be set"
+    );
+
+    let tools = client.list_all_tools().await.unwrap();
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+    assert!(names.contains(&"product-search"), "{names:?}");
+    assert!(names.contains(&"query"), "{names:?}");
+    assert!(names.contains(&"list_data_sources"), "{names:?}");
+
+    let result = client
+        .call_tool(CallToolRequestParams {
+            name: "product-search".into(),
+            arguments: json!({"brand": "acme"}).as_object().cloned(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(result.is_error, Some(false));
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn unreachable_server_fails_list_tools_but_not_the_handshake() {
+    let home = tempfile::TempDir::new().unwrap();
+    // Nothing listens on port 1: the handshake still succeeds (initialize
+    // needs no REST round trip); tools/list surfaces the connect error.
+    let client =
+        ().serve(spawn_transport("http://127.0.0.1:1", home.path()))
+            .await
+            .expect("handshake needs no server");
+    let err = client.list_all_tools().await.unwrap_err();
+    let msg = format!("{err}");
+    assert!(msg.contains("cannot reach skardi-server"), "{msg}");
+    client.cancel().await.unwrap();
+}

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -6,6 +6,7 @@ pub mod jobs_handlers;
 pub mod logging;
 pub mod metrics;
 pub mod optimizer_registry;
+pub(crate) mod param_schema;
 pub mod pipeline_handlers;
 // Extracted to its own crate so downstream distributions (the cloud engine)
 // can adopt the SAME ledger — file format, flags, semantics — without

--- a/crates/server/src/param_schema.rs
+++ b/crates/server/src/param_schema.rs
@@ -17,11 +17,19 @@ pub(crate) fn param_json_schema(
 ) -> Value {
     // `VALUES {name}` is a multi-row tuple list at request time; the inferred
     // Utf8 would be an actively wrong constraint, so it overrides wholesale.
+    // minItems on both levels: the renderer rejects `[]` (no zero-row VALUES
+    // expansion) and `[[]]` (rows must have a non-zero, consistent width) —
+    // equal width itself is not expressible in JSON Schema, so the renderer
+    // remains the backstop for that half.
     if VALUES_PLACEHOLDER_RE
         .captures_iter(sql_template)
         .any(|cap| &cap[1] == param_name)
     {
-        return json!({"type": "array", "items": {"type": "array"}});
+        return json!({
+            "type": "array",
+            "minItems": 1,
+            "items": {"type": "array", "minItems": 1}
+        });
     }
     with_null_union(base_fragment(field_type))
 }
@@ -36,7 +44,13 @@ fn base_fragment(field_type: &DataType) -> Value {
         DataType::Date32 | DataType::Date64 => json!({"type": "string", "format": "date"}),
         DataType::Timestamp(_, _) => json!({"type": "string", "format": "date-time"}),
         DataType::List(inner) => {
-            json!({"type": "array", "items": base_fragment(inner.data_type())})
+            // minItems: the renderer rejects every empty array ("provide at
+            // least one row/element"); nesting inherits it via the recursion.
+            json!({
+                "type": "array",
+                "minItems": 1,
+                "items": base_fragment(inner.data_type())
+            })
         }
         _ => json!({}),
     }
@@ -108,7 +122,7 @@ mod tests {
         let dt = DataType::List(Field::new("item", DataType::Utf8, true).into());
         assert_eq!(
             schema(dt),
-            json!({"type": ["array", "null"], "items": {"type": "string"}})
+            json!({"type": ["array", "null"], "minItems": 1, "items": {"type": "string"}})
         );
     }
 
@@ -122,7 +136,11 @@ mod tests {
         let sql = "INSERT INTO docs (id, name, vec) values {rows}";
         assert_eq!(
             param_json_schema(&DataType::Utf8, sql, "rows"),
-            json!({"type": "array", "items": {"type": "array"}})
+            json!({
+                "type": "array",
+                "minItems": 1,
+                "items": {"type": "array", "minItems": 1}
+            })
         );
         // only the parameter named in the VALUES clause gets the override
         assert_eq!(

--- a/crates/server/src/param_schema.rs
+++ b/crates/server/src/param_schema.rs
@@ -1,0 +1,138 @@
+//! Per-parameter JSON Schema fragments for the enriched pipeline inventory.
+//!
+//! Computed server-side (the enriched `GET /pipelines` response carries no
+//! SQL, so downstream bindings cannot run the `VALUES` detection themselves).
+//! The DataType → JSON Schema mapping and the unconditional `"null"` union
+//! are specified in docs/superpowers/specs/2026-08-13-mcp-stdio-binding-design.md.
+
+use datafusion::arrow::datatypes::DataType;
+use serde_json::{Value, json};
+use skardi::pipeline::inferencer::VALUES_PLACEHOLDER_RE;
+
+/// The complete JSON Schema fragment for one pipeline parameter.
+pub(crate) fn param_json_schema(
+    field_type: &DataType,
+    sql_template: &str,
+    param_name: &str,
+) -> Value {
+    // `VALUES {name}` is a multi-row tuple list at request time; the inferred
+    // Utf8 would be an actively wrong constraint, so it overrides wholesale.
+    if VALUES_PLACEHOLDER_RE
+        .captures_iter(sql_template)
+        .any(|cap| &cap[1] == param_name)
+    {
+        return json!({"type": "array", "items": {"type": "array"}});
+    }
+    with_null_union(base_fragment(field_type))
+}
+
+/// The type-table mapping without the null union (list items use this raw).
+fn base_fragment(field_type: &DataType) -> Value {
+    match field_type {
+        DataType::Utf8 | DataType::LargeUtf8 => json!({"type": "string"}),
+        dt if dt.is_integer() => json!({"type": "integer"}),
+        dt if dt.is_floating() || dt.is_decimal() => json!({"type": "number"}),
+        DataType::Boolean => json!({"type": "boolean"}),
+        DataType::Date32 | DataType::Date64 => json!({"type": "string", "format": "date"}),
+        DataType::Timestamp(_, _) => json!({"type": "string", "format": "date-time"}),
+        DataType::List(inner) => {
+            json!({"type": "array", "items": base_fragment(inner.data_type())})
+        }
+        _ => json!({}),
+    }
+}
+
+/// Fold `"null"` into the fragment's `type` — unconditionally, because the
+/// server accepts an explicit JSON `null` for every parameter (rendered as
+/// SQL `NULL`) and the inferrer hardcodes `nullable: true`. The `{}` (any)
+/// fragment already admits null and is left alone.
+fn with_null_union(mut fragment: Value) -> Value {
+    if let Some(ty) = fragment.get("type").cloned() {
+        fragment["type"] = json!([ty, "null"]);
+    }
+    fragment
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::datatypes::{Field, TimeUnit};
+
+    fn schema(dt: DataType) -> Value {
+        param_json_schema(&dt, "SELECT 1 WHERE x = {p}", "p")
+    }
+
+    #[test]
+    fn maps_scalar_types_with_null_union() {
+        assert_eq!(schema(DataType::Utf8), json!({"type": ["string", "null"]}));
+        assert_eq!(
+            schema(DataType::LargeUtf8),
+            json!({"type": ["string", "null"]})
+        );
+        assert_eq!(
+            schema(DataType::Int64),
+            json!({"type": ["integer", "null"]})
+        );
+        assert_eq!(
+            schema(DataType::UInt32),
+            json!({"type": ["integer", "null"]})
+        );
+        assert_eq!(
+            schema(DataType::Float64),
+            json!({"type": ["number", "null"]})
+        );
+        assert_eq!(
+            schema(DataType::Decimal128(10, 2)),
+            json!({"type": ["number", "null"]})
+        );
+        assert_eq!(
+            schema(DataType::Boolean),
+            json!({"type": ["boolean", "null"]})
+        );
+    }
+
+    #[test]
+    fn maps_temporal_types_with_format() {
+        assert_eq!(
+            schema(DataType::Date32),
+            json!({"type": ["string", "null"], "format": "date"})
+        );
+        assert_eq!(
+            schema(DataType::Timestamp(TimeUnit::Nanosecond, None)),
+            json!({"type": ["string", "null"], "format": "date-time"})
+        );
+    }
+
+    #[test]
+    fn maps_lists_with_typed_items() {
+        let dt = DataType::List(Field::new("item", DataType::Utf8, true).into());
+        assert_eq!(
+            schema(dt),
+            json!({"type": ["array", "null"], "items": {"type": "string"}})
+        );
+    }
+
+    #[test]
+    fn unknown_types_map_to_any() {
+        assert_eq!(schema(DataType::Binary), json!({}));
+    }
+
+    #[test]
+    fn values_placeholder_overrides_the_type_table() {
+        let sql = "INSERT INTO docs (id, name, vec) values {rows}";
+        assert_eq!(
+            param_json_schema(&DataType::Utf8, sql, "rows"),
+            json!({"type": "array", "items": {"type": "array"}})
+        );
+        // only the parameter named in the VALUES clause gets the override
+        assert_eq!(
+            param_json_schema(&DataType::Utf8, sql, "other"),
+            json!({"type": ["string", "null"]})
+        );
+        // a parenthesized tuple list is not the multi-row shape
+        assert_eq!(
+            param_json_schema(&DataType::Utf8, "INSERT INTO t VALUES ({rows})", "rows"),
+            json!({"type": ["string", "null"]})
+        );
+    }
+}

--- a/crates/server/src/pipeline_handlers.rs
+++ b/crates/server/src/pipeline_handlers.rs
@@ -20,13 +20,14 @@ use datafusion::prelude::SessionContext;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use skardi::engine::Engine;
-use skardi::pipeline::pipeline::Pipeline;
+use skardi::pipeline::pipeline::{Pipeline, StandardPipeline};
 use skardi::sources::providers::graph::udtf::GraphSourceHealth;
 use std::collections::HashMap;
 use std::time::Instant;
 
 use crate::auth::routes::require_session;
 use crate::config::{DataSourceType, HierarchyLevel};
+use crate::param_schema::param_json_schema;
 use crate::query_audit::{QueryAuditStatus, finish_audit};
 use crate::response::{
     ErrorResponse, create_error_response, create_success_response, record_batch_to_json,
@@ -378,6 +379,24 @@ pub async fn pipeline_health_check(
     })))
 }
 
+/// The enriched parameter list for one pipeline, sorted by name so the
+/// response is deterministic (RequestSchema.fields is a HashMap).
+fn enriched_parameters(pipeline: &StandardPipeline) -> Vec<Value> {
+    let sql = &pipeline.query_definition().sql;
+    let mut fields: Vec<_> = pipeline.request_schema().fields.iter().collect();
+    fields.sort_by(|(a, _), (b, _)| a.cmp(b));
+    fields
+        .into_iter()
+        .map(|(name, field)| {
+            serde_json::json!({
+                "name": name,
+                "data_type": format!("{:?}", field.field_type),
+                "json_schema": param_json_schema(&field.field_type, sql, name),
+            })
+        })
+        .collect()
+}
+
 /// List all pipelines endpoint - GET /pipelines
 pub async fn list_pipelines(State(app_state): State<AppState>) -> Result<Json<Value>, StatusCode> {
     let config = app_state
@@ -392,7 +411,9 @@ pub async fn list_pipelines(State(app_state): State<AppState>) -> Result<Json<Va
             serde_json::json!({
                 "name": name,
                 "version": pipeline.version(),
-                "endpoint": format!("/{}/execute", name)
+                "endpoint": format!("/{}/execute", name),
+                "description": pipeline.metadata.description,
+                "parameters": enriched_parameters(pipeline)
             })
         })
         .collect();
@@ -423,14 +444,20 @@ pub async fn get_pipelines_info(
     })?;
 
     if let Some(pipeline) = config.pipelines.get(&name) {
-        let request_schema = pipeline.request_schema();
-        let params: Vec<Value> = request_schema
-            .fields
-            .iter()
+        let sql = &pipeline.query_definition().sql;
+        let mut fields: Vec<_> = pipeline.request_schema().fields.iter().collect();
+        fields.sort_by(|(a, _), (b, _)| a.cmp(b));
+        let params: Vec<Value> = fields
+            .into_iter()
             .map(|(param_name, field_type)| {
                 serde_json::json!({
                     "name": param_name,
-                    "type": format!("{:?}", field_type)
+                    // Legacy Debug dump of the whole InferredFieldType, kept
+                    // as-is; `data_type` and `json_schema` are the additive,
+                    // machine-consumable forms.
+                    "type": format!("{:?}", field_type),
+                    "data_type": format!("{:?}", field_type.field_type),
+                    "json_schema": param_json_schema(&field_type.field_type, sql, param_name)
                 })
             })
             .collect();
@@ -441,6 +468,7 @@ pub async fn get_pipelines_info(
                 "name": pipeline.name(),
                 "version": pipeline.version(),
                 "endpoint": format!("/{}/execute", name),
+                "description": pipeline.metadata.description,
                 "parameters": params,
                 "created_at": pipeline.metadata.created_at,
                 "updated_at": pipeline.metadata.updated_at

--- a/crates/server/src/pipeline_handlers.rs
+++ b/crates/server/src/pipeline_handlers.rs
@@ -444,23 +444,18 @@ pub async fn get_pipelines_info(
     })?;
 
     if let Some(pipeline) = config.pipelines.get(&name) {
-        let sql = &pipeline.query_definition().sql;
-        let mut fields: Vec<_> = pipeline.request_schema().fields.iter().collect();
-        fields.sort_by(|(a, _), (b, _)| a.cmp(b));
-        let params: Vec<Value> = fields
-            .into_iter()
-            .map(|(param_name, field_type)| {
-                serde_json::json!({
-                    "name": param_name,
-                    // Legacy Debug dump of the whole InferredFieldType, kept
-                    // as-is; `data_type` and `json_schema` are the additive,
-                    // machine-consumable forms.
-                    "type": format!("{:?}", field_type),
-                    "data_type": format!("{:?}", field_type.field_type),
-                    "json_schema": param_json_schema(&field_type.field_type, sql, param_name)
-                })
-            })
-            .collect();
+        // The shared parameter shape (ordering, data_type, json_schema) has
+        // one home in enriched_parameters; only this endpoint carries the
+        // legacy `type` key (a Debug dump of the whole InferredFieldType),
+        // so it is merged in here rather than widening the list endpoint.
+        let fields = &pipeline.request_schema().fields;
+        let mut params = enriched_parameters(pipeline);
+        for param in &mut params {
+            let field = param["name"].as_str().and_then(|n| fields.get(n));
+            if let Some(field) = field {
+                param["type"] = serde_json::json!(format!("{field:?}"));
+            }
+        }
 
         Ok(Json(serde_json::json!({
             "success": true,

--- a/crates/server/tests/pipelines_http.rs
+++ b/crates/server/tests/pipelines_http.rs
@@ -424,7 +424,11 @@ spec:
     assert_eq!(params[0]["data_type"].as_str(), Some("Utf8"));
     assert_eq!(
         params[0]["json_schema"],
-        json!({"type": "array", "items": {"type": "array"}})
+        json!({
+            "type": "array",
+            "minItems": 1,
+            "items": {"type": "array", "minItems": 1}
+        })
     );
 }
 

--- a/crates/server/tests/pipelines_http.rs
+++ b/crates/server/tests/pipelines_http.rs
@@ -296,6 +296,136 @@ async fn http_list_pipelines_returns_registered() {
     assert_eq!(entry["name"].as_str(), Some("product-search"));
     assert_eq!(entry["version"].as_str(), Some("1.0.0"));
     assert_eq!(entry["endpoint"].as_str(), Some("/product-search/execute"));
+    assert_eq!(
+        entry["description"].as_str(),
+        Some("Filter products by brand + max price")
+    );
+    // Parameters are sorted by name: brand, max_price. `{max_price}` infers
+    // Float64 via the `max_` prefix strip → column `price`.
+    let params = entry["parameters"].as_array().expect("parameters array");
+    assert_eq!(params.len(), 2, "params: {params:?}");
+    assert_eq!(params[0]["name"].as_str(), Some("brand"));
+    assert_eq!(params[0]["data_type"].as_str(), Some("Utf8"));
+    assert_eq!(
+        params[0]["json_schema"],
+        json!({"type": ["string", "null"]})
+    );
+    assert_eq!(params[1]["name"].as_str(), Some("max_price"));
+    assert_eq!(params[1]["data_type"].as_str(), Some("Float64"));
+    assert_eq!(
+        params[1]["json_schema"],
+        json!({"type": ["number", "null"]})
+    );
+}
+
+// ---------------------------------------------------------------------------
+// GET /pipelines — a pipeline whose YAML omits `description:` reports JSON
+// null (present key), so bindings can distinguish "no description" cleanly.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn http_list_pipelines_description_is_null_when_yaml_omits_it() {
+    let (state, tmp) = make_app_state(false).await;
+    let ctx = Arc::clone(&state.session_ctx);
+    let yaml_path = tmp.path().join("no-description.yaml");
+    write_yaml(
+        &yaml_path,
+        r#"
+kind: pipeline
+metadata:
+  name: "no-description"
+  version: "1.0.0"
+spec:
+  query: |
+    SELECT id FROM products WHERE brand = {brand}
+"#,
+    );
+    let pipeline = StandardPipeline::load_from_file(&yaml_path, ctx)
+        .await
+        .unwrap();
+    state
+        .config
+        .write()
+        .unwrap()
+        .pipelines
+        .insert(pipeline.name().to_string(), pipeline);
+    let app = configure_routes(state);
+
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/pipelines")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_to_json(resp).await;
+    let entry = &body["pipelines"].as_array().unwrap()[0];
+    assert_eq!(entry["name"].as_str(), Some("no-description"));
+    assert!(
+        entry.get("description").is_some_and(Value::is_null),
+        "description should be a present JSON null, got: {entry}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// GET /pipelines — a `VALUES {rows}` parameter gets the array-of-arrays
+// schema override instead of the (actively wrong) inferred-Utf8 mapping.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn http_list_pipelines_values_param_gets_array_of_arrays_schema() {
+    let (state, tmp) = make_app_state(false).await;
+    let ctx = Arc::clone(&state.session_ctx);
+    let yaml_path = tmp.path().join("bulk-insert.yaml");
+    write_yaml(
+        &yaml_path,
+        r#"
+kind: pipeline
+metadata:
+  name: "bulk-insert"
+  version: "1.0.0"
+spec:
+  query: |
+    INSERT INTO products (id, brand, price, category) VALUES {rows}
+"#,
+    );
+    let pipeline = StandardPipeline::load_from_file(&yaml_path, ctx)
+        .await
+        .unwrap();
+    state
+        .config
+        .write()
+        .unwrap()
+        .pipelines
+        .insert(pipeline.name().to_string(), pipeline);
+    let app = configure_routes(state);
+
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/pipelines")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_to_json(resp).await;
+    let entry = &body["pipelines"].as_array().unwrap()[0];
+    assert_eq!(entry["name"].as_str(), Some("bulk-insert"));
+    let params = entry["parameters"].as_array().expect("parameters array");
+    assert_eq!(params.len(), 1, "params: {params:?}");
+    assert_eq!(params[0]["name"].as_str(), Some("rows"));
+    assert_eq!(params[0]["data_type"].as_str(), Some("Utf8"));
+    assert_eq!(
+        params[0]["json_schema"],
+        json!({"type": "array", "items": {"type": "array"}})
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -322,17 +452,34 @@ async fn http_get_pipeline_info_returns_metadata_and_params() {
     assert_eq!(body["success"], true);
     assert_eq!(body["pipeline"]["name"].as_str(), Some("product-search"));
     assert_eq!(body["pipeline"]["version"].as_str(), Some("1.0.0"));
-    // Inferred params come from `{brand}` and `{max_price}` in the SQL.
-    // The handler returns them as an array of `{ name, type }` objects;
-    // iteration order is unstable so assert by name-set rather than index.
-    let names: Vec<&str> = body["pipeline"]["parameters"]
+    assert_eq!(
+        body["pipeline"]["description"].as_str(),
+        Some("Filter products by brand + max price")
+    );
+    // Inferred params come from `{brand}` and `{max_price}` in the SQL,
+    // sorted by name for a deterministic response.
+    let params = body["pipeline"]["parameters"]
         .as_array()
-        .expect("parameters array")
-        .iter()
-        .map(|p| p["name"].as_str().unwrap())
-        .collect();
-    assert!(names.contains(&"brand"), "params: {names:?}");
-    assert!(names.contains(&"max_price"), "params: {names:?}");
+        .expect("parameters array");
+    assert_eq!(params.len(), 2, "params: {params:?}");
+    assert_eq!(params[0]["name"].as_str(), Some("brand"));
+    assert_eq!(params[1]["name"].as_str(), Some("max_price"));
+    // The legacy `type` Debug dump of the whole InferredFieldType survives
+    // unchanged next to the additive machine-consumable fields.
+    assert!(
+        params[0]["type"].as_str().unwrap().contains("field_type"),
+        "params: {params:?}"
+    );
+    assert_eq!(params[0]["data_type"].as_str(), Some("Utf8"));
+    assert_eq!(
+        params[0]["json_schema"],
+        json!({"type": ["string", "null"]})
+    );
+    assert_eq!(params[1]["data_type"].as_str(), Some("Float64"));
+    assert_eq!(
+        params[1]["json_schema"],
+        json!({"type": ["number", "null"]})
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/skardi/src/pipeline/inferencer.rs
+++ b/crates/skardi/src/pipeline/inferencer.rs
@@ -6,9 +6,19 @@ use datafusion::sql::sqlparser::ast::{Expr, SetExpr, Statement};
 use datafusion::sql::sqlparser::dialect::GenericDialect;
 use datafusion::sql::sqlparser::parser::Parser;
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use super::types::{InferredFieldType, RequestSchema, ResponseSchema};
+
+/// Detects the multi-row tuple-list shape `VALUES {name}` (case-insensitive,
+/// no trailing boundary — `}` is a non-word character, so a trailing `\b`
+/// would never match). Capture group 1 is the parameter name. Shared by the
+/// placeholder converters below and by skardi-server's parameter-schema
+/// enrichment, which must agree with the loader on what counts as this shape.
+pub static VALUES_PLACEHOLDER_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r"(?i)\bVALUES\s*\{([a-zA-Z_][a-zA-Z0-9_]*)\}")
+        .expect("VALUES placeholder regex is valid")
+});
 
 /// SQL schema inference engine for extracting parameter and response schemas from SQL queries
 /// TODO: Fix the issue that extra parameters in the request is allowed
@@ -175,9 +185,7 @@ impl SqlSchemaInferrer {
         // breaking pipeline load. Substitute with `VALUES (?)` so the SQL
         // parses as a single-row tuple stub; runtime types still come from
         // the renderer, not from this stub.
-        let values_pattern = regex::Regex::new(r"(?i)\bVALUES\s*\{([a-zA-Z_][a-zA-Z0-9_]*)\}")
-            .map_err(|e| anyhow!("Failed to compile VALUES placeholder regex: {}", e))?;
-        sql_with_placeholders = values_pattern
+        sql_with_placeholders = VALUES_PLACEHOLDER_RE
             .replace_all(&sql_with_placeholders, "VALUES (?)")
             .to_string();
 
@@ -639,9 +647,9 @@ impl SqlSchemaInferrer {
     fn replace_parameters_for_parsing(&self, sql: &str) -> Result<String> {
         // Pre-pass: `VALUES {name}` → `VALUES (NULL)` so the multi-row
         // tuple-list shape parses (`VALUES NULL` is not valid SQL).
-        let values_pattern = regex::Regex::new(r"(?i)\bVALUES\s*\{[a-zA-Z_][a-zA-Z0-9_]*\}")
-            .map_err(|e| anyhow!("Failed to compile VALUES placeholder regex: {}", e))?;
-        let sql = values_pattern.replace_all(sql, "VALUES (NULL)").to_string();
+        let sql = VALUES_PLACEHOLDER_RE
+            .replace_all(sql, "VALUES (NULL)")
+            .to_string();
 
         let parameter_pattern = regex::Regex::new(r"\{[a-zA-Z_][a-zA-Z0-9_]*\}")
             .map_err(|e| anyhow!("Failed to compile parameter regex: {}", e))?;
@@ -1269,5 +1277,22 @@ mod tests {
         assert!(inferrer.is_dml_statement("  insert into t (a) values (1)"));
         assert!(!inferrer.is_dml_statement("SELECT * FROM t"));
         assert!(!inferrer.is_dml_statement("  select * from t"));
+    }
+
+    #[test]
+    fn values_placeholder_regex_detects_the_multi_row_shape() {
+        let re = &*VALUES_PLACEHOLDER_RE;
+        // case-insensitive, optional whitespace, captures the name
+        let cap = re.captures("INSERT INTO t (a, b) values {rows}").unwrap();
+        assert_eq!(&cap[1], "rows");
+        let cap = re.captures("INSERT INTO t VALUES{rows}").unwrap();
+        assert_eq!(&cap[1], "rows");
+        // a parenthesized tuple of scalar params is NOT the multi-row shape
+        assert!(re.captures("INSERT INTO t VALUES ({a}, {b})").is_none());
+        // a parameter merely named like the keyword is not a match either
+        assert!(
+            re.captures("SELECT * FROM t WHERE x = {values_x}")
+                .is_none()
+        );
     }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -465,6 +465,36 @@ error. When the server has auditing enabled, a `503` with `error_type
 "query_audit_error"` means the job **was not submitted** and the call is
 safe to retry.
 
+## MCP — `skardi mcp`
+
+Serves the Model Context Protocol over stdio, bridging an MCP host (Claude
+Desktop, Cursor, …) to a running skardi-server: pipelines become MCP tools,
+plus built-in `query` and `list_data_sources` tools. The host spawns the
+subcommand as a child process — you don't run it by hand. Claude Desktop
+config:
+
+```json
+{
+  "mcpServers": {
+    "skardi": {
+      "command": "skardi",
+      "args": ["mcp", "--server", "http://localhost:8080"]
+    }
+  }
+}
+```
+
+There are no subcommand-specific flags: the global `--server` / `--token` /
+`--context` resolution applies, exactly as for every other subcommand. See
+[mcp.md](mcp.md) for the tool surface, host setup, auth notes, and
+troubleshooting.
+
+Exit codes follow the table below only for errors surfaced **before**
+serving starts (a cloud context is refused with `1`; nothing is probed at
+startup, so `2` is rare here). Once the MCP session is up, REST failures —
+unreachable server included — are reported in-band as tool errors, and the
+process exits `0` when the host closes stdin.
+
 ## Exit codes
 
 | Code | Meaning |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -82,8 +82,10 @@ server-side errors); pipelines without a description get
 from the inferred Arrow type — strings, integers, numbers, booleans, dates,
 timestamps, and arrays all map to their JSON Schema counterparts, each
 nullable (`"type": ["string", "null"]`) because explicit `NULL` is a valid
-parameter value. Multi-row `VALUES {name}` placeholders are typed as
-array-of-arrays. Every parameter is required and unknown keys are rejected.
+parameter value. Arrays declare `minItems: 1` (the server rejects empty
+arrays before execution), and multi-row `VALUES {name}` placeholders are
+typed as array-of-arrays with non-empty rows. Every parameter is required
+and unknown keys are rejected.
 
 ### `query`
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -87,6 +87,11 @@ arrays before execution), and multi-row `VALUES {name}` placeholders are
 typed as array-of-arrays with non-empty rows. Every parameter is required
 and unknown keys are rejected.
 
+Every pipeline call carries the connection's session id as
+`X-Skardi-Session-Id` — the same id `query` sends in
+`ai_context.session_id` — so one MCP session's pipeline runs and ad-hoc
+queries group together in the query audit ledger.
+
 ### `query`
 
 Ad-hoc SQL against the federated engine — the MCP face of `POST /query`.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,164 @@
+# MCP Binding — `skardi mcp`
+
+`skardi mcp` serves the [Model Context Protocol](https://modelcontextprotocol.io)
+over stdio, making Skardi's pipelines and ad-hoc query surface available to
+any MCP host — Claude Desktop, Cursor, or your own agent loop. It is the
+third agent-facing binding of the same pipeline YAML, next to the shell verb
+(`skardi run`) and REST (`POST /<name>/execute`).
+
+The subcommand is a transport bridge, not a second engine: the host spawns
+`skardi mcp` as a long-lived child process and speaks JSON-RPC to it over
+stdin/stdout; every tool call is proxied to a running `skardi-server` over
+REST and the response is returned verbatim.
+
+```
+┌──────────────┐  stdio (JSON-RPC)  ┌────────────────────┐  HTTP (REST)  ┌───────────────┐
+│  MCP host     │ ◄───────────────► │  skardi mcp         │ ◄──────────► │  skardi-server │
+│ (Claude       │  spawned as a     │  (CLI subcommand:   │  ApiClient,  │  (executes     │
+│  Desktop, …)  │  child process    │   MCP ⇄ REST bridge)│  Bearer auth │   SQL)         │
+└──────────────┘                    └────────────────────┘               └───────────────┘
+```
+
+---
+
+## Host setup
+
+Claude Desktop (`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "skardi": {
+      "command": "skardi",
+      "args": ["mcp", "--server", "http://localhost:8080"]
+    }
+  }
+}
+```
+
+Cursor (`.cursor/mcp.json`, same `mcpServers` shape):
+
+```json
+{
+  "mcpServers": {
+    "skardi": {
+      "command": "skardi",
+      "args": ["mcp", "--server", "http://localhost:8080"]
+    }
+  }
+}
+```
+
+`skardi mcp` takes no subcommand-specific configuration: the server URL and
+Bearer token resolve exactly as for every other subcommand — flag (`--server`,
+`--token`) → environment (`SKARDI_SERVER_URL`, `SKARDI_API_TOKEN`) → config
+file (`~/.skardi/config.yaml`, honoring the current context). Because the
+bridge is transport-level, pointing `--server` at a remote skardi-server
+also works, making `skardi mcp` a local MCP gateway to a remote deployment.
+
+One exception: **cloud contexts are refused.** The cloud gateway serves only
+`query` and `schema`; it does not serve pipeline execution or
+`/data_source`, so `skardi mcp` in a cloud context exits with an error
+before serving instead of offering tools that would all fail.
+
+---
+
+## Tool surface
+
+### Pipeline tools
+
+Every pipeline registered on the server becomes one MCP tool. Tool names
+must match `^[a-zA-Z0-9_-]{1,64}$`, so pipeline names are sanitized: any
+other character becomes `_` and names are truncated to 64. If two pipelines
+sanitize to the same name, the later one (in original-name sort order) gets
+a numeric suffix (`_2`, `_3`, …); a pipeline literally named `query` or
+`list_data_sources` is exposed as `query_pipeline` /
+`list_data_sources_pipeline` so it never shadows the built-ins.
+
+The tool description is the pipeline's `metadata.description` with the
+original pipeline name appended (so renamed tools stay correlatable with
+server-side errors); pipelines without a description get
+``Execute pipeline `<name>` ``. The input schema is generated per parameter
+from the inferred Arrow type — strings, integers, numbers, booleans, dates,
+timestamps, and arrays all map to their JSON Schema counterparts, each
+nullable (`"type": ["string", "null"]`) because explicit `NULL` is a valid
+parameter value. Multi-row `VALUES {name}` placeholders are typed as
+array-of-arrays. Every parameter is required and unknown keys are rejected.
+
+### `query`
+
+Ad-hoc SQL against the federated engine — the MCP face of `POST /query`.
+
+| Argument | Type | Notes |
+|---|---|---|
+| `sql` | string, **required** | One statement. DML only on `access_mode: read_write` sources; DDL is always rejected. |
+| `max_rows` | integer, optional | Result row cap; server default 1000. |
+| `purpose` | string, optional | One line on why you are running this query. Sent as `ai_context: {purpose, session_id}` and recorded in the server's query audit log; the `session_id` is one UUID per MCP connection, so a session's queries group together in the ledger. Omitted entirely when not provided. |
+
+### `list_data_sources`
+
+No arguments. Returns the server's data sources with tables, column
+schemas, and semantic descriptions — the same body as `GET /data_source`.
+Call it before writing ad-hoc SQL with `query`.
+
+---
+
+## Freshness
+
+The pipeline inventory is fetched from `GET /pipelines` on **every**
+`tools/list` request — a pipeline added to the server appears as soon as the
+host re-lists. Hosts that list once at connect time and never again keep
+their snapshot until reconnect. The bridge does not emit `listChanged`
+notifications in v1.
+
+---
+
+## Auth notes
+
+The bridge sends the Bearer token it inherits from normal CLI config
+resolution on every REST call. Note that on today's server, `GET /pipelines`
+(the tool inventory) and `GET /data_source` are readable without a token —
+existing REST behavior, not something the bridge adds. Deployments whose
+table names or column semantics are sensitive should weigh access to
+`/data_source` and `/pipelines` together.
+
+---
+
+## Timeouts & lifecycle
+
+- **No bridge-side request timeout.** A hung server hangs the tool call
+  until the MCP host's own tool-call timeout fires — every mainstream host
+  has one, and stacking a second timeout under it would only create
+  ambiguity about which fired.
+- **Concurrent tool calls are served in parallel.** A slow `query` does not
+  block `tools/list` or other calls.
+- **Lifecycle is host-driven.** When the host closes stdin, the bridge exits
+  `0`; in-flight REST calls die with the process.
+
+REST failures during serving are reported in-band, not as crashes: any
+failed tool call — a 4xx/5xx from the server or an unreachable server —
+becomes a tool result with `isError: true` carrying the error text (the same
+"cannot reach skardi-server" wording the CLI prints). A `tools/list` that
+can't reach the server is the one JSON-RPC-level error, since there is no
+tool result to attach it to.
+
+---
+
+## Troubleshooting
+
+- **`cannot reach skardi-server at <url>`** — the bridge can't connect.
+  Check the three config knobs in resolution order: `--server` in the host's
+  `args`, `SKARDI_SERVER_URL` in the host's environment, and `server` in
+  `~/.skardi/config.yaml`. Remember the host spawns the bridge with *its*
+  environment, which may not be your shell's.
+- **Host reports a broken/failed MCP connection at startup** — stdout is
+  the JSON-RPC channel, so anything that prints to it corrupts the framing.
+  Don't wrap the `command` in a shell script or launcher that echoes
+  (version banners, `set -x`, profile output); point the host directly at
+  the `skardi` binary.
+- **Tool named differently than the pipeline** — see the sanitization and
+  collision rules above; the original pipeline name is always echoed in the
+  tool description.
+- **Result size** — `query` results are capped by `max_rows` (default
+  1000). Pipeline executions are not row-capped server-side; the bridge
+  refuses response bodies over 256 MB (the CLI-wide client ceiling).

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -15,8 +15,8 @@ One pipeline YAML drives every agent-facing surface:
 - **Shell** — `skardi run <name> --param=…` from the CLI today.
 - **Claude skills** — auto-generated Markdown under `.claude/skills/` (v1.1
   roadmap).
-- **MCP tools** — same YAML projected to MCP for non-Claude hosts (v1.1
-  roadmap).
+- **MCP tools** — same YAML projected to MCP tools for non-Claude hosts via
+  `skardi mcp` — see [mcp.md](mcp.md).
 
 This page covers the pipeline YAML shape, parameter inference, invocation,
 and response format. For the HTTP binding and shared concerns (context

--- a/docs/superpowers/plans/2026-08-25-mcp-stdio-binding.md
+++ b/docs/superpowers/plans/2026-08-25-mcp-stdio-binding.md
@@ -1,0 +1,1223 @@
+# MCP stdio Binding (`skardi mcp`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship Skardi's third agent-facing binding — an MCP-over-stdio server (`skardi mcp`) that projects every loaded pipeline plus `query` and `list_data_sources` as MCP tools, proxying to skardi-server over REST.
+
+**Architecture:** Two-crate change. `crates/server` enriches `GET /pipelines` and `GET /pipeline/:name` with `description` and per-parameter `json_schema` fragments (Option A, decided in the spec). `crates/cli` gains a `skardi mcp` subcommand: a manual `rmcp::ServerHandler` implementation that fetches the enriched inventory on every `tools/list`, projects it to MCP tools, and routes `tools/call` through the existing `ApiClient`. A small prerequisite lands in `crates/skardi`: the `VALUES {name}` detection regex is exported as a shared static (it is currently transcribed twice, inline, in inferencer.rs).
+
+**Tech Stack:** rmcp 3.1.4 (`default-features = false`), tokio, reqwest (existing `ApiClient`), wiremock for tests, uuid (workspace pin) for the per-connection session id.
+
+**Spec:** `docs/superpowers/specs/2026-08-13-mcp-stdio-binding-design.md`
+
+**Resolved open decisions (Owen, 2026-08-25):**
+1. `query` includes the optional `purpose` parameter → `ai_context: {purpose, session_id}`.
+2. Built-in tools are unprefixed: `query`, `list_data_sources`.
+3. Lifecycle per spec recommendations: concurrent `tools/call` (rmcp's default — it spawns a task per request), stdin close → exit 0, no bridge-side request timeout (host's tool-call timeout is the backstop; documented in docs/mcp.md).
+
+**Spec facts corrected against the current tree (fixed autonomously per review):**
+- `docs/agent_data_plane.md` no longer exists (removed in the README repositioning, #205) — that doc task is dropped.
+- README no longer has a roadmap checkbox or "MCP-soon" banner — the README task is now: update the "One definition, both bindings" copy (§4, ~line 113) to cover MCP as the third binding.
+
+## Global Constraints
+
+- **No local test runs.** Nobody runs tests locally — verification happens exclusively on GitHub CI. Do NOT run `cargo test` / `cargo nextest` / `cargo check` locally. The only pre-push command is `cargo fmt --all`.
+- **No commits by Claude.** Each task ends with the working tree edited and `cargo fmt --all` run. Owen reviews and commits. "Checkpoint" steps below mean: stop editing, summarize, wait.
+- CI bare-runs all `#[ignore]` tests (`cargo llvm-cov --no-report nextest --all-features -- --ignored`); nothing in this plan needs `#[ignore]`.
+- Workspace: edition 2024, toolchain 1.96.1, `unused_qualifications = "deny"` (don't fully-qualify paths already imported), clippy `large_futures = "warn"`.
+- rmcp is pinned at **3.1.4** (MSRV 1.88 — satisfied). Its 3.x API differs from 0.x: `CallToolRequestParams` (plural), `call_tool` returns `CallToolResponse` (enum; `From<CallToolResult>` exists), content is `ContentBlock`, model structs are `#[non_exhaustive]` (use constructors, never struct literals).
+- **stdout is the MCP wire.** Nothing in the `skardi mcp` code path may print to stdout — no `output::print_result`, no `println!`. Diagnostics go to stderr via `eprintln!` (matching the CLI's existing house style; the CLI has no tracing/log framework and this plan doesn't add one — a deliberate, minimal deviation from the spec's "tracing/env_logger" wording).
+- Server responses stay additive: existing fields (including `GET /pipeline/:name`'s Debug-dump `type` string) are unchanged; new fields are added alongside.
+- Parameters in both enriched endpoints are **sorted by name** (RequestSchema.fields is a HashMap; sorting makes responses and tests deterministic).
+
+---
+
+### Task 1: Export the shared `VALUES {name}` regex from `crates/skardi`
+
+The pattern `r"(?i)\bVALUES\s*\{([a-zA-Z_][a-zA-Z0-9_]*)\}"` is currently compiled inline twice in `crates/skardi/src/pipeline/inferencer.rs` (line 178 in `convert_named_to_placeholders`, and line 642 — without the capture group — in `replace_parameters_for_parsing`). The server-side enrichment (Task 2) needs the exact same detection; the spec says to share the compiled regex rather than re-transcribe it. `crates/server` has no `regex` dependency, so the shared item lives in `skardi`.
+
+**Files:**
+- Modify: `crates/skardi/src/pipeline/inferencer.rs`
+- Test: same file's `#[cfg(test)] mod tests` (add if the module lacks regex-level tests)
+
+**Interfaces:**
+- Produces: `pub static VALUES_PLACEHOLDER_RE: LazyLock<Regex>` in `skardi::pipeline::inferencer` — capture group 1 is the parameter name. Task 2 consumes it as `skardi::pipeline::inferencer::VALUES_PLACEHOLDER_RE`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `inferencer.rs`'s test module:
+
+```rust
+#[test]
+fn values_placeholder_regex_detects_the_multi_row_shape() {
+    let re = &*VALUES_PLACEHOLDER_RE;
+    // case-insensitive, optional whitespace, captures the name
+    let cap = re.captures("INSERT INTO t (a, b) values {rows}").unwrap();
+    assert_eq!(&cap[1], "rows");
+    let cap = re.captures("INSERT INTO t VALUES{rows}").unwrap();
+    assert_eq!(&cap[1], "rows");
+    // a parenthesized tuple of scalar params is NOT the multi-row shape
+    assert!(re.captures("INSERT INTO t VALUES ({a}, {b})").is_none());
+    // a parameter merely named like the keyword is not a match either
+    assert!(re.captures("SELECT * FROM t WHERE x = {values_x}").is_none());
+}
+```
+
+- [ ] **Step 2: Add the static and deduplicate both call sites**
+
+At module level in `inferencer.rs` (near the top, after imports):
+
+```rust
+use std::sync::LazyLock;
+
+/// Detects the multi-row tuple-list shape `VALUES {name}` (case-insensitive,
+/// no trailing boundary — `}` is a non-word character, so a trailing `\b`
+/// would never match). Capture group 1 is the parameter name. Shared by the
+/// placeholder converters below and by skardi-server's parameter-schema
+/// enrichment, which must agree with the loader on what counts as this shape.
+pub static VALUES_PLACEHOLDER_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r"(?i)\bVALUES\s*\{([a-zA-Z_][a-zA-Z0-9_]*)\}")
+        .expect("VALUES placeholder regex is valid")
+});
+```
+
+Then:
+- In `convert_named_to_placeholders` (lines 171–182): delete the inline `values_pattern` compilation and its error mapping; use `VALUES_PLACEHOLDER_RE.replace_all(&sql_with_placeholders, "VALUES (?)")`. Keep the existing explanatory comment about why the stub is `VALUES (?)`.
+- In `replace_parameters_for_parsing` (line 642): delete that inline compilation too and use the same static (the capture group is inert for a `replace_all` whose replacement string doesn't reference it — read the surrounding lines first and keep the replacement string exactly as it is today).
+
+- [ ] **Step 3: `cargo fmt --all`**
+
+- [ ] **Step 4: Checkpoint** — summarize the diff for Owen.
+
+---
+
+### Task 2: Server-side parameter → JSON Schema computation
+
+Pure function in `crates/server`, next to the handlers that will call it. Implements the spec's mapping table, the unconditional null union, and the `VALUES {name}` override.
+
+**Files:**
+- Create: `crates/server/src/param_schema.rs`
+- Modify: `crates/server/src/lib.rs` (or wherever sibling modules are declared — check how `pipeline_handlers` is declared and mirror it) to add `pub(crate) mod param_schema;`
+- Test: unit tests inside `param_schema.rs`
+
+**Interfaces:**
+- Consumes: `skardi::pipeline::inferencer::VALUES_PLACEHOLDER_RE` (Task 1); `datafusion::arrow::datatypes::DataType` (same type as the direct `arrow` dep — arrow 57 is unified across the workspace).
+- Produces: `pub(crate) fn param_json_schema(field_type: &DataType, sql_template: &str, param_name: &str) -> serde_json::Value` — Task 3 calls it per parameter.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::datatypes::{DataType, Field, TimeUnit};
+    use serde_json::json;
+
+    fn schema(dt: DataType) -> serde_json::Value {
+        param_json_schema(&dt, "SELECT 1 WHERE x = {p}", "p")
+    }
+
+    #[test]
+    fn maps_scalar_types_with_null_union() {
+        assert_eq!(schema(DataType::Utf8), json!({"type": ["string", "null"]}));
+        assert_eq!(schema(DataType::LargeUtf8), json!({"type": ["string", "null"]}));
+        assert_eq!(schema(DataType::Int64), json!({"type": ["integer", "null"]}));
+        assert_eq!(schema(DataType::UInt32), json!({"type": ["integer", "null"]}));
+        assert_eq!(schema(DataType::Float64), json!({"type": ["number", "null"]}));
+        assert_eq!(schema(DataType::Decimal128(10, 2)), json!({"type": ["number", "null"]}));
+        assert_eq!(schema(DataType::Boolean), json!({"type": ["boolean", "null"]}));
+    }
+
+    #[test]
+    fn maps_temporal_types_with_format() {
+        assert_eq!(
+            schema(DataType::Date32),
+            json!({"type": ["string", "null"], "format": "date"})
+        );
+        assert_eq!(
+            schema(DataType::Timestamp(TimeUnit::Nanosecond, None)),
+            json!({"type": ["string", "null"], "format": "date-time"})
+        );
+    }
+
+    #[test]
+    fn maps_lists_with_typed_items() {
+        let dt = DataType::List(Field::new("item", DataType::Utf8, true).into());
+        assert_eq!(
+            schema(dt),
+            json!({"type": ["array", "null"], "items": {"type": "string"}})
+        );
+    }
+
+    #[test]
+    fn unknown_types_map_to_any() {
+        assert_eq!(schema(DataType::Binary), json!({}));
+    }
+
+    #[test]
+    fn values_placeholder_overrides_the_type_table() {
+        let sql = "INSERT INTO docs (id, name, vec) values {rows}";
+        assert_eq!(
+            param_json_schema(&DataType::Utf8, sql, "rows"),
+            json!({"type": "array", "items": {"type": "array"}})
+        );
+        // only the parameter named in the VALUES clause gets the override
+        assert_eq!(
+            param_json_schema(&DataType::Utf8, sql, "other"),
+            json!({"type": ["string", "null"]})
+        );
+        // a parenthesized tuple list is not the multi-row shape
+        assert_eq!(
+            param_json_schema(&DataType::Utf8, "INSERT INTO t VALUES ({rows})", "rows"),
+            json!({"type": ["string", "null"]})
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Implement**
+
+```rust
+//! Per-parameter JSON Schema fragments for the enriched pipeline inventory.
+//!
+//! Computed server-side (the enriched `GET /pipelines` response carries no
+//! SQL, so downstream bindings cannot run the `VALUES` detection themselves).
+//! The DataType → JSON Schema mapping and the unconditional `"null"` union
+//! are specified in docs/superpowers/specs/2026-08-13-mcp-stdio-binding-design.md.
+
+use datafusion::arrow::datatypes::DataType;
+use serde_json::{Value, json};
+use skardi::pipeline::inferencer::VALUES_PLACEHOLDER_RE;
+
+/// The complete JSON Schema fragment for one pipeline parameter.
+pub(crate) fn param_json_schema(field_type: &DataType, sql_template: &str, param_name: &str) -> Value {
+    // `VALUES {name}` is a multi-row tuple list at request time; the inferred
+    // Utf8 would be an actively wrong constraint, so it overrides wholesale.
+    if VALUES_PLACEHOLDER_RE
+        .captures_iter(sql_template)
+        .any(|cap| &cap[1] == param_name)
+    {
+        return json!({"type": "array", "items": {"type": "array"}});
+    }
+    with_null_union(base_fragment(field_type))
+}
+
+/// The type-table mapping without the null union (list items use this raw).
+fn base_fragment(field_type: &DataType) -> Value {
+    match field_type {
+        DataType::Utf8 | DataType::LargeUtf8 => json!({"type": "string"}),
+        dt if dt.is_integer() => json!({"type": "integer"}),
+        DataType::Float16 | DataType::Float32 | DataType::Float64 => json!({"type": "number"}),
+        DataType::Decimal128(_, _) | DataType::Decimal256(_, _) => json!({"type": "number"}),
+        DataType::Boolean => json!({"type": "boolean"}),
+        DataType::Date32 | DataType::Date64 => json!({"type": "string", "format": "date"}),
+        DataType::Timestamp(_, _) => json!({"type": "string", "format": "date-time"}),
+        DataType::List(inner) => {
+            json!({"type": "array", "items": base_fragment(inner.data_type())})
+        }
+        _ => json!({}),
+    }
+}
+
+/// Fold `"null"` into the fragment's `type` — unconditionally, because the
+/// server accepts an explicit JSON `null` for every parameter (rendered as
+/// SQL `NULL`) and the inferrer hardcodes `nullable: true`. The `{}` (any)
+/// fragment already admits null and is left alone.
+fn with_null_union(mut fragment: Value) -> Value {
+    if let Some(ty) = fragment.get("type").cloned() {
+        fragment["type"] = json!([ty, "null"]);
+    }
+    fragment
+}
+```
+
+Notes for the implementer:
+- `DataType::is_integer()` exists on arrow 57's `DataType` and covers `Int8..Int64` and `UInt8..UInt64`.
+- If `Decimal32`/`Decimal64` variants exist in arrow 57, add them to the number arm (check the enum; compile will not force it since there's a `_` fallback — grep `Decimal` in the arrow docs/source first).
+- If clippy objects to the `dt if dt.is_integer()` guard order vs. concrete patterns, reorder — behavior must keep `Utf8` before the guard.
+
+- [ ] **Step 3: `cargo fmt --all`**
+
+- [ ] **Step 4: Checkpoint** — summarize for Owen.
+
+---
+
+### Task 3: Enrich `GET /pipelines` and `GET /pipeline/:name`
+
+**Files:**
+- Modify: `crates/server/src/pipeline_handlers.rs:381-462` (`list_pipelines`, `get_pipelines_info`)
+- Test: `crates/server/tests/pipelines_http.rs` (extend the two existing tests; add a no-description fixture and a `VALUES` fixture)
+
+**Interfaces:**
+- Consumes: `param_json_schema` (Task 2); `StandardPipeline` fields `metadata.description`, `query_definition.sql`, `request_schema.fields` (all `pub`; trait accessors `pipeline.request_schema()` / `pipeline.query_definition()` exist).
+- Produces: each `GET /pipelines` list item and the `GET /pipeline/:name` `pipeline` object gain `"description": <string|null>` and `"parameters": [{"name", "data_type", "json_schema"}]` sorted by name. `/pipeline/:name` parameters additionally KEEP the existing `"type"` Debug string unchanged. This is the exact contract Task 5's projection consumes.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `crates/server/tests/pipelines_http.rs`, extend `http_list_pipelines_returns_registered` (after the existing assertions on the `product-search` entry — its fixture already has `description: "Filter products by brand + max price"` and params `{brand}` → Utf8, `{max_price}` → Float64 via the `max_` prefix strip):
+
+```rust
+    assert_eq!(
+        entry["description"].as_str(),
+        Some("Filter products by brand + max price")
+    );
+    // parameters are sorted by name: brand, max_price
+    let params = entry["parameters"].as_array().expect("parameters array");
+    assert_eq!(params.len(), 2);
+    assert_eq!(params[0]["name"].as_str(), Some("brand"));
+    assert_eq!(params[0]["data_type"].as_str(), Some("Utf8"));
+    assert_eq!(params[0]["json_schema"], serde_json::json!({"type": ["string", "null"]}));
+    assert_eq!(params[1]["name"].as_str(), Some("max_price"));
+    assert_eq!(params[1]["data_type"].as_str(), Some("Float64"));
+    assert_eq!(params[1]["json_schema"], serde_json::json!({"type": ["number", "null"]}));
+```
+
+Extend `http_get_pipeline_info_returns_metadata_and_params` similarly (description + per-param `data_type`/`json_schema`), and assert the pre-existing `type` key is still present on each parameter (`params[0]["type"].as_str().unwrap().contains("field_type")` — it is the Debug dump of the whole `InferredFieldType`).
+
+Add two new tests:
+
+```rust
+#[tokio::test]
+async fn http_list_pipelines_description_is_null_when_yaml_omits_it() {
+    // Load a second pipeline whose metadata has no `description:` line
+    // (mirror make_app_state's fixture-loading, minus that line), insert it
+    // into state.config.write().unwrap().pipelines, then GET /pipelines and
+    // assert its entry has "description": null (present key, JSON null).
+}
+
+#[tokio::test]
+async fn http_list_pipelines_values_param_gets_array_of_arrays_schema() {
+    // Fixture pipeline:
+    //   kind: pipeline
+    //   metadata: { name: "bulk-insert", version: "1.0.0" }
+    //   spec:
+    //     query: |
+    //       INSERT INTO products (id, brand, price, category) VALUES {rows}
+    // Load it against the same `products` MemTable SessionContext, insert
+    // into state, GET /pipelines, find the "bulk-insert" entry and assert
+    // its single parameter is:
+    //   {"name": "rows", "data_type": "Utf8",
+    //    "json_schema": {"type": "array", "items": {"type": "array"}}}
+}
+```
+
+(Write these fully — the comment bodies above describe intent; the code follows `make_app_state` / `body_to_json` patterns already in the file. The mutate-state-after-construction pattern is at `pipeline_handlers.rs:1987` in the unit tests: `let mut config = app_state.config.write().unwrap();`.)
+
+- [ ] **Step 2: Implement**
+
+Add a private helper in `pipeline_handlers.rs`:
+
+```rust
+/// The enriched parameter list for one pipeline, sorted by name so the
+/// response is deterministic (RequestSchema.fields is a HashMap).
+fn enriched_parameters(pipeline: &StandardPipeline) -> Vec<Value> {
+    let sql = &pipeline.query_definition().sql;
+    let mut fields: Vec<_> = pipeline.request_schema().fields.iter().collect();
+    fields.sort_by(|(a, _), (b, _)| a.cmp(b));
+    fields
+        .into_iter()
+        .map(|(name, field)| {
+            serde_json::json!({
+                "name": name,
+                "data_type": format!("{:?}", field.field_type),
+                "json_schema": crate::param_schema::param_json_schema(
+                    &field.field_type, sql, name
+                ),
+            })
+        })
+        .collect()
+}
+```
+
+(If `unused_qualifications` complains about the `crate::param_schema::` path with an import present, import `param_json_schema` at the top instead — pick one form, not both.)
+
+In `list_pipelines` (line 392's `json!` block), add:
+
+```rust
+"description": pipeline.metadata.description,
+"parameters": enriched_parameters(pipeline),
+```
+
+In `get_pipelines_info`: add `"description": pipeline.metadata.description` to the `pipeline` object (line 440's block), and rebuild the `params` vec (lines 427–436) from the sorted field list so each entry is:
+
+```rust
+serde_json::json!({
+    "name": param_name,
+    "type": format!("{:?}", field_type),   // unchanged legacy Debug dump
+    "data_type": format!("{:?}", field_type.field_type),
+    "json_schema": crate::param_schema::param_json_schema(
+        &field_type.field_type, &pipeline.query_definition().sql, param_name
+    ),
+})
+```
+
+`StandardPipeline` may need importing into scope for the helper's signature — it's already imported in the test module; check the non-test imports (`skardi::pipeline::pipeline::StandardPipeline`).
+
+- [ ] **Step 3: `cargo fmt --all`**
+
+- [ ] **Step 4: Checkpoint** — server-side change complete; summarize for Owen. (This is the natural boundary if Owen wants the server change as its own commit/PR.)
+
+---
+
+### Task 4: CLI — dependencies, `Mcp` subcommand, capability gate
+
+**Files:**
+- Modify: `crates/cli/Cargo.toml`
+- Modify: `crates/cli/src/main.rs` (Commands enum, dispatch, `capability_of`, the exhaustiveness test at `main.rs:369-382`)
+- Modify: `crates/cli/src/cloud.rs` (`Capability` enum at `cloud.rs:28-63`)
+- Test: `crates/cli/tests/cloud_gating.rs` (one new case)
+
+**Interfaces:**
+- Consumes: `ClientConfig::resolve` / `cloud::ensure_available` / `ApiClient::new` — the standard dispatch pipeline, unchanged.
+- Produces: `Commands::Mcp` variant dispatching to `mcp::run(client)` (Task 6 defines `pub async fn run(client: ApiClient) -> anyhow::Result<()>` in a new top-level `src/mcp/` module, following the `src/login/` precedent); `Capability::Mcp` with `served_by_gateway() == false` (a cloud context refuses `skardi mcp` — the bridge needs pipeline execution and `/data_source`, which the gateway does not serve).
+
+- [ ] **Step 1: Dependencies**
+
+In `crates/cli/Cargo.toml` `[dependencies]`:
+
+```toml
+rmcp = { version = "3.1.4", default-features = false, features = ["server", "transport-io"] }
+uuid = { workspace = true }
+```
+
+In `[dev-dependencies]` (feature unification adds the client features for tests only):
+
+```toml
+rmcp = { version = "3.1.4", default-features = false, features = ["client", "transport-child-process"] }
+```
+
+Note: rmcp's `server` feature force-enables `schemars 1.x`; the lockfile already contains schemars 1.2.1, so no new major. Manual dynamic tools never touch schemars — `Tool::input_schema` is `Arc<serde_json::Map<String, Value>>`.
+
+- [ ] **Step 2: Write the failing test (cloud gating)**
+
+In `crates/cli/tests/cloud_gating.rs`, add a case following the file's existing pattern (spawn helper `skardi(home, args)` at `:18-26`, cloud-context config fixture written `chmod 0600`): `skardi mcp` against a cloud context must exit non-zero with the same refusal stderr the other non-gateway commands get, and must issue no network traffic (no wiremock expectations needed if the existing cases assert purely on exit code + stderr — mirror whichever assertion style the neighboring cases use).
+
+- [ ] **Step 3: Wire the subcommand**
+
+`main.rs` Commands enum — add after `Health`:
+
+```rust
+/// Serve MCP over stdio, proxying tools to the server (for MCP hosts).
+///
+/// Spawned by an MCP host (Claude Desktop, Cursor, ...) as a long-lived
+/// child process; speaks JSON-RPC on stdout, so it prints nothing else there.
+Mcp,
+```
+
+`cloud.rs` `Capability` enum: add `Mcp` variant; its display/name string (check how the enum renders in refusal messages) is `"mcp"`; `served_by_gateway()` stays `matches!(self, Capability::Query | Capability::Schema)` (i.e. `Mcp` is not added there).
+
+`main.rs` `capability_of`: add `Commands::Mcp => Some(Capability::Mcp)`.
+
+`main.rs` dispatch match: add
+
+```rust
+Commands::Mcp => mcp::run(client).await,
+```
+
+— note this arm moves `client` by value (the bridge owns it); the other arms borrow, which is fine since match arms are exclusive. Add `mod mcp;` to the module declarations at `main.rs:20-27`. Create a stub `crates/cli/src/mcp/mod.rs` so the crate compiles:
+
+```rust
+use crate::client::ApiClient;
+
+pub async fn run(_client: ApiClient) -> anyhow::Result<()> {
+    anyhow::bail!("not implemented yet")
+}
+```
+
+Update the exhaustiveness test `the_command_set_is_covered_exhaustively` (`main.rs:369-382`) with the `Mcp` arm.
+
+- [ ] **Step 4: `cargo fmt --all`**
+
+- [ ] **Step 5: Checkpoint** — summarize for Owen.
+
+---
+
+### Task 5: CLI — tool projection (pure functions)
+
+**Files:**
+- Create: `crates/cli/src/mcp/projection.rs`
+- Modify: `crates/cli/src/mcp/mod.rs` (add `mod projection;`)
+- Test: unit tests inside `projection.rs`
+
+**Interfaces:**
+- Consumes: the enriched `GET /pipelines` body (Task 3's contract) as `&serde_json::Value`.
+- Produces (Task 6 consumes):
+  - `pub(crate) fn project(inventory: &Value) -> (Vec<Tool>, HashMap<String, String>)` — tools = projected pipelines + the two built-ins appended; map = tool name → original pipeline name (pipelines only).
+  - `pub(crate) fn builtin_tools() -> Vec<Tool>` (also used standalone in tests).
+  - `pub(crate) const RESERVED_NAMES: [&str; 2] = ["query", "list_data_sources"];`
+
+rmcp types used: `rmcp::model::{Tool, JsonObject}`. Build schemas with `serde_json::json!` then `serde_json::from_value::<JsonObject>(...)`; construct tools with `Tool::new(name, description, schema)` (`Tool` is `#[non_exhaustive]` — constructor only).
+
+- [ ] **Step 1: Write the failing tests** (table-driven, in-module)
+
+Cover, with exact expected values:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn inventory(pipelines: serde_json::Value) -> serde_json::Value {
+        json!({"success": true, "pipelines": pipelines, "count": 0})
+    }
+
+    #[test]
+    fn sanitizes_names_to_the_mcp_charset() {
+        assert_eq!(sanitize("product-search"), "product-search");
+        assert_eq!(sanitize("my.pipe/v2"), "my_pipe_v2");
+        assert_eq!(sanitize("空 格"), "___"); // every non-[a-zA-Z0-9_-] byte→char replaced
+        assert_eq!(sanitize(&"x".repeat(80)).len(), 64);
+    }
+
+    #[test]
+    fn reserved_names_get_the_pipeline_suffix() {
+        let (tools, map) = project(&inventory(json!([
+            {"name": "query", "version": "1", "endpoint": "/query/execute",
+             "description": null, "parameters": []}
+        ])));
+        assert_eq!(map.get("query_pipeline").map(String::as_str), Some("query"));
+        assert!(tools.iter().any(|t| t.name == "query_pipeline"));
+        // the built-in `query` is still present and distinct
+        assert!(tools.iter().any(|t| t.name == "query"));
+    }
+
+    #[test]
+    fn collisions_suffix_in_sorted_original_name_order() {
+        let (_, map) = project(&inventory(json!([
+            {"name": "a.b", "version": "1", "endpoint": "/a.b/execute", "description": null, "parameters": []},
+            {"name": "a_b", "version": "1", "endpoint": "/a_b/execute", "description": null, "parameters": []},
+            {"name": "a_b_2", "version": "1", "endpoint": "/a_b_2/execute", "description": null, "parameters": []}
+        ])));
+        // sorted originals: "a.b" < "a_b" < "a_b_2"
+        assert_eq!(map.get("a_b").map(String::as_str), Some("a.b"));
+        // "a_b" collides; "_2" is taken by the literal "a_b_2" pipeline → "_3"
+        assert_eq!(map.get("a_b_2").map(String::as_str), Some("a_b_2"));
+        assert_eq!(map.get("a_b_3").map(String::as_str), Some("a_b"));
+    }
+
+    #[test]
+    fn suffixes_never_push_past_64_chars() {
+        let long = "x".repeat(64);
+        let (_, map) = project(&inventory(json!([
+            {"name": long.clone(), "version": "1", "endpoint": "/x/execute", "description": null, "parameters": []},
+            {"name": format!("{long}y"), "version": "1", "endpoint": "/xy/execute", "description": null, "parameters": []}
+        ])));
+        assert!(map.keys().all(|k| k.len() <= 64));
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn description_falls_back_when_yaml_omits_it() {
+        let (tools, _) = project(&inventory(json!([
+            {"name": "p", "version": "1", "endpoint": "/p/execute", "description": null, "parameters": []}
+        ])));
+        let tool = tools.iter().find(|t| t.name == "p").unwrap();
+        assert_eq!(tool.description.as_deref(), Some("Execute pipeline `p`"));
+    }
+
+    #[test]
+    fn input_schema_assembles_fragments_with_required_and_closed_object() {
+        let (tools, _) = project(&inventory(json!([
+            {"name": "p", "version": "1", "endpoint": "/p/execute",
+             "description": "Search products",
+             "parameters": [
+                {"name": "brand", "data_type": "Utf8", "json_schema": {"type": ["string", "null"]}},
+                {"name": "max_price", "data_type": "Float64", "json_schema": {"type": ["number", "null"]}}
+             ]}
+        ])));
+        let tool = tools.iter().find(|t| t.name == "p").unwrap();
+        let schema = serde_json::to_value(tool.input_schema.as_ref()).unwrap();
+        assert_eq!(schema, json!({
+            "type": "object",
+            "properties": {
+                "brand": {"type": ["string", "null"]},
+                "max_price": {"type": ["number", "null"]}
+            },
+            "required": ["brand", "max_price"],
+            "additionalProperties": false
+        }));
+        // original pipeline name echoed in the description for error correlation
+        assert!(tool.description.as_deref().unwrap().contains('p'));
+    }
+
+    #[test]
+    fn builtins_have_the_specified_schemas() {
+        let tools = builtin_tools();
+        let query = tools.iter().find(|t| t.name == "query").unwrap();
+        let schema = serde_json::to_value(query.input_schema.as_ref()).unwrap();
+        assert_eq!(schema["required"], json!(["sql"]));
+        assert_eq!(schema["properties"]["sql"], json!({"type": "string"}));
+        assert_eq!(schema["properties"]["max_rows"]["type"], json!("integer"));
+        assert!(schema["properties"]["purpose"].is_object());
+        let lds = tools.iter().find(|t| t.name == "list_data_sources").unwrap();
+        let schema = serde_json::to_value(lds.input_schema.as_ref()).unwrap();
+        assert_eq!(schema["type"], json!("object"));
+    }
+}
+```
+
+(Adjust `t.name == "..."` comparisons for `Cow` — `t.name.as_ref() == "..."` — as the compiler demands. The `sanitize("空 格")` expectation: replacement is per-`char`, so two hanzi + one space → `___`.)
+
+- [ ] **Step 2: Implement**
+
+```rust
+//! Projection of the enriched pipeline inventory into MCP tool definitions.
+//! Pure functions — everything here is unit-testable without a server.
+
+use std::collections::HashMap;
+
+use rmcp::model::{JsonObject, Tool};
+use serde_json::{Value, json};
+
+pub(crate) const RESERVED_NAMES: [&str; 2] = ["query", "list_data_sources"];
+const MAX_TOOL_NAME: usize = 64;
+
+/// Replace every char outside [a-zA-Z0-9_-] with '_' and truncate to 64.
+fn sanitize(name: &str) -> String {
+    name.chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '_' || c == '-' { c } else { '_' })
+        .take(MAX_TOOL_NAME)
+        .collect()
+}
+
+/// Assign unique tool names in sorted order of original pipeline name.
+/// `taken` starts with the reserved built-ins; a candidate equal to a
+/// reserved name is first renamed with `_pipeline` (stderr warning), then
+/// the collision pass appends `_2`, `_3`, ... re-truncating the base so
+/// base + suffix never exceeds 64, iterating until unique.
+fn assign_tool_names(original_names: &[&str]) -> Vec<(String, String)> {
+    let mut sorted: Vec<&str> = original_names.to_vec();
+    sorted.sort_unstable();
+    let mut taken: std::collections::HashSet<String> =
+        RESERVED_NAMES.iter().map(|s| s.to_string()).collect();
+    let mut assigned = Vec::with_capacity(sorted.len());
+    for original in sorted {
+        let mut candidate = sanitize(original);
+        if RESERVED_NAMES.contains(&candidate.as_str()) {
+            eprintln!(
+                "warning: pipeline '{original}' collides with the built-in `{candidate}` tool; exposing it as `{candidate}_pipeline`"
+            );
+            candidate = format!("{candidate}_pipeline");
+            candidate.truncate(MAX_TOOL_NAME);
+        }
+        if taken.contains(&candidate) {
+            let mut n = 2usize;
+            loop {
+                let suffix = format!("_{n}");
+                let mut base = candidate.clone();
+                base.truncate(MAX_TOOL_NAME - suffix.len());
+                let renamed = format!("{base}{suffix}");
+                if !taken.contains(&renamed) {
+                    candidate = renamed;
+                    break;
+                }
+                n += 1;
+            }
+        }
+        taken.insert(candidate.clone());
+        assigned.push((candidate, original.to_string()));
+    }
+    assigned
+}
+
+fn object_schema(properties: Value, required: Vec<&str>) -> JsonObject {
+    serde_json::from_value(json!({
+        "type": "object",
+        "properties": properties,
+        "required": required,
+        "additionalProperties": false
+    }))
+    .expect("literal schema is a JSON object")
+}
+
+fn pipeline_tool(tool_name: &str, pipeline_name: &str, entry: &Value) -> Tool {
+    let description = match entry["description"].as_str() {
+        Some(d) if !d.trim().is_empty() => format!("{d} (pipeline `{pipeline_name}`)"),
+        _ => format!("Execute pipeline `{pipeline_name}`"),
+    };
+    let mut properties = serde_json::Map::new();
+    let mut required = Vec::new();
+    if let Some(params) = entry["parameters"].as_array() {
+        for param in params {
+            if let Some(name) = param["name"].as_str() {
+                properties.insert(name.to_string(), param["json_schema"].clone());
+                required.push(name.to_string());
+            }
+        }
+    }
+    let schema: JsonObject = serde_json::from_value(json!({
+        "type": "object",
+        "properties": properties,
+        "required": required,
+        "additionalProperties": false
+    }))
+    .expect("assembled schema is a JSON object");
+    Tool::new(tool_name.to_string(), description, schema)
+}
+
+pub(crate) fn builtin_tools() -> Vec<Tool> {
+    let query_schema = object_schema(
+        json!({
+            "sql": {"type": "string"},
+            "max_rows": {"type": "integer", "description": "Result row cap; server default 1000."},
+            "purpose": {"type": "string", "description": "One line on why you are running this query; recorded in the query audit log."}
+        }),
+        vec!["sql"],
+    );
+    let lds_schema = object_schema(json!({}), vec![]);
+    vec![
+        Tool::new(
+            "query",
+            "Run ad-hoc SQL against Skardi's federated engine. DML is only accepted on data sources configured with access_mode: read_write; DDL is always rejected. Use list_data_sources first to see available tables.",
+            query_schema,
+        ),
+        Tool::new(
+            "list_data_sources",
+            "List Skardi's data sources: tables, column schemas, and plain-English semantic descriptions. Call this before writing ad-hoc SQL with `query`.",
+            lds_schema,
+        ),
+    ]
+}
+
+/// Project the enriched `GET /pipelines` body into (tools, tool→pipeline map).
+pub(crate) fn project(inventory: &Value) -> (Vec<Tool>, HashMap<String, String>) {
+    let entries: HashMap<&str, &Value> = inventory["pipelines"]
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .filter_map(|e| e["name"].as_str().map(|n| (n, e)))
+                .collect()
+        })
+        .unwrap_or_default();
+    let originals: Vec<&str> = entries.keys().copied().collect();
+    let mut tools = Vec::new();
+    let mut map = HashMap::new();
+    for (tool_name, pipeline_name) in assign_tool_names(&originals) {
+        let entry = entries[pipeline_name.as_str()];
+        tools.push(pipeline_tool(&tool_name, &pipeline_name, entry));
+        map.insert(tool_name, pipeline_name);
+    }
+    tools.extend(builtin_tools());
+    (tools, map)
+}
+```
+
+Implementation notes:
+- The `sanitize` truncation is by `char` count via `.take(64)`, but every kept char is ASCII (`_`, `-`, alphanumeric), so char count == byte count and `String::truncate` in the suffix pass can't split a code point.
+- Description fallback text is exactly ``Execute pipeline `<name>` `` per the spec's field-source table; when a real description exists, the original pipeline name is appended in parens (spec: "the original pipeline name is echoed in the tool description so the model can correlate with server-side errors").
+- The collision test expectations above pin the algorithm — if the implementation and test disagree, re-derive from the spec's sanitization section (spec lines 171–186), not from the code.
+
+- [ ] **Step 3: `cargo fmt --all`**
+
+- [ ] **Step 4: Checkpoint** — summarize for Owen.
+
+---
+
+### Task 6: CLI — the bridge (`ServerHandler`) and `mcp::run`
+
+**Files:**
+- Create: `crates/cli/src/mcp/bridge.rs`
+- Modify: `crates/cli/src/mcp/mod.rs` (real `run`, `mod bridge;`)
+- Test: wiremock unit tests inside `bridge.rs`
+
+**Interfaces:**
+- Consumes: `ApiClient::{get, post}` (both return `Result<Value, ApiError>`), `encode_component`, `projection::project`.
+- Produces: `pub(crate) struct McpBridge` with **inherent** async methods `do_list_tools(&self) -> Result<ListToolsResult, McpError>` and `do_call_tool(&self, name: &str, args: Option<JsonObject>) -> Result<CallToolResult, McpError>` — the `ServerHandler` trait impl is a thin wrapper over these, because `RequestContext<RoleServer>` is `#[non_exhaustive]` and cannot be constructed in tests; wiremock tests drive the `do_*` methods directly, and the Task 7 e2e covers the trait wiring.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `bridge.rs`'s test module (pattern: `commands/query.rs:53-183` — local `test_config` helper, `MockServer`, `body_json` matchers):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ClientConfig;
+    use serde_json::json;
+    use wiremock::matchers::{body_json, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn test_config(server: &str) -> ClientConfig {
+        ClientConfig { server: server.to_string(), token: None, context: None }
+    }
+
+    fn bridge(server: &MockServer) -> McpBridge {
+        McpBridge::new(ApiClient::new(&test_config(&server.uri())).unwrap())
+    }
+
+    fn inventory() -> serde_json::Value {
+        json!({"success": true, "count": 1, "data_sources": 0,
+               "pipelines": [{"name": "product-search", "version": "1.0.0",
+                 "endpoint": "/product-search/execute",
+                 "description": "Filter products",
+                 "parameters": [{"name": "brand", "data_type": "Utf8",
+                                 "json_schema": {"type": ["string", "null"]}}]}]})
+    }
+
+    #[tokio::test]
+    async fn list_tools_projects_pipelines_and_builtins() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET")).and(path("/pipelines"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(inventory()))
+            .expect(1).mount(&server).await;
+        let bridge = bridge(&server);
+        let result = bridge.do_list_tools().await.unwrap();
+        let names: Vec<&str> = result.tools.iter().map(|t| t.name.as_ref()).collect();
+        assert!(names.contains(&"product-search"));
+        assert!(names.contains(&"query"));
+        assert!(names.contains(&"list_data_sources"));
+    }
+
+    #[tokio::test]
+    async fn list_tools_maps_connect_failure_to_a_protocol_error() {
+        let bridge = McpBridge::new(
+            ApiClient::new(&test_config("http://127.0.0.1:1")).unwrap(),
+        );
+        let err = bridge.do_list_tools().await.unwrap_err();
+        assert!(err.message.contains("cannot reach skardi-server"), "{}", err.message);
+    }
+
+    #[tokio::test]
+    async fn pipeline_call_posts_flat_body_and_returns_verbatim_json() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET")).and(path("/pipelines"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(inventory()))
+            .mount(&server).await;
+        Mock::given(method("POST")).and(path("/product-search/execute"))
+            .and(body_json(json!({"brand": "acme"})))
+            .respond_with(ResponseTemplate::new(200)
+                .set_body_json(json!({"success": true, "data": [], "rows": 0})))
+            .expect(1).mount(&server).await;
+        let bridge = bridge(&server);
+        bridge.do_list_tools().await.unwrap(); // builds the dispatch map
+        let args = json!({"brand": "acme"}).as_object().cloned();
+        let result = bridge.do_call_tool("product-search", args).await.unwrap();
+        assert_eq!(result.is_error, Some(false));
+    }
+
+    #[tokio::test]
+    async fn unknown_tool_is_a_protocol_error_nudging_a_relist() {
+        let server = MockServer::start().await;
+        let bridge = bridge(&server);
+        let err = bridge.do_call_tool("nope", None).await.unwrap_err();
+        assert!(err.message.contains("unknown tool"), "{}", err.message);
+        assert!(err.message.contains("tools/list"), "{}", err.message);
+    }
+
+    #[tokio::test]
+    async fn query_with_purpose_sends_ai_context_with_a_stable_session_id() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST")).and(path("/query"))
+            .respond_with(ResponseTemplate::new(200)
+                .set_body_json(json!({"success": true, "data": [], "rows": 0})))
+            .expect(2).mount(&server).await;
+        let bridge = bridge(&server);
+        for _ in 0..2 {
+            let args = json!({"sql": "select 1", "purpose": "why"}).as_object().cloned();
+            bridge.do_call_tool("query", args).await.unwrap();
+        }
+        let requests = server.received_requests().await.unwrap();
+        let bodies: Vec<serde_json::Value> = requests.iter()
+            .map(|r| serde_json::from_slice(&r.body).unwrap()).collect();
+        let sid0 = bodies[0]["ai_context"]["session_id"].as_str().unwrap();
+        let sid1 = bodies[1]["ai_context"]["session_id"].as_str().unwrap();
+        assert_eq!(sid0, sid1);
+        assert_eq!(bodies[0]["ai_context"]["purpose"], json!("why"));
+    }
+
+    #[tokio::test]
+    async fn query_without_purpose_omits_ai_context_entirely() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST")).and(path("/query"))
+            .and(body_json(json!({"sql": "select 1", "max_rows": 5})))
+            .respond_with(ResponseTemplate::new(200)
+                .set_body_json(json!({"success": true, "data": [], "rows": 0})))
+            .expect(1).mount(&server).await;
+        let bridge = bridge(&server);
+        let args = json!({"sql": "select 1", "max_rows": 5}).as_object().cloned();
+        let result = bridge.do_call_tool("query", args).await.unwrap();
+        assert_eq!(result.is_error, Some(false));
+    }
+
+    #[tokio::test]
+    async fn server_error_becomes_is_error_tool_result_with_error_type() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST")).and(path("/query"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+                "success": false, "error": "Missing required parameters: brand",
+                "error_type": "parameter_validation_error"})))
+            .mount(&server).await;
+        let bridge = bridge(&server);
+        let args = json!({"sql": "select 1"}).as_object().cloned();
+        let result = bridge.do_call_tool("query", args).await.unwrap();
+        assert_eq!(result.is_error, Some(true));
+        let text = serde_json::to_string(&result.content).unwrap();
+        assert!(text.contains("parameter_validation_error"), "{text}");
+    }
+
+    #[tokio::test]
+    async fn list_data_sources_proxies_get_data_source_verbatim() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET")).and(path("/data_source"))
+            .respond_with(ResponseTemplate::new(200)
+                .set_body_json(json!({"success": true, "data": [], "count": 0})))
+            .expect(1).mount(&server).await;
+        let bridge = bridge(&server);
+        let result = bridge.do_call_tool("list_data_sources", None).await.unwrap();
+        assert_eq!(result.is_error, Some(false));
+    }
+}
+```
+
+(Adjust field-access details — `ErrorData.message` is `Cow<'static, str>`; `result.content` serialization — as the compiler demands, keeping the assertions' meaning.)
+
+- [ ] **Step 2: Implement the bridge**
+
+```rust
+//! MCP ⇄ REST bridge: a manual `ServerHandler` whose tools come from the
+//! server's pipeline inventory at list time. All REST I/O goes through the
+//! CLI's `ApiClient`; stdout belongs to the JSON-RPC transport, so nothing
+//! here may print to it.
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use rmcp::ErrorData as McpError;
+use rmcp::ServerHandler;
+use rmcp::model::{
+    CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, Implementation,
+    JsonObject, ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
+};
+use rmcp::service::{RequestContext, RoleServer};
+use serde_json::Value;
+
+use crate::client::{ApiClient, ApiError, encode_component};
+use crate::mcp::projection;
+
+const INSTRUCTIONS: &str = "Skardi is a federated SQL data plane: operator-defined \
+pipelines plus an ad-hoc SQL engine over the configured data sources. Prefer the \
+pipeline tools for tasks they cover. Before writing ad-hoc SQL with `query`, call \
+`list_data_sources` to see tables, schemas, and their plain-English descriptions.";
+
+pub(crate) struct McpBridge {
+    client: ApiClient,
+    /// tool name → original pipeline name; rebuilt on every tools/list.
+    tool_map: RwLock<HashMap<String, String>>,
+    /// One UUID per MCP connection; sent as ai_context.session_id when the
+    /// model provides a `purpose`. This is the v1 agent-identity seam.
+    session_id: String,
+}
+
+impl McpBridge {
+    pub(crate) fn new(client: ApiClient) -> Self {
+        McpBridge {
+            client,
+            tool_map: RwLock::new(HashMap::new()),
+            session_id: uuid::Uuid::new_v4().to_string(),
+        }
+    }
+
+    pub(crate) async fn do_list_tools(&self) -> Result<ListToolsResult, McpError> {
+        let inventory = self
+            .client
+            .get("/pipelines")
+            .await
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        let (tools, map) = projection::project(&inventory);
+        *self.tool_map.write().expect("tool map lock") = map;
+        Ok(ListToolsResult::with_all_items(tools))
+    }
+
+    pub(crate) async fn do_call_tool(
+        &self,
+        name: &str,
+        args: Option<JsonObject>,
+    ) -> Result<CallToolResult, McpError> {
+        let outcome = match name {
+            "query" => self.call_query(args).await,
+            "list_data_sources" => self.client.get("/data_source").await,
+            _ => {
+                let pipeline = self.tool_map.read().expect("tool map lock").get(name).cloned();
+                match pipeline {
+                    Some(pipeline) => {
+                        let body = Value::Object(args.unwrap_or_default());
+                        let path = format!("/{}/execute", encode_component(&pipeline));
+                        self.client.post(&path, &body).await
+                    }
+                    None => {
+                        return Err(McpError::invalid_params(
+                            format!(
+                                "unknown tool '{name}' — the pipeline inventory may have \
+                                 changed; re-issue tools/list to refresh it"
+                            ),
+                            None,
+                        ));
+                    }
+                }
+            }
+        };
+        Ok(match outcome {
+            // Success: the response JSON verbatim, no client-side reshaping.
+            Ok(value) => CallToolResult::success(vec![ContentBlock::text(value.to_string())]),
+            // Execution errors are for the model to see and react to, not
+            // protocol errors: ApiError's Display already carries the
+            // server's message and error_type.
+            Err(err) => CallToolResult::error(vec![ContentBlock::text(err.to_string())]),
+        })
+    }
+
+    /// The one choke-point that assembles the query body; later versions
+    /// extend this to full identity injection without touching call sites.
+    async fn call_query(&self, args: Option<JsonObject>) -> Result<Value, ApiError> {
+        let args = args.unwrap_or_default();
+        let mut body = serde_json::Map::new();
+        for key in ["sql", "max_rows"] {
+            if let Some(v) = args.get(key) {
+                body.insert(key.to_string(), v.clone());
+            }
+        }
+        if let Some(purpose) = args.get("purpose").and_then(Value::as_str) {
+            let purpose = purpose.trim();
+            if !purpose.is_empty() {
+                body.insert(
+                    "ai_context".to_string(),
+                    serde_json::json!({"purpose": purpose, "session_id": self.session_id}),
+                );
+            }
+        }
+        self.client.post("/query", &Value::Object(body)).await
+    }
+}
+
+impl ServerHandler for McpBridge {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::new("skardi", env!("CARGO_PKG_VERSION")))
+            .with_instructions(INSTRUCTIONS)
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, McpError> {
+        self.do_list_tools().await
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResponse, McpError> {
+        self.do_call_tool(&request.name, request.arguments)
+            .await
+            .map(CallToolResponse::from)
+    }
+}
+```
+
+Adjust to what rmcp 3.1.4 actually exports (paths verified against docs.rs/rmcp/3.1.4 during research, but re-check on first compile): `McpError` is `rmcp::model::ErrorData` re-exported at crate root as `ErrorData`; `RequestContext`/`RoleServer` live under `rmcp::service`; `ServerInfo::new` / `with_server_info` / `with_instructions` are the constructor chain; trait methods are RPITIT so plain `async fn` implementations work.
+
+- [ ] **Step 3: Implement `mcp::run` in `mod.rs`**
+
+```rust
+//! `skardi mcp` — serve MCP over stdio, proxying every tool call to a
+//! running skardi-server over REST. The host (Claude Desktop, Cursor, ...)
+//! spawns this subcommand as a long-lived child process.
+
+mod bridge;
+mod projection;
+
+use rmcp::ServiceExt;
+use rmcp::transport::stdio;
+
+use crate::client::ApiClient;
+
+pub async fn run(client: ApiClient) -> anyhow::Result<()> {
+    let service = bridge::McpBridge::new(client)
+        .serve(stdio())
+        .await
+        .map_err(|e| anyhow::anyhow!("MCP initialize handshake failed: {e}"))?;
+    // Runs until the host closes stdin (or cancels); in-flight request tasks
+    // die with the process — nobody is left to read their results.
+    service.waiting().await?;
+    Ok(())
+}
+```
+
+Exit behavior: `waiting()` returning `QuitReason::Closed` falls through to `Ok(())` → exit 0, satisfying the decided lifecycle. Concurrency needs no code: rmcp spawns a task per incoming request.
+
+- [ ] **Step 4: `cargo fmt --all`**
+
+- [ ] **Step 5: Checkpoint** — summarize for Owen.
+
+---
+
+### Task 7: End-to-end spawned-binary test
+
+Guards the "stdout is protocol-only" invariant permanently: any stray stdout print breaks the initialize handshake.
+
+**Files:**
+- Create: `crates/cli/tests/mcp_e2e.rs`
+
+**Interfaces:**
+- Consumes: `env!("CARGO_BIN_EXE_skardi")`; rmcp dev-features `client` + `transport-child-process`; wiremock.
+
+- [ ] **Step 1: Write the test file**
+
+```rust
+//! End-to-end: spawn the real `skardi mcp` binary and speak MCP to it over
+//! stdio with an rmcp client, against a wiremock "server". Also the
+//! permanent guard for the stdout-is-protocol-only invariant — any stray
+//! print to stdout breaks the initialize handshake below.
+#![cfg(unix)]
+
+use rmcp::ServiceExt;
+use rmcp::model::CallToolRequestParams;
+use rmcp::transport::{ConfigureCommandExt, TokioChildProcess};
+use serde_json::json;
+use wiremock::matchers::{body_json, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn spawn_transport(server_url: &str, home: &std::path::Path) -> TokioChildProcess {
+    TokioChildProcess::new(tokio::process::Command::new(env!("CARGO_BIN_EXE_skardi")).configure(
+        |cmd| {
+            cmd.env("HOME", home)
+                .env_remove("SKARDI_SERVER_URL")
+                .env_remove("SKARDI_API_TOKEN")
+                .env_remove("SKARDI_CONTEXT")
+                .args(["mcp", "--server", server_url]);
+        },
+    ))
+    .expect("spawn skardi mcp")
+}
+
+fn inventory() -> serde_json::Value {
+    json!({"success": true, "count": 1, "data_sources": 0,
+           "pipelines": [{"name": "product-search", "version": "1.0.0",
+             "endpoint": "/product-search/execute",
+             "description": "Filter products by brand",
+             "parameters": [{"name": "brand", "data_type": "Utf8",
+                             "json_schema": {"type": ["string", "null"]}}]}]})
+}
+
+#[tokio::test]
+async fn initialize_list_and_call_round_trip() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET")).and(path("/pipelines"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(inventory()))
+        .mount(&server).await;
+    Mock::given(method("POST")).and(path("/product-search/execute"))
+        .and(body_json(json!({"brand": "acme"})))
+        .respond_with(ResponseTemplate::new(200)
+            .set_body_json(json!({"success": true, "data": [{"id": 1}], "rows": 1})))
+        .expect(1).mount(&server).await;
+
+    let home = tempfile::TempDir::new().unwrap();
+    let client = ()
+        .serve(spawn_transport(&server.uri(), home.path()))
+        .await
+        .expect("initialize handshake (fails on any stray stdout output)");
+
+    let info = client.peer_info().expect("server info");
+    assert!(info.capabilities.tools.is_some());
+
+    let tools = client.list_all_tools().await.unwrap();
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+    assert!(names.contains(&"product-search"), "{names:?}");
+    assert!(names.contains(&"query"), "{names:?}");
+    assert!(names.contains(&"list_data_sources"), "{names:?}");
+
+    let result = client
+        .call_tool(CallToolRequestParams {
+            name: "product-search".into(),
+            arguments: json!({"brand": "acme"}).as_object().cloned(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(result.is_error, Some(false));
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn unreachable_server_fails_list_tools_but_not_the_handshake() {
+    let home = tempfile::TempDir::new().unwrap();
+    // Nothing listens on port 1: the handshake still succeeds (no REST call
+    // is needed for initialize); tools/list surfaces the connect error.
+    let client = ()
+        .serve(spawn_transport("http://127.0.0.1:1", home.path()))
+        .await
+        .expect("handshake needs no server");
+    let err = client.list_all_tools().await.unwrap_err();
+    let msg = format!("{err}");
+    assert!(msg.contains("cannot reach skardi-server"), "{msg}");
+    client.cancel().await.unwrap();
+}
+```
+
+(Verify against rmcp 3.1.4's actual client API on first compile: `peer_info()` field paths, `list_all_tools`, the error's Display. Adjust assertion plumbing, not assertion meaning. If `ServerInfo`'s instructions are reachable via `peer_info()`, also assert they're non-empty.)
+
+- [ ] **Step 2: `cargo fmt --all`**
+
+- [ ] **Step 3: Checkpoint** — summarize for Owen; good point to push the branch and let CI run everything so far.
+
+---
+
+### Task 8: Documentation
+
+**Files:**
+- Create: `docs/mcp.md`
+- Modify: `docs/cli.md` (new `## MCP — \`skardi mcp\`` section between `## Jobs` (ends ~line 467) and `## Exit codes` (line 468))
+- Modify: `docs/pipelines.md:18` (MCP bullet: "(v1.1 roadmap)" → shipped, link `mcp.md`)
+- Modify: `README.md` §4 (~lines 113-124): "One definition, both bindings" copy now covers three bindings; add a `skardi mcp` line to the example block's comment or adjacent text
+- Modify: `docs/superpowers/specs/2026-08-13-mcp-stdio-binding-design.md` — move the three "Open decisions" to the "Decided" section, dated 2026-08-25, with the chosen values; correct the two stale doc-task facts (agent_data_plane.md gone; README roadmap gone)
+
+**Interfaces:** none (prose).
+
+- [ ] **Step 1: Write `docs/mcp.md`**
+
+Sections (per spec's doc list, plus the decided lifecycle notes):
+- **What it is** — third agent-facing binding; architecture one-liner + the host-spawns-bridge diagram from the spec.
+- **Host setup** — Claude Desktop `claude_desktop_config.json` example (verbatim from the spec, lines 112-121) and a Cursor `mcpServers` example; note config resolution is identical to every other subcommand (flag → env → `~/.skardi/config.yaml`), and pointing `--server` at a remote skardi-server makes the bridge a local MCP gateway to it. Note: cloud contexts are refused (the gateway doesn't serve pipeline execution or `/data_source`).
+- **Tool surface** — pipeline tools (name sanitization + collision rules in two sentences; description fallback), `query` (schema incl. `purpose` → audit log), `list_data_sources`.
+- **Freshness** — inventory fetched on every `tools/list`; hosts that never re-list keep their snapshot; no `listChanged` in v1.
+- **Auth notes** — Bearer token inherited from CLI config; `list_data_sources` and the pipeline inventory are readable without a token on today's server (existing REST behavior — deployments with sensitive semantics should weigh `/data_source` and `/pipelines` together).
+- **Timeouts & lifecycle** — no bridge-side request timeout: a hung server hangs the tool call until the host's own tool-call timeout fires; bridge exits 0 when the host closes stdin; concurrent tool calls are served in parallel.
+- **Troubleshooting** — "server unreachable" error text and the three config knobs; stdout purity (don't wrap the command in anything that prints); result size (query capped by `max_rows`, pipeline executions uncapped server-side, 256 MB client ceiling).
+
+- [ ] **Step 2: Update `docs/cli.md`**
+
+New section with: one-paragraph description, the Claude Desktop config block, a note that `skardi mcp` takes no subcommand-specific flags (global `--server`/`--token`/`--context` apply), link to `mcp.md` for the tool surface, and a sentence in **Exit codes** context: resolution/handshake failures follow the existing exit-code contract (2 = unreachable applies only to errors surfaced before serving; after serving starts, REST failures are reported in-band as tool errors).
+
+- [ ] **Step 3: Update `docs/pipelines.md`, `README.md`, and the spec's Decided section**
+
+- pipelines.md line 18: `- **MCP tools** — same YAML projected to MCP tools for non-Claude hosts via \`skardi mcp\` — see [mcp.md](mcp.md).`
+- README §4: change "One definition, both bindings" to cover MCP (e.g. "One definition, every binding — shell, REST, and MCP") and add one comment line to the code block: `# MCP — hosts without a shell (Claude Desktop, …): skardi mcp`. Keep the section's shape; minimal edit.
+- Spec: append to `## Decided`:
+  - `purpose` on `query`: **included** (2026-08-25).
+  - Built-in tool naming: **unprefixed** `query` / `list_data_sources` (2026-08-25).
+  - Lifecycle: concurrent calls **yes** (rmcp default), stdin close → **exit 0**, request timeout — **none in the bridge**, host timeout is the backstop, documented in docs/mcp.md (2026-08-25).
+  Delete the now-resolved `## Open decisions` section (or annotate each item "→ Decided, see above").
+
+- [ ] **Step 4: Check links** — CI's `Markdown links` job validates relative links and anchors; make sure `docs/mcp.md` exists before anything links to it and anchors match exactly.
+
+- [ ] **Step 5: `cargo fmt --all`** (no-op for docs, run anyway as the pre-push habit)
+
+- [ ] **Step 6: Final checkpoint** — full-branch summary for Owen; Owen commits/pushes; verification happens on GitHub CI.
+
+---
+
+## Self-review notes (spec coverage)
+
+- Spec §Tool projection (sanitization, collision, reserved names, fallback description, schema assembly, VALUES override) → Tasks 2, 5.
+- Spec §Server-side change Option A (both endpoints, json_schema fragments, tests in crates/server) → Tasks 2, 3. The shared-regex "ideally" → Task 1.
+- Spec §Built-in tools incl. `purpose`/`ai_context` seam → Tasks 5, 6.
+- Spec §Freshness (fetch per list_tools, rebuild map) → Task 6.
+- Spec §Execution flow & error mapping (flat body, verbatim success JSON, isError for REST failures, protocol error for unknown tool naming tools/list, connect-error wording via ApiError Display) → Task 6.
+- Spec §Testing (projection unit tests in cli, mapping tests in server, wiremock bridge tests, spawned-binary e2e guarding stdout purity) → Tasks 2, 3, 5, 6, 7.
+- Spec §Documentation updates → Task 8 (two items corrected against the current tree; noted in header).
+- Spec §Non-goals — nothing here implements HTTP transport, jobs tools, OAuth, listChanged, resources, prompts, or per-parameter YAML descriptions.
+- Not in spec, forced by the tree: `Capability::Mcp` cloud gating (Task 4) — the dispatch pipeline requires every command to declare a capability; `Mcp` is not gateway-served.

--- a/docs/superpowers/specs/2026-08-13-mcp-stdio-binding-design.md
+++ b/docs/superpowers/specs/2026-08-13-mcp-stdio-binding-design.md
@@ -434,11 +434,13 @@ here needs `#[ignore]`, as all tests are self-contained.
 - `docs/cli.md` — new `mcp` subcommand section with host config examples.
 - `docs/pipelines.md` — MCP moves from "v1.1 roadmap" to shipped in the
   surfaces list.
-- `README.md` — check the roadmap `5` MCP box; revise "MCP-soon" phrasing.
+- `README.md` — §4 "One definition, both bindings" copy now covers three
+  bindings. (The roadmap checkboxes and "MCP-soon" phrasing this item
+  originally targeted were removed by the #205 repositioning.)
 - New `docs/mcp.md` — host setup (Claude Desktop, Cursor), tool surface,
   auth notes, troubleshooting.
-- `docs/agent_data_plane.md` — MCP binding status + the identity-seam
-  paragraph gets its "first carrier" footnote (`ai_context` via `query`).
+- ~~`docs/agent_data_plane.md`~~ — removed from the tree by #205; no longer
+  applicable.
 
 ## Non-goals (v1)
 
@@ -467,21 +469,14 @@ here needs `#[ignore]`, as all tests are self-contained.
   "Server-side change". This is a required change to `crates/server`, not
   deferred — the zero-server-change alternative (Option B) is rejected and
   kept in that section only for the record.
-
-## Open decisions
-
-1. **`purpose` parameter on `query`** — include as optional (recommended,
-   as specced) or omit entirely from v1.
-2. **Built-in tool naming** — `query` / `list_data_sources` as specced, or
-   e.g. `skardi_query` prefixing to reduce collision odds with user
-   pipeline names (recommendation: unprefixed; MCP hosts already namespace
-   tools per server, and reserved-name suffixing covers the edge).
-3. **Bridge lifecycle knobs** — three currently-implicit choices to pin at
-   implementation time: whether concurrent `tools/call` requests are served
-   in parallel as rmcp dispatches them (recommendation: yes — a slow
-   `query` must not block `list_tools`); what happens on stdin close
-   (recommendation: abort in-flight REST calls, exit 0); and whether the
-   bridge sets a request timeout — `ApiClient` builds its reqwest client
-   with **no timeout today**, so a hung server hangs the tool call until
-   the host's own tool-call timeout fires (recommendation: rely on the
-   host's timeout in v1 and say so in docs/mcp.md).
+- **`purpose` parameter on `query`: included** (2026-08-25) — optional
+  string, sent as `ai_context: {purpose, session_id}` with one v4 UUID per
+  MCP connection as the session id; omitted entirely when not provided.
+- **Built-in tool naming: unprefixed** `query` / `list_data_sources`
+  (2026-08-25) — MCP hosts already namespace tools per server, and
+  reserved-name suffixing (`_pipeline`) covers the collision edge.
+- **Bridge lifecycle** (2026-08-25) — concurrent `tools/call` requests are
+  served in parallel (rmcp's default per-request task spawn); stdin close →
+  exit 0 (in-flight REST calls die with the process); no bridge-side
+  request timeout — the host's tool-call timeout is the backstop,
+  documented in docs/mcp.md.


### PR DESCRIPTION
Implements the MCP stdio binding per `docs/superpowers/specs/2026-08-13-mcp-stdio-binding-design.md`: a new `skardi mcp` subcommand serving MCP over stdio as an MCP ⇄ REST bridge, plus the spec's Option A server-side inventory enrichment.

## What changed

- **skardi**: the multi-row `VALUES {name}` detection regex is hoisted into a shared `VALUES_PLACEHOLDER_RE` export (two inline call sites now use it; behavior unchanged).
- **server (Option A)**: `GET /pipelines` items gain `description` + `parameters` with complete per-param `json_schema` fragments; `GET /pipeline/:name` params gain `data_type` + `json_schema` next to the existing Debug-dump `type` field (additive). New `param_schema` module maps Arrow DataTypes → JSON Schema with an unconditional null union; `VALUES` params become array-of-arrays. Params emit in name order for deterministic responses.
- **cli**: new `mcp` module — `projection.rs` (tool-name sanitization `^[a-zA-Z0-9_-]{1,64}$`, sorted-order `_2`/`_3` collision suffixing, `_pipeline` suffix for pipelines shadowing built-ins, schema assembly) and `bridge.rs` (rmcp 3.1.4 `ServerHandler`; inventory re-fetched on every `tools/list`; REST failures surface in-band as `isError` tool results; success bodies pass through verbatim). Built-ins: `query` (optional `purpose` → `ai_context {purpose, session_id}`, one UUID per connection) and `list_data_sources`. Stdin close → exit 0; no bridge-side timeout (host timeout is the backstop); concurrent calls run in parallel.
- **docs**: new `docs/mcp.md` (host setup, tool surface, freshness, auth, lifecycle, troubleshooting); `cli.md` `## MCP` section; `pipelines.md` MCP bullet roadmap → shipped; README §4 "One definition, every binding"; spec's three open decisions moved to Decided (2026-08-25).

## Decisions resolved with Owen (2026-08-25)

- `purpose` param on `query`: **included** (optional; omitted from the request body entirely when absent).
- Built-in tool naming: **unprefixed** `query` / `list_data_sources`.
- Lifecycle: concurrent `tools/call` **yes** (rmcp default), stdin close → **exit 0**, **no bridge request timeout** (documented in docs/mcp.md).

## Notes for review (out-of-spec implementation decisions)

1. **`Capability::Mcp`**: the dispatch pipeline requires every command to declare a capability; cloud contexts refuse `skardi mcp` before serving (the gateway serves neither pipeline execution nor `/data_source`).
2. **Inherent `do_*` methods**: rmcp's `RequestContext` is `#[non_exhaustive]` and unconstructible in tests, so the logic lives in inherent methods with thin trait wrappers.
3. **`eprintln!` instead of tracing**: the CLI has no logging framework; the spec's tracing/env_logger wording is downgraded to stderr prints (stdout is the protocol channel and stays untouched).
4. **Name-sorted parameter emission** on the server, so responses and tests are deterministic.
5. The old `type` Debug-dump field on `GET /pipeline/:name` is kept verbatim; new info rides the added fields.

## Testing

Per house convention nothing was run locally except `cargo fmt` — verification is this PR's CI. Coverage added: param_schema unit tests, extended + 2 new server HTTP tests, 7 projection unit tests, 8 wiremock bridge tests, a cloud-gating test, and a spawned-binary e2e that walks the full MCP handshake over stdio (doubling as the permanent guard for the stdout-is-protocol-only invariant). The local markdown-link checker flags `mcp.md` links only because it validates against `git ls-files` — resolved by these commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)