### PR TITLE
docs(readme): name the agent hosts the skill runs on

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ turns a folder of documents — or a datastore you already run — into governed
 searchable context served over HTTP by `skardi-server`: hybrid search (vector +
 FTS + RRF), defaulting to a local SQLite file the skill creates and owns, or
 pointed at Postgres + pgvector, MongoDB, or Lance. The same skill also runs on
-Codex, Cursor, Pi, OpenClaw, and Hermes; per-host installation instructions are in
-the [skardi-skills README](https://github.com/SkardiLabs/skardi-skills#installation).
+Codex, Cursor, Pi, dsh, OpenClaw, and Hermes; per-host installation instructions
+are in the [skardi-skills README](https://github.com/SkardiLabs/skardi-skills#installation).
 
 **CLI** — pre-built for `x86_64`/`aarch64` Linux and Apple Silicon (Intel Macs:
 build from source — the one-liner below has no published artifact there):

--- a/README.md
+++ b/README.md
@@ -175,9 +175,8 @@ you:
 turns a folder of documents — or a datastore you already run — into governed,
 searchable context served over HTTP by `skardi-server`: hybrid search (vector +
 FTS + RRF), defaulting to a local SQLite file the skill creates and owns, or
-pointed at Postgres + pgvector, MongoDB, or Lance. The same skill runs on Codex,
-Cursor, Pi, dsh, OpenClaw, and Hermes — anything that speaks the
-[Agent Skills](https://agentskills.io/) standard. Per-host install paths are in
+pointed at Postgres + pgvector, MongoDB, or Lance. The same skill also runs on
+Codex, Cursor, Pi, OpenClaw, and Hermes; per-host installation instructions are in
 the [skardi-skills README](https://github.com/SkardiLabs/skardi-skills#installation).
 
 **CLI** — pre-built for `x86_64`/`aarch64` Linux and Apple Silicon (Intel Macs:

--- a/README.md
+++ b/README.md
@@ -175,9 +175,10 @@ you:
 turns a folder of documents — or a datastore you already run — into governed,
 searchable context served over HTTP by `skardi-server`: hybrid search (vector +
 FTS + RRF), defaulting to a local SQLite file the skill creates and owns, or
-pointed at Postgres + pgvector, MongoDB, or Lance. For Cursor and other
-[Agent Skills](https://agentskills.io/)-compatible hosts, see the
-[skardi-skills README](https://github.com/SkardiLabs/skardi-skills#installation).
+pointed at Postgres + pgvector, MongoDB, or Lance. The same skill runs on Codex,
+Cursor, Pi, dsh, OpenClaw, and Hermes — anything that speaks the
+[Agent Skills](https://agentskills.io/) standard. Per-host install paths are in
+the [skardi-skills README](https://github.com/SkardiLabs/skardi-skills#installation).
 
 **CLI** — pre-built for `x86_64`/`aarch64` Linux and Apple Silicon (Intel Macs:
 build from source — the one-liner below has no published artifact there):


### PR DESCRIPTION
## What

The Install section said the skill runs on Claude Code, then sent everyone else
away with "For Cursor and other Agent Skills-compatible hosts, see the
skardi-skills README." A reader on Codex or OpenClaw had no way to tell from
this page whether the skill was for them.

It now names the hosts — Codex, Cursor, Pi, dsh, OpenClaw, Hermes — and still
sends the per-host directories to skardi-skills, so this section does not grow.
Net change is one sentence.

## Companion PR

The install paths themselves land in
SkardiLabs/skardi-skills#29 — that PR carries the per-host
directories and the verification notes. Merging this one first would point at a
section that does not exist yet, so land the skills PR first.
