### PR TITLE
feat(cli): send ai_context from skardi query --purpose/--session-id

### DIFF
--- a/crates/cli/src/commands/query.rs
+++ b/crates/cli/src/commands/query.rs
@@ -2,9 +2,17 @@
 
 use crate::client::ApiClient;
 use crate::output::print_result;
+use crate::session::MAX_SESSION_ID_CHARS;
 use anyhow::{Context, Result, bail};
 use serde_json::{Value, json};
 use std::path::PathBuf;
+
+/// Maximum `ai_context.purpose` length, in characters. Restates the server's
+/// `query_handlers::MAX_PURPOSE_CHARS` under the same name — `skardi-cli`
+/// does not depend on the server crate, so this cannot be a shared item, but
+/// an identical name keeps `grep MAX_PURPOSE_CHARS` finding every site that
+/// must move together.
+const MAX_PURPOSE_CHARS: usize = 2000;
 
 /// Run `skardi query`: resolve the SQL text to send (file wins over `-e`
 /// when both are given), `POST` it to `/query`, and hand the response
@@ -15,9 +23,12 @@ pub async fn run(
     file: Option<PathBuf>,
     max_rows: Option<usize>,
     table: bool,
+    purpose: Option<String>,
+    session_id: Option<String>,
 ) -> Result<()> {
     let text = resolve_sql(sql, file)?;
-    let body = build_body(&text, max_rows);
+    let ai_context = build_ai_context(purpose, session_id)?;
+    let body = build_body(&text, max_rows, ai_context);
 
     let response = client.post("/query", &body).await?;
     print_result(&response, table);
@@ -40,19 +51,66 @@ fn resolve_sql(sql: Option<String>, file: Option<PathBuf>) -> Result<String> {
     }
 }
 
