### PR TITLE
refactor(sources): lift the shared pack-test Arrow/SQL accessors into testutil

### DIFF
--- a/crates/skardi/src/sources/providers/open_connector/packs/discord.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/discord.rs
@@ -110,14 +110,14 @@ mod tests {
     use crate::sources::providers::open_connector::row_path::RowPath;
     use crate::sources::providers::open_connector::source_pack::SourcePackTable;
     use crate::sources::providers::open_connector::testutil::{
-        EnvVarGuard, MockGateway, MockResponse, RecordedRequest, boolean, collect, discovery_ok,
-        envelope_ok, fingerprint_uncovered_columns, utf8,
+        EnvVarGuard, MockGateway, MockResponse, RecordedRequest, boolean, collect, column_values,
+        discovery_ok, envelope_ok, execute_inputs, fingerprint_uncovered_columns, utf8,
     };
     use crate::sources::providers::open_connector::{
         OpenConnectorConfig, OpenConnectorGateways, register_open_connector_tables,
         register_open_connector_udtfs,
     };
-    use arrow::array::{Array, ListArray, StringArray, UInt64Array};
+    use arrow::array::{Array, ListArray, UInt64Array};
     use arrow::record_batch::RecordBatch;
     use datafusion::prelude::SessionContext;
     use serde_json::{Value, json};
@@ -525,18 +525,6 @@ bindings:
         (gateway, ctx)
     }
 
-    fn execute_inputs(gateway: &MockGateway) -> Vec<Value> {
-        gateway
-            .requests()
-            .into_iter()
-            .filter(|r| r.method == "POST")
-            .map(|r| {
-                serde_json::from_str::<Value>(&r.body).expect("request body is JSON")["input"]
-                    .clone()
-            })
-            .collect()
-    }
-
     fn sorted_keys(input: &Value) -> Vec<String> {
         let mut keys: Vec<String> = input
             .as_object()
@@ -596,19 +584,11 @@ bindings:
         let batches = collect(&ctx, "SELECT id FROM saas.me.guilds").await;
         // Row identity, not just cardinality: the exact ids of both pages
         // survive, in wire order, with no duplicate and no boundary drop.
-        let ids: Vec<String> = batches
-            .iter()
-            .flat_map(|b| {
-                let col: &StringArray = b.column(0).as_any().downcast_ref().expect("Utf8 ids");
-                (0..col.len())
-                    .map(|i| col.value(i).to_string())
-                    .collect::<Vec<_>>()
-            })
-            .collect();
+        let ids = column_values(&batches, "id");
         let expected: Vec<String> = (1..=201).map(|i| format!("g-{i:04}")).collect();
         assert_eq!(ids, expected, "both pages scanned, boundary row intact");
 
-        let inputs = execute_inputs(&gateway);
+        let inputs = execute_inputs(&gateway, "");
         // Three requests: two row pages plus the terminating empty page —
         // the standard keyset tax.
         assert_eq!(inputs.len(), 3, "two row pages plus the empty terminator");
@@ -673,7 +653,7 @@ bindings:
         let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
         assert_eq!(rows, 5, "LIMIT truncates the first page");
         assert_eq!(
-            execute_inputs(&gateway).len(),
+            execute_inputs(&gateway, "").len(),
             1,
             "a satisfied LIMIT issues exactly one request — no empty terminator"
         );
@@ -849,7 +829,7 @@ bindings:
         let batches = collect(&ctx, "SELECT connection_type FROM saas.me.connections").await;
         assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 1);
 
-        let inputs = execute_inputs(&gateway);
+        let inputs = execute_inputs(&gateway, "");
         assert_eq!(inputs.len(), 1, "single_page = exactly one request");
         // The EXACT key set is empty: the action declares no inputs, and
         // single_page injects none — a stray key would be a strict-schema
@@ -890,18 +870,10 @@ bindings:
 
         // Row identity in wire order, not cardinality.
         let batches = collect(&ctx, "SELECT id FROM saas.me.sticker_packs").await;
-        let ids: Vec<String> = batches
-            .iter()
-            .flat_map(|b| {
-                let col: &StringArray = b.column(0).as_any().downcast_ref().expect("Utf8 ids");
-                (0..col.len())
-                    .map(|i| col.value(i).to_string())
-                    .collect::<Vec<_>>()
-            })
-            .collect();
+        let ids = column_values(&batches, "id");
         assert_eq!(ids, ["sp-2", "sp-1"]);
 
-        let inputs = execute_inputs(&gateway);
+        let inputs = execute_inputs(&gateway, "");
         assert_eq!(inputs.len(), 1, "single_page = exactly one request");
         assert_eq!(sorted_keys(&inputs[0]), Vec::<String>::new());
     }

--- a/crates/skardi/src/sources/providers/open_connector/packs/discord.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/discord.rs
@@ -110,14 +110,14 @@ mod tests {
     use crate::sources::providers::open_connector::row_path::RowPath;
     use crate::sources::providers::open_connector::source_pack::SourcePackTable;
     use crate::sources::providers::open_connector::testutil::{
-        EnvVarGuard, MockGateway, MockResponse, RecordedRequest, discovery_ok, envelope_ok,
-        fingerprint_uncovered_columns,
+        EnvVarGuard, MockGateway, MockResponse, RecordedRequest, boolean, collect, discovery_ok,
+        envelope_ok, fingerprint_uncovered_columns, utf8,
     };
     use crate::sources::providers::open_connector::{
         OpenConnectorConfig, OpenConnectorGateways, register_open_connector_tables,
         register_open_connector_udtfs,
     };
-    use arrow::array::{Array, BooleanArray, ListArray, StringArray, UInt64Array};
+    use arrow::array::{Array, ListArray, StringArray, UInt64Array};
     use arrow::record_batch::RecordBatch;
     use datafusion::prelude::SessionContext;
     use serde_json::{Value, json};
@@ -141,24 +141,6 @@ mod tests {
             .expect("converter")
             .convert(rows, 1)
             .expect("fixture converts")
-    }
-
-    fn utf8<'a>(batch: &'a RecordBatch, name: &str) -> &'a StringArray {
-        batch
-            .column_by_name(name)
-            .unwrap_or_else(|| panic!("column {name}"))
-            .as_any()
-            .downcast_ref()
-            .expect("Utf8 column")
-    }
-
-    fn boolean<'a>(batch: &'a RecordBatch, name: &str) -> &'a BooleanArray {
-        batch
-            .column_by_name(name)
-            .unwrap_or_else(|| panic!("column {name}"))
-            .as_any()
-            .downcast_ref()
-            .expect("Boolean column")
     }
 
     fn uint64<'a>(batch: &'a RecordBatch, name: &str) -> &'a UInt64Array {
@@ -541,15 +523,6 @@ bindings:
         .expect("gateway registration succeeds");
         register_open_connector_udtfs(&ctx, gateways).expect("UDTF registration succeeds");
         (gateway, ctx)
-    }
-
-    async fn collect(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch> {
-        ctx.sql(sql)
-            .await
-            .expect("plan")
-            .collect()
-            .await
-            .expect("collect")
     }
 
     fn execute_inputs(gateway: &MockGateway) -> Vec<Value> {

--- a/crates/skardi/src/sources/providers/open_connector/packs/feishu.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/feishu.rs
@@ -110,14 +110,14 @@ mod tests {
     use crate::sources::providers::open_connector::row_path::RowPath;
     use crate::sources::providers::open_connector::source_pack::SourcePackTable;
     use crate::sources::providers::open_connector::testutil::{
-        EnvVarGuard, MockGateway, MockResponse, discovery_ok, envelope_ok,
-        fingerprint_uncovered_columns,
+        EnvVarGuard, MockGateway, MockResponse, boolean, collect, discovery_ok, envelope_ok,
+        fingerprint_uncovered_columns, utf8,
     };
     use crate::sources::providers::open_connector::{
         OpenConnectorConfig, OpenConnectorGateways, register_open_connector_tables,
         register_open_connector_udtfs,
     };
-    use arrow::array::{Array, BooleanArray, StringArray, TimestampMillisecondArray};
+    use arrow::array::{Array, StringArray, TimestampMillisecondArray};
     use arrow::record_batch::RecordBatch;
     use datafusion::prelude::SessionContext;
     use serde_json::{Value, json};
@@ -168,24 +168,6 @@ mod tests {
             .expect("converter")
             .convert(rows, 1)
             .expect("fixture converts")
-    }
-
-    fn utf8<'a>(batch: &'a RecordBatch, name: &str) -> &'a StringArray {
-        batch
-            .column_by_name(name)
-            .unwrap_or_else(|| panic!("column {name}"))
-            .as_any()
-            .downcast_ref()
-            .expect("Utf8 column")
-    }
-
-    fn boolean<'a>(batch: &'a RecordBatch, name: &str) -> &'a BooleanArray {
-        batch
-            .column_by_name(name)
-            .unwrap_or_else(|| panic!("column {name}"))
-            .as_any()
-            .downcast_ref()
-            .expect("Boolean column")
     }
 
     fn millis<'a>(batch: &'a RecordBatch, name: &str) -> &'a TimestampMillisecondArray {
@@ -558,15 +540,6 @@ bindings:
         .expect("gateway registration succeeds");
         register_open_connector_udtfs(&ctx, gateways).expect("UDTF registration succeeds");
         (gateway, ctx)
