### PR TITLE
docs(readme): point Install at both skills, and mark skardi mcp unreleased

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ skardi run weekly-churn -p window='7 days'
 curl -X POST localhost:8080/weekly-churn/execute \
   -H 'Content-Type: application/json' -d '{"window": "7 days"}'
 # same pipeline as an MCP tool — hosts without a shell (Claude Desktop, …)
+# from a source checkout until `skardi mcp` ships in a tagged release
 skardi mcp
 ```
 
@@ -165,21 +166,28 @@ scratch.
 
 ## Install
 
-**Claude Code** — the fastest path. A skill that stands the whole thing up for
-you:
+**Claude Code** — the fastest path. Two skills: one stands the whole thing up,
+the other queries what is already running.
 
 ```text
 /plugin marketplace add SkardiLabs/skardi-skills
 /plugin install auto-context@skardi-skills
+/plugin install retrieval@skardi-skills
 ```
 
-[`auto_context`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto_context)
+[`auto-context`](https://github.com/SkardiLabs/skardi-skills/tree/main/auto-context)
 turns a folder of documents — or a datastore you already run — into governed,
 searchable context served over HTTP by `skardi-server`: hybrid search (vector +
 FTS + RRF), defaulting to a local SQLite file the skill creates and owns, or
-pointed at Postgres + pgvector, MongoDB, or Lance. The same skill also runs on
-Codex, Cursor, Pi, dsh, OpenClaw, and Hermes; per-host installation instructions
-are in the [skardi-skills README](https://github.com/SkardiLabs/skardi-skills#installation).
+pointed at Postgres + pgvector, MongoDB, or Lance.
+[`retrieval`](https://github.com/SkardiLabs/skardi-skills/tree/main/retrieval)
+covers the other direction: answering questions from a server that is already
+running. It discovers the sources, named pipelines and table schemas that
+deployment exposes, tries semantic search before falling back to read-only SQL,
+and checks truncation before trusting a count. It builds no index, writes no
+data, and starts no server. Both also run on Codex, Cursor, Pi, dsh, OpenClaw,
+and Hermes; per-host installation instructions are in the
+[skardi-skills README](https://github.com/SkardiLabs/skardi-skills#installation).
 
 **CLI** — pre-built for `x86_64`/`aarch64` Linux and Apple Silicon (Intel Macs:
 build from source — the one-liner below has no published artifact there):


### PR DESCRIPTION
Three places where the README had drifted from what a reader can actually get today. Docs only.

## The `auto_context` link 404s

Install links to `skardi-skills/tree/main/auto_context`. That directory was renamed to `auto-context` in SkardiLabs/skardi-skills#29 — underscore names are silently dropped by dsh — so the link has been dead since that merge. Fixed, and the inline code label matches the real directory again.

## `retrieval` had no entry point

SkardiLabs/skardi-skills#27 shipped the `retrieval` skill on 2026-08-26 and Install never mentioned it. The only path a reader could see was "turn a folder into a knowledge base" — while the second path this README's own loop depends on, *query a server that is already running*, had nowhere to start from. Added its install line and a short description taken from the skill's own README entry.

The intro line said "A skill"; it now says two, since that is what the block installs.

## `skardi mcp` is presented as available, but is not released

The **4 — The agent has a new tool** block shows `skardi mcp` alongside `skardi run` and the REST call, as one of three bindings you can use now. #227 landed after `v0.5.0`, so anyone on the released CLI gets an unknown-subcommand error there. The `--query-audit-db` line a few paragraphs up already carries exactly this caveat, so this adds the matching one rather than inventing a new convention.

## Verified

- `auto-context/` and `retrieval/` both resolve on `skardi-skills` `main`; `auto_context/` returns 404 (`gh api repos/SkardiLabs/skardi-skills/contents/<path>`)
- `git grep -c mcp v0.5.0 -- crates/cli/src/main.rs` → zero hits; same grep on `main` finds the subcommand
- `python3 scripts/check_markdown_links.py` → all relative markdown links resolve

No behaviour changes.