### PR TITLE
docs(skills): graph-source — connect and query a property graph (Cypher over AGE) end-to-end

### DIFF
--- a/docs/superpowers/skills/README.md
+++ b/docs/superpowers/skills/README.md
@@ -16,3 +16,4 @@ the link points into the repo.
 | Skill | Purpose |
 | --- | --- |
 | [source-pack](source-pack/SKILL.md) | Develop a new Open Connector source pack end-to-end: live contract reconciliation, implementation under the admission gate, self-review against the repo's review standards, PR submission. |
+| [graph-source](graph-source/SKILL.md) | Connect a property graph (Cypher over AGE) to Skardi end-to-end: least-privilege provisioning, `type: graph` declaration and views, registration-state verification, correct query patterns, pipeline parameterization, troubleshooting. |

--- a/docs/superpowers/skills/graph-source/SKILL.md
+++ b/docs/superpowers/skills/graph-source/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: graph-source
+description: >-
+  Connect a property graph (knowledge graph, GraphRAG corpus, Apache AGE /
+  openCypher data) to Skardi and query it through SQL, end to end: provision
+  the AGE backend with a least-privilege role, declare the `type: graph`
+  source and its views in context YAML, verify registration health, write
+  correct queries (`cypher_query`, `graph_schema`, the JSON getters), and
+  wire Cypher parameters into pipelines. Use this skill whenever the user
+  wants graph data queryable in Skardi, mentions graphs, Cypher, AGE,
+  Neo4j-style data, knowledge graphs, GraphRAG, `kg.*` tables,
+  `cypher_query`, or is debugging a degraded graph source, a
+  `RowCapExceeded`, or a silently-NULL property column — even if they never
+  say the words "graph source".
+---
+
+# Connecting a graph source to Skardi
+
+You are wiring a property graph into Skardi as SQL tables. Skardi does
+not parse or store graphs — the graph engine (Apache AGE: openCypher
+inside Postgres) owns storage and traversal; Skardi forwards **read-only**
+Cypher and maps results into Arrow rows with a planning-time-stable
+schema. Design: `docs/superpowers/specs/2026-08-08-graph-engine-bypass-design.md`;
+operational truth: `docs/graph.md`. When this skill and those documents
+disagree, the documents win — check them, then fix this skill.
+
+**Scope, stated so you don't promise what doesn't exist:** the shipped
+backend is AGE (milestone status M4 — `type: graph` sources, YAML
+catalog views, the `cypher_query` / `graph_schema` UDTFs, pipeline
+parameter passthrough). Neo4j and Kuzu are later milestones: the config
+carries a `backend:` field for them, but do not write configuration or
+guidance for a backend that has no implementation. Milestone one is
+read-only end to end; write paths are deferred by design.
+
+The reason this skill exists: every trap below is real, was hit, and is
+documented — but scattered. The two that cost the most debugging time:
+**the ad-hoc `columns` argument binds positionally** (two same-typed
+columns declared out of RETURN order swap silently — no error, wrong
+data), and **a view's SQL `WHERE` does not push into its Cypher** (a
+query that wants one row still fails `RowCapExceeded` if the view is
+unbounded). Both are invisible until they bite.
+
+## The workflow
+
+Work the phases in order. Each phase names its reference file — read it
+before doing that phase's work, not after it goes wrong.
+
+### Phase 1 — Provision the backend
+
+Read [references/provisioning.md](references/provisioning.md).
+
+Stand up (or locate) the AGE instance and create a **least-privilege
+reader role** — never a superuser, and never "fix" a failing
+registration by upgrading the credential. Credentials enter Skardi as
+environment-variable NAMES only; a password embedded in
+`connection_string` is rejected at config load.
+
+### Phase 2 — Declare the source
+
+Read [references/configuration.md](references/configuration.md).
+
+Write the `type: graph` entry in context YAML: `hierarchy_level:
+catalog` (required — views register as `<name>.main.<view>`), the
+`graph:` block (backend, graph_name, credential env-var names, bounds),
+and the views. Decide view vs ad-hoc deliberately:
+
+- **Declare a view** when agents need a predictable table name and the
+  query shape is stable. A view's Cypher **must carry its own bound**
+  (`WHERE` / `LIMIT` inside the Cypher) — SQL predicates over the view
+  do not push down.
+- **Leave it to ad-hoc `cypher_query`** when the predicate belongs to
+  the caller. The caller places the bound where it works.
+
+### Phase 3 — Verify registration
+
+Read the registration-semantics section of
+[references/configuration.md](references/configuration.md), then start
+the server and check which of the three states you got:
+
+- **healthy** — backend reachable, every view validated with one live
+  call. Note what that proves: arity always; type and `nullable: false`
+  only for the sampled row. Per-row enforcement lives in execution.
+- **refused** (server does not start) — the backend ANSWERED and a view's
+  contract is broken (RETURN arity/types disagree with the declared
+  schema), or the server answered with an error (bad credentials, AGE
+  absent, graph missing). This is a bug in your declaration or
+  deployment, not an outage — fix it, don't retry it.
+- **degraded** — genuine connectivity failure only (DNS, refused dial,
+  network timeout). Views still register on declared schemas; the first
+  scan retries; recovery flips healthy on ANY server response.
+
+Then prove the read path with the discovery UDTF and one view scan:
+
+```sql
+SELECT * FROM graph_schema('kg');          -- one (label, kind) row per label
+SELECT * FROM kg.main.people LIMIT 5;
+```
+
+### Phase 4 — Write the queries
+
+Read [references/querying.md](references/querying.md) — it carries the
+positional-binding rule, the getter table, and the patterns. The three
+rules that prevent silent wrong answers:
+
+1. **`columns` is positional.** Declare ad-hoc columns in RETURN order;
+   the names are labels for SQL, not a lookup key.
+2. **Properties are JSON text; pick the getter by the stored JSON
+   type.** `json_get_str` on a numeric property returns NULL — not an
+   error, not a coercion. `age` needs `json_get_int`.
+3. **`->` / `->>` / `?` are deliberately not installed** (the rewrite
+   would break federated pushdown session-wide). Use the getter UDFs.
+
+### Phase 5 — Pipeline it (when a pipeline is asked for)
+
+Read the pipelines section of
+[references/querying.md](references/querying.md). One spelling works:
+the `{param}` placeholder occupies the **whole `params` argument** of
+`cypher_query`, and the caller passes the params JSON **as a string**.
+Connection, cypher, and columns stay strict literals — they determine
+the plan, so a placeholder cannot produce one.
+
+### When something breaks
+
+Read [references/troubleshooting.md](references/troubleshooting.md) —
+symptom → diagnosis, including how graph health surfaces through
+`GET /data_source` (and what the skardi-cloud gateway's projection
+deliberately hides from tenants).
+
+## Working style
+
+- **Verify against the running system, not this skill.** One
+  `graph_schema('kg')` call answers more than an hour of config
+  re-reading. The milestone status and bounds cited here were true when
+  written; `docs/graph.md` and the config code are the authority.
+- **No credentials anywhere but env-var names.** Not in YAML, not in
+  logs, not in error reports you paste. Connection strings are never
+  echoed — they may carry credentials on other deployments even though
+  this one must not.
+- **Errors are typed and name their cause.** If you see an untyped or
+  misleading graph error, that's a bug worth filing, not working around.
+- **Don't widen bounds to make symptoms disappear.** `max_rows` and
+  `query_timeout_seconds` are protections; the fix for `RowCapExceeded`
+  is a bound in the view's Cypher, and the fix for a timeout is usually
+  a narrower traversal.

