### PR TITLE
feat(open-connector): accept a single response object as one row

### DIFF
--- a/crates/skardi/src/sources/providers/open_connector/error.rs
+++ b/crates/skardi/src/sources/providers/open_connector/error.rs
@@ -452,6 +452,18 @@ pub enum OpenConnectorError {
         found: String,
     },
 
+    /// A raw-action scan asked for the object row shape. Object rows are a
+    /// pack-declared contract (`row_shape: object`) whose response shape is
+    /// pinned by a fingerprint; an ad-hoc action has no such gate, and
+    /// deriving a row schema from the response ROOT rather than a row array
+    /// is a different inference rule that has not been designed. Deferred
+    /// deliberately, with this error, rather than guessed at.
+    #[error(
+        "Open Connector raw-action scans do not support object rows: '$' selects the response root, \
+         which only pack tables may declare via 'row_shape: object'. Use a row path locating a row array."
+    )]
+    ObjectRowsUnsupportedForRawAction,
+
     /// The row path resolved to a non-array value; relational rows must be an
     /// array of objects.
     #[error(

--- a/crates/skardi/src/sources/providers/open_connector/exec.rs
+++ b/crates/skardi/src/sources/providers/open_connector/exec.rs
@@ -33,7 +33,9 @@ use super::error::OpenConnectorError;
 use super::json_to_arrow::RowConverter;
 use super::pagination::{CursorContinuation, Pagination, PaginationStrategy};
 use super::row_path::RowPath;
+use super::source_pack::RowShape;
 use super::source_pack::{FixedValue, SourcePackTable};
+use std::slice;
 
 /// The scanned collection's identity and pagination contract — the shape
 /// shared by YAML-bound source-pack tables and `open_connector_scan` raw
