### PR TITLE
feat: author-written parameter descriptions (spec.parameters)

### DIFF
--- a/crates/server/src/pipeline_handlers.rs
+++ b/crates/server/src/pipeline_handlers.rs
@@ -392,11 +392,10 @@ fn enriched_parameters(pipeline: &StandardPipeline) -> Vec<Value> {
             // The author's one-liner rides inside the JSON Schema itself
             // (standard `description` keyword), so schema consumers — the
             // MCP bridge copies it verbatim into the tool's properties —
-            // surface it with no changes of their own.
+            // surface it with no changes of their own. The loader already
+            // normalized: entries are trimmed and never blank.
             if let Some(doc) = pipeline.parameter_docs.get(name) {
-                if !doc.trim().is_empty() {
-                    schema["description"] = serde_json::json!(doc);
-                }
+                schema["description"] = serde_json::json!(doc);
             }
             serde_json::json!({
                 "name": name,

--- a/crates/server/src/pipeline_handlers.rs
+++ b/crates/server/src/pipeline_handlers.rs
@@ -388,10 +388,20 @@ fn enriched_parameters(pipeline: &StandardPipeline) -> Vec<Value> {
     fields
         .into_iter()
         .map(|(name, field)| {
+            let mut schema = param_json_schema(&field.field_type, sql, name);
+            // The author's one-liner rides inside the JSON Schema itself
+            // (standard `description` keyword), so schema consumers — the
+            // MCP bridge copies it verbatim into the tool's properties —
+            // surface it with no changes of their own.
+            if let Some(doc) = pipeline.parameter_docs.get(name) {
+                if !doc.trim().is_empty() {
+                    schema["description"] = serde_json::json!(doc);
+                }
+            }
             serde_json::json!({
                 "name": name,
                 "data_type": format!("{:?}", field.field_type),
-                "json_schema": param_json_schema(&field.field_type, sql, name),
+                "json_schema": schema,
             })
         })
         .collect()

--- a/crates/server/tests/pipelines_http.rs
+++ b/crates/server/tests/pipelines_http.rs
@@ -79,6 +79,8 @@ metadata:
   version: "1.0.0"
   description: "Filter products by brand + max price"
 spec:
+  parameters:
+    brand: "Exact brand name; null matches every brand"
   query: |
     SELECT id, brand, price, category
     FROM products
@@ -301,14 +303,19 @@ async fn http_list_pipelines_returns_registered() {
         Some("Filter products by brand + max price")
     );
     // Parameters are sorted by name: brand, max_price. `{max_price}` infers
-    // Float64 via the `max_` prefix strip → column `price`.
+    // Float64 via the `max_` prefix strip → column `price`. `brand` carries
+    // the author's spec.parameters one-liner inside its json_schema;
+    // undocumented `max_price` gets no description key.
     let params = entry["parameters"].as_array().expect("parameters array");
     assert_eq!(params.len(), 2, "params: {params:?}");
     assert_eq!(params[0]["name"].as_str(), Some("brand"));
     assert_eq!(params[0]["data_type"].as_str(), Some("Utf8"));
     assert_eq!(
         params[0]["json_schema"],
-        json!({"type": ["string", "null"]})
+        json!({
+            "type": ["string", "null"],
+            "description": "Exact brand name; null matches every brand"
+        })
     );
     assert_eq!(params[1]["name"].as_str(), Some("max_price"));
     assert_eq!(params[1]["data_type"].as_str(), Some("Float64"));
@@ -475,9 +482,14 @@ async fn http_get_pipeline_info_returns_metadata_and_params() {
         "params: {params:?}"
     );
     assert_eq!(params[0]["data_type"].as_str(), Some("Utf8"));
+    // Both inventory endpoints get the description from the one shared
+    // enrichment (enriched_parameters).
     assert_eq!(
         params[0]["json_schema"],
-        json!({"type": ["string", "null"]})
+        json!({
+            "type": ["string", "null"],
+            "description": "Exact brand name; null matches every brand"
+        })
     );
     assert_eq!(params[1]["data_type"].as_str(), Some("Float64"));
     assert_eq!(

--- a/crates/skardi/src/pipeline/pipeline.rs
+++ b/crates/skardi/src/pipeline/pipeline.rs
@@ -490,11 +490,35 @@ impl StandardPipeline {
         };
 
         // Optional author-written parameter descriptions (name → one line).
-        let parameter_docs: HashMap<String, String> = match spec_section.get("parameters") {
+        // Normalized right here so downstream consumers publish the text
+        // as-is: YAML block scalars keep a trailing newline (trimmed away),
+        // and a blank description is an author slip, not a request to
+        // publish nothing.
+        let raw_docs: HashMap<String, String> = match spec_section.get("parameters") {
             Some(section) => serde_yaml::from_value(section.clone())
                 .map_err(|e| anyhow!("Failed to parse spec.parameters section: {}", e))?,
             None => HashMap::new(),
         };
+        let mut parameter_docs = HashMap::with_capacity(raw_docs.len());
+        let mut blank: Vec<String> = Vec::new();
+        for (name, doc) in raw_docs {
+            let doc = doc.trim();
+            if doc.is_empty() {
+                blank.push(name);
+            } else {
+                parameter_docs.insert(name, doc.to_string());
+            }
+        }
+        // All offenders at once, sorted: HashMap iteration order is
+        // arbitrary, and naming one random slip per restart would make the
+        // author fix them one server boot at a time.
+        if !blank.is_empty() {
+            blank.sort();
+            return Err(anyhow!(
+                "spec.parameters gives blank descriptions for {:?} — write one line or drop the key",
+                blank,
+            ));
+        }
 
         let inferencer = SqlSchemaInferrer::new(ctx.clone())?;
         let request_schema = inferencer
@@ -503,18 +527,21 @@ impl StandardPipeline {
 
         // A described parameter the SQL does not declare is a typo or a doc
         // string gone stale after a query edit — refuse to load rather than
-        // publish documentation that lies.
-        for documented in parameter_docs.keys() {
-            if !request_schema.fields.contains_key(documented) {
-                let mut declared: Vec<&String> = request_schema.fields.keys().collect();
-                declared.sort();
-                return Err(anyhow!(
-                    "spec.parameters describes '{}', but the SQL declares no {{{}}} placeholder (declared parameters: {:?})",
-                    documented,
-                    documented,
-                    declared,
-                ));
-            }
+        // publish documentation that lies. Same all-at-once, sorted
+        // reporting as the blank check above.
+        let mut unknown: Vec<&String> = parameter_docs
+            .keys()
+            .filter(|k| !request_schema.fields.contains_key(*k))
+            .collect();
+        if !unknown.is_empty() {
+            unknown.sort();
+            let mut declared: Vec<&String> = request_schema.fields.keys().collect();
+            declared.sort();
+            return Err(anyhow!(
+                "spec.parameters describes {:?}, but the SQL declares no such placeholder (declared parameters: {:?})",
+                unknown,
+                declared,
+            ));
         }
 
         let response_schema = inferencer
@@ -1192,18 +1219,40 @@ metadata:
   version: "1.0.0"
 spec:
   parameters:
-    brand: "Exact brand name; null matches every brand"
+    brand: >
+      Exact brand name; null matches every brand
   query: |
     SELECT brand, price FROM products
     WHERE ({brand} IS NULL OR brand = {brand}) AND price < {max_price}
 "#;
         let pipeline = load_yaml(yaml, ctx_with_products()).await.unwrap();
+        // The `>` block scalar carries a trailing newline; the loader
+        // normalizes it away, so the stored text is exactly the sentence.
         assert_eq!(
             pipeline.parameter_docs.get("brand").map(String::as_str),
             Some("Exact brand name; null matches every brand")
         );
         // Descriptions are optional per parameter: no entry, no error.
         assert!(!pipeline.parameter_docs.contains_key("max_price"));
+    }
+
+    #[tokio::test]
+    async fn spec_parameters_reject_blank_descriptions() {
+        let yaml = r#"
+kind: pipeline
+metadata:
+  name: "blank"
+  version: "1.0.0"
+spec:
+  parameters:
+    brand: "   "
+  query: |
+    SELECT brand, price FROM products WHERE brand = {brand}
+"#;
+        let err = load_yaml(yaml, ctx_with_products())
+            .await
+            .expect_err("a blank description is an author slip and must fail the load");
+        assert!(err.to_string().contains("blank description"), "{err}");
     }
 
     #[tokio::test]
@@ -1216,14 +1265,18 @@ metadata:
 spec:
   parameters:
     brnad: "typo for brand"
+    prise: "typo for price"
   query: |
     SELECT brand, price FROM products WHERE brand = {brand}
 "#;
         let err = load_yaml(yaml, ctx_with_products())
             .await
             .expect_err("a described parameter missing from the SQL must fail the load");
+        // Both offenders in one error (sorted), not one arbitrary pick per
+        // restart — HashMap iteration order must not leak into the message.
         let msg = err.to_string();
-        assert!(msg.contains("'brnad'"), "{msg}");
+        assert!(msg.contains(r#""brnad""#), "{msg}");
+        assert!(msg.contains(r#""prise""#), "{msg}");
         assert!(msg.contains("declared parameters"), "{msg}");
     }
 }

--- a/crates/skardi/src/pipeline/pipeline.rs
+++ b/crates/skardi/src/pipeline/pipeline.rs
@@ -526,9 +526,14 @@ impl StandardPipeline {
             .await?;
 
         // A described parameter the SQL does not declare is a typo or a doc
-        // string gone stale after a query edit — refuse to load rather than
-        // publish documentation that lies. Same all-at-once, sorted
-        // reporting as the blank check above.
+        // string gone stale after a query edit. The description would never
+        // be read (the publisher looks descriptions up by declared name), so
+        // the failure mode is a sentence silently missing from the published
+        // schema — refuse to load instead. The blast radius is deliberate:
+        // the server propagates any pipeline load failure, so this typo
+        // aborts startup; a loud deploy-time error over a quiet runtime
+        // omission. Same all-at-once, sorted reporting as the blank check
+        // above.
         let mut unknown: Vec<&String> = parameter_docs
             .keys()
             .filter(|k| !request_schema.fields.contains_key(*k))

--- a/crates/skardi/src/pipeline/pipeline.rs
+++ b/crates/skardi/src/pipeline/pipeline.rs
@@ -4,6 +4,7 @@ use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use datafusion::prelude::SessionContext;
 use serde::Serialize;
+use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
@@ -293,6 +294,11 @@ pub struct StandardPipeline {
     pub request_schema: Arc<RequestSchema>,
     /// Query definition containing the SQL query and parameter list
     pub query_definition: QueryDefinition,
+    /// Author-written one-line parameter descriptions from `spec.parameters`
+    /// in the YAML, keyed by parameter name. Optional per parameter; every
+    /// key is validated at load time against the inferred request schema.
+    #[serde(skip)]
+    pub parameter_docs: HashMap<String, String>,
     /// Response schema defining the output fields and their types (inferred at runtime)
     #[serde(skip)]
     pub response_schema: Arc<ResponseSchema>,
@@ -352,6 +358,7 @@ impl StandardPipeline {
             request_schema: Arc::new(request_schema),
             query_definition,
             response_schema: Arc::new(response_schema),
+            parameter_docs: HashMap::new(),
             inferencer: Arc::new(SqlSchemaInferrer::new(ctx)?),
         })
     }
@@ -452,8 +459,9 @@ impl StandardPipeline {
 
     /// Build a `StandardPipeline` from an already-parsed YAML root.
     ///
-    /// Pulls `metadata` + `spec.query` out of the value and infers request
-    /// and response schemas against `ctx`. Does not inspect the `kind:`
+    /// Pulls `metadata` + `spec.query` (and the optional `spec.parameters`
+    /// description map) out of the value and infers request and response
+    /// schemas against `ctx`. Does not inspect the `kind:`
     /// discriminator — callers are expected to have already validated it.
     /// Used by both the pipeline loader (`kind: pipeline`) and the job
     /// loader (`kind: job`), which share the same metadata + query body.
@@ -481,21 +489,47 @@ impl StandardPipeline {
             parameters: Vec::new(),
         };
 
+        // Optional author-written parameter descriptions (name → one line).
+        let parameter_docs: HashMap<String, String> = match spec_section.get("parameters") {
+            Some(section) => serde_yaml::from_value(section.clone())
+                .map_err(|e| anyhow!("Failed to parse spec.parameters section: {}", e))?,
+            None => HashMap::new(),
+        };
+
         let inferencer = SqlSchemaInferrer::new(ctx.clone())?;
         let request_schema = inferencer
             .extract_request_schema(&query_definition.sql)
             .await?;
+
+        // A described parameter the SQL does not declare is a typo or a doc
+        // string gone stale after a query edit — refuse to load rather than
+        // publish documentation that lies.
+        for documented in parameter_docs.keys() {
+            if !request_schema.fields.contains_key(documented) {
+                let mut declared: Vec<&String> = request_schema.fields.keys().collect();
+                declared.sort();
+                return Err(anyhow!(
+                    "spec.parameters describes '{}', but the SQL declares no {{{}}} placeholder (declared parameters: {:?})",
+                    documented,
+                    documented,
+                    declared,
+                ));
+            }
+        }
+
         let response_schema = inferencer
             .extract_response_schema(&query_definition.sql)
             .await?;
 
-        StandardPipeline::new(
+        let mut pipeline = StandardPipeline::new(
             metadata,
             request_schema,
             query_definition,
             response_schema,
             ctx,
-        )
+        )?;
+        pipeline.parameter_docs = parameter_docs;
+        Ok(pipeline)
     }
 }
 
@@ -1117,5 +1151,79 @@ spec:
             re_inferred_response.fields.len(),
             response_schema.fields.len()
         );
+    }
+
+    /// A minimal registered table so `{brand}` / `{max_price}` inference works.
+    fn ctx_with_products() -> Arc<SessionContext> {
+        use datafusion::arrow::array::{Float64Array, StringArray};
+        use datafusion::arrow::datatypes::{DataType, Field, Schema};
+        use datafusion::arrow::record_batch::RecordBatch;
+
+        let ctx = Arc::new(SessionContext::new());
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("brand", DataType::Utf8, true),
+            Field::new("price", DataType::Float64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![Some("Apple")])),
+                Arc::new(Float64Array::from(vec![1.0])),
+            ],
+        )
+        .unwrap();
+        ctx.register_batch("products", batch).unwrap();
+        ctx
+    }
+
+    async fn load_yaml(yaml: &str, ctx: Arc<SessionContext>) -> Result<StandardPipeline> {
+        use std::io::Write;
+        let mut temp = tempfile::NamedTempFile::new().unwrap();
+        temp.write_all(yaml.as_bytes()).unwrap();
+        StandardPipeline::load_from_file(temp.path(), ctx).await
+    }
+
+    #[tokio::test]
+    async fn spec_parameters_load_into_parameter_docs() {
+        let yaml = r#"
+kind: pipeline
+metadata:
+  name: "documented"
+  version: "1.0.0"
+spec:
+  parameters:
+    brand: "Exact brand name; null matches every brand"
+  query: |
+    SELECT brand, price FROM products
+    WHERE ({brand} IS NULL OR brand = {brand}) AND price < {max_price}
+"#;
+        let pipeline = load_yaml(yaml, ctx_with_products()).await.unwrap();
+        assert_eq!(
+            pipeline.parameter_docs.get("brand").map(String::as_str),
+            Some("Exact brand name; null matches every brand")
+        );
+        // Descriptions are optional per parameter: no entry, no error.
+        assert!(!pipeline.parameter_docs.contains_key("max_price"));
+    }
+
+    #[tokio::test]
+    async fn spec_parameters_reject_names_the_sql_does_not_declare() {
+        let yaml = r#"
+kind: pipeline
+metadata:
+  name: "typoed"
+  version: "1.0.0"
+spec:
+  parameters:
+    brnad: "typo for brand"
+  query: |
+    SELECT brand, price FROM products WHERE brand = {brand}
+"#;
+        let err = load_yaml(yaml, ctx_with_products())
+            .await
+            .expect_err("a described parameter missing from the SQL must fail the load");
+        let msg = err.to_string();
+        assert!(msg.contains("'brnad'"), "{msg}");
+        assert!(msg.contains("declared parameters"), "{msg}");
     }
 }

--- a/demo/rag/server/pipelines/search_fulltext.yaml
+++ b/demo/rag/server/pipelines/search_fulltext.yaml
@@ -10,11 +10,10 @@ metadata:
     used to generate the pgvector embedding, so FTS and vector search
     stay on a single source of truth.
 
-# Parameters:
-#   {query} - Search terms (web-search syntax: AND, "phrase", or, -not)
-#   {limit} - Maximum number of results
-
 spec:
+  parameters:
+    query: 'Search terms (web-search syntax: AND, "phrase", or, -not)'
+    limit: "Maximum number of results"
   query: |
     SELECT id, content, _score
     FROM pg_fts('documents', 'content', {query}, {limit})

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -85,7 +85,11 @@ nullable (`"type": ["string", "null"]`) because explicit `NULL` is a valid
 parameter value. Arrays declare `minItems: 1` (the server rejects empty
 arrays before execution), and multi-row `VALUES {name}` placeholders are
 typed as array-of-arrays with non-empty rows. Every parameter is required
-and unknown keys are rejected.
+and unknown keys are rejected. A pipeline author can attach a one-line
+description to any parameter via `spec.parameters` in the pipeline YAML
+(see [pipelines.md](pipelines.md)); it rides inside that parameter's
+schema as the standard `description` keyword, so the model no longer has
+to guess semantics from the parameter name alone.
 
 Every pipeline call carries the connection's session id as
 `X-Skardi-Session-Id` — the same id `query` sends in

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -75,7 +75,7 @@ description to any parameter:
 spec:
   parameters:
     brand: "Exact brand name; null matches every brand"
-    max_price: "Upper price bound in USD, inclusive"
+    max_price: "Upper price bound in USD, exclusive"
   query: |
     SELECT ...
     WHERE ({brand} IS NULL OR "Brand" = {brand})
@@ -85,11 +85,16 @@ spec:
 Descriptions are documentation, not declaration — the parameter set still
 comes from the SQL, and every key under `spec.parameters` must name a
 `{placeholder}` the query declares; a misspelled or stale key fails the
-load. Each description is published as the standard `description` keyword
+load, and so does a blank description. Text is trimmed on load, so block
+scalars (`>`) publish without their trailing newline. Each description is published as the standard `description` keyword
 inside that parameter's `json_schema` in the enriched `GET /pipelines`
 inventory, which `skardi mcp` projects verbatim into MCP tool input
 schemas — the sentence written here is exactly what a model reads before
 filling the parameter.
+
+Job YAML (`kind: job`) shares the same loader, so `spec.parameters` is
+accepted and validated there too — but only pipelines publish the text:
+`GET /jobs` lists parameter names alone.
 
 ### Parameter shapes
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -66,6 +66,31 @@ Each `POST /<name>/execute` body is a JSON object keyed by placeholder
 name; the CLI takes `--param name=value` flags with optional typed
 suffixes (`--param limit:int=10`).
 
+### Parameter descriptions
+
+An optional `spec.parameters` map attaches a one-line, human-written
+description to any parameter:
+
+```yaml
+spec:
+  parameters:
+    brand: "Exact brand name; null matches every brand"
+    max_price: "Upper price bound in USD, inclusive"
+  query: |
+    SELECT ...
+    WHERE ({brand} IS NULL OR "Brand" = {brand})
+      AND ({max_price} IS NULL OR "Price" < {max_price})
+```
+
+Descriptions are documentation, not declaration — the parameter set still
+comes from the SQL, and every key under `spec.parameters` must name a
+`{placeholder}` the query declares; a misspelled or stale key fails the
+load. Each description is published as the standard `description` keyword
+inside that parameter's `json_schema` in the enriched `GET /pipelines`
+inventory, which `skardi mcp` projects verbatim into MCP tool input
+schemas — the sentence written here is exactly what a model reads before
+filling the parameter.
+
 ### Parameter shapes
 
 The `{name}` token is replaced with a SQL-safe literal at execution time.


### PR DESCRIPTION
## Goal

Tool schemas generated for MCP carry only types (`{"type": ["string", "null"]}`) — the model has to guess a parameter's semantics from its name. This adds the missing input channel: a pipeline author writes one line of prose per parameter, and it lands verbatim in front of the model.

## Shape

```yaml
spec:
  parameters:
    query: 'Search terms (web-search syntax: AND, "phrase", or, -not)'
    limit: "Maximum number of results"
  query: |
    SELECT id, content, _score
    FROM pg_fts('documents', 'content', {query}, {limit})
```

- **Documentation, not declaration.** The parameter set still comes from the SQL placeholders; `spec.parameters` is optional per pipeline and per parameter.
- **Strict at load.** A described name the SQL does not declare (a typo, or a doc string gone stale after a query edit) fails the load, with the declared parameter list in the error — the published schema never lies.

## Flow

1. **skardi** — `build_from_parsed` reads the optional `spec.parameters` map into `StandardPipeline.parameter_docs` and validates every key against the inferred request schema.
2. **server** — `enriched_parameters` (the single home of the parameter shape) folds each one-liner into that parameter's `json_schema` as the standard JSON Schema `description` keyword, on both `GET /pipelines` and `GET /pipeline/:name`.
3. **bridge** — zero changes: `skardi mcp` already copies `json_schema` verbatim into tool properties, so descriptions reach MCP hosts on the next `tools/list`.

## Tests

- skardi: descriptions load; undocumented parameters have no entry; unknown described name rejects the file with a useful error.
- server: described `brand` publishes `description` inside `json_schema` on both inventory endpoints; undocumented `max_price` carries no `description` key.

## Docs & demo

`docs/pipelines.md` gains a *Parameter descriptions* section; `docs/mcp.md` points authors at it. One demo (`demo/rag/server/pipelines/search_fulltext.yaml`) converts its `# Parameters:` comment block into the structured form as the exemplar — the ~30 remaining demo comment blocks are left for a follow-up sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)