-    }
-
-    async fn collect(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch> {
-        ctx.sql(sql)
-            .await
-            .expect("plan")
-            .collect()
-            .await
-            .expect("collect")
     }
 
     fn ids_of(batches: &[RecordBatch]) -> Vec<String> {

--- a/crates/skardi/src/sources/providers/open_connector/packs/feishu.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/feishu.rs
@@ -110,8 +110,8 @@ mod tests {
     use crate::sources::providers::open_connector::row_path::RowPath;
     use crate::sources::providers::open_connector::source_pack::SourcePackTable;
     use crate::sources::providers::open_connector::testutil::{
-        EnvVarGuard, MockGateway, MockResponse, boolean, collect, discovery_ok, envelope_ok,
-        fingerprint_uncovered_columns, utf8,
+        EnvVarGuard, MockGateway, MockResponse, boolean, collect, column_values, discovery_ok,
+        envelope_ok, execute_inputs, fingerprint_uncovered_columns, utf8,
     };
     use crate::sources::providers::open_connector::{
         OpenConnectorConfig, OpenConnectorGateways, register_open_connector_tables,
@@ -542,34 +542,6 @@ bindings:
         (gateway, ctx)
     }
 
-    fn ids_of(batches: &[RecordBatch]) -> Vec<String> {
-        batches
-            .iter()
-            .flat_map(|batch| {
-                let ids = batch
-                    .column_by_name("id")
-                    .expect("id column")
-                    .as_any()
-                    .downcast_ref::<StringArray>()
-                    .expect("Utf8 ids")
-                    .clone();
-                (0..ids.len()).map(move |i| ids.value(i).to_string())
-            })
-            .collect()
-    }
-
-    fn execute_inputs(gateway: &MockGateway) -> Vec<Value> {
-        gateway
-            .requests()
-            .into_iter()
-            .filter(|r| r.method == "POST")
-            .map(|r| {
-                serde_json::from_str::<Value>(&r.body).expect("request body is JSON")["input"]
-                    .clone()
-            })
-            .collect()
-    }
-
     fn chat_row(id: &str) -> Value {
         json!({"chat_id": id, "name": id})
     }
@@ -605,9 +577,9 @@ bindings:
             setup_with_gateway(gateway, "SKARDI_TEST_OC_FEISHU_CHATS", "chats").await;
 
         let batches = collect(&ctx, "SELECT id FROM saas.ws.chats ORDER BY id").await;
-        assert_eq!(ids_of(&batches), vec!["oc-1", "oc-2", "oc-3"]);
+        assert_eq!(column_values(&batches, "id"), vec!["oc-1", "oc-2", "oc-3"]);
 
-        let inputs = execute_inputs(&gateway);
+        let inputs = execute_inputs(&gateway, "");
         assert_eq!(inputs.len(), 2, "two cursor pages");
         assert!(inputs[0].get("pageToken").is_none(), "{}", inputs[0]);
         assert_eq!(inputs[1]["pageToken"], "tok-2");
@@ -657,9 +629,9 @@ bindings:
         .await;
         // Inexact pushdown: DataFusion re-trims, so only the matching row
         // survives even though the stub returned both.
-        assert_eq!(ids_of(&batches), vec!["om-1"]);
+        assert_eq!(column_values(&batches, "id"), vec!["om-1"]);
 
-        let inputs = execute_inputs(&gateway);
+        let inputs = execute_inputs(&gateway, "");
         assert_eq!(inputs.len(), 1);
         let input = &inputs[0];
         assert_eq!(input["containerIdType"], "chat", "container kind pin");
@@ -738,7 +710,7 @@ bindings:
             .collect();
         assert_eq!(guids, vec!["t-1"], "status filtering happened locally");
 
-        let input = &execute_inputs(&gateway)[0];
+        let input = &execute_inputs(&gateway, "")[0];
         assert_eq!(input["type"], "my_tasks", "population pin");
         let mut keys: Vec<&str> = input
             .as_object()
@@ -785,7 +757,7 @@ bindings:
 
         let batches = collect(&ctx, "SELECT space_id FROM saas.ws.wiki_spaces").await;
         assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 1);
-        let inputs = execute_inputs(&gateway);
+        let inputs = execute_inputs(&gateway, "");
         assert_eq!(
             inputs.len(),
             1,
@@ -844,7 +816,7 @@ bindings:
 
         let batches = collect(&ctx, "SELECT node_token FROM saas.ws.wiki_nodes").await;
         assert_eq!(batches[0].num_rows(), 1);
-        let input = &execute_inputs(&gateway)[0];
+        let input = &execute_inputs(&gateway, "")[0];
         assert_eq!(input["spaceId"], "sp-1", "required resource forwarded");
         assert_eq!(
             input["parentNodeToken"], "wikcn-parent",
@@ -918,9 +890,9 @@ bindings:
             setup_with_gateway(gateway, "SKARDI_TEST_OC_FEISHU_LIMIT", "chats").await;
 
         let batches = collect(&ctx, "SELECT id FROM saas.ws.chats LIMIT 2").await;
-        assert_eq!(ids_of(&batches).len(), 2);
+        assert_eq!(column_values(&batches, "id").len(), 2);
         assert_eq!(
-            execute_inputs(&gateway).len(),
+            execute_inputs(&gateway, "").len(),
             1,
             "one page satisfied LIMIT"
         );
@@ -950,7 +922,7 @@ bindings:
 
         let from_table = collect(&ctx, "SELECT member_id, name FROM saas.ws.chat_members").await;
         assert_eq!(
-            execute_inputs(&gateway)[0]["pageSize"],
+            execute_inputs(&gateway, "")[0]["pageSize"],
             100,
             "declared page size rides the wire"
         );

--- a/crates/skardi/src/sources/providers/open_connector/packs/github.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/github.rs
@@ -631,7 +631,7 @@ bindings:
     use crate::sources::hierarchy::HierarchyLevel;
     use crate::sources::providers::open_connector::testutil;
     use crate::sources::providers::open_connector::testutil::{
-        MockGateway, MockResponse, RecordedRequest, discovery_ok, envelope_ok,
+        MockGateway, MockResponse, RecordedRequest, collect, discovery_ok, envelope_ok,
     };
     use crate::sources::providers::open_connector::{
         OpenConnectorConfig, OpenConnectorGateways, register_open_connector_tables,
@@ -745,15 +745,6 @@ bindings:
         }
         register_open_connector_udtfs(&ctx, gateways).expect("UDTF registration succeeds");
         (gateway, ctx)
-    }
-
-    async fn collect(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch> {
-        ctx.sql(sql)
-            .await
-            .expect("plan")
-            .collect()
-            .await
-            .expect("collect")
     }
 
     fn rows_of(batches: &[RecordBatch]) -> usize {

--- a/crates/skardi/src/sources/providers/open_connector/packs/github.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/github.rs
@@ -72,9 +72,7 @@ mod tests {
     use crate::sources::providers::open_connector::pagination::PaginationStrategy;
     use crate::sources::providers::open_connector::row_path::RowPath;
     use crate::sources::providers::open_connector::source_pack::SourcePackTable;
-    use arrow::array::{
-        Array, BooleanArray, ListArray, StringArray, TimestampMillisecondArray, UInt64Array,
-    };
+    use arrow::array::{Array, ListArray, StringArray, TimestampMillisecondArray, UInt64Array};
     use arrow::record_batch::RecordBatch;
 
     /// Discovery responses serve the CAPTURED live contracts, so every e2e
@@ -376,15 +374,6 @@ bindings:
             .expect("fixture converts")
     }
 
-    fn strings<'a>(batch: &'a RecordBatch, column: &str) -> &'a StringArray {
-        batch
-            .column_by_name(column)
-            .unwrap_or_else(|| panic!("column {column}"))
-            .as_any()
-            .downcast_ref()
-            .expect("Utf8 column")
-    }
-
     fn u64s<'a>(batch: &'a RecordBatch, column: &str) -> &'a UInt64Array {
         batch
             .column_by_name(column)
@@ -392,15 +381,6 @@ bindings:
             .as_any()
             .downcast_ref()
             .expect("UInt64 column")
-    }
-
-    fn bools<'a>(batch: &'a RecordBatch, column: &str) -> &'a BooleanArray {
-        batch
-            .column_by_name(column)
-            .unwrap_or_else(|| panic!("column {column}"))
-            .as_any()
-            .downcast_ref()
-            .expect("Boolean column")
     }
 
     fn timestamps<'a>(batch: &'a RecordBatch, column: &str) -> &'a TimestampMillisecondArray {
@@ -436,16 +416,13 @@ bindings:
 
         assert_eq!(u64s(&batch, "id").value(0), 101);
         assert_eq!(u64s(&batch, "number").value(2), 3);
-        assert_eq!(
-            strings(&batch, "title").value(0),
-            "Scan panics on empty page"
-        );
-        assert_eq!(strings(&batch, "state").value(1), "closed");
+        assert_eq!(utf8(&batch, "title").value(0), "Scan panics on empty page");
+        assert_eq!(utf8(&batch, "state").value(1), "closed");
 
         // JSON null body and null `user` parent become SQL NULL.
-        assert!(strings(&batch, "body").is_null(1));
-        assert_eq!(strings(&batch, "author_login").value(0), "octocat");
-        assert!(strings(&batch, "author_login").is_null(1));
+        assert!(utf8(&batch, "body").is_null(1));
+        assert_eq!(utf8(&batch, "author_login").value(0), "octocat");
+        assert!(utf8(&batch, "author_login").is_null(1));
 
         // Object lists pluck the declared key; empty arrays stay empty lists.
         assert_eq!(
@@ -512,12 +489,12 @@ bindings:
             include_str!("fixtures/github/repositories.json"),
         );
         assert_eq!(batch.num_rows(), 2);
-        assert_eq!(strings(&batch, "full_name").value(0), "acme/widgets");
-        assert!(bools(&batch, "private").value(1));
-        assert!(bools(&batch, "archived").value(1));
-        assert_eq!(strings(&batch, "language").value(0), "Rust");
-        assert!(strings(&batch, "language").is_null(1));
-        assert!(strings(&batch, "description").is_null(1));
+        assert_eq!(utf8(&batch, "full_name").value(0), "acme/widgets");
+        assert!(boolean(&batch, "private").value(1));
+        assert!(boolean(&batch, "archived").value(1));
+        assert_eq!(utf8(&batch, "language").value(0), "Rust");
+        assert!(utf8(&batch, "language").is_null(1));
+        assert!(utf8(&batch, "description").is_null(1));
         assert!(timestamps(&batch, "pushed_at").is_null(1));
         assert_eq!(u64s(&batch, "stargazers_count").value(0), 42);
     }
@@ -529,9 +506,9 @@ bindings:
             include_str!("fixtures/github/issue_comments.json"),
         );
         assert_eq!(batch.num_rows(), 2);
-        assert_eq!(strings(&batch, "body").value(0), "Reproduced on main.");
-        assert!(strings(&batch, "body").is_null(1));
-        assert!(strings(&batch, "author_login").is_null(1));
+        assert_eq!(utf8(&batch, "body").value(0), "Reproduced on main.");
+        assert!(utf8(&batch, "body").is_null(1));
+        assert!(utf8(&batch, "author_login").is_null(1));
     }
 
     #[test]
@@ -541,9 +518,9 @@ bindings:
             include_str!("fixtures/github/pull_requests.json"),
         );
         assert_eq!(batch.num_rows(), 2);
-        assert_eq!(strings(&batch, "head_ref").value(0), "feature/dark-mode");
-        assert_eq!(strings(&batch, "base_ref").value(0), "main");
-        assert!(bools(&batch, "draft").value(0));
+        assert_eq!(utf8(&batch, "head_ref").value(0), "feature/dark-mode");
+        assert_eq!(utf8(&batch, "base_ref").value(0), "main");
+        assert!(boolean(&batch, "draft").value(0));
         assert!(timestamps(&batch, "merged_at").is_null(0), "open PR");
         assert!(!timestamps(&batch, "merged_at").is_null(1), "merged PR");
     }