@@ -89,6 +91,7 @@ pub struct OpenConnectorExec {
     target: ScanTarget,
     converter: Arc<RowConverter>,
     row_path: RowPath,
+    row_shape: RowShape,
     resource: Value,
     filter_inputs: Vec<(String, Value)>,
     projection: Option<Vec<usize>>,
@@ -125,6 +128,7 @@ impl OpenConnectorExec {
         target: ScanTarget,
         converter: Arc<RowConverter>,
         row_path: RowPath,
+        row_shape: RowShape,
         resource: Value,
         filter_inputs: Vec<(String, Value)>,
         projection: Option<Vec<usize>>,
@@ -153,6 +157,7 @@ impl OpenConnectorExec {
             target,
             converter,
             row_path,
+            row_shape,
             resource,
             filter_inputs,
             projection,
@@ -274,6 +279,7 @@ struct ScanState {
     target: ScanTarget,
     converter: Arc<RowConverter>,
     row_path: RowPath,
+    row_shape: RowShape,
     resource: Value,
     filter_inputs: Vec<(String, Value)>,
     projection: Option<Vec<usize>>,
@@ -361,6 +367,7 @@ impl ScanState {
             target: exec.target.clone(),
             converter: exec.converter.clone(),
             row_path: exec.row_path.clone(),
+            row_shape: exec.row_shape,
             resource: exec.resource.clone(),
             filter_inputs: exec.filter_inputs.clone(),
             projection: exec.projection.clone(),
@@ -541,7 +548,14 @@ impl ScanState {
                 code,
             });
         }
-        let rows = self.row_path.rows(&envelope, page)?;
+        // Object-shaped tables hand the single response object to the SAME
+        // converter as a one-element slice: `from_ref` borrows it in place,
+        // so there is no clone of the response and no second conversion
+        // path to keep in sync with schema, projection, and error handling.
+        let rows = match self.row_shape {
+            RowShape::Array => self.row_path.rows(&envelope, page)?,
+            RowShape::Object => slice::from_ref(self.row_path.row_object(&envelope, page)?),
+        };
         let batch = self.converter.convert(rows, page)?;
         // Conversion is synchronous, so it cannot be preempted by Tokio; do
         // not emit its result if it consumed the remaining scan budget.
@@ -659,6 +673,7 @@ mod tests {
             ScanTarget::from_pack_table(table, source_pack_version),
             Arc::new(RowConverter::new(table.fields).expect("converter")),
             RowPath::parse(table.row_path).expect("row path"),
+            table.row_shape,
             json!({}),
             vec![],
             None,
@@ -713,6 +728,7 @@ mod tests {
             id: "split.entries",
             action_id: "split.list",
             row_path: "$.entries",
+            row_shape: RowShape::Array,
             fields: &[FieldMapping {
                 name: "id",
                 path: "id",
@@ -739,6 +755,142 @@ mod tests {
                 cursor_only: true,
             }),
         }))
+    }
+
+    /// A point-read table whose whole response IS the row — the
+    /// `feishu.get_document_content` shape this extension exists for.
+    fn object_row_table() -> &'static SourcePackTable {
+        Box::leak(Box::new(SourcePackTable {
+            id: "docs.document_content",
+            action_id: "docs.get_document_content",
+            row_path: "$",
+            row_shape: RowShape::Object,
+            fields: &[
+                FieldMapping {
+                    name: "document_id",
+                    path: "documentId",
+                    field_type: FieldType::Utf8,
+                    nullable: false,
+                },
+                FieldMapping {
+                    name: "content",
+                    path: "content",
+                    field_type: FieldType::Utf8,
+                    nullable: true,
+                },
+            ],
+            pagination: PaginationStrategy::SinglePage {
+                next_cursor_path: None,
+            },
+            required_resources: &["documentId"],
+            optional_resources: &[],
+            exclusive_resources: &[],
+            fixed_inputs: &[],
+            filters: &[],
+            error_path: None,
+            expected_fingerprint: None,
+            continuation: None,
+        }))
+    }
+
+    #[tokio::test]
+    async fn object_row_response_becomes_exactly_one_row() {
+        // The end-to-end proof: a single-object response reaches the same
+        // converter as an array of one and yields one row with real values,
+        // in one gateway call.
+        let gateway = MockGateway::start(|req: &RecordedRequest| {
+            if req.path == "/v1/actions/docs.get_document_content" {
+                return MockResponse::ok(&envelope_ok(
+                    &json!({"documentId": "doc-1", "content": "hello world"}).to_string(),
+                ));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+
+        let table = object_row_table();
+        let exec = OpenConnectorExec::new(
+            online_client(&gateway).await,
+            None,
+            "saas".to_string(),
+            Some("ws".to_string()),
+            None,
+            ScanTarget::from_pack_table(table, 1),
+            Arc::new(RowConverter::new(table.fields).expect("converter")),
+            RowPath::parse_object_root(table.row_path).expect("object root"),
+            table.row_shape,
+            json!({"documentId": "doc-1"}),
+            vec![],
+            None,
+            None,
+            10,
+            1000,
+            Duration::from_secs(30),
+        )
+        .expect("build exec");
+
+        let mut state = ScanState::new(&exec).expect("state");
+        let first = state
+            .next_page()
+            .await
+            .expect("page")
+            .expect("one batch is emitted");
+        assert_eq!(
+            first.num_rows(),
+            1,
+            "the response object is exactly one row"
+        );
+        let content = first
+            .column(1)
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::StringArray>()
+            .expect("utf8 column");
+        assert_eq!(content.value(0), "hello world", "values survive conversion");
+        assert!(
+            state.next_page().await.expect("second page").is_none(),
+            "a single-page object table stops after one call"
+        );
+    }
+
+    #[tokio::test]
+    async fn object_row_table_fails_loudly_when_the_response_is_not_an_object() {
+        // A point read that returns null/array/primitive must fail, not
+        // report zero rows — "this document has no content" would be a lie.
+        let gateway = MockGateway::start(|req: &RecordedRequest| {
+            if req.path == "/v1/actions/docs.get_document_content" {
+                return MockResponse::ok(&envelope_ok(&json!(null).to_string()));
+            }
+            MockResponse::new(404, "{}")
+        })
+        .await;
+
+        let table = object_row_table();
+        let exec = OpenConnectorExec::new(
+            online_client(&gateway).await,
+            None,
+            "saas".to_string(),
+            Some("ws".to_string()),
+            None,
+            ScanTarget::from_pack_table(table, 1),
+            Arc::new(RowConverter::new(table.fields).expect("converter")),
+            RowPath::parse_object_root(table.row_path).expect("object root"),
+            table.row_shape,
+            json!({"documentId": "doc-1"}),
+            vec![],
+            None,
+            None,
+            10,
+            1000,
+            Duration::from_secs(30),
+        )
+        .expect("build exec");
+
+        let mut state = ScanState::new(&exec).expect("state");
+        let err = state.next_page().await.expect_err("null must fail loudly");
+        assert!(
+            err.to_string().contains("expected an object"),
+            "unexpected error: {err}"
+        );
     }
 
     #[tokio::test]
@@ -784,6 +936,7 @@ mod tests {
             ScanTarget::from_pack_table(table, 1),
             Arc::new(RowConverter::new(table.fields).expect("converter")),
             RowPath::parse(table.row_path).expect("row path"),
+            table.row_shape,
             json!({"path": "/docs"}),
             vec![],
             None,

--- a/crates/skardi/src/sources/providers/open_connector/exec.rs
+++ b/crates/skardi/src/sources/providers/open_connector/exec.rs
@@ -63,6 +63,12 @@ pub struct ScanTarget {
     /// [`super::pagination::CursorContinuation`]); `None` for raw scans and
     /// for every table whose provider accepts the cursor on its own action.
     pub continuation: Option<CursorContinuation>,
+    /// Whether the row path locates an array of rows or a single row object
+    /// (see [`RowShape`]). Carried on the target rather than passed
+    /// alongside it: this is the per-table response contract, exactly like
+    /// `pagination` and `error_path`. Raw scans are always
+    /// [`RowShape::Array`].
+    pub row_shape: RowShape,
 }
 
 impl ScanTarget {
@@ -76,6 +82,7 @@ impl ScanTarget {
             fixed_inputs: table.fixed_inputs,
             source_pack_version,
             continuation: table.continuation,
+            row_shape: table.row_shape,
         }
     }
 }
@@ -91,7 +98,6 @@ pub struct OpenConnectorExec {
     target: ScanTarget,
     converter: Arc<RowConverter>,
     row_path: RowPath,
-    row_shape: RowShape,
     resource: Value,
     filter_inputs: Vec<(String, Value)>,
     projection: Option<Vec<usize>>,
@@ -128,7 +134,6 @@ impl OpenConnectorExec {
         target: ScanTarget,
         converter: Arc<RowConverter>,
         row_path: RowPath,
-        row_shape: RowShape,
         resource: Value,
         filter_inputs: Vec<(String, Value)>,
         projection: Option<Vec<usize>>,
@@ -157,7 +162,6 @@ impl OpenConnectorExec {
             target,
             converter,
             row_path,
-            row_shape,
             resource,
             filter_inputs,
             projection,
@@ -279,7 +283,6 @@ struct ScanState {
     target: ScanTarget,
     converter: Arc<RowConverter>,
     row_path: RowPath,
-    row_shape: RowShape,
     resource: Value,
     filter_inputs: Vec<(String, Value)>,
     projection: Option<Vec<usize>>,
@@ -367,7 +370,6 @@ impl ScanState {
             target: exec.target.clone(),
             converter: exec.converter.clone(),
             row_path: exec.row_path.clone(),
-            row_shape: exec.row_shape,
             resource: exec.resource.clone(),
             filter_inputs: exec.filter_inputs.clone(),
             projection: exec.projection.clone(),
@@ -552,7 +554,7 @@ impl ScanState {
         // converter as a one-element slice: `from_ref` borrows it in place,
         // so there is no clone of the response and no second conversion
         // path to keep in sync with schema, projection, and error handling.
-        let rows = match self.row_shape {
+        let rows = match self.target.row_shape {
             RowShape::Array => self.row_path.rows(&envelope, page)?,
             RowShape::Object => slice::from_ref(self.row_path.row_object(&envelope, page)?),
         };
@@ -673,7 +675,6 @@ mod tests {
             ScanTarget::from_pack_table(table, source_pack_version),
             Arc::new(RowConverter::new(table.fields).expect("converter")),
             RowPath::parse(table.row_path).expect("row path"),
-            table.row_shape,
             json!({}),
             vec![],
             None,
@@ -818,7 +819,6 @@ mod tests {
             ScanTarget::from_pack_table(table, 1),
             Arc::new(RowConverter::new(table.fields).expect("converter")),
             RowPath::parse_object_root(table.row_path).expect("object root"),
-            table.row_shape,
             json!({"documentId": "doc-1"}),
             vec![],
             None,
@@ -874,7 +874,6 @@ mod tests {
             ScanTarget::from_pack_table(table, 1),
             Arc::new(RowConverter::new(table.fields).expect("converter")),
             RowPath::parse_object_root(table.row_path).expect("object root"),
-            table.row_shape,
             json!({"documentId": "doc-1"}),
             vec![],
             None,
@@ -936,7 +935,6 @@ mod tests {
             ScanTarget::from_pack_table(table, 1),
             Arc::new(RowConverter::new(table.fields).expect("converter")),
             RowPath::parse(table.row_path).expect("row path"),
-            table.row_shape,
             json!({"path": "/docs"}),
             vec![],
             None,

--- a/crates/skardi/src/sources/providers/open_connector/packs/loader.rs
+++ b/crates/skardi/src/sources/providers/open_connector/packs/loader.rs
@@ -43,7 +43,7 @@ use crate::sources::providers::open_connector::pagination::{
 };
 use crate::sources::providers::open_connector::row_path::RowPath;
 use crate::sources::providers::open_connector::source_pack::{
-    FixedValue, SourcePack, SourcePackTable,
+    FixedValue, RowShape, SourcePack, SourcePackTable,
 };
 
 /// Parse an embedded pack asset, memoized in `cell`.
@@ -141,6 +141,7 @@ fn convert_table(
         id,
         action_id,
         row_path: leak_str(doc.row_path),
+        row_shape: doc.row_shape.into(),
         fields: leak_slice(fields),
         pagination,
         required_resources: leak_str_slice(doc.resources.required),
@@ -163,7 +164,26 @@ fn validate_table(table: &SourcePackTable) -> Result<(), String> {
     let id = table.id;
     // Structural pieces the engine parses lazily elsewhere fail HERE so a
     // generated asset gets one complete diagnostic pass.
-    RowPath::parse(table.row_path).map_err(|e| format!("{id}: {e}"))?;
+    // Two shapes, two contracts. Array tables keep the strict path parser;
+    // object tables get the root-only one, so `$` never becomes valid for a
+    // table that is supposed to locate a row array.
+    match table.row_shape {
+        RowShape::Array => {
+            RowPath::parse(table.row_path).map_err(|e| format!("{id}: {e}"))?;
+        }
+        RowShape::Object => {
+            RowPath::parse_object_root(table.row_path).map_err(|e| format!("{id}: {e}"))?;
+            // An object row IS the whole response, so there is nothing for a
+            // second request to return. Any multi-page strategy here is a
+            // declaration error that would otherwise re-fetch the same row
+            // until a page limit stopped it.
+            if !matches!(table.pagination, PaginationStrategy::SinglePage { .. }) {
+                return Err(format!(
+                    "{id}: row_shape 'object' requires pagination strategy 'single_page'"
+                ));
+            }
+        }
+    }
     if let Some(path) = table.error_path {
         RowPath::parse(path).map_err(|e| format!("{id}: {e}"))?;
     }
@@ -566,6 +586,10 @@ enum KindTag {
 struct TableDoc {
     action: String,
     row_path: String,
+    /// Response shape. Omitted means `array`, so every pack written before
+    /// object rows existed keeps its exact behaviour.
+    #[serde(default)]
+    row_shape: RowShapeDoc,
     #[serde(default)]
     fingerprint: Option<String>,
     pagination: PaginationDoc,
@@ -578,6 +602,23 @@ struct TableDoc {
     columns: Vec<ColumnDoc>,
     #[serde(default)]
     filters: Vec<FilterDoc>,
+}
+
+#[derive(Deserialize, Default, Clone, Copy)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+enum RowShapeDoc {
+    #[default]
+    Array,
+    Object,
+}
+
+impl From<RowShapeDoc> for RowShape {
+    fn from(doc: RowShapeDoc) -> Self {
+        match doc {
+            RowShapeDoc::Array => Self::Array,
+            RowShapeDoc::Object => Self::Object,
+        }
+    }
 }
 
 #[derive(Deserialize, Default)]
@@ -990,6 +1031,120 @@ tables:
         )
         .unwrap_err();
         assert!(err.contains("total_page_path"), "{err}");
+    }
+
+    #[test]
+    fn row_shape_defaults_to_array_for_every_existing_pack() {
+        // The zero-behaviour-change invariant: a pack that says nothing
+        // about shape must load exactly as it did before object rows.
+        let pack = parse_pack(
+            r#"
+kind: pack
+pack: demo
+version: 1
+tables:
+  items:
+    action: demo.list
+    row_path: "$.items"
+    pagination: { strategy: single_page }
+    columns:
+      - { name: id, path: id, type: uint64, nullable: false }
+"#,
+        )
+        .expect("a pack without row_shape still parses");
+        assert_eq!(pack.tables[0].row_shape, RowShape::Array);
+    }
+
+    #[test]
+    fn object_row_shape_parses_with_root_path_and_single_page() {
+        let pack = parse_pack(
+            r#"
+kind: pack
+pack: demo
+version: 1
+tables:
+  document_content:
+    action: demo.get_document_content
+    row_path: "$"
+    row_shape: object
+    pagination: { strategy: single_page }
+    columns:
+      - { name: content, path: content, type: utf8, nullable: true }
+"#,
+        )
+        .expect("object rows at the root with single_page are valid");
+        assert_eq!(pack.tables[0].row_shape, RowShape::Object);
+        assert_eq!(pack.tables[0].row_path, "$");
+    }
+
+    #[test]
+    fn object_row_shape_requires_single_page() {
+        // An object row IS the whole response: a second page could only
+        // re-fetch the same row.
+        let err = parse_pack(
+            r#"
+kind: pack
+pack: demo
+version: 1
+tables:
+  document_content:
+    action: demo.get_document_content
+    row_path: "$"
+    row_shape: object
+    pagination:
+      strategy: cursor
+      cursor_input: pageToken
+      next_cursor_path: "$.pageToken"
+      page_size_input: pageSize
+      page_size: 100
+    columns:
+      - { name: content, path: content, type: utf8, nullable: true }
+"#,
+        )
+        .unwrap_err();
+        assert!(err.contains("single_page"), "{err}");
+    }
+
+    #[test]
+    fn object_row_shape_rejects_a_non_root_path() {
+        let err = parse_pack(
+            r#"
+kind: pack
+pack: demo
+version: 1
+tables:
+  document_content:
+    action: demo.get_document_content
+    row_path: "$.document"
+    row_shape: object
+    pagination: { strategy: single_page }
+    columns:
+      - { name: content, path: content, type: utf8, nullable: true }
+"#,
+        )
+        .unwrap_err();
+        assert!(err.contains("'$'"), "{err}");
+    }
+
+    #[test]
+    fn array_row_shape_still_rejects_the_root_path() {
+        // The array contract is unchanged: `$` remains invalid there.
+        let err = parse_pack(
+            r#"
+kind: pack
+pack: demo
+version: 1
+tables:
+  items:
+    action: demo.list
+    row_path: "$"
+    pagination: { strategy: single_page }
+    columns:
+      - { name: id, path: id, type: uint64, nullable: false }
+"#,
+        )
+        .unwrap_err();
+        assert!(err.contains("row path"), "{err}");
     }
 
     #[test]

--- a/crates/skardi/src/sources/providers/open_connector/row_path.rs
+++ b/crates/skardi/src/sources/providers/open_connector/row_path.rs
@@ -1,10 +1,17 @@
 //! Row-path parsing and extraction.
 //!
 //! A source-pack table declares a fixed *row path* — the JSON location of
-//! the row array inside an action's response envelope (`$.issues`,
+//! the rows inside an action's response envelope (`$.issues`,
 //! `$.data.items`). Paths are deliberately limited to object-key segments:
 //! they are relational contracts maintained by Skardi, not a user query
 //! language, so arrays/wildcards are out of scope.
+//!
+//! Root `$` is a separate, narrower case: it is accepted ONLY when a table
+//! declares `row_shape: object`, for actions whose whole response IS the
+//! single row (a point read such as `feishu.get_document_content`). It is
+//! parsed through [`RowPath::parse_object_root`], never through
+//! [`RowPath::parse`], so the array contract stays exactly as strict as it
+//! was for every table that locates a row array.
 
 use serde_json::Value;
 
@@ -53,6 +60,60 @@ impl RowPath {
     }
 
     /// The path as written, e.g. `$.data.items`.
+    /// Parse the root path `$` for an object-row table.
+    ///
+    /// Separate from [`RowPath::parse`] on purpose: making `$` valid there
+    /// would silently legalise a rowless path for the 37 array-shaped
+    /// tables, where it can only ever be a mistake. Only the object-row
+    /// loader reaches this constructor, and only after it has checked that
+    /// the table declares `row_shape: object`.
+    ///
+    /// # Example
+    /// ```
+    /// use skardi::sources::providers::open_connector::row_path::RowPath;
+    ///
+    /// let path = RowPath::parse_object_root("$").unwrap();
+    /// assert_eq!(path.as_str(), "$");
+    /// assert!(RowPath::parse_object_root("$.data").is_err()); // only root
+    /// ```
+    pub fn parse_object_root(path: &str) -> Result<Self, OpenConnectorError> {
+        if path != "$" {
+            return Err(OpenConnectorError::InvalidRowPath {
+                path: path.to_string(),
+                reason: "object row shape selects the response root; the only valid path is '$'"
+                    .to_string(),
+            });
+        }
+        Ok(Self {
+            raw: path.to_string(),
+            segments: Vec::new(),
+        })
+    }
+
+    /// Extract the single row object at the path.
+    ///
+    /// A response that is null, an array, or a primitive fails loudly with
+    /// [`OpenConnectorError::RowPathNotObject`] rather than degrading to an
+    /// empty result: a point read that returns "no object" is a contract
+    /// break at the gateway, and a silent zero-row scan would report it as
+    /// "this document has no content".
+    pub fn row_object<'a>(
+        &self,
+        value: &'a Value,
+        page: usize,
+    ) -> Result<&'a Value, OpenConnectorError> {
+        let target = self.extract(value, page)?;
+        if !target.is_object() {
+            return Err(OpenConnectorError::RowPathNotObject {
+                path: self.raw.clone(),
+                segment: "<root>".to_string(),
+                page,
+                found: json_kind(target),
+            });
+        }
+        Ok(target)
+    }
+
     pub fn as_str(&self) -> &str {
         &self.raw
     }
@@ -139,6 +200,56 @@ mod tests {
                     Err(OpenConnectorError::InvalidRowPath { .. })
                 ),
                 "{bad} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn object_root_parses_only_the_bare_root() {
+        assert_eq!(RowPath::parse_object_root("$").unwrap().as_str(), "$");
+        for bad in ["$.data", "data", "", "$$"] {
+            assert!(
+                matches!(
+                    RowPath::parse_object_root(bad),
+                    Err(OpenConnectorError::InvalidRowPath { .. })
+                ),
+                "{bad} should be rejected for object rows"
+            );
+        }
+    }
+
+    #[test]
+    fn object_root_stays_invalid_for_the_array_parser() {
+        // The whole point of a separate constructor: `$` must not become a
+        // legal row path for the array-shaped tables.
+        assert!(matches!(
+            RowPath::parse("$"),
+            Err(OpenConnectorError::InvalidRowPath { .. })
+        ));
+    }
+
+    #[test]
+    fn row_object_returns_the_response_root() {
+        let page = json!({"documentId": "doc-1", "content": "hello"});
+        let row = RowPath::parse_object_root("$")
+            .unwrap()
+            .row_object(&page, 1)
+            .unwrap();
+        assert_eq!(row, &page);
+    }
+
+    #[test]
+    fn row_object_fails_loudly_on_null_array_and_primitive() {
+        // A point read that did not return an object is a broken contract;
+        // it must never degrade into an empty (zero-row) scan.
+        for bad in [json!(null), json!([{"id": 1}]), json!("text"), json!(7)] {
+            let err = RowPath::parse_object_root("$")
+                .unwrap()
+                .row_object(&bad, 1)
+                .unwrap_err();
+            assert!(
+                matches!(err, OpenConnectorError::RowPathNotObject { .. }),
+                "{bad} should fail as not-an-object, got {err}"
             );
         }
     }

--- a/crates/skardi/src/sources/providers/open_connector/source_pack.rs
+++ b/crates/skardi/src/sources/providers/open_connector/source_pack.rs
@@ -58,6 +58,28 @@ impl FixedValue {
     }
 }
 
+/// How an action's response carries its rows.
+///
+/// Every table mapped before 2026-09 locates a row *array* (`$.items`), and
+/// that stays the default: a pack that says nothing about shape behaves
+/// exactly as it did. [`RowShape::Object`] covers point-read actions whose
+/// entire response IS one row — `feishu.get_document_content`, Notion's
+/// rendered Markdown — which have no array anywhere to point a row path at.
+///
+/// This is a response-shape declaration, not a query feature: the object is
+/// handed to the same converter as an array of one, so there is a single
+/// conversion path and object rows get the same schema, projection, and
+/// error handling as every other row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RowShape {
+    /// The row path resolves to an array of row objects.
+    #[default]
+    Array,
+    /// The row path resolves to a single object that IS the row. Valid only
+    /// with single-page pagination.
+    Object,
+}
+
 /// One stable table definition inside a source pack.
 #[derive(Debug, Clone, Copy)]
 pub struct SourcePackTable {
@@ -65,8 +87,13 @@ pub struct SourcePackTable {
     pub id: &'static str,
     /// Open Connector action backing the table (read-only by construction).
     pub action_id: &'static str,
-    /// Fixed row path of the row array in the action response.
+    /// Fixed row path of the rows in the action response. For
+    /// [`RowShape::Array`] this locates the row array; for
+    /// [`RowShape::Object`] it is the root `$`.
     pub row_path: &'static str,
+    /// Whether `row_path` resolves to an array of rows or to a single row
+    /// object. Defaults to [`RowShape::Array`]; see [`RowShape`].
+    pub row_shape: RowShape,
     /// Fixed Arrow schema and field mappings.
     pub fields: &'static [FieldMapping],
     /// Pagination strategy.
@@ -862,6 +889,7 @@ mod tests {
             id,
             action_id: "t.action",
             row_path: "$.items",
+            row_shape: RowShape::Array,
             fields: &[],
             pagination: PaginationStrategy::SinglePage {
                 next_cursor_path: None,

--- a/crates/skardi/src/sources/providers/open_connector/source_pack.rs
+++ b/crates/skardi/src/sources/providers/open_connector/source_pack.rs
@@ -670,6 +670,28 @@ mod tests {
     use super::*;
 
     #[test]
+    fn every_shipped_table_is_array_shaped() {
+        // The zero-behaviour-change invariant, asserted against what
+        // actually ships rather than a synthetic YAML: object rows are new,
+        // so no built-in table may have acquired the shape by accident. The
+        // day a pack legitimately declares one (feishu document_content),
+        // this test names it explicitly instead of being deleted.
+        let registry = SourcePackRegistry::builtins().expect("embedded assets parse");
+        let mut object_tables = Vec::new();
+        for pack in registry.packs.values() {
+            for table in pack.tables {
+                if table.row_shape == RowShape::Object {
+                    object_tables.push(table.id);
+                }
+            }
+        }
+        assert!(
+            object_tables.is_empty(),
+            "no shipped pack declares object rows yet, found: {object_tables:?}"
+        );
+    }
+
+    #[test]
     fn builtin_mock_pack_is_registered() {
         let registry = SourcePackRegistry::builtins().expect("embedded assets parse");
         let pack = registry.require("mock").unwrap();

--- a/crates/skardi/src/sources/providers/open_connector/table.rs
+++ b/crates/skardi/src/sources/providers/open_connector/table.rs
@@ -19,6 +19,7 @@ use super::exec::{OpenConnectorExec, ScanTarget};
 use super::filters::translate_filters;
 use super::json_to_arrow::RowConverter;
 use super::row_path::RowPath;
+use super::source_pack::RowShape;
 use super::source_pack::SourcePackTable;
 
 /// A source-pack table bound to a concrete resource (one binding).
@@ -75,7 +76,10 @@ impl OpenConnectorTableProvider {
         scan_timeout: Duration,
     ) -> Result<Self, super::error::OpenConnectorError> {
         let converter = Arc::new(RowConverter::new(table.fields)?);
-        let row_path = RowPath::parse(table.row_path)?;
+        let row_path = match table.row_shape {
+            RowShape::Array => RowPath::parse(table.row_path)?,
+            RowShape::Object => RowPath::parse_object_root(table.row_path)?,
+        };
         // Same bind-time guarantee as the row path: a malformed pack-authored
         // pagination path fails here at registration, not mid-scan.
         table.pagination.validate()?;
@@ -156,6 +160,7 @@ impl TableProvider for OpenConnectorTableProvider {
             ScanTarget::from_pack_table(self.table, self.source_pack_version),
             Arc::clone(&self.converter),
             self.row_path.clone(),
+            self.table.row_shape,
             self.resource.clone(),
             translated.inputs,
             projection.cloned(),
@@ -195,6 +200,7 @@ mod tests {
             id: "test.t",
             action_id: "test.action",
             row_path: "$.items",
+            row_shape: RowShape::Array,
             fields: &[FieldMapping {
                 name: "id",
                 path: "id",

--- a/crates/skardi/src/sources/providers/open_connector/table.rs
+++ b/crates/skardi/src/sources/providers/open_connector/table.rs
@@ -160,7 +160,6 @@ impl TableProvider for OpenConnectorTableProvider {
             ScanTarget::from_pack_table(self.table, self.source_pack_version),
             Arc::clone(&self.converter),
             self.row_path.clone(),
-            self.table.row_shape,
             self.resource.clone(),
             translated.inputs,
             projection.cloned(),

--- a/crates/skardi/src/sources/providers/open_connector/table_functions.rs
+++ b/crates/skardi/src/sources/providers/open_connector/table_functions.rs
@@ -362,6 +362,9 @@ impl TableFunctionImpl for OpenConnectorScanFunction {
                 error_path: None,
                 fixed_inputs: &[],
                 source_pack_version: 0,
+                // Raw actions are array-only; see
+                // `ObjectRowsUnsupportedForRawAction`.
+                row_shape: RowShape::Array,
                 // Raw scans declare no pagination contract at all, so
                 // there is no listing to continue.
                 continuation: None,
@@ -435,7 +438,6 @@ impl TableProvider for RawScanProvider {
             self.target.clone(),
             Arc::clone(&self.converter),
             self.row_path.clone(),
-            RowShape::Array,
             self.input.clone(),
             Vec::new(),
             projection.cloned(),
@@ -1064,6 +1066,27 @@ raw_action_allowlist:
             r#"SELECT * FROM open_connector_scan('saas', 'mock.list_items',
                                                  '{"workspace":"demo"}', '$.items')"#,
             "is classified as mutating",
+        )
+        .await;
+        assert!(execute_requests(&gateway).is_empty(), "rejected pre-HTTP");
+    }
+
+    #[tokio::test]
+    async fn scan_udtf_rejects_the_object_root_path_before_http() {
+        // Object rows are a pack-declared contract. A caller asking for one
+        // ad hoc must be told so at planning time, by the targeted error —
+        // not fall through to `RowPath::parse`'s generic "no segments", and
+        // not reach the gateway.
+        let gateway =
+            MockGateway::start(|req| gateway_handler(req, 5, Some(true), ITEMS_OUTPUT_SCHEMA))
+                .await;
+        let config = parse_config(ALLOWLIST_CONFIG, "SKARDI_TEST_OC_UDTF_SCAN_OBJECT_ROOT", 0);
+        let ctx = setup(&gateway, &config, "SKARDI_TEST_OC_UDTF_SCAN_OBJECT_ROOT").await;
+        expect_plan_error(
+            &ctx,
+            r#"SELECT * FROM open_connector_scan('saas', 'mock.list_items',
+                                                 '{"workspace":"demo"}', '$')"#,
+            "do not support object rows",
         )
         .await;
         assert!(execute_requests(&gateway).is_empty(), "rejected pre-HTTP");

--- a/crates/skardi/src/sources/providers/open_connector/table_functions.rs
+++ b/crates/skardi/src/sources/providers/open_connector/table_functions.rs
@@ -55,6 +55,7 @@ use super::json_to_arrow::RowConverter;
 use super::pagination::PaginationStrategy;
 use super::raw_schema::derive_raw_columns;
 use super::row_path::RowPath;
+use super::source_pack::RowShape;
 use super::source_pack::SourcePackRegistry;
 use super::table::OpenConnectorTableProvider;
 use crate::sources::providers::udtf_args::strict_string_arg;
@@ -329,6 +330,15 @@ impl TableFunctionImpl for OpenConnectorScanFunction {
             "action inputs",
         )?;
 
+        // Raw actions stay array-only; see
+        // `OpenConnectorError::ObjectRowsUnsupportedForRawAction` for why the
+        // object shape is a pack-declared contract rather than something a
+        // caller can request ad hoc.
+        if row_path == "$" {
+            return Err(plan_error(
+                OpenConnectorError::ObjectRowsUnsupportedForRawAction,
+            ));
+        }
         let row_path = RowPath::parse(&row_path).map_err(plan_error)?;
         // Deterministic row type or planning error — derived purely from the
         // in-memory discovered output schema.
@@ -425,6 +435,7 @@ impl TableProvider for RawScanProvider {
             self.target.clone(),
             Arc::clone(&self.converter),
             self.row_path.clone(),
+            RowShape::Array,
             self.input.clone(),
             Vec::new(),
             projection.cloned(),

--- a/docs/superpowers/skills/source-pack/references/implementation.md
+++ b/docs/superpowers/skills/source-pack/references/implementation.md
@@ -127,8 +127,8 @@ Work module by module; the reference packs are the style guide.
    embedded YAML assets. Author the declaration in the YAML (`kind: pack`,
    `pack:`, `version:`, `tables:` keyed by bare short names — the id is
    derived as `<pack>.<table>`; per-table `action`, `row_path`,
-   `fingerprint`, `pagination`, `resources`, `fixed_inputs`, `columns`,
-   `filters`, `error_path`; design rationale as YAML comments). The `.rs`
+   `row_shape`, `fingerprint`, `pagination`, `resources`, `fixed_inputs`,
+   `columns`, `filters`, `error_path`; design rationale as YAML comments). The `.rs`
    module is a small accessor (`OnceLock` + `loader::builtin` +
    `include_str!`) plus the module doc and the test suite; add the
    registry entry in `source_pack.rs` builtins and a `mod` line in
@@ -140,6 +140,35 @@ Work module by module; the reference packs are the style guide.
    your authoring attention goes to the SEMANTIC choices the loader
    cannot check: which action, which columns, which fidelity, which
    termination signal.
+   **Response shape.** `row_shape` defaults to `array`: `row_path` locates
+   the row array, which is how every shipped table works. A point-read
+   action whose ENTIRE response is the row — `feishu.get_document_content`,
+   Notion's rendered Markdown — declares `row_shape: object` instead, and
+   then three rules apply, all enforced at load time:
+
+   - `row_path` must be exactly `"$"` (the response root). Any deeper path
+     is rejected; `$` remains invalid for array tables.
+   - pagination must be `single_page`. An object row IS the whole response,
+     so a second page could only re-fetch the same row.
+   - a response that is null, an array, or a primitive fails the scan
+     loudly. It never degrades to zero rows — "this document has no
+     content" would be a lie about a broken action contract.
+
+   ```yaml
+   document_content:
+     action: feishu.get_document_content
+     row_path: "$"
+     row_shape: object
+     pagination: { strategy: single_page }
+     columns:
+       - { name: content, path: content, type: utf8, nullable: true }
+   ```
+
+   Raw-action scans (`open_connector_scan`) do NOT accept `$`: object rows
+   are a pack-declared contract whose response shape a fingerprint pins,
+   and deriving a row type from the response root is a different inference
+   rule. Asking for it fails at planning time with a targeted error.
+
 2. **Fixtures** (`packs/fixtures/<provider>/*.json`) — redacted,
    provider-shaped pages covering ALL SIX admission-gate categories:
    null-bearing, null-parent, empty-list/empty-page, nested,


### PR DESCRIPTION
Implements the engine half of #197, to the design @bakey set out in the 2026-08-10 comment and confirmed as the contract of record on 2026-08-30.

## What this enables

Point-read actions — `feishu.get_document_content`, Notion's rendered Markdown — return **one object at the root**. No `row_path` can locate a row array in that, so their content has been unreachable from SQL. A pack can now declare `row_shape: object` and say its response *is* the row.

No shipped pack uses it yet; the Feishu `document_content` table is the follow-up this unblocks.

## Against the contract

| Contract | Where |
| --- | --- |
| `RowShape::{Array, Object}` as a typed field on `SourcePackTable` **and the execution target** | `source_pack.rs`; carried on `ScanTarget` alongside `pagination` / `error_path`, since it is the same kind of per-table response contract |
| Root `$` accepted **only** for object rows, not a global relaxation of `RowPath::parse` | separate constructor `RowPath::parse_object_root`; `parse` is untouched and still rejects `$` |
| `object` only with `single_page` | `validate_table`, load time |
| selected value must be an object; null / array / primitive fail loudly | `RowPath::row_object` → `RowPathNotObject` |
| existing packs default to `array`, zero behaviour change | `#[serde(default)]` + `Default` on `RowShape` |
| `std::slice::from_ref` into the existing converter, no second conversion path | `exec.rs` — the object is borrowed in place and handed to the same `RowConverter` as a one-element slice |

## Raw-action schema inference: deferred, with a typed error

You asked for this decision to be written down rather than guessed at later. **Raw scans (`open_connector_scan`) stay array-only**, and asking for `$` fails at planning time with `ObjectRowsUnsupportedForRawAction`.

Reasoning: `derive_raw_columns` descends `row_path.segments()` to find the row type. An object row has zero segments, so it would silently treat the response envelope as the row schema — a different inference rule, not a relaxation of the existing one. Pack tables have a fingerprint pinning their response shape; an ad-hoc action has no such gate. Supporting it later is additive; guessing at it now is not.

## Tests

11 new, all green (`cargo test --workspace`):

- **`row_path`** — root parses only as bare `$`; `$` stays invalid for the array parser; object extraction returns the root; null / array / primitive each fail as `RowPathNotObject` (the "never degrade to zero rows" invariant).
- **`loader`** — object shape parses with root + `single_page`; rejected without `single_page`; rejected with a non-root path; array shape still rejects `$`.
- **`source_pack`** — every shipped table across all ten built-in packs is asserted array-shaped, so no pack can acquire object rows unnoticed. When Feishu `document_content` lands it should name itself here rather than delete the test.
- **`exec`** — end to end against a mock gateway: a single-object response yields exactly one row with correct column values and stops after one call; a null response fails loudly instead of returning an empty scan.
- **`table_functions`** — a raw UDTF scan passing `$` fails at planning with the targeted error and issues no HTTP request.

One caveat worth stating: `unknown_pipeline_request_is_logged` (skardi-server, untouched by this change) failed once during a full-workspace run and passed on the clean tree, in isolation, and on every run since. It looks like parallel-execution sensitivity in that log-capture test rather than anything from here, but I could not reproduce it deliberately, so I am not claiming more than that.

## Docs

The source-pack authoring guide documents `row_shape`, the root-only path, the `single_page` requirement, and the raw-action refusal. README is unchanged — no new published pack or user-queryable table, so the capability tables stay accurate.

## Not in scope

Fingerprint / live-verification gates are untouched, per your note that you would run that half once this merges.