--- a/docs/superpowers/skills/graph-source/references/configuration.md
+++ b/docs/superpowers/skills/graph-source/references/configuration.md
@@ -1,0 +1,134 @@
+# Declaring the source: the full contract
+
+## The context YAML
+
+```yaml
+kind: context
+spec:
+  data_sources:
+    - name: kg                        # the catalog name: views live at kg.main.<view>
+      type: graph
+      hierarchy_level: catalog        # REQUIRED — anything else is refused at registration
+      connection_string: postgres://localhost:5432/graphrag   # no credentials here (enforced)
+      graph:
+        backend: age                  # the shipped backend; neo4j/kuzu are later milestones
+        graph_name: knowledge         # AGE graphs are named per database
+        username_env: KG_READER_USER  # env-var NAMES, never values
+        password_env: KG_READER_PASS
+        query_timeout_seconds: 30     # default 30; valid 1..=86400
+        max_rows: 10000               # default 10000; valid 1..=1000000
+        max_connections: 4            # default 4; valid 1..=64
+        views:
+          - name: people
+            cypher: |
+              MATCH (p:Person)
+              WHERE p.active
+              RETURN p.name AS name, p.age AS age
+              LIMIT 5000
+            schema:
+              - name: name
+                type: string
+              - name: age
+                type: int
+```
+
+Notes that prevent re-derivation:
+
+- `hierarchy_level: catalog` is required — the error if you omit it says
+  so, but say it here too: views are catalog tables, so the source must
+  register in catalog mode.
+- The view above carries `WHERE` and `LIMIT` **inside its Cypher**. That
+  is not decoration — see "A view's bound lives in its Cypher" below.
+- Column `type` vocabulary (same for views and the ad-hoc `columns`
+  argument, lowercase): `string|str|utf8`, `int|integer|bigint`,
+  `float|double`, `bool|boolean`, `json`, `node`, `relationship`,
+  `path`.
+- **View names must be lowercase identifiers** (`[a-z_][a-z0-9_]*`) —
+  enforced at config load, with a reason worth knowing: the name becomes
+  the catalog table `<source>.main.<view>`, and DataFusion folds
+  unquoted SQL identifiers to lowercase, so a view named `userPosts`
+  would register fine, show up in `/data_source`, and be unreachable
+  from any unquoted `SELECT`. The validator rejects the spelling rather
+  than silently lowercasing it.
+- Every column defaults to `nullable: true`. Declaring
+  `nullable: false` is an author's assertion: a null arriving in such a
+  column is a **typed error naming the column and row**, not silent
+  corruption. Assert it only where the graph genuinely guarantees it.
+
+## A view's bound lives in its Cypher
+
+SQL-side predicates over a view do NOT push down into its Cypher.
+`SELECT * FROM kg.main.people WHERE name = 'ada'` fetches the view's
+rows (up to `max_rows`) and filters locally. A SQL `LIMIT` does push to
+the consumption side — the fetch stops early — but a bare `WHERE` over
+a view larger than `max_rows` fails with a typed `RowCapExceeded`,
+**even when the query wants one row**.
+
+So: write selective reads INTO the view's Cypher (`WHERE` / `LIMIT`
+there), or use ad-hoc `cypher_query` where the predicate is the
+caller's to place. Filter→Cypher parameterization is a named possible
+future improvement; today the bound lives in the view. Raising
+`max_rows` to make the error go away is almost always the wrong fix —
+it converts a typed refusal into an unbounded fetch.
+
+## Bounds, and what each one actually does
+
+- `query_timeout_seconds` becomes the server-side `statement_timeout`
+  PLUS a client-side wrap. A query past it fails with a typed timeout.
+- `max_rows` caps **consumed** rows with a typed `RowCapExceeded`, and
+  the fetch is a real SQL LIMIT of `min(limit, max_rows + 1)` — the
+  wire is bounded too, not just the buffer.
+- `max_connections` sizes the pool; pool queueing is bounded by the
+  same timeout.
+
+## Registration semantics: healthy, degraded, refused
+
+Availability and contract violations part ways deliberately. The graph
+backend is a shared external database whose transient blip must not
+hold every unrelated source hostage at startup — this diverges from
+Open Connector's hard-fail health check, on purpose.
+
+**Healthy** — backend reachable, every view validated with one live
+call (the Cypher runs fetching at most one row; the result must convert
+against the declared schema). Be honest about what that proves:
+**arity always** (the backend raises it regardless of row order);
+**type and `nullable: false` only for the sampled row** — Cypher
+without `ORDER BY` guarantees nothing about which row comes back, so a
+view over heterogeneous data can register healthy and still fail a
+later scan on a different row. Validation is a bounded preflight, not a
+proof of the contract over the whole graph; per-row enforcement lives
+in execution.
+
+**Refused (server does not start)** — the backend ANSWERED and
+something is wrong that retrying cannot fix: a view whose RETURN arity
+or types disagree with its declared schema (the error names the view
+and carries the backend's complaint), wrong credentials, AGE not
+installed, the graph missing, or a view whose validation hits the
+statement timeout (the server accepted the query; a too-slow view is a
+boot-time diagnosis, not an outage). Fix the declaration or the
+deployment and restart.
+
+**Degraded** — only genuine connectivity failures qualify: DNS, a
+refused dial, a network timeout — no server answered. (A pool acquire
+timeout counts: sqlx retries a refused dial until the acquire deadline,
+so an unreachable backend surfaces as `PoolTimedOut`.) Views still
+register with their declared (planning-sufficient) schemas;
+`GET /data_source` reports `status: "degraded"` plus `status_reason`
+(the registration error) and `status_changed_at`; the first scan
+retries. The registration preflight is bounded by
+`min(query_timeout_seconds, 30s)` — the traversal timeout may be hours,
+but boot never blocks longer than 30 s on a dead host.
+
+**Recovery answers exactly one question: did the backend come back?** A
+retry that gets ANY response flips the source healthy — including a
+response in which a view fails its contract. The still-broken view then
+fails its OWN scans with the typed error execution already produces,
+while every other view works. Recovery deliberately does not hold
+registration's all-or-nothing line: keeping the whole source degraded
+over one un-provable view would disable every view permanently with no
+startup signal, and `/data_source`'s "degraded" would misread as
+"backend unreachable". Availability failures arm a backoff of
+`query_timeout_seconds` clamped to `[30s, 300s]`; inside the window
+scans fail fast with the cached diagnosis instead of re-paying the full
+N-view re-validation. An ad-hoc `cypher_query` / `graph_schema` call on
+a degraded source IS the retry.

--- a/docs/superpowers/skills/graph-source/references/provisioning.md
+++ b/docs/superpowers/skills/graph-source/references/provisioning.md
@@ -1,0 +1,76 @@
+# Provisioning the AGE backend
+
+The read-only guarantee is **backend-enforced** (a `READ ONLY`
+transaction wraps every query; the plan-time keyword guard is UX, not
+the boundary). That is why the deployment posture matters: Skardi's
+credential defines what a compromised or buggy query could ever do.
+
+## The least-privilege reader role
+
+Run Skardi's graph connection as a role that can read the graph and
+nothing else — **never a superuser**:
+
+```sql
+-- As the administrator, once:
+CREATE ROLE kg_reader LOGIN PASSWORD '…';
+GRANT CONNECT ON DATABASE graphrag TO kg_reader;  -- explicit, in case PUBLIC's default was revoked
+GRANT USAGE ON SCHEMA ag_catalog TO kg_reader;
+GRANT SELECT ON ALL TABLES IN SCHEMA ag_catalog TO kg_reader;
+
+-- Per graph (AGE stores each graph in a schema of the same name):
+GRANT USAGE ON SCHEMA your_graph TO kg_reader;
+GRANT SELECT ON ALL TABLES IN SCHEMA your_graph TO kg_reader;
+```
+
+`ag_catalog` access is what lets `graph_schema()` enumerate labels and
+what registration probes (`ag_catalog.ag_graph`) to distinguish "AGE is
+absent" from other failures.
+
+## Why `LOAD 'age'` is best-effort, and what to do instead
+
+The client issues `LOAD 'age'` on each connection as best-effort,
+deliberately: `LOAD` is superuser-only for libraries outside
+`$libdir/plugins`, and requiring it would force the exact credential
+this recipe exists to avoid.
+
+- The official `apache/age` image ships
+  `shared_preload_libraries = age` — a reader role works as-is.
+- On self-managed Postgres, set `shared_preload_libraries = 'age'` (or
+  `session_preload_libraries`) in postgresql.conf.
+- If registration fails with an `ag_catalog.ag_graph` probe error, AGE
+  is genuinely absent from the server. Install it there. Do NOT solve
+  this by upgrading Skardi's credential to superuser so `LOAD` works —
+  that trades a one-line postgresql.conf fix for a standing privilege
+  escalation.
+
+## Credentials: env-var names only
+
+Config carries credentials as environment-variable **names**
+(`username_env`, `password_env`), never values. A password embedded in
+`connection_string` is rejected at config load — this is enforcement,
+not convention. Consequences for how you work:
+
+- Export the variables in the server's environment (or the operator's
+  Secret on cloud deployments); the YAML names them.
+- Never echo a connection string into logs, error reports, or chat —
+  on deployments that violate the rule elsewhere, the string is where
+  the credential hides.
+
+## A local AGE for development
+
+```bash
+docker run -d --name age -p 5455:5432 \
+  -e POSTGRES_PASSWORD=devonly apache/age
+```
+
+Then create the graph and the reader role inside it:
+
+```sql
+SELECT * FROM ag_catalog.create_graph('knowledge');
+-- …CREATE ROLE kg_reader… as above, plus your seed data via cypher()
+```
+
+The container image already preloads AGE, so the reader role works
+without any superuser step. Seed data goes in with AGE's own
+`cypher('knowledge', $$ CREATE (:Person {name: 'ada', age: 36}) $$)`
+as the admin role — Skardi's surface is read-only and cannot seed.

