### PR TITLE
docs(readme): give each Agent Skills host its own install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ skardi run weekly-churn -p window='7 days'
 curl -X POST localhost:8080/weekly-churn/execute \
   -H 'Content-Type: application/json' -d '{"window": "7 days"}'
 # same pipeline as an MCP tool — hosts without a shell (Claude Desktop, …)
+# from a source checkout until `skardi mcp` ships in a tagged release
 skardi mcp
 ```
 

--- a/README.md
+++ b/README.md
@@ -171,13 +171,43 @@ you:
 /plugin install auto-context@skardi-skills
 ```
 
-[`auto_context`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_context)
+[`auto-context`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto-context)
 turns a folder of documents — or a datastore you already run — into governed,
 searchable context served over HTTP by `skardi-server`: hybrid search (vector +
 FTS + RRF), defaulting to a local SQLite file the skill creates and owns, or
-pointed at Postgres + pgvector, MongoDB, or Lance. The same skill also runs on
-Codex, Cursor, Pi, dsh, OpenClaw, and Hermes; per-host installation instructions
-are in the [skardi-skills README](https://github.com/SkardiLabs/skardi-skills#installation).
+pointed at Postgres + pgvector, MongoDB, or Lance.
+[`retrieval`](https://github.com/SkardiLabs/skardi-skills/tree/main/retrieval)
+teaches the agent to answer questions from a `skardi-server` you already run.
+
+**Other Agent Skills hosts** — the same two skills run on Codex, Cursor, Pi,
+dsh, OpenClaw and Hermes. They differ only in where the skill directory goes,
+and all of them install from a checkout:
+
+```bash
+git clone https://github.com/SkardiLabs/skardi-skills.git && cd skardi-skills
+```
+
+Codex, Cursor, Pi and dsh all read the cross-tool `~/.agents/skills/`
+convention, so one copy covers all four:
+
+```bash
+mkdir -p ~/.agents/skills
+cp -r auto-context/skills/auto-context ~/.agents/skills/auto-context
+cp -r retrieval/skills/retrieval ~/.agents/skills/retrieval
+```
+
+[OpenClaw](https://docs.openclaw.ai/cli/skills) installs through its own CLI
+instead of copying, and [Hermes](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills)
+reads `~/.hermes/skills/`:
+
+```bash
+openclaw skills install ./auto-context/skills/auto-context   # add --global for every workspace
+mkdir -p ~/.hermes/skills && cp -r auto-context/skills/auto-context ~/.hermes/skills/auto-context
+```
+
+Per-host native directories, project-scoped installs and the Hermes
+`external_dirs` option are covered in the
+[skardi-skills README](https://github.com/SkardiLabs/skardi-skills#installation).
 
 **CLI** — pre-built for `x86_64`/`aarch64` Linux and Apple Silicon (Intel Macs:
 build from source — the one-liner below has no published artifact there):

--- a/README.md
+++ b/README.md
@@ -163,15 +163,7 @@ scratch.
 
 ## Install
 
-**Claude Code** — the fastest path. A skill that stands the whole thing up for
-you:
-
-```text
-/plugin marketplace add SkardiLabs/skardi-skills
-/plugin install auto-context@skardi-skills
-```
-
-[`auto-context`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto-context)
+Two skills. [`auto-context`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto-context)
 turns a folder of documents — or a datastore you already run — into governed,
 searchable context served over HTTP by `skardi-server`: hybrid search (vector +
 FTS + RRF), defaulting to a local SQLite file the skill creates and owns, or
@@ -179,16 +171,24 @@ pointed at Postgres + pgvector, MongoDB, or Lance.
 [`retrieval`](https://github.com/SkardiLabs/skardi-skills/tree/main/retrieval)
 teaches the agent to answer questions from a `skardi-server` you already run.
 
-**Other Agent Skills hosts** — the same two skills run on Codex, Cursor, Pi,
-dsh, OpenClaw and Hermes. They differ only in where the skill directory goes,
-and all of them install from a checkout:
+Both run on every [Agent Skills](https://agentskills.io/) host below. They
+differ only in where the skill directory goes.
+
+**Claude Code** installs from the marketplace:
+
+```text
+/plugin marketplace add SkardiLabs/skardi-skills
+/plugin install auto-context@skardi-skills
+```
+
+Every other host installs from a checkout:
 
 ```bash
 git clone https://github.com/SkardiLabs/skardi-skills.git && cd skardi-skills
 ```
 
-Codex, Cursor, Pi and dsh all read the cross-tool `~/.agents/skills/`
-convention, so one copy covers all four:
+**Codex, Cursor, Pi, dsh and OpenCode** all read the cross-tool
+`~/.agents/skills/` convention, so one copy covers all five:
 
 ```bash
 mkdir -p ~/.agents/skills
@@ -196,8 +196,8 @@ cp -r auto-context/skills/auto-context ~/.agents/skills/auto-context
 cp -r retrieval/skills/retrieval ~/.agents/skills/retrieval
 ```
 
-[OpenClaw](https://docs.openclaw.ai/cli/skills) installs through its own CLI
-instead of copying, and [Hermes](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills)
+**[OpenClaw](https://docs.openclaw.ai/cli/skills)** installs through its own CLI
+instead of copying, and **[Hermes](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills)**
 reads `~/.hermes/skills/`:
 
 ```bash


### PR DESCRIPTION
## Why

The Install section already named Codex, Cursor, Pi, dsh, OpenClaw and Hermes, but only Claude Code could be followed without leaving the page — everyone else got a pointer to another repo. Reading the section, it still looks like a Claude Code–only project.

## What changed

- **Per-host commands, inline.** One copy into `~/.agents/skills/` covers Codex, Cursor, Pi and dsh (they share that cross-tool convention). OpenClaw installs through its own CLI; Hermes reads `~/.hermes/skills/`.
- **Fixed a 404.** The `auto_context` link still pointed at the pre-rename path; the directory is `auto-context` now.
- **Added `retrieval`** next to `auto-context`, since both skills ship from the same repo.

Native per-host directories, project-scoped installs and the Hermes `external_dirs` option stay in the [skardi-skills README](https://github.com/SkardiLabs/skardi-skills#installation) — this section gives the shortest path that works, not the full matrix.

## Verification

- `python3 scripts/check_markdown_links.py` → all relative links resolve
- Directory names checked against `skardi-skills@main`: `auto-context`, `retrieval`