-/// Build the `/query` request body: `{"sql": text}`, plus a `"max_rows"`
-/// key only when `max_rows` was actually passed.
-fn build_body(sql: &str, max_rows: Option<usize>) -> Value {
+/// Build the `/query` request body: `{"sql": text}`, plus `"max_rows"` and
+/// `"ai_context"` keys only when those were actually passed.
+fn build_body(sql: &str, max_rows: Option<usize>, ai_context: Option<Value>) -> Value {
     let mut body = json!({ "sql": sql });
     if let Some(max_rows) = max_rows {
         body["max_rows"] = json!(max_rows);
     }
+    if let Some(ai_context) = ai_context {
+        body["ai_context"] = ai_context;
+    }
     body
+}
+
+/// Build the optional `ai_context` object from the `--purpose` /
+/// `--session-id` pair: `Ok(None)` when neither was given, `Err` when a value
+/// is present that the server would reject.
+///
+/// The pair is all-or-nothing because the server's `validate_ai_context`
+/// requires both fields once `ai_context` is present at all. Clap's
+/// `requires` already rejects one-without-the-other at parse time; the arms
+/// below keep this function honest for any other caller rather than silently
+/// dropping a half-filled context.
+///
+/// Deliberately NOT reusing [`crate::session::validate_session_id`]. That
+/// predicate mirrors the `X-Skardi-Session-Id` *header* rules — visible ASCII
+/// only, no space, no comma — which exist because an intermediary may reshape
+/// a header value. `/query` carries the session id inside the JSON body,
+/// where the server asks only for a non-empty string within the cap, so
+/// applying the header predicate here would reject values the server accepts.
+/// Only the cap is shared, hence the constant import.
+fn build_ai_context(purpose: Option<String>, session_id: Option<String>) -> Result<Option<Value>> {
+    match (purpose, session_id) {
+        (None, None) => Ok(None),
+        (Some(purpose), Some(session_id)) => {
+            validate_context_string(&purpose, "--purpose", MAX_PURPOSE_CHARS)?;
+            validate_context_string(&session_id, "--session-id", MAX_SESSION_ID_CHARS)?;
+            Ok(Some(
+                json!({ "purpose": purpose, "session_id": session_id }),
+            ))
+        }
+        (Some(_), None) => bail!("--purpose requires --session-id"),
+        (None, Some(_)) => bail!("--session-id requires --purpose"),
+    }
+}
+
+/// Require a context value to be non-empty and within `max_chars`, naming the
+/// flag it came from so the message points at what to fix.
+fn validate_context_string(value: &str, flag: &str, max_chars: usize) -> Result<()> {
+    if value.is_empty() {
+        bail!("{flag} must not be empty");
+    }
+    if value.chars().count() > max_chars {
+        bail!("{flag} must be at most {max_chars} characters");
+    }
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{build_body, run};
+    use super::{MAX_PURPOSE_CHARS, MAX_SESSION_ID_CHARS, build_ai_context, build_body, run};
     use crate::client::ApiClient;
     use crate::config::ClientConfig;
     use serde_json::json;
@@ -82,14 +140,97 @@ mod tests {
 
     #[test]
     fn build_body_without_max_rows_has_only_sql() {
-        let body = build_body("select 1", None);
+        let body = build_body("select 1", None, None);
         assert_eq!(body, json!({"sql": "select 1"}));
     }
 
     #[test]
     fn build_body_with_max_rows_has_both_keys() {
-        let body = build_body("select 1", Some(50));
+        let body = build_body("select 1", Some(50), None);
         assert_eq!(body, json!({"sql": "select 1", "max_rows": 50}));
+    }
+
+    #[test]
+    fn build_body_with_ai_context_carries_it_verbatim() {
+        let ctx = json!({"purpose": "weekly PR ageing", "session_id": "sess-9"});
+        let body = build_body("select 1", None, Some(ctx.clone()));
+        assert_eq!(body, json!({"sql": "select 1", "ai_context": ctx}));
+    }
+
+    // -- 1b. ai_context builder ------------------------------------------
+
+    #[test]
+    fn neither_flag_yields_no_ai_context() {
+        assert_eq!(build_ai_context(None, None).unwrap(), None);
+    }
+
+    #[test]
+    fn both_flags_yield_the_object_the_server_validates() {
+        let ctx = build_ai_context(Some("count paid orders".into()), Some("sess-1".into()))
+            .unwrap()
+            .expect("expected an ai_context");
+        assert_eq!(
+            ctx,
+            json!({"purpose": "count paid orders", "session_id": "sess-1"})
+        );
+    }
+
+    #[test]
+    fn one_flag_without_the_other_is_an_error() {
+        // Clap's `requires` catches this at parse time; the builder stays
+        // honest for any other caller instead of dropping half a context.
+        let err = build_ai_context(Some("p".into()), None).unwrap_err();
+        assert!(
+            err.to_string().contains("--purpose requires --session-id"),
+            "error was: {err}"
+        );
+
+        let err = build_ai_context(None, Some("s".into())).unwrap_err();
+        assert!(
+            err.to_string().contains("--session-id requires --purpose"),
+            "error was: {err}"
+        );
+    }
+
+    #[test]
+    fn empty_or_oversized_values_are_rejected_naming_the_flag() {
+        let cases = [
+            (String::new(), "sess-1".to_string(), "--purpose"),
+            ("p".to_string(), String::new(), "--session-id"),
+            (
+                "x".repeat(MAX_PURPOSE_CHARS + 1),
+                "sess-1".to_string(),
+                "--purpose",
+            ),
+            (
+                "p".to_string(),
+                "x".repeat(MAX_SESSION_ID_CHARS + 1),
+                "--session-id",
+            ),
+        ];
+
+        for (purpose, session_id, flag) in cases {
+            let err = build_ai_context(Some(purpose), Some(session_id)).unwrap_err();
+            assert!(
+                err.to_string().contains(flag),
+                "expected a {flag} message, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn body_session_ids_are_not_held_to_the_header_predicate() {
+        // `/query` carries the session id in JSON, not in a header, so the
+        // spaces / non-ASCII / comma rules of `session::validate_session_id`
+        // must NOT apply here — the server accepts any non-empty string
+        // within the cap, and rejecting more than it does would be a
+        // client-side regression invisible from the server side.
+        for sid in ["sess 1", "会话-1", "sess-1, sess-2", "  padded  "] {
+            let ctx = build_ai_context(Some("p".into()), Some(sid.to_string()))
+                .unwrap()
+                .expect("expected an ai_context");
+            assert_eq!(ctx["session_id"], json!(sid));
+        }
     }
 
     // -- 2. run posts the expected body and succeeds ---------------------
@@ -106,7 +247,16 @@ mod tests {
             .await;
 
         let client = ApiClient::new(&test_config(&server.uri())).unwrap();
-        let result = run(&client, Some("select 1".to_string()), None, None, false).await;
+        let result = run(
+            &client,
+            Some("select 1".to_string()),
+            None,
+            None,
+            false,
+            None,
+            None,
+        )
+        .await;
 
         assert!(result.is_ok(), "expected Ok, got {result:?}");
     }
@@ -134,6 +284,8 @@ mod tests {
             Some(file.path().to_path_buf()),
             None,
             false,
+            None,
+            None,
         )
         .await;
 
@@ -148,9 +300,72 @@ mod tests {
         // real request here would surface as a connect error, not this one.
         let client = ApiClient::new(&test_config("http://127.0.0.1:1")).unwrap();
 
-        let err = run(&client, None, None, None, false).await.unwrap_err();
+        let err = run(&client, None, None, None, false, None, None)
+            .await
+            .unwrap_err();
 
         assert!(err.to_string().contains("no SQL given"), "error was: {err}");
+    }
+
+    // -- 4b. --purpose/--session-id reach the wire as ai_context ---------
+
+    #[tokio::test]
+    async fn run_with_purpose_and_session_id_posts_ai_context() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/query"))
+            .and(body_json(json!({
+                "sql": "select 1",
+                "ai_context": {"purpose": "count paid orders", "session_id": "sess-1"},
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(success_envelope()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(&test_config(&server.uri())).unwrap();
+        let result = run(
+            &client,
+            Some("select 1".to_string()),
+            None,
+            None,
+            false,
+            Some("count paid orders".to_string()),
+            Some("sess-1".to_string()),
+        )
+        .await;
+
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+    }
+
+    // -- 4c. a rejected context never reaches the server ------------------
+
+    #[tokio::test]
+    async fn invalid_context_errors_without_contacting_server() {
+        let server = MockServer::start().await;
+        // expect(0): the check must fail before the request, otherwise the
+        // server's 400 round trip is what the user waits for.
+        Mock::given(method("POST"))
+            .and(path("/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(success_envelope()))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(&test_config(&server.uri())).unwrap();
+        let err = run(
+            &client,
+            Some("select 1".to_string()),
+            None,
+            None,
+            false,
+            Some(String::new()),
+            Some("sess-1".to_string()),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(err.to_string().contains("--purpose"), "error was: {err}");
     }
 
     // -- 5. server error envelope propagates with error_type -------------
@@ -171,9 +386,17 @@ mod tests {
             .await;
 
         let client = ApiClient::new(&test_config(&server.uri())).unwrap();
-        let err = run(&client, Some("select foo".to_string()), None, None, false)
-            .await
-            .unwrap_err();
+        let err = run(
+            &client,
+            Some("select foo".to_string()),
+            None,
+            None,
+            false,
+            None,
+            None,
+        )
+        .await
+        .unwrap_err();
 
         assert!(
             err.to_string().contains("sql_validation_error"),

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -106,6 +106,19 @@ enum Commands {
         /// render results as a table instead of JSON
         #[arg(long)]
         table: bool,
+
+        /// Why this query is being run, recorded with it in the server's
+        /// audit ledger (sent as ai_context.purpose). Requires
+        /// --session-id: the server rejects an ai_context carrying only one
+        /// of the pair.
+        #[arg(long, value_name = "TEXT", requires = "session_id")]
+        purpose: Option<String>,
+
+        /// Session id grouping this query with the rest of its session in
+        /// the server's audit ledger (sent as ai_context.session_id).
+        /// Requires --purpose, for the same reason.
+        #[arg(long, value_name = "ID", requires = "purpose")]
+        session_id: Option<String>,
     },
 
     /// Execute a named server pipeline and print the result.
@@ -248,7 +261,9 @@ async fn dispatch(cli: Cli) -> anyhow::Result<()> {
             file,
             max_rows,
             table,
-        } => commands::query::run(&client, sql, file, max_rows, table).await,
+            purpose,
+            session_id,
+        } => commands::query::run(&client, sql, file, max_rows, table, purpose, session_id).await,
 
         Commands::Run {
             name,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -336,6 +336,10 @@ skardi query -e "SELECT * FROM events" --max-rows 50
 
 # Render as an ASCII table instead of JSON
 skardi query -e "SELECT * FROM products LIMIT 10" --table
+
+# Record why this query ran, and which session it belongs to
+skardi query -e "SELECT count(*) FROM orders WHERE status = 'paid'" \
+  --purpose "weekly paid-order count" --session-id sess-2026-08-27
 ```
 
 Default output is the response's `data` array, pretty-printed JSON, on
@@ -358,6 +362,28 @@ piping:
 ```
 note: results truncated; pass a higher --max-rows to see the rest
 ```
+
+### Recording intent — `--purpose` / `--session-id`
+
+The two flags travel together as the request body's `ai_context` object,
+which the server records in its query audit ledger when it was started with
+`--query-audit-db`. `--purpose` says why the query ran; `--session-id`
+groups it with the rest of one agent session, so a later reader can tell a
+repeated question from a one-off. Without them the ledger still records the
+SQL, but nothing about intent — the column that makes "we have answered this
+before" answerable stays empty.
+
+Either flag requires the other: the server rejects an `ai_context` carrying
+only one of the pair, so the CLI refuses it at parse time rather than
+spending a round trip on a 400. Values are checked client-side before any
+request (non-empty, `--purpose` ≤ 2000 characters, `--session-id` ≤ 200).
+
+Unlike `run --session-id`, which travels as an HTTP header and is therefore
+held to header-safe characters, these values ride inside JSON — any
+non-empty string within the cap is accepted, spaces and non-ASCII included.
+
+The ledger is opt-in and off by default; see `--query-audit-db` in
+[docs/server.md](server.md).
 
 ## Pipelines
 


### PR DESCRIPTION
Closes #218.

## Why

`POST /query` has accepted an `ai_context` object since after v0.5.0 and records it in the audit ledger next to the SQL. The CLI could not fill it — `skardi query` sent only `sql` and `max_rows` — so every row the CLI wrote left `ai_context` and `session_id` NULL. A reader of that ledger could see which statements ran but not why, and not which of them belonged to the same session. Those are the two columns session-level analysis groups on, so the ledger was effectively intent-blind for CLI traffic.

## What changed

`skardi query --purpose <TEXT> --session-id <ID>` now sends

```json
{"sql": "...", "ai_context": {"purpose": "...", "session_id": "..."}}
```

Absent both flags the body is byte-for-byte what it was before.

The pair is all-or-nothing, matching the server's `validate_ai_context`: clap's `requires` rejects one-without-the-other at parse time, and `build_ai_context` enforces the same contract for any non-clap caller rather than silently dropping half a context. Values are checked client-side (non-empty, purpose ≤ 2000, session id ≤ 200) so a bad one fails before the request instead of as a 400 round trip.

## One design note worth reviewing

This deliberately does **not** reuse `session::validate_session_id`. That predicate mirrors the `X-Skardi-Session-Id` *header* rules — visible ASCII, no space, no comma — which exist because an intermediary may reshape a header value (RFC 9110 §5.3/§5.5). `/query` carries the session id inside the JSON body, where the server asks only for a non-empty string within `MAX_SESSION_ID_CHARS`. Reusing the header predicate would reject values the server accepts, and that rejection would be invisible from the server side. Only the cap is shared, and `body_session_ids_are_not_held_to_the_header_predicate` pins the difference so a later "let's unify these" refactor fails loudly.

## Verification

`cargo test -p skardi-cli` — 217 pass, clippy clean.

Live against a server started with `--query-audit-db`, five invocations:

| invocation | result |
|---|---|
| `--purpose "weekly paid-order count" --session-id sess-2026-08-27` | row written, both columns populated |
| no flags | row written, both columns NULL (unchanged behaviour) |
| `--purpose` alone | refused at parse time, no request sent |
| `--purpose ""` | refused client-side, no request sent |
| `--purpose "中文用途" --session-id "会话 一"` | accepted and recorded verbatim |

Ledger after those five — three rows, exactly the three that were let through:

```
SELECT 1 AS n  {"purpose":"weekly paid-order count","session_id":"sess-2026-08-27"}  sess-2026-08-27
SELECT 2 AS n
SELECT 5 AS n  {"purpose":"中文用途","session_id":"会话 一"}                          会话 一
```

## Docs

`docs/cli.md` gains a `--purpose` / `--session-id` section under `query`, including the header-vs-body distinction above and a pointer to `--query-audit-db`.