--- a/docs/superpowers/skills/graph-source/references/querying.md
+++ b/docs/superpowers/skills/graph-source/references/querying.md
@@ -1,0 +1,123 @@
+# Writing the queries
+
+## Discovery first
+
+```sql
+SELECT * FROM graph_schema('kg');
+```
+
+One `(label, kind)` row per label, straight off `ag_catalog` — kinds
+are node vs relationship labels. Run this before writing Cypher against
+an unfamiliar graph; it is also the cheapest liveness probe a degraded
+source can get (the call IS the recovery retry).
+
+## Ad-hoc `cypher_query`
+
+```sql
+SELECT name, n
+FROM cypher_query(
+  'kg',                                                    -- source name
+  'MATCH (n:Person) WHERE n.age > $min RETURN n.name, n',  -- read-only Cypher
+  '{"min": 30}',                                           -- params JSON (or NULL)
+  '{"name": "string", "n": "node"}'                        -- declared columns
+);
+```
+
+**The `columns` argument is REQUIRED on AGE, and it binds
+POSITIONALLY.** The declared entries pair with the RETURN clause's
+items **in order**; the names are labels for the SQL side, not a lookup
+key into the Cypher. Two same-typed columns declared out of RETURN
+order swap **silently** — no error, plausible-looking wrong data. When
+you touch a query, re-check the declaration order against the RETURN
+clause; when you review one, check it there first.
+
+Type mismatches, by contrast, fail loudly: each returned value converts
+against its declared type, and a mismatch is a typed error carrying
+column name, row index, expected type, and found JSON kind.
+
+Writes are rejected twice — a keyword guard at plan time (UX) and the
+backend's `READ ONLY` transaction (the actual boundary). Don't try to
+smuggle mutations; milestone one is read-only by design.
+
+## Properties are JSON text: the getter rules
+
+A `node` column is a struct — `STRUCT<id, labels, properties>` (a
+relationship likewise, with endpoint ids) — and `properties` is the
+JSON-text field INSIDE it. Address the field, then the key:
+`json_get_str(n.properties, 'name')`. Passing the whole struct column
+to a getter (`json_get_str(n, 'properties', 'name')`) is the natural
+wrong guess and does not work — the getters take JSON text, not a
+struct. The `datafusion-functions-json` getters are registered on every
+server session:
+
+```sql
+SELECT json_get_str(n.properties, 'name'),
+       json_get_int(n.properties, 'age')
+FROM cypher_query('kg', 'MATCH (n:Person) RETURN n', '{}', '{"n": "node"}');
+```
+
+Two rules, both of which fail silently when broken:
+
+1. **Pick the getter by the STORED JSON type.** `json_get_str` on a
+   numeric property returns NULL — not a coercion, not an error. A
+   silently-NULL column is the classic symptom of the wrong getter:
+   `age`, `since`, counts → `json_get_int` / `json_get_float`.
+2. **The `->` / `->>` / `?` operators are deliberately NOT installed.**
+   The crate's operator rewrite would convert them into `json_get(...)`
+   calls at planning time, session-wide, which the federation unparser
+   cannot translate back for federated sources. Spell it out:
+   `properties->>'name'` → `json_get_str(properties, 'name')`;
+   `properties->'a'->>'b'` → `json_get_str(properties, 'a', 'b')`;
+   `properties ? 'key'` → `json_contains(properties, 'key')`.
+
+Nested access passes multiple keys to one getter, as above — do not
+chain getters.
+
+## Views vs ad-hoc: the decision, restated as a rule
+
+| You control the predicate | Use |
+|---|---|
+| No — agents/dashboards need a stable table name and a fixed shape | A view, whose Cypher carries its own `WHERE`/`LIMIT` |
+| Yes — the caller knows what it's filtering on | `cypher_query`, with the predicate (and `$params`) in the Cypher |
+
+The failure mode this table prevents: a view declared without a bound,
+consumed with SQL `WHERE`, works in the demo (small graph) and dies in
+production with `RowCapExceeded` the day the graph outgrows `max_rows`.
+
+## Pipelines: request parameters → Cypher parameters
+
+Pipeline parameters substitute into SQL textually, and the two passes
+(inference vs execution) disagree about nested-literal positions — a
+`{param}` INSIDE the params JSON string literal cannot work. The one
+spelling that works: **the placeholder occupies the whole `params`
+argument**.
+
+```yaml
+kind: pipeline
+metadata:
+  name: people-over-age
+spec:
+  query: |
+    SELECT name, age
+    FROM cypher_query(
+      'kg',
+      'MATCH (p:Person) WHERE p.age > $min RETURN p.name AS name, p.age AS age',
+      {params},
+      '{"name": "string", "age": "int"}'
+    )
+```
+
+At pipeline-load time `{params}` becomes `NULL`, which the UDTF accepts
+as "no parameters" (schema inference needs only the literal `columns`).
+At request time the caller passes the params JSON **as a string**:
+
+```bash
+curl -X POST localhost:8080/people-over-age/execute \
+  -H 'Content-Type: application/json' \
+  -d '{"params": "{\"min\": 40}"}'
+```
+
+The connection, cypher, and columns arguments stay strict literals —
+they determine the plan, so a placeholder cannot produce one. If you
+need a parameterized column set, that is two pipelines, not one clever
+one.