@@ -555,9 +532,9 @@ bindings:
             include_str!("fixtures/github/reviews.json"),
         );
         assert_eq!(batch.num_rows(), 2);
-        assert_eq!(strings(&batch, "state").value(0), "APPROVED");
-        assert!(strings(&batch, "author_login").is_null(1));
-        assert!(strings(&batch, "commit_id").is_null(1));
+        assert_eq!(utf8(&batch, "state").value(0), "APPROVED");
+        assert!(utf8(&batch, "author_login").is_null(1));
+        assert!(utf8(&batch, "commit_id").is_null(1));
         assert!(timestamps(&batch, "submitted_at").is_null(1));
     }
 
@@ -571,10 +548,10 @@ bindings:
             include_str!("fixtures/github/commits.json"),
         );
         assert_eq!(batch.num_rows(), 2);
-        assert_eq!(strings(&batch, "author_login").value(0), "octocat");
-        assert!(strings(&batch, "author_login").is_null(1));
-        assert_eq!(strings(&batch, "author_name").value(1), "Legacy Importer");
-        assert_eq!(strings(&batch, "message").value(0), "feat: add dark mode");
+        assert_eq!(utf8(&batch, "author_login").value(0), "octocat");
+        assert!(utf8(&batch, "author_login").is_null(1));
+        assert_eq!(utf8(&batch, "author_name").value(1), "Legacy Importer");
+        assert_eq!(utf8(&batch, "message").value(0), "feat: add dark mode");
         assert!(!timestamps(&batch, "committed_at").is_null(0));
     }
 
@@ -585,13 +562,13 @@ bindings:
             include_str!("fixtures/github/workflow_runs.json"),
         );
         assert_eq!(batch.num_rows(), 2);
-        assert_eq!(strings(&batch, "conclusion").value(0), "success");
+        assert_eq!(utf8(&batch, "conclusion").value(0), "success");
         assert!(
-            strings(&batch, "conclusion").is_null(1),
+            utf8(&batch, "conclusion").is_null(1),
             "conclusion is NULL while a run is in progress"
         );
-        assert!(strings(&batch, "name").is_null(1));
-        assert_eq!(strings(&batch, "status").value(1), "in_progress");
+        assert!(utf8(&batch, "name").is_null(1));
+        assert_eq!(utf8(&batch, "status").value(1), "in_progress");
         assert_eq!(u64s(&batch, "run_number").value(0), 128);
     }
 
@@ -602,11 +579,11 @@ bindings:
             include_str!("fixtures/github/releases.json"),
         );
         assert_eq!(batch.num_rows(), 2);
-        assert_eq!(strings(&batch, "tag_name").value(0), "v1.2.0");
-        assert!(bools(&batch, "draft").value(1));
+        assert_eq!(utf8(&batch, "tag_name").value(0), "v1.2.0");
+        assert!(boolean(&batch, "draft").value(1));
         assert!(timestamps(&batch, "published_at").is_null(1), "draft");
-        assert!(strings(&batch, "name").is_null(1));
-        assert!(strings(&batch, "author_login").is_null(1));
+        assert!(utf8(&batch, "name").is_null(1));
+        assert!(utf8(&batch, "author_login").is_null(1));
     }
 
     #[test]