--- a/docs/superpowers/skills/graph-source/references/troubleshooting.md
+++ b/docs/superpowers/skills/graph-source/references/troubleshooting.md
@@ -1,0 +1,57 @@
+# Troubleshooting
+
+Work symptom-first. Every graph error is typed and names its cause;
+an error that doesn't is itself a bug worth filing.
+
+## Symptom table
+
+| Symptom | Cause → fix |
+|---|---|
+| `Operator ->> is not yet supported` (also `->`, `?`) | The operator rewrite is deliberately not installed (it breaks federated pushdown session-wide). Use the getters: `json_get_str(properties, 'name')`, `json_get_str(properties, 'a', 'b')`, `json_contains(properties, 'key')`. |
+| A property column is all NULL, no error | Wrong getter for the stored JSON type — `json_get_str` on a numeric property returns NULL, not a coercion. Switch to `json_get_int` / `json_get_float`. |
+| Two columns look swapped | The ad-hoc `columns` argument binds positionally against the RETURN clause. Re-order the declaration to match RETURN — the names never did the matching. |
+| `graph scan exceeded max_rows = …` on a view scan | SQL `WHERE` over a view does not push into Cypher; the view fetched everything. Bound the view's own Cypher (`WHERE`/`LIMIT`) or move the read to `cypher_query`. Raising `max_rows` is the last resort, not the fix. |
+| `graph query timed out after Ns` | The statement ran past `query_timeout_seconds` server-side. Narrow the traversal or raise the timeout. If the backend was never reached you'd see `could not acquire a connection …` instead — that one is connectivity, not query shape. |
+| `graph source is registered DEGRADED (registration error: … Connection refused …)` | Backend unreachable at startup and still unreachable on retry. Check host/port and the env-var credentials. The source flips healthy on its own once any query gets a response; inside the backoff window (`query_timeout_seconds` clamped to 30–300 s) scans fail fast with the cached diagnosis. |
+| `graph view '<name>' failed validation: …` at startup, server refuses to start | A reachable backend rejected the view's contract — RETURN arity/types disagree with the declared `schema`. The error carries the backend's complaint; align the declaration with the Cypher and restart. Not retryable. |
+| Startup failure naming `ag_catalog.ag_graph` | AGE is absent from that Postgres. Install it / set `shared_preload_libraries = 'age'`. Never fix this by granting Skardi superuser so `LOAD` works. |
+| `type: graph requires hierarchy: catalog` | Set `hierarchy_level: catalog` on the source — views are catalog tables. |
+| A null in a `nullable: false` view column | Typed error naming column and row. The declaration was an author's assertion the graph doesn't honor — either fix the data or stop asserting. |
+
+## Distinguishing the three failure families
+
+1. **Connectivity** (degraded, retried, self-healing): no server
+   answered — DNS, refused dial, network timeout, `PoolTimedOut`.
+2. **Contract** (refused at boot, or typed per-scan errors after
+   recovery): the server answered and disagreed — view validation,
+   type mismatches, nullability assertions.
+3. **Bounds** (typed per-query errors): `RowCapExceeded`, statement
+   timeout. These are protections doing their job; the fix is in the
+   query or view, not in removing the protection.
+
+Recovery semantics worth re-reading when confused about state: a retry
+that gets ANY response flips the source healthy — a still-broken view
+then fails its own scans while the others work. Only "no answer at all"
+keeps a source degraded. And health is written only at registration and
+recovery: `status_changed_at` is when the status last TRANSITIONED, not
+a liveness heartbeat — "healthy" is one-way until a scan fails.
+
+## Health through the gateway (cloud deployments)
+
+Graph sources are today the only sources that populate the
+`status` / `status_reason` / `status_changed_at` trio on the OSS
+`GET /data_source`. On a **skardi-cloud gateway**, know two things:
+
+- The gateway's response projection **deliberately drops the whole
+  status trio** (skardi-cloud's contexts/login design §7.4.1 —
+  `status_reason` is operator text that can carry a DSN or hostname).
+  A tenant's agent sees a degraded graph source as a source with its
+  declared tables and no health fields — `skardi schema` cannot tell
+  "degraded" from "healthy and empty".
+- Diagnosing health on cloud therefore happens on the operator side:
+  the OSS engine's own `/data_source` (in-cluster), or the server logs,
+  which carry the registration error and every transition.
+
+Do not file "the gateway lost my status_reason" as a bug — it is a
+recorded projection decision, and the place to revisit it is that
+design's §7.4.1, not the gateway code.


### PR DESCRIPTION
A shared Claude Code skill (`docs/superpowers/skills/graph-source/`, installed per the README's symlink convention) that takes a developer from an Apache AGE instance to queryable SQL tables in Skardi, end to end. Sibling to `source-pack`: that one onboards SaaS/API sources, this one onboards graph sources.

## Structure

- **SKILL.md** — five phases (provision → declare → verify registration → query → pipeline), a view-vs-ad-hoc decision guide, and the working style (verify against the running system; env-var names only; don't widen bounds to hide symptoms).
- **references/provisioning.md** — the least-privilege `kg_reader` recipe, why `LOAD 'age'` is best-effort and what to do instead (never superuser), a local dev AGE.
- **references/configuration.md** — the full `type: graph` contract (verified against `sources/providers/graph/config.rs`: defaults 30 s / 10 000 rows / 4 conns and their valid ranges), the lowercase view-name rule and its DataFusion ident-folding rationale, "a view's bound lives in its Cypher", and the healthy/degraded/refused registration semantics including what recovery does and does not answer.
- **references/querying.md** — positional `columns` binding, node columns as `STRUCT<id, labels, properties>` with `.properties` as the JSON text, the getter-by-stored-type rule, the deliberately-absent `->`/`->>` rewrite, and the one working `{params}` pipeline spelling.
- **references/troubleshooting.md** — symptom → diagnosis table, the three failure families (connectivity / contract / bounds), and the cloud caveat: skardi-cloud's gateway projection deliberately drops the `status` trio (its contexts/login design §7.4.1), so tenant-side `skardi schema` cannot distinguish a degraded graph source from a healthy empty one — diagnose on the operator side.

**Scope is AGE-only on purpose** — the config carries `backend:` for neo4j/kuzu, but writing guidance for unshipped backends would manufacture fake contracts (the same lesson source-pack's history teaches about un-reconciled contracts).

## Evaluation before submission

Three realistic tasks (onboard an AGE graph with two views; diagnose a `RowCapExceeded` on a one-row `WHERE`; build a parameterized pipeline), each run twice by independent agents — once with the skill, once as a no-skill baseline **inside this repo** (the honest baseline: it can and did find `docs/graph.md`). Graded against 15 written assertions:

| | with skill | baseline |
|---|---|---|
| assertions passed | **15/15** | 13/15 |
| mean tokens | 43.2k | 65.2k (−34%) |
| mean wall-clock | 88 s | 134 s (−34%) |

The two baseline failures are the ones that matter: its onboarding YAML shipped **both views with unbounded Cypher** (the production `RowCapExceeded` trap — it knew the rule, warned in prose, and didn't apply it to its own deliverable), and its verification query passed the whole node STRUCT to `json_get_str` instead of `col.properties` (the query fails). On the diagnosis and pipeline tasks both sides were fully correct — there the skill's value is the 2.5× token/time gap on the diagnosis task (42k/72s vs 89k/177s), since the baseline re-derives from source every time.

The eval also improved the skill: the lowercase view-name rule (which the baseline found in `config.rs` and the draft lacked) and the STRUCT `.properties` access spelling were added because the runs surfaced them.

## Not in this PR

- No `.gitignore` change and no tracked `.claude/` — installation stays the README's per-clone symlink, per the repo's convention.
- Eval workspace/transcripts are session-local scratch, not committed; the summary above is the durable record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)