@@ -631,7 +608,8 @@ bindings:
     use crate::sources::hierarchy::HierarchyLevel;
     use crate::sources::providers::open_connector::testutil;
     use crate::sources::providers::open_connector::testutil::{
-        MockGateway, MockResponse, RecordedRequest, collect, discovery_ok, envelope_ok,
+        MockGateway, MockResponse, RecordedRequest, boolean, collect, discovery_ok, envelope_ok,
+        utf8,
     };
     use crate::sources::providers::open_connector::{
         OpenConnectorConfig, OpenConnectorGateways, register_open_connector_tables,

--- a/crates/skardi/src/sources/providers/open_connector/packs/gmail.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/gmail.rs
@@ -198,8 +198,8 @@ mod tests {
     use crate::sources::providers::open_connector::row_path::RowPath;
     use crate::sources::providers::open_connector::source_pack::{FixedValue, SourcePackTable};
     use crate::sources::providers::open_connector::testutil::{
-        EnvVarGuard, MockGateway, MockResponse, collect, column_values, convert_page, discovery_ok,
-        envelope_err, envelope_ok, fingerprint_uncovered_columns, input_keys, utf8,
+        EnvVarGuard, MockGateway, MockResponse, collect, column_values, convert_first_page,
+        discovery_ok, envelope_err, envelope_ok, fingerprint_uncovered_columns, input_keys, utf8,
     };
     use crate::sources::providers::open_connector::{
         OpenConnectorConfig, OpenConnectorGateways, register_open_connector_tables,
@@ -248,7 +248,7 @@ mod tests {
 
     fn convert_fixture(table: &SourcePackTable, fixture: &str) -> RecordBatch {
         let page: Value = serde_json::from_str(fixture).expect("fixture parses");
-        convert_page(table, &page)
+        convert_first_page(table, &page)
     }
 
     #[test]
@@ -323,7 +323,7 @@ mod tests {
         // back to "" (kept verbatim, never NULL), labelIds defaults to an
         // empty array (an empty list, not NULL), and an undeclared
         // upstream field rides along ignored.
-        let batch = convert_page(
+        let batch = convert_first_page(
             table("threads"),
             &json!({"threads": [
                 {"threadId": "t-1", "snippet": "", "historyId": null, "extra": true},
@@ -332,7 +332,7 @@ mod tests {
         assert!(utf8(&batch, "history_id").is_null(0));
         assert_eq!(utf8(&batch, "snippet").value(0), "");
 
-        let batch = convert_page(
+        let batch = convert_first_page(
             table("messages"),
             &json!({"messages": [{
                 "messageId": "m-1", "threadId": "t-1", "labelIds": [],
@@ -351,7 +351,7 @@ mod tests {
         assert!(!labels.is_null(0));
         assert_eq!(labels.value(0).len(), 0);
 
-        let batch = convert_page(
+        let batch = convert_first_page(
             table("drafts"),
             &json!({"drafts": [{"id": "r-1", "message": {"messageId": "", "threadId": ""}}]}),
         );
@@ -364,7 +364,7 @@ mod tests {
         // always emits `message`, but a nullable column behind a null
         // parent must become SQL NULL (not an error, not a panic) if that
         // ever drifts — the admission gate's null-parent category.
-        let batch = convert_page(
+        let batch = convert_first_page(
             table("drafts"),
             &json!({"drafts": [{"id": "r-1", "message": null}]}),
         );

--- a/crates/skardi/src/sources/providers/open_connector/packs/gmail.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/gmail.rs
@@ -198,8 +198,8 @@ mod tests {
     use crate::sources::providers::open_connector::row_path::RowPath;
     use crate::sources::providers::open_connector::source_pack::{FixedValue, SourcePackTable};
     use crate::sources::providers::open_connector::testutil::{
-        EnvVarGuard, MockGateway, MockResponse, discovery_ok, envelope_err, envelope_ok,
-        fingerprint_uncovered_columns,
+        EnvVarGuard, MockGateway, MockResponse, collect, column_values, convert_page, discovery_ok,
+        envelope_err, envelope_ok, fingerprint_uncovered_columns, input_keys, utf8,
     };
     use crate::sources::providers::open_connector::{
         OpenConnectorConfig, OpenConnectorGateways, register_open_connector_tables,
@@ -249,26 +249,6 @@ mod tests {
     fn convert_fixture(table: &SourcePackTable, fixture: &str) -> RecordBatch {
         let page: Value = serde_json::from_str(fixture).expect("fixture parses");
         convert_page(table, &page)
-    }
-
-    fn convert_page(table: &SourcePackTable, page: &Value) -> RecordBatch {
-        let rows = RowPath::parse(table.row_path)
-            .expect("row path")
-            .rows(page, 1)
-            .expect("row array");
-        RowConverter::new(table.fields)
-            .expect("converter")
-            .convert(rows, 1)
-            .expect("page converts")
-    }
-
-    fn utf8<'a>(batch: &'a RecordBatch, name: &str) -> &'a StringArray {
-        batch
-            .column_by_name(name)
-            .unwrap_or_else(|| panic!("column {name}"))
-            .as_any()
-            .downcast_ref()
-            .expect("Utf8 column")
     }
 
     #[test]
@@ -757,31 +737,6 @@ bindings:
         (gateway, ctx)
     }
 
-    async fn collect(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch> {
-        ctx.sql(sql)
-            .await
-            .expect("plan")
-            .collect()
-            .await
-            .expect("collect")
-    }
-
-    fn column_values(batches: &[RecordBatch], name: &str) -> Vec<String> {
-        batches
-            .iter()
-            .flat_map(|batch| {
-                let values = batch
-                    .column_by_name(name)
-                    .unwrap_or_else(|| panic!("column {name}"))
-                    .as_any()
-                    .downcast_ref::<StringArray>()
-                    .expect("Utf8 column")
-                    .clone();
-                (0..values.len()).map(move |i| values.value(i).to_string())
-            })
-            .collect()
-    }
-
     fn execute_inputs(gateway: &MockGateway, action_path: &str) -> Vec<Value> {
         gateway
             .requests()
@@ -792,17 +747,6 @@ bindings:
                     .clone()
             })
             .collect()
-    }
-
-    fn input_keys(input: &Value) -> Vec<&str> {
-        let mut keys: Vec<&str> = input
-            .as_object()
-            .expect("input object")
-            .keys()
-            .map(String::as_str)
-            .collect();
-        keys.sort_unstable();
-        keys
     }
 
     fn thread_row(id: &str) -> Value {

--- a/crates/skardi/src/sources/providers/open_connector/packs/gmail.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/gmail.rs
@@ -199,7 +199,8 @@ mod tests {
     use crate::sources::providers::open_connector::source_pack::{FixedValue, SourcePackTable};
     use crate::sources::providers::open_connector::testutil::{
         EnvVarGuard, MockGateway, MockResponse, collect, column_values, convert_first_page,
-        discovery_ok, envelope_err, envelope_ok, fingerprint_uncovered_columns, input_keys, utf8,
+        discovery_ok, envelope_err, envelope_ok, execute_inputs, fingerprint_uncovered_columns,
+        input_keys, utf8,
     };
     use crate::sources::providers::open_connector::{
         OpenConnectorConfig, OpenConnectorGateways, register_open_connector_tables,
@@ -735,18 +736,6 @@ bindings:
         .expect("gateway registration succeeds");
         register_open_connector_udtfs(&ctx, gateways).expect("UDTF registration succeeds");
         (gateway, ctx)
-    }
-
-    fn execute_inputs(gateway: &MockGateway, action_path: &str) -> Vec<Value> {
-        gateway
-            .requests()
-            .into_iter()
-            .filter(|r| r.method == "POST" && r.path.ends_with(action_path))
-            .map(|r| {
-                serde_json::from_str::<Value>(&r.body).expect("request body is JSON")["input"]
-                    .clone()
-            })
-            .collect()
     }
 
     fn thread_row(id: &str) -> Value {

--- a/crates/skardi/src/sources/providers/open_connector/packs/google_drive.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/google_drive.rs
@@ -161,16 +161,14 @@ mod tests {
     use crate::sources::providers::open_connector::row_path::RowPath;
     use crate::sources::providers::open_connector::source_pack::{FixedValue, SourcePackTable};
     use crate::sources::providers::open_connector::testutil::{
-        EnvVarGuard, MockGateway, MockResponse, discovery_ok, envelope_err, envelope_ok,
-        fingerprint_uncovered_columns,
+        EnvVarGuard, MockGateway, MockResponse, boolean, collect, column_values, convert_page,
+        discovery_ok, envelope_err, envelope_ok, fingerprint_uncovered_columns, input_keys, utf8,
     };
     use crate::sources::providers::open_connector::{
         OpenConnectorConfig, OpenConnectorGateways, register_open_connector_tables,
         register_open_connector_udtfs,
     };
-    use arrow::array::{
-        Array, BooleanArray, Int64Array, ListArray, StringArray, TimestampMillisecondArray,
-    };
+    use arrow::array::{Array, Int64Array, ListArray, StringArray, TimestampMillisecondArray};
     use arrow::record_batch::RecordBatch;
     use datafusion::prelude::SessionContext;
     use serde_json::{Value, json};
@@ -224,26 +222,6 @@ mod tests {
         convert_page(table, &page)
     }
 
-    fn convert_page(table: &SourcePackTable, page: &Value) -> RecordBatch {
-        let rows = RowPath::parse(table.row_path)
-            .expect("row path")
-            .rows(page, 1)
-            .expect("row array");
-        RowConverter::new(table.fields)
-            .expect("converter")
-            .convert(rows, 1)
-            .expect("page converts")
-    }
-
-    fn utf8<'a>(batch: &'a RecordBatch, name: &str) -> &'a StringArray {
-        batch
-            .column_by_name(name)
-            .unwrap_or_else(|| panic!("column {name}"))
-            .as_any()
-            .downcast_ref()
-            .expect("Utf8 column")
-    }
-
     fn int64<'a>(batch: &'a RecordBatch, name: &str) -> &'a Int64Array {
         batch
             .column_by_name(name)
@@ -251,15 +229,6 @@ mod tests {
             .as_any()
             .downcast_ref()
             .expect("Int64 column")
-    }
-
-    fn boolean<'a>(batch: &'a RecordBatch, name: &str) -> &'a BooleanArray {
-        batch
-            .column_by_name(name)
-            .unwrap_or_else(|| panic!("column {name}"))
-            .as_any()
-            .downcast_ref()
-            .expect("Boolean column")
     }
 
     fn timestamp<'a>(batch: &'a RecordBatch, name: &str) -> &'a TimestampMillisecondArray {
@@ -1354,31 +1323,6 @@ bindings:
         (gateway, ctx)
     }
 
-    async fn collect(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch> {
-        ctx.sql(sql)
-            .await
-            .expect("plan")
-            .collect()
-            .await
-            .expect("collect")
-    }
-
-    fn column_values(batches: &[RecordBatch], name: &str) -> Vec<String> {
-        batches
-            .iter()
-            .flat_map(|batch| {
-                let values = batch
-                    .column_by_name(name)
-                    .unwrap_or_else(|| panic!("column {name}"))
-                    .as_any()
-                    .downcast_ref::<StringArray>()
-                    .expect("Utf8 column")
-                    .clone();
-                (0..values.len()).map(move |i| values.value(i).to_string())
-            })
-            .collect()
-    }
-
     fn execute_inputs(gateway: &MockGateway, action_path: &str) -> Vec<Value> {
         gateway
             .requests()
@@ -1389,17 +1333,6 @@ bindings:
                     .clone()
             })
             .collect()
-    }
-
-    fn input_keys(input: &Value) -> Vec<&str> {
-        let mut keys: Vec<&str> = input
-            .as_object()
-            .expect("input object")
-            .keys()
-            .map(String::as_str)
-            .collect();
-        keys.sort_unstable();
-        keys
     }
 
     /// A minimal normalized file row: identity plus enough to prove the

--- a/crates/skardi/src/sources/providers/open_connector/packs/google_drive.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/google_drive.rs
@@ -162,8 +162,8 @@ mod tests {
     use crate::sources::providers::open_connector::source_pack::{FixedValue, SourcePackTable};
     use crate::sources::providers::open_connector::testutil::{
         EnvVarGuard, MockGateway, MockResponse, boolean, collect, column_values,
-        convert_first_page, discovery_ok, envelope_err, envelope_ok, fingerprint_uncovered_columns,
-        input_keys, utf8,
+        convert_first_page, discovery_ok, envelope_err, envelope_ok, execute_inputs,
+        fingerprint_uncovered_columns, input_keys, utf8,
     };
     use crate::sources::providers::open_connector::{
         OpenConnectorConfig, OpenConnectorGateways, register_open_connector_tables,
@@ -1322,18 +1322,6 @@ bindings:
         .expect("gateway registration succeeds");
         register_open_connector_udtfs(&ctx, gateways).expect("UDTF registration succeeds");
         (gateway, ctx)
-    }
-
-    fn execute_inputs(gateway: &MockGateway, action_path: &str) -> Vec<Value> {
-        gateway
-            .requests()
-            .into_iter()
-            .filter(|r| r.method == "POST" && r.path.ends_with(action_path))
-            .map(|r| {
-                serde_json::from_str::<Value>(&r.body).expect("request body is JSON")["input"]
-                    .clone()
-            })
-            .collect()
     }
 
     /// A minimal normalized file row: identity plus enough to prove the

--- a/crates/skardi/src/sources/providers/open_connector/packs/google_drive.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/google_drive.rs
@@ -161,8 +161,9 @@ mod tests {
     use crate::sources::providers::open_connector::row_path::RowPath;
     use crate::sources::providers::open_connector::source_pack::{FixedValue, SourcePackTable};
     use crate::sources::providers::open_connector::testutil::{
-        EnvVarGuard, MockGateway, MockResponse, boolean, collect, column_values, convert_page,
-        discovery_ok, envelope_err, envelope_ok, fingerprint_uncovered_columns, input_keys, utf8,
+        EnvVarGuard, MockGateway, MockResponse, boolean, collect, column_values,
+        convert_first_page, discovery_ok, envelope_err, envelope_ok, fingerprint_uncovered_columns,
+        input_keys, utf8,
     };
     use crate::sources::providers::open_connector::{
         OpenConnectorConfig, OpenConnectorGateways, register_open_connector_tables,
@@ -219,7 +220,7 @@ mod tests {
 
     fn convert_fixture(table: &SourcePackTable, fixture: &str) -> RecordBatch {
         let page: Value = serde_json::from_str(fixture).expect("fixture parses");
-        convert_page(table, &page)
+        convert_first_page(table, &page)
     }
 
     fn int64<'a>(batch: &'a RecordBatch, name: &str) -> &'a Int64Array {
@@ -461,7 +462,7 @@ mod tests {
             ],
             "nextPageToken": null
         });
-        let batch = convert_page(table("drives"), &page);
+        let batch = convert_first_page(table("drives"), &page);
         assert!(boolean(&batch, "hidden").is_null(0));
         for flag in [
             "admin_managed_restrictions",
@@ -568,7 +569,7 @@ mod tests {
             }],
             "nextPageToken": null
         });
-        let synthetic = convert_page(table("file_permissions"), &page);
+        let synthetic = convert_first_page(table("file_permissions"), &page);
         assert!(timestamp(&synthetic, "expiration_time").is_valid(0));
 
         // `kind` (constant) and `permissionDetails` (a second table's
@@ -628,7 +629,7 @@ mod tests {
             ],
             "nextPageToken": null
         });
-        let batch = convert_page(table("files"), &page);
+        let batch = convert_first_page(table("files"), &page);
         assert_eq!(batch.num_rows(), 3);
 
         for column in ["web_view_link", "drive_id"] {
@@ -814,7 +815,7 @@ mod tests {
             ("file_permissions", "permissions", 11),
         ] {
             let t = table(short);
-            let batch = convert_page(t, &json!({row_key: [], "nextPageToken": null}));
+            let batch = convert_first_page(t, &json!({row_key: [], "nextPageToken": null}));
             assert_eq!(batch.num_rows(), 0, "{short}");
             assert_eq!(
                 batch.num_columns(),

--- a/crates/skardi/src/sources/providers/open_connector/packs/notion.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/notion.rs
@@ -92,14 +92,14 @@ mod tests {
     use crate::sources::providers::open_connector::row_path::RowPath;
     use crate::sources::providers::open_connector::source_pack::SourcePackTable;
     use crate::sources::providers::open_connector::testutil::{
-        EnvVarGuard, MockGateway, MockResponse, discovery_ok, envelope_ok,
-        fingerprint_uncovered_columns,
+        EnvVarGuard, MockGateway, MockResponse, boolean, collect, discovery_ok, envelope_ok,
+        fingerprint_uncovered_columns, utf8,
     };
     use crate::sources::providers::open_connector::{
         OpenConnectorConfig, OpenConnectorGateways, register_open_connector_tables,
         register_open_connector_udtfs,
     };
-    use arrow::array::{Array, BooleanArray, ListArray, StringArray, TimestampMillisecondArray};
+    use arrow::array::{Array, ListArray, StringArray, TimestampMillisecondArray};
     use arrow::record_batch::RecordBatch;
     use datafusion::prelude::SessionContext;
     use serde_json::{Value, json};
@@ -148,24 +148,6 @@ mod tests {
             .expect("converter")
             .convert(rows, 1)
             .expect("fixture converts")
-    }
-
-    fn utf8<'a>(batch: &'a RecordBatch, name: &str) -> &'a StringArray {
-        batch
-            .column_by_name(name)
-            .unwrap_or_else(|| panic!("column {name}"))
-            .as_any()
-            .downcast_ref()
-            .expect("Utf8 column")
-    }
-
-    fn boolean<'a>(batch: &'a RecordBatch, name: &str) -> &'a BooleanArray {
-        batch
-            .column_by_name(name)
-            .unwrap_or_else(|| panic!("column {name}"))
-            .as_any()
-            .downcast_ref()
-            .expect("Boolean column")
     }
 
     #[test]
@@ -433,15 +415,6 @@ bindings:
         .expect("gateway registration succeeds");
         register_open_connector_udtfs(&ctx, gateways).expect("UDTF registration succeeds");
         (gateway, ctx)
-    }
-
-    async fn collect(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch> {
-        ctx.sql(sql)
-            .await
-            .expect("plan")
-            .collect()
-            .await
-            .expect("collect")
     }
 
     fn ids_of(batches: &[RecordBatch]) -> Vec<String> {

--- a/crates/skardi/src/sources/providers/open_connector/packs/notion.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/notion.rs
@@ -92,8 +92,8 @@ mod tests {
     use crate::sources::providers::open_connector::row_path::RowPath;
     use crate::sources::providers::open_connector::source_pack::SourcePackTable;
     use crate::sources::providers::open_connector::testutil::{
-        EnvVarGuard, MockGateway, MockResponse, boolean, collect, discovery_ok, envelope_ok,
-        fingerprint_uncovered_columns, utf8,
+        EnvVarGuard, MockGateway, MockResponse, boolean, collect, column_values, discovery_ok,
+        envelope_ok, execute_inputs, fingerprint_uncovered_columns, utf8,
     };
     use crate::sources::providers::open_connector::{
         OpenConnectorConfig, OpenConnectorGateways, register_open_connector_tables,
@@ -417,34 +417,6 @@ bindings:
         (gateway, ctx)
     }
 
-    fn ids_of(batches: &[RecordBatch]) -> Vec<String> {
-        batches
-            .iter()
-            .flat_map(|batch| {
-                let ids = batch
-                    .column_by_name("id")
-                    .expect("id column")
-                    .as_any()
-                    .downcast_ref::<StringArray>()
-                    .expect("Utf8 ids")
-                    .clone();
-                (0..ids.len()).map(move |i| ids.value(i).to_string())
-            })
-            .collect()
-    }
-
-    fn execute_inputs(gateway: &MockGateway) -> Vec<Value> {
-        gateway
-            .requests()
-            .into_iter()
-            .filter(|r| r.method == "POST")
-            .map(|r| {
-                serde_json::from_str::<Value>(&r.body).expect("request body is JSON")["input"]
-                    .clone()
-            })
-            .collect()
-    }
-
     fn user_row(id: &str) -> Value {
         json!({"object": "user", "id": id, "name": id, "type": "person"})
     }
@@ -480,9 +452,9 @@ bindings:
             setup_with_gateway(gateway, "SKARDI_TEST_OC_NOTION_USERS", "users").await;
 
         let batches = collect(&ctx, "SELECT id FROM saas.ws.users ORDER BY id").await;
-        assert_eq!(ids_of(&batches), vec!["u-1", "u-2", "u-3"]);
+        assert_eq!(column_values(&batches, "id"), vec!["u-1", "u-2", "u-3"]);
 
-        let inputs = execute_inputs(&gateway);
+        let inputs = execute_inputs(&gateway, "");
         assert_eq!(inputs.len(), 2, "two cursor pages");
         assert_eq!(inputs[1]["startCursor"], "cur-2");
         for (page, (input, expected_keys)) in inputs
@@ -543,11 +515,11 @@ bindings:
         .await;
 
         let batches = collect(&ctx, "SELECT id FROM saas.ws.pages").await;
-        assert_eq!(ids_of(&batches), vec!["p-1"]);
+        assert_eq!(column_values(&batches, "id"), vec!["p-1"]);
         let batches = collect(&ctx, "SELECT id FROM saas.ws.data_sources").await;
-        assert_eq!(ids_of(&batches), vec!["ds-1"]);
+        assert_eq!(column_values(&batches, "id"), vec!["ds-1"]);
 
-        for input in execute_inputs(&gateway) {
+        for input in execute_inputs(&gateway, "") {
             assert_eq!(input["query"], "", "empty query pin: {input}");
             assert_eq!(input["filter"]["property"], "object", "{input}");
             let mut keys: Vec<&str> = input
@@ -588,8 +560,8 @@ bindings:
             setup_with_gateway(gateway, "SKARDI_TEST_OC_NOTION_BLOCKS", "block_children").await;
 
         let batches = collect(&ctx, "SELECT id, type FROM saas.ws.block_children").await;
-        assert_eq!(ids_of(&batches), vec!["b-1"]);
-        let inputs = execute_inputs(&gateway);
+        assert_eq!(column_values(&batches, "id"), vec!["b-1"]);
+        let inputs = execute_inputs(&gateway, "");
         assert_eq!(
             inputs[0]["blockId"], "b-root",
             "resource forwarded verbatim"
@@ -660,9 +632,9 @@ bindings:
             setup_with_gateway(gateway, "SKARDI_TEST_OC_NOTION_LIMIT", "users").await;
 
         let batches = collect(&ctx, "SELECT id FROM saas.ws.users LIMIT 2").await;
-        assert_eq!(ids_of(&batches).len(), 2);
+        assert_eq!(column_values(&batches, "id").len(), 2);
         assert_eq!(
-            execute_inputs(&gateway).len(),
+            execute_inputs(&gateway, "").len(),
             1,
             "one page satisfied LIMIT"
         );

--- a/crates/skardi/src/sources/providers/open_connector/packs/one_drive.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/one_drive.rs
@@ -183,14 +183,14 @@ mod tests {
     use crate::sources::providers::open_connector::row_path::RowPath;
     use crate::sources::providers::open_connector::source_pack::SourcePackTable;
     use crate::sources::providers::open_connector::testutil::{
-        EnvVarGuard, MockGateway, MockResponse, discovery_ok, envelope_err, envelope_ok,
-        fingerprint_uncovered_columns,
+        EnvVarGuard, MockGateway, MockResponse, collect, column_values, convert_page, discovery_ok,
+        envelope_err, envelope_ok, fingerprint_uncovered_columns, input_keys, utf8,
     };
     use crate::sources::providers::open_connector::{
         OpenConnectorConfig, OpenConnectorGateways, register_open_connector_tables,
         register_open_connector_udtfs,
     };
-    use arrow::array::{Array, Int64Array, StringArray, TimestampMillisecondArray};
+    use arrow::array::{Array, Int64Array, TimestampMillisecondArray};
     use arrow::record_batch::RecordBatch;
     use datafusion::prelude::SessionContext;
     use percent_encoding::percent_decode_str;
@@ -255,26 +255,6 @@ mod tests {
     fn convert_fixture(table: &SourcePackTable, fixture: &str) -> RecordBatch {
         let page: Value = serde_json::from_str(fixture).expect("fixture parses");
         convert_page(table, &page)
-    }
-
-    fn convert_page(table: &SourcePackTable, page: &Value) -> RecordBatch {
-        let rows = RowPath::parse(table.row_path)
-            .expect("row path")
-            .rows(page, 1)
-            .expect("row array");
-        RowConverter::new(table.fields)
-            .expect("converter")
-            .convert(rows, 1)
-            .expect("page converts")
-    }
-
-    fn utf8<'a>(batch: &'a RecordBatch, name: &str) -> &'a StringArray {
-        batch
-            .column_by_name(name)
-            .unwrap_or_else(|| panic!("column {name}"))
-            .as_any()
-            .downcast_ref()
-            .expect("Utf8 column")
     }
 
     fn int64<'a>(batch: &'a RecordBatch, name: &str) -> &'a Int64Array {
@@ -1471,31 +1451,6 @@ bindings:
         (gateway, ctx)
     }
 
-    async fn collect(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch> {
-        ctx.sql(sql)
-            .await
-            .expect("plan")
-            .collect()
-            .await
-            .expect("collect")
-    }
-
-    fn column_values(batches: &[RecordBatch], name: &str) -> Vec<String> {
-        batches
-            .iter()
-            .flat_map(|batch| {
-                let values = batch
-                    .column_by_name(name)
-                    .unwrap_or_else(|| panic!("column {name}"))
-                    .as_any()
-                    .downcast_ref::<StringArray>()
-                    .expect("Utf8 column")
-                    .clone();
-                (0..values.len()).map(move |i| values.value(i).to_string())
-            })
-            .collect()
-    }
-
     fn execute_inputs(gateway: &MockGateway, action_path: &str) -> Vec<Value> {
         gateway
             .requests()
@@ -1506,17 +1461,6 @@ bindings:
                     .clone()
             })
             .collect()
-    }
-
-    fn input_keys(input: &Value) -> Vec<&str> {
-        let mut keys: Vec<&str> = input
-            .as_object()
-            .expect("input object")
-            .keys()
-            .map(String::as_str)
-            .collect();
-        keys.sort_unstable();
-        keys
     }
 
     /// A minimal file row: enough keys to exercise identity plus one

--- a/crates/skardi/src/sources/providers/open_connector/packs/one_drive.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/one_drive.rs
@@ -183,8 +183,8 @@ mod tests {
     use crate::sources::providers::open_connector::row_path::RowPath;
     use crate::sources::providers::open_connector::source_pack::SourcePackTable;
     use crate::sources::providers::open_connector::testutil::{
-        EnvVarGuard, MockGateway, MockResponse, collect, column_values, convert_page, discovery_ok,
-        envelope_err, envelope_ok, fingerprint_uncovered_columns, input_keys, utf8,
+        EnvVarGuard, MockGateway, MockResponse, collect, column_values, convert_first_page,
+        discovery_ok, envelope_err, envelope_ok, fingerprint_uncovered_columns, input_keys, utf8,
     };
     use crate::sources::providers::open_connector::{
         OpenConnectorConfig, OpenConnectorGateways, register_open_connector_tables,
@@ -254,7 +254,7 @@ mod tests {
 
     fn convert_fixture(table: &SourcePackTable, fixture: &str) -> RecordBatch {
         let page: Value = serde_json::from_str(fixture).expect("fixture parses");
-        convert_page(table, &page)
+        convert_first_page(table, &page)
     }
 
     fn int64<'a>(batch: &'a RecordBatch, name: &str) -> &'a Int64Array {
@@ -433,7 +433,7 @@ mod tests {
             ],
             "nextLink": null
         });
-        let batch = convert_page(table("drive_items"), &page);
+        let batch = convert_first_page(table("drive_items"), &page);
         assert_eq!(batch.num_rows(), 2);
 
         // Every nullable column, whatever its arrow type, and whether the
@@ -496,7 +496,7 @@ mod tests {
             }],
             "nextLink": null
         });
-        let batch = convert_page(table("drive_items"), &page);
+        let batch = convert_first_page(table("drive_items"), &page);
         assert!(utf8(&batch, "created_by_display_name").is_null(0));
         assert!(utf8(&batch, "last_modified_by_display_name").is_null(0));
         // The row is otherwise intact — a null identity is not a broken row.
@@ -945,7 +945,7 @@ mod tests {
         // the concurrency tags (phase 4), so drive_item_search maps 14.
         for (short, columns) in [("drive_items", 16), ("drive_item_search", 14)] {
             let t = table(short);
-            let batch = convert_page(t, &json!({"items": [], "nextLink": null}));
+            let batch = convert_first_page(t, &json!({"items": [], "nextLink": null}));
             assert_eq!(batch.num_rows(), 0, "{short}");
             assert_eq!(
                 batch.num_columns(),

--- a/crates/skardi/src/sources/providers/open_connector/packs/one_drive.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/one_drive.rs
@@ -184,7 +184,8 @@ mod tests {
     use crate::sources::providers::open_connector::source_pack::SourcePackTable;
     use crate::sources::providers::open_connector::testutil::{
         EnvVarGuard, MockGateway, MockResponse, collect, column_values, convert_first_page,
-        discovery_ok, envelope_err, envelope_ok, fingerprint_uncovered_columns, input_keys, utf8,
+        discovery_ok, envelope_err, envelope_ok, execute_inputs, fingerprint_uncovered_columns,
+        input_keys, utf8,
     };
     use crate::sources::providers::open_connector::{
         OpenConnectorConfig, OpenConnectorGateways, register_open_connector_tables,
@@ -1449,18 +1450,6 @@ bindings:
         .expect("gateway registration succeeds");
         register_open_connector_udtfs(&ctx, gateways).expect("UDTF registration succeeds");
         (gateway, ctx)
-    }
-
-    fn execute_inputs(gateway: &MockGateway, action_path: &str) -> Vec<Value> {
-        gateway
-            .requests()
-            .into_iter()
-            .filter(|r| r.method == "POST" && r.path.ends_with(action_path))
-            .map(|r| {
-                serde_json::from_str::<Value>(&r.body).expect("request body is JSON")["input"]
-                    .clone()
-            })
-            .collect()
     }
 
     /// A minimal file row: enough keys to exercise identity plus one

--- a/crates/skardi/src/sources/providers/open_connector/packs/outlook.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/outlook.rs
@@ -185,8 +185,9 @@ mod tests {
     use crate::sources::providers::open_connector::row_path::RowPath;
     use crate::sources::providers::open_connector::source_pack::{FixedValue, SourcePackTable};
     use crate::sources::providers::open_connector::testutil::{
-        EnvVarGuard, MockGateway, MockResponse, boolean, collect, column_values, convert_page,
-        discovery_ok, envelope_err, envelope_ok, fingerprint_uncovered_columns, input_keys, utf8,
+        EnvVarGuard, MockGateway, MockResponse, boolean, collect, column_values,
+        convert_first_page, discovery_ok, envelope_err, envelope_ok, fingerprint_uncovered_columns,
+        input_keys, utf8,
     };
     use crate::sources::providers::open_connector::{
         OpenConnectorConfig, OpenConnectorGateways, register_open_connector_tables,
@@ -296,7 +297,7 @@ mod tests {
 
     fn convert_fixture(table: &SourcePackTable, fixture: &str) -> RecordBatch {
         let page: Value = serde_json::from_str(fixture).expect("fixture parses");
-        convert_page(table, &page)
+        convert_first_page(table, &page)
     }
 
     #[test]
@@ -631,7 +632,7 @@ mod tests {
         // SYNTHETIC: the live mailbox had no hidden folders (the pin's
         // on/off responses were identical), so the is_hidden=true
         // conversion arm is pinned here rather than by the capture.
-        let batch = convert_page(
+        let batch = convert_first_page(
             table("mail_folders"),
             &json!({"mailFolders": [
                 {"id": "f-hidden", "displayName": "Hidden", "isHidden": true},
@@ -652,7 +653,7 @@ mod tests {
         // parent becomes SQL NULL, never an error. Deleting this test
         // because "the wire never does that" would drop the only
         // coverage of the admission gate's null-parent category.
-        let batch = convert_page(
+        let batch = convert_first_page(
             table("messages"),
             &json!({"messages": [
                 {"id": "m-1", "from": null},
@@ -674,7 +675,7 @@ mod tests {
         // (SYNTHETIC — the live wire under the select pin never nulls
         // a field, but passthrough offers no such guarantee): null is
         // SQL NULL while "" stays an empty string.
-        let batch = convert_page(
+        let batch = convert_first_page(
             table("messages"),
             &json!({"messages": [
                 {"id": "m-1", "subject": "s"},
@@ -703,7 +704,7 @@ mod tests {
     fn empty_page_keeps_schema_stable() {
         // Zero rows still yield the full column set — an empty mailbox
         // must DESCRIBE like a populated one.
-        let batch = convert_page(table("messages"), &json!({"messages": []}));
+        let batch = convert_first_page(table("messages"), &json!({"messages": []}));
         assert_eq!(batch.num_rows(), 0);
         assert_eq!(batch.num_columns(), table("messages").fields.len());
     }

--- a/crates/skardi/src/sources/providers/open_connector/packs/outlook.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/outlook.rs
@@ -185,8 +185,8 @@ mod tests {
     use crate::sources::providers::open_connector::row_path::RowPath;
     use crate::sources::providers::open_connector::source_pack::{FixedValue, SourcePackTable};
     use crate::sources::providers::open_connector::testutil::{
-        EnvVarGuard, MockGateway, MockResponse, discovery_ok, envelope_err, envelope_ok,
-        fingerprint_uncovered_columns,
+        EnvVarGuard, MockGateway, MockResponse, boolean, collect, column_values, convert_page,
+        discovery_ok, envelope_err, envelope_ok, fingerprint_uncovered_columns, input_keys, utf8,
     };
     use crate::sources::providers::open_connector::{
         OpenConnectorConfig, OpenConnectorGateways, register_open_connector_tables,
@@ -297,35 +297,6 @@ mod tests {
     fn convert_fixture(table: &SourcePackTable, fixture: &str) -> RecordBatch {
         let page: Value = serde_json::from_str(fixture).expect("fixture parses");
         convert_page(table, &page)
-    }
-
-    fn convert_page(table: &SourcePackTable, page: &Value) -> RecordBatch {
-        let rows = RowPath::parse(table.row_path)
-            .expect("row path")
-            .rows(page, 1)
-            .expect("row array");
-        RowConverter::new(table.fields)
-            .expect("converter")
-            .convert(rows, 1)
-            .expect("page converts")
-    }
-
-    fn utf8<'a>(batch: &'a RecordBatch, name: &str) -> &'a StringArray {
-        batch
-            .column_by_name(name)
-            .unwrap_or_else(|| panic!("column {name}"))
-            .as_any()
-            .downcast_ref()
-            .expect("Utf8 column")
-    }
-
-    fn boolean<'a>(batch: &'a RecordBatch, name: &str) -> &'a BooleanArray {
-        batch
-            .column_by_name(name)
-            .unwrap_or_else(|| panic!("column {name}"))
-            .as_any()
-            .downcast_ref()
-            .expect("Boolean column")
     }
 
     #[test]
@@ -1011,31 +982,6 @@ bindings:
         (gateway, ctx)
     }
 
-    async fn collect(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch> {
-        ctx.sql(sql)
-            .await
-            .expect("plan")
-            .collect()
-            .await
-            .expect("collect")
-    }
-
-    fn column_values(batches: &[RecordBatch], name: &str) -> Vec<String> {
-        batches
-            .iter()
-            .flat_map(|batch| {
-                let values = batch
-                    .column_by_name(name)
-                    .unwrap_or_else(|| panic!("column {name}"))
-                    .as_any()
-                    .downcast_ref::<StringArray>()
-                    .expect("Utf8 column")
-                    .clone();
-                (0..values.len()).map(move |i| values.value(i).to_string())
-            })
-            .collect()
-    }
-
     fn execute_inputs(gateway: &MockGateway, action_path: &str) -> Vec<Value> {
         gateway
             .requests()
@@ -1046,17 +992,6 @@ bindings:
                     .clone()
             })
             .collect()
-    }
-
-    fn input_keys(input: &Value) -> Vec<&str> {
-        let mut keys: Vec<&str> = input
-            .as_object()
-            .expect("input object")
-            .keys()
-            .map(String::as_str)
-            .collect();
-        keys.sort_unstable();
-        keys
     }
 
     /// The full select pin, as the wire must carry it on every request.

--- a/crates/skardi/src/sources/providers/open_connector/packs/outlook.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/outlook.rs
@@ -186,16 +186,14 @@ mod tests {
     use crate::sources::providers::open_connector::source_pack::{FixedValue, SourcePackTable};
     use crate::sources::providers::open_connector::testutil::{
         EnvVarGuard, MockGateway, MockResponse, boolean, collect, column_values,
-        convert_first_page, discovery_ok, envelope_err, envelope_ok, fingerprint_uncovered_columns,
-        input_keys, utf8,
+        convert_first_page, discovery_ok, envelope_err, envelope_ok, execute_inputs,
+        fingerprint_uncovered_columns, input_keys, utf8,
     };
     use crate::sources::providers::open_connector::{
         OpenConnectorConfig, OpenConnectorGateways, register_open_connector_tables,
         register_open_connector_udtfs,
     };
-    use arrow::array::{
-        Array, BooleanArray, Int64Array, ListArray, StringArray, TimestampMillisecondArray,
-    };
+    use arrow::array::{Array, Int64Array, ListArray, StringArray, TimestampMillisecondArray};
     use arrow::record_batch::RecordBatch;
     use datafusion::prelude::SessionContext;
     use serde_json::{Value, json};
@@ -385,12 +383,7 @@ mod tests {
             utf8(&batch, "conversation_id").value(7),
         );
         assert_eq!(
-            batch
-                .column_by_name("conversation_id")
-                .expect("column")
-                .as_any()
-                .downcast_ref::<StringArray>()
-                .expect("Utf8")
+            utf8(&batch, "conversation_id")
                 .iter()
                 .flatten()
                 .collect::<std::collections::HashSet<_>>()
@@ -442,12 +435,7 @@ mod tests {
         assert_eq!(utf8(&batch, "well_known_name").value(7), "inbox");
         assert_eq!(utf8(&batch, "well_known_name").value(6), "sentitems");
         assert!(utf8(&batch, "well_known_name").is_null(0));
-        let hidden: &BooleanArray = batch
-            .column_by_name("is_hidden")
-            .expect("column")
-            .as_any()
-            .downcast_ref()
-            .expect("Boolean column");
+        let hidden = boolean(&batch, "is_hidden");
         assert!((0..9).all(|i| !hidden.value(i)));
         let children: &Int64Array = batch
             .column_by_name("child_folder_count")
@@ -981,18 +969,6 @@ bindings:
         .expect("gateway registration succeeds");
         register_open_connector_udtfs(&ctx, gateways).expect("UDTF registration succeeds");
         (gateway, ctx)
-    }
-
-    fn execute_inputs(gateway: &MockGateway, action_path: &str) -> Vec<Value> {
-        gateway
-            .requests()
-            .into_iter()
-            .filter(|r| r.method == "POST" && r.path.ends_with(action_path))
-            .map(|r| {
-                serde_json::from_str::<Value>(&r.body).expect("request body is JSON")["input"]
-                    .clone()
-            })
-            .collect()
     }
 
     /// The full select pin, as the wire must carry it on every request.

--- a/crates/skardi/src/sources/providers/open_connector/packs/slack.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/slack.rs
@@ -99,16 +99,14 @@ mod tests {
     use crate::sources::providers::open_connector::row_path::RowPath;
     use crate::sources::providers::open_connector::source_pack::SourcePackTable;
     use crate::sources::providers::open_connector::testutil::{
-        EnvVarGuard, MockGateway, MockResponse, RecordedRequest, discovery_ok, envelope_err,
-        envelope_ok,
+        EnvVarGuard, MockGateway, MockResponse, RecordedRequest, boolean, collect, discovery_ok,
+        envelope_err, envelope_ok, utf8,
     };
     use crate::sources::providers::open_connector::{
         OpenConnectorConfig, OpenConnectorError, OpenConnectorGateways,
         register_open_connector_tables, register_open_connector_udtfs,
     };
-    use arrow::array::{
-        Array, BooleanArray, ListArray, StringArray, TimestampMillisecondArray, UInt64Array,
-    };
+    use arrow::array::{Array, ListArray, StringArray, TimestampMillisecondArray, UInt64Array};
     use arrow::record_batch::RecordBatch;
     use datafusion::prelude::SessionContext;
     use serde_json::{Value, json};
@@ -288,24 +286,6 @@ bindings:
             .expect("converter")
             .convert(rows, 1)
             .expect("fixture converts")
-    }
-
-    fn utf8<'a>(batch: &'a RecordBatch, name: &str) -> &'a StringArray {
-        batch
-            .column_by_name(name)
-            .unwrap()
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap()
-    }
-
-    fn boolean<'a>(batch: &'a RecordBatch, name: &str) -> &'a BooleanArray {
-        batch
-            .column_by_name(name)
-            .unwrap()
-            .as_any()
-            .downcast_ref::<BooleanArray>()
-            .unwrap()
     }
 
     fn timestamp<'a>(batch: &'a RecordBatch, name: &str) -> &'a TimestampMillisecondArray {
@@ -593,15 +573,6 @@ bindings:
         .expect("gateway registration succeeds");
         register_open_connector_udtfs(&ctx, gateways).expect("UDTF registration succeeds");
         ctx
-    }
-
-    async fn collect(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch> {
-        ctx.sql(sql)
-            .await
-            .expect("plan")
-            .collect()
-            .await
-            .expect("collect")
     }
 
     fn rows_of(batches: &[RecordBatch]) -> usize {

--- a/crates/skardi/src/sources/providers/open_connector/packs/slack.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/slack.rs
@@ -99,14 +99,14 @@ mod tests {
     use crate::sources::providers::open_connector::row_path::RowPath;
     use crate::sources::providers::open_connector::source_pack::SourcePackTable;
     use crate::sources::providers::open_connector::testutil::{
-        EnvVarGuard, MockGateway, MockResponse, RecordedRequest, boolean, collect, discovery_ok,
-        envelope_err, envelope_ok, utf8,
+        EnvVarGuard, MockGateway, MockResponse, RecordedRequest, boolean, collect, column_values,
+        discovery_ok, envelope_err, envelope_ok, utf8,
     };
     use crate::sources::providers::open_connector::{
         OpenConnectorConfig, OpenConnectorError, OpenConnectorGateways,
         register_open_connector_tables, register_open_connector_udtfs,
     };
-    use arrow::array::{Array, ListArray, StringArray, TimestampMillisecondArray, UInt64Array};
+    use arrow::array::{Array, ListArray, TimestampMillisecondArray, UInt64Array};
     use arrow::record_batch::RecordBatch;
     use datafusion::prelude::SessionContext;
     use serde_json::{Value, json};
@@ -580,21 +580,6 @@ bindings:
     }
 
     /// The `id` column of collected batches, in emission order.
-    fn ids_of(batches: &[RecordBatch]) -> Vec<String> {
-        batches
-            .iter()
-            .flat_map(|batch| {
-                let ids = batch
-                    .column_by_name("id")
-                    .expect("id column")
-                    .as_any()
-                    .downcast_ref::<StringArray>()
-                    .expect("Utf8 ids")
-                    .clone();
-                (0..ids.len()).map(move |i| ids.value(i).to_string())
-            })
-            .collect()
-    }
 
     fn execute_bodies(gateway: &MockGateway) -> Vec<String> {
         gateway
@@ -861,7 +846,7 @@ bindings:
 
         let batches = collect(&ctx, "SELECT id FROM saas.ws.files WHERE user_id = 'U0001'").await;
         assert_eq!(
-            ids_of(&batches),
+            column_values(&batches, "id"),
             vec!["F0001"],
             "exactly U0001's file survives; the ignoring provider's extra row is trimmed"
         );
@@ -915,7 +900,7 @@ bindings:
         )
         .await;
         assert_eq!(
-            ids_of(&batches),
+            column_values(&batches, "id"),
             vec!["F0002", "F0003"],
             "the boundary row stays; the older row is filtered locally"
         );
@@ -1069,7 +1054,10 @@ bindings:
         let ctx = setup(&gateway, "users", "SKARDI_TEST_OC_SLACK_USERS_CURSOR").await;
 
         let batches = collect(&ctx, "SELECT id FROM saas.ws.users ORDER BY id").await;
-        assert_eq!(ids_of(&batches), vec!["U0001", "U0002", "U0003"]);
+        assert_eq!(
+            column_values(&batches, "id"),
+            vec!["U0001", "U0002", "U0003"]
+        );
 
         let inputs: Vec<Value> = execute_bodies(&gateway)
             .iter()

--- a/crates/skardi/src/sources/providers/open_connector/testutil.rs
+++ b/crates/skardi/src/sources/providers/open_connector/testutil.rs
@@ -1,6 +1,7 @@
 //! Test support for the Open Connector suites: the mock gateway (a thin
-//! flavor over the crate-shared mock HTTP server), envelope builders, and a
-//! tracing capture for asserting on emitted events.
+//! flavor over the crate-shared mock HTTP server), envelope builders, the
+//! Arrow/SQL accessors every pack suite leans on, and a tracing capture
+//! for asserting on emitted events.
 //!
 //! The server itself lives in [`crate::util::mock_http`] — hand-rolled over
 //! `tokio::net::TcpListener` so the test suite needs no mock HTTP crate,
@@ -12,7 +13,15 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
+use arrow::array::{BooleanArray, StringArray};
+use arrow::record_batch::RecordBatch;
+use datafusion::prelude::SessionContext;
+use serde_json::Value;
 use tracing::field::{Field, Visit};
+
+use crate::sources::providers::open_connector::json_to_arrow::RowConverter;
+use crate::sources::providers::open_connector::row_path::RowPath;
+use crate::sources::providers::open_connector::source_pack::SourcePackTable;
 
 pub(crate) use crate::util::mock_http::{
     MockHttpServer as MockGateway, MockResponse, RecordedRequest,
@@ -62,6 +71,81 @@ pub(crate) fn discovery_ok(
     envelope_ok(&format!(
         r#"{{"inputSchema":{input_schema},"outputSchema":{output_schema},"execution":{{"locallyExecutable":{locally_executable}{read_only}}}}}"#
     ))
+}
+
+/// Run one SQL statement to completion and return every result batch.
+pub(crate) async fn collect(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch> {
+    ctx.sql(sql)
+        .await
+        .expect("plan")
+        .collect()
+        .await
+        .expect("collect")
+}
+
+/// Convert one gateway page into a batch through the table's declared row
+/// path and field mappings — the same path the scan takes, so a fixture
+/// asserted through this helper vouches for the real conversion.
+pub(crate) fn convert_page(table: &SourcePackTable, page: &Value) -> RecordBatch {
+    let rows = RowPath::parse(table.row_path)
+        .expect("row path")
+        .rows(page, 1)
+        .expect("row array");
+    RowConverter::new(table.fields)
+        .expect("converter")
+        .convert(rows, 1)
+        .expect("page converts")
+}
+
+/// A named column downcast to `StringArray`; panics name the missing
+/// column so a schema drift reads as itself, not as a bare `unwrap`.
+pub(crate) fn utf8<'a>(batch: &'a RecordBatch, name: &str) -> &'a StringArray {
+    batch
+        .column_by_name(name)
+        .unwrap_or_else(|| panic!("column {name}"))
+        .as_any()
+        .downcast_ref()
+        .expect("Utf8 column")
+}
+
+/// A named column downcast to `BooleanArray`.
+pub(crate) fn boolean<'a>(batch: &'a RecordBatch, name: &str) -> &'a BooleanArray {
+    batch
+        .column_by_name(name)
+        .unwrap_or_else(|| panic!("column {name}"))
+        .as_any()
+        .downcast_ref()
+        .expect("Boolean column")
+}
+
+/// Every value of a Utf8 column across all result batches, in row order.
+pub(crate) fn column_values(batches: &[RecordBatch], name: &str) -> Vec<String> {
+    batches
+        .iter()
+        .flat_map(|batch| {
+            let values = batch
+                .column_by_name(name)
+                .unwrap_or_else(|| panic!("column {name}"))
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("Utf8 column")
+                .clone();
+            (0..values.len()).map(move |i| values.value(i).to_string())
+        })
+        .collect()
+}
+
+/// The sorted top-level keys of one recorded executor input, for asserting
+/// exactly which inputs traveled on the wire.
+pub(crate) fn input_keys(input: &Value) -> Vec<&str> {
+    let mut keys: Vec<&str> = input
+        .as_object()
+        .expect("input object")
+        .keys()
+        .map(String::as_str)
+        .collect();
+    keys.sort_unstable();
+    keys
 }
 
 /// One tracing event captured by [`capture_events`].

--- a/crates/skardi/src/sources/providers/open_connector/testutil.rs
+++ b/crates/skardi/src/sources/providers/open_connector/testutil.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
-use arrow::array::{BooleanArray, StringArray};
+use arrow::array::{Array, BooleanArray, StringArray};
 use arrow::record_batch::RecordBatch;
 use datafusion::prelude::SessionContext;
 use serde_json::Value;

--- a/crates/skardi/src/sources/providers/open_connector/testutil.rs
+++ b/crates/skardi/src/sources/providers/open_connector/testutil.rs
@@ -77,16 +77,18 @@ pub(crate) fn discovery_ok(
 pub(crate) async fn collect(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch> {
     ctx.sql(sql)
         .await
-        .expect("plan")
+        .unwrap_or_else(|e| panic!("failed to plan {sql}: {e}"))
         .collect()
         .await
-        .expect("collect")
+        .unwrap_or_else(|e| panic!("failed to collect {sql}: {e}"))
 }
 
 /// Convert one gateway page into a batch through the table's declared row
 /// path and field mappings — the same path the scan takes, so a fixture
-/// asserted through this helper vouches for the real conversion.
-pub(crate) fn convert_page(table: &SourcePackTable, page: &Value) -> RecordBatch {
+/// asserted through this helper vouches for the real conversion. Error
+/// context is pinned to page 1, as the name promises: fixtures are
+/// single-page corpora, never a mid-scan continuation.
+pub(crate) fn convert_first_page(table: &SourcePackTable, page: &Value) -> RecordBatch {
     let rows = RowPath::parse(table.row_path)
         .expect("row path")
         .rows(page, 1)
@@ -97,40 +99,50 @@ pub(crate) fn convert_page(table: &SourcePackTable, page: &Value) -> RecordBatch
         .expect("page converts")
 }
 
-/// A named column downcast to `StringArray`; panics name the missing
-/// column so a schema drift reads as itself, not as a bare `unwrap`.
+/// A named column downcast to `StringArray`; panics name the column and,
+/// on a type mismatch, the Arrow type actually found, so a schema drift
+/// reads as itself, not as a bare `unwrap`.
 pub(crate) fn utf8<'a>(batch: &'a RecordBatch, name: &str) -> &'a StringArray {
-    batch
+    let column = batch
         .column_by_name(name)
-        .unwrap_or_else(|| panic!("column {name}"))
+        .unwrap_or_else(|| panic!("column {name}"));
+    column
         .as_any()
         .downcast_ref()
-        .expect("Utf8 column")
+        .unwrap_or_else(|| panic!("column {name} is {:?}, not Utf8", column.data_type()))
 }
 
 /// A named column downcast to `BooleanArray`.
 pub(crate) fn boolean<'a>(batch: &'a RecordBatch, name: &str) -> &'a BooleanArray {
-    batch
+    let column = batch
         .column_by_name(name)
-        .unwrap_or_else(|| panic!("column {name}"))
+        .unwrap_or_else(|| panic!("column {name}"));
+    column
         .as_any()
         .downcast_ref()
-        .expect("Boolean column")
+        .unwrap_or_else(|| panic!("column {name} is {:?}, not Boolean", column.data_type()))
 }
 
 /// Every value of a Utf8 column across all result batches, in row order.
+/// Panics on a NULL slot rather than reading the underlying buffer as if
+/// it held a value — a caller asserting over a nullable column needs
+/// options, which this helper deliberately does not offer.
 pub(crate) fn column_values(batches: &[RecordBatch], name: &str) -> Vec<String> {
     batches
         .iter()
         .flat_map(|batch| {
-            let values = batch
+            let column = batch
                 .column_by_name(name)
-                .unwrap_or_else(|| panic!("column {name}"))
+                .unwrap_or_else(|| panic!("column {name}"));
+            let values = column
                 .as_any()
                 .downcast_ref::<StringArray>()
-                .expect("Utf8 column")
+                .unwrap_or_else(|| panic!("column {name} is {:?}, not Utf8", column.data_type()))
                 .clone();
-            (0..values.len()).map(move |i| values.value(i).to_string())
+            (0..values.len()).map(move |i| {
+                assert!(!values.is_null(i), "column {name} is NULL at row {i}");
+                values.value(i).to_string()
+            })
         })
         .collect()
 }

--- a/crates/skardi/src/sources/providers/open_connector/testutil.rs
+++ b/crates/skardi/src/sources/providers/open_connector/testutil.rs
@@ -123,26 +123,42 @@ pub(crate) fn boolean<'a>(batch: &'a RecordBatch, name: &str) -> &'a BooleanArra
         .unwrap_or_else(|| panic!("column {name} is {:?}, not Boolean", column.data_type()))
 }
 
-/// Every value of a Utf8 column across all result batches, in row order.
-/// Panics on a NULL slot rather than reading the underlying buffer as if
-/// it held a value — a caller asserting over a nullable column needs
-/// options, which this helper deliberately does not offer.
+/// Every value of a Utf8 column across all result batches, in row order;
+/// the panic's row index counts across batches, matching the returned
+/// Vec. Panics on a NULL slot rather than reading the underlying buffer
+/// as if it held a value — a deliberate tightening over the pack-local
+/// originals, which silently yielded `""` there. A caller asserting over
+/// a nullable column needs options, which this helper does not offer.
 pub(crate) fn column_values(batches: &[RecordBatch], name: &str) -> Vec<String> {
+    let mut offset = 0;
     batches
         .iter()
         .flat_map(|batch| {
-            let column = batch
-                .column_by_name(name)
-                .unwrap_or_else(|| panic!("column {name}"));
-            let values = column
-                .as_any()
-                .downcast_ref::<StringArray>()
-                .unwrap_or_else(|| panic!("column {name} is {:?}, not Utf8", column.data_type()))
-                .clone();
+            let values = utf8(batch, name).clone();
+            let base = offset;
+            offset += values.len();
             (0..values.len()).map(move |i| {
-                assert!(!values.is_null(i), "column {name} is NULL at row {i}");
+                assert!(
+                    !values.is_null(i),
+                    "column {name} is NULL at row {}",
+                    base + i
+                );
                 values.value(i).to_string()
             })
+        })
+        .collect()
+}
+
+/// The `input` payload of every execute POST the gateway recorded, in
+/// wire order — filtered to one action when `action_path` is non-empty
+/// (a single-action pack passes `""` and takes every execute).
+pub(crate) fn execute_inputs(gateway: &MockGateway, action_path: &str) -> Vec<Value> {
+    gateway
+        .requests()
+        .into_iter()
+        .filter(|r| r.method == "POST" && r.path.ends_with(action_path))
+        .map(|r| {
+            serde_json::from_str::<Value>(&r.body).expect("request body is JSON")["input"].clone()
         })
         .collect()
 }


### PR DESCRIPTION
## What

The Open Connector pack test modules each carried their own copy of the same mechanical Arrow/SQL helpers. Measured across `packs/*.rs`: `collect` in 9 modules, `utf8` in 8, `boolean` in 6, `convert_page` / `column_values` / `input_keys` in 4 each, `execute_inputs` in 7 (4 with an `action_path` filter, 3 without), and `ids_of` in 3 plus two inline spellings — all byte-identical within each group, except slack's older `utf8`/`boolean`, which used bare `unwrap()` instead of naming the missing column.

This lifts them all into `open_connector::testutil` — already the home for exactly this kind of shared test scaffolding (`envelope_ok`, `discovery_ok`, `fingerprint_uncovered_columns`, `EnvVarGuard`) — and points all 9 modules at them, google_drive included (rebased onto #226 after it merged mid-review). github's `strings`/`bools` were the same accessors under other names and are renamed at their call sites; outlook's two hand-rolled downcasts (the conversation_id HashSet count and `is_hidden`) now go through `utf8`/`boolean`. Net −436 lines across the two commits; no assertions change.

## Review-driven hardening (beyond the verbatim move)

- `collect` panics now carry the SQL that failed to plan/collect.
- `utf8`/`boolean` mismatch panics name the column **and** the actual Arrow type found.
- `column_values` asserts non-NULL per slot instead of silently reading the buffer as `""` (all current call sites read non-null identity columns, so nothing regresses today); its panic row index counts across batches; and it composes over `utf8` instead of re-implementing the lookup+downcast.
- `convert_page` is renamed `convert_first_page`: it hardcodes page 1, and the old name let a fixture for page 3 report errors as "page 1".
- The shared `execute_inputs` takes `action_path`; a single-action pack passes `""` (always matches, since `ends_with("")` is true) — one function covers both prior shapes.

One CI round-trip found the only non-mechanical wrinkle: `column_values` calls `.len()` on a concrete `StringArray`, which resolves through the `Array` trait — in the pack modules the trait rode along on each module's imports, and the lift had to bring it explicitly (`utf8`/`boolean` didn't need it: their receiver is a `dyn Array` trait object, whose method lookup works without the trait in scope).

## Deliberately not moved

- **Pack-local single-type accessors** (`timestamp`, `timestamps`, `millis`, `int64`, `uint64`, github's `u64s`/`string_list`): one or two copies each, several under pack-specific names. Sharing them is not yet paying for the move.
- **google_drive's `utf8_list` / `list_items`**: genuinely new (no sibling pack has list columns); they stay with the pack until a second user shows up.
- **`convert_fixture`**: three different spellings across packs (some inline the conversion, some delegate to `convert_first_page`, with different expect messages); unifying it would change behavior text, not just location.
- **discord's `sorted_keys`**: same idea as `input_keys` but returns `Vec<String>`; converging it would touch assertion types, not just location.
- **`table_functions.rs`'s `collect`**: same shape but outside `packs/`; can switch to the shared helper in a follow-up if wanted.

## In-flight branches

#216 (dropbox) still carries local copies; after this merges it can drop them for the testutil imports on rebase — a mechanical change on that branch.

## Verification

`cargo fmt --check` clean locally; correctness rides on CI running the full suite — the change moves test helpers (plus the hardening above) and touches no production code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)