### PR TITLE
feat(server): MCP streamable HTTP transport — /mcp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9750,6 +9750,7 @@ dependencies = [
  "skardi-mcp-core",
  "tempfile",
  "tokio",
+ "tracing-subscriber",
  "uuid",
  "wiremock",
 ]
@@ -9761,6 +9762,7 @@ dependencies = [
  "percent-encoding",
  "rmcp",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9729,10 +9729,20 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2 0.10.9",
+ "skardi-mcp-core",
  "tempfile",
  "tokio",
  "uuid",
  "wiremock",
+]
+
+[[package]]
+name = "skardi-mcp-core"
+version = "0.5.0"
+dependencies = [
+ "percent-encoding",
+ "rmcp",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,6 +1242,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8913,19 +8919,28 @@ version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a15bc53261a9dc37e105df006e4656c598379a8f9581f8950debb130f27a7cf"
 dependencies = [
+ "async-trait",
+ "base64 0.23.1",
+ "bytes",
  "chrono",
  "futures",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
  "indexmap 2.14.0",
  "pastey",
  "pin-project-lite",
  "process-wrap",
+ "rand 0.10.2",
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "sse-stream",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tower-service",
  "tracing",
  "uuid",
 ]
@@ -9788,10 +9803,12 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
+ "rmcp",
  "serde",
  "serde_json",
  "serde_yaml",
  "skardi",
+ "skardi-mcp-core",
  "skardi-query-audit",
  "tempfile",
  "thiserror 1.0.69",
@@ -9803,6 +9820,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -10060,6 +10078,19 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "whoami 1.6.1",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8819,7 +8819,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots 1.0.8",
 ]
@@ -8855,12 +8855,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.4",
+ "tokio-util",
  "tower 0.5.3",
  "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -8932,6 +8934,7 @@ dependencies = [
  "pin-project-lite",
  "process-wrap",
  "rand 0.10.2",
+ "reqwest 0.13.4",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -9803,6 +9806,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
+ "reqwest 0.12.28",
  "rmcp",
  "serde",
  "serde_json",
@@ -11704,6 +11708,19 @@ name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 
 [workspace]
 members = [ "crates/cli",
+            "crates/mcp-core",
             "crates/skardi",
             "crates/query-audit",
             "crates/server"]

--- a/README.md
+++ b/README.md
@@ -110,8 +110,9 @@ spec:
 ```
 
 **4 — The agent has a new tool.** One definition, every binding — shell, REST,
-and MCP — so the same promoted pipeline works in Claude Code, Cursor, your own
-loop, or any HTTP host, with no wrapper code to maintain.
+and MCP over both transports (local stdio and remote streamable HTTP) — so the
+same promoted pipeline works in Claude Code, Cursor, your own loop, claude.ai,
+or any HTTP host, with no wrapper code to maintain.
 
 ```bash
 # shell verb — any agent with a Bash tool, no MCP config
@@ -119,9 +120,17 @@ skardi run weekly-churn -p window='7 days'
 # same pipeline, served as REST
 curl -X POST localhost:8080/weekly-churn/execute \
   -H 'Content-Type: application/json' -d '{"window": "7 days"}'
-# same pipeline as an MCP tool — hosts without a shell (Claude Desktop, …)
+# same pipeline as an MCP tool — hosts that spawn a local process (Claude Desktop, …)
 skardi mcp
+# … and as remote MCP — hosts that only take a URL (claude.ai, hosted agents):
+# the server above already serves http://localhost:8080/mcp. With auth enabled
+# every request carries a Bearer token; a public hostname is declared with
+# --mcp-allowed-host api.example.com (loopback is always allowed).
 ```
+
+Both MCP bindings — the local `skardi mcp` bridge and the server's `/mcp`
+endpoint — project the same tool surface; [docs/mcp.md](docs/mcp.md) covers
+host setup, auth, the host allowlist, and reverse proxies for both.
 
 Promoting queries into pipelines is only the simplest form of **Act**. The same ledger supports
 acting on *intentions*: when every weekday morning ends with the same GitHub +

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,9 +20,14 @@ dirs = "5.0"
 percent-encoding = "2.3"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 # The MCP-over-stdio bridge (`skardi mcp`). default-features = false keeps
-# rmcp's HTTP stack (and any axum version skew) out of the dependency graph;
-# `transport-io` is the server-side stdio transport.
+# rmcp's optional stacks out of THIS crate's own dependency graph;
+# `transport-io` is the server-side stdio transport. Note: with resolver = "2",
+# a whole-workspace build unifies features across members, so skardi-server's
+# rmcp HTTP features do get compiled into that build graph — the pin here
+# governs what `cargo build -p skardi-cli` alone pulls in. rmcp has no runtime
+# axum dependency (verified against the 3.1.4 source), so no axum skew either way.
 rmcp = { version = "=3.1.4", default-features = false, features = ["server", "transport-io"] }
+skardi-mcp-core = { path = "../mcp-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -28,6 +28,9 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 # axum dependency (verified against the 3.1.4 source), so no axum skew either way.
 rmcp = { version = "=3.1.4", default-features = false, features = ["server", "transport-io"] }
 skardi-mcp-core = { path = "../mcp-core" }
+# mcp-core emits its projection warnings via `tracing`; the bridge installs a
+# stderr subscriber (stdout is the JSON-RPC channel) so hosts still see them.
+tracing-subscriber = "0.3"
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/cli/src/client.rs
+++ b/crates/cli/src/client.rs
@@ -4,7 +4,6 @@
 //! responses (and transport failures) into a uniform `ApiError`.
 
 use crate::config::ClientConfig;
-use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
 use reqwest::header::{AUTHORIZATION, HeaderName, HeaderValue};
 use reqwest::{Client, RequestBuilder, Response, StatusCode};
 use serde_json::Value;
@@ -12,16 +11,10 @@ use std::error::Error as StdError;
 use std::fmt;
 use std::net::{Ipv4Addr, Ipv6Addr};
 
-/// Characters percent-encoded by [`encode_component`]: everything except
-/// ASCII alphanumerics and the RFC 3986 "unreserved" marks (`-`, `.`, `_`,
-/// `~`). Deliberately conservative — over-encoding is always valid, while
-/// missing a reserved character (`/`, `?`, `#`, `%`, space, …) mis-routes
-/// the request.
-const URL_COMPONENT: &AsciiSet = &NON_ALPHANUMERIC
-    .remove(b'-')
-    .remove(b'.')
-    .remove(b'_')
-    .remove(b'~');
+// The pipeline-name → URL path encoding is part of the tool→REST translation
+// contract shared with the server's /mcp binding; the CLI re-exports it so
+// command modules keep importing from crate::client.
+pub use skardi_mcp_core::encode_component;
 
 /// [`WORKSPACE_HEADER`] lowercased, for `HeaderName::from_static` — which
 /// panics on any uppercase byte, and is the only constructor that cannot fail
@@ -56,13 +49,6 @@ fn retry_after_seconds(response: &Response) -> Option<u64> {
         .trim()
         .parse()
         .ok()
-}
-
-/// Percent-encode one URL path segment or query value (user-supplied
-/// pipeline/job names, run ids) so characters like `/`, `?`, `#`, `%`, and
-/// spaces cannot alter the request route.
-pub fn encode_component(raw: &str) -> String {
-    utf8_percent_encode(raw, URL_COMPONENT).to_string()
 }
 
 /// A thin HTTP client for a single skardi-server instance.
@@ -584,22 +570,6 @@ mod tests {
     fn base_url_strips_trailing_slash() {
         let client = ApiClient::new(&config("http://h:1/", None)).unwrap();
         assert_eq!(client.base_url, "http://h:1");
-    }
-
-    #[test]
-    fn encode_component_escapes_reserved_and_keeps_unreserved() {
-        use super::encode_component;
-
-        assert_eq!(encode_component("a/b"), "a%2Fb");
-        assert_eq!(encode_component("a b?c#d%e"), "a%20b%3Fc%23d%25e");
-        assert_eq!(encode_component("a&b=c"), "a%26b%3Dc");
-        // Unreserved characters pass through untouched.
-        assert_eq!(
-            encode_component("daily-report_v2.1~x"),
-            "daily-report_v2.1~x"
-        );
-        // Non-ASCII is UTF-8 percent-encoded.
-        assert_eq!(encode_component("café"), "caf%C3%A9");
     }
 
     #[test]

--- a/crates/cli/src/mcp/bridge.rs
+++ b/crates/cli/src/mcp/bridge.rs
@@ -21,8 +21,9 @@ use rmcp::service::{RequestContext, RoleServer};
 use serde_json::Value;
 use uuid::Uuid;
 
+use skardi_mcp_core::projection;
+
 use crate::client::{ApiClient, ApiError, encode_component};
-use crate::mcp::projection;
 
 const INSTRUCTIONS: &str = "Skardi is a federated SQL data plane: operator-defined \
 pipelines plus an ad-hoc SQL engine over the configured data sources. Prefer the \

--- a/crates/cli/src/mcp/mod.rs
+++ b/crates/cli/src/mcp/mod.rs
@@ -4,7 +4,6 @@
 //! JSON-RPC channel, so nothing on this path may print to it.
 
 mod bridge;
-mod projection;
 
 use rmcp::ServiceExt;
 use rmcp::transport::stdio;

--- a/crates/cli/src/mcp/mod.rs
+++ b/crates/cli/src/mcp/mod.rs
@@ -11,6 +11,11 @@ use rmcp::transport::stdio;
 use crate::client::ApiClient;
 
 pub async fn run(client: ApiClient) -> anyhow::Result<()> {
+    // mcp-core's projection warnings go through `tracing`; without a
+    // subscriber they would vanish. stderr, because stdout is the protocol.
+    let _ = tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .try_init();
     let service = bridge::McpBridge::new(client)
         .serve(stdio())
         .await

--- a/crates/mcp-core/Cargo.toml
+++ b/crates/mcp-core/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "skardi-mcp-core"
+version.workspace = true
+edition.workspace = true
+description = "Shared MCP projection layer: pipeline inventory -> MCP tool definitions"
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+
+[dependencies]
+# Model types only — no features. Preserves the intent behind the CLI's
+# deliberate default-features = false pin (rmcp's transports stay out of
+# this crate's own graph; each binding picks its transport itself).
+rmcp = { version = "=3.1.4", default-features = false }
+percent-encoding = "2.3"
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/mcp-core/Cargo.toml
+++ b/crates/mcp-core/Cargo.toml
@@ -15,6 +15,10 @@ license.workspace = true
 rmcp = { version = "=3.1.4", default-features = false }
 percent-encoding = "2.3"
 serde_json = { workspace = true }
+# Projection warnings (name collisions, missing inventory fields) go through
+# tracing: the server routes them into its structured logs, and the stdio
+# bridge installs a stderr subscriber so hosts still see them.
+tracing = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/mcp-core/src/lib.rs
+++ b/crates/mcp-core/src/lib.rs
@@ -1,0 +1,48 @@
+//! The knowledge shared by every Skardi MCP binding: projecting the enriched
+//! `GET /pipelines` inventory into MCP tool definitions, the built-in tool
+//! names, and the pipeline-name → URL path encoding of the tool→REST
+//! translation contract. The dispatch matches themselves deliberately stay
+//! per-binding (stdio bridge, server `/mcp`): same shape, different error
+//! types and identity carriers.
+
+pub mod projection;
+
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
+
+/// Characters percent-encoded by [`encode_component`]: everything except
+/// ASCII alphanumerics and the RFC 3986 "unreserved" marks (`-`, `.`, `_`,
+/// `~`). Deliberately conservative — over-encoding is always valid, while
+/// missing a reserved character (`/`, `?`, `#`, `%`, space, …) mis-routes
+/// the request.
+const URL_COMPONENT: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~');
+
+/// Percent-encode one URL path segment or query value (user-supplied
+/// pipeline/job names, run ids) so characters like `/`, `?`, `#`, `%`, and
+/// spaces cannot alter the request route.
+pub fn encode_component(raw: &str) -> String {
+    utf8_percent_encode(raw, URL_COMPONENT).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    // Moved with the function from `crates/cli/src/client.rs`.
+    #[test]
+    fn encode_component_escapes_reserved_and_keeps_unreserved() {
+        use super::encode_component;
+
+        assert_eq!(encode_component("a/b"), "a%2Fb");
+        assert_eq!(encode_component("a b?c#d%e"), "a%20b%3Fc%23d%25e");
+        assert_eq!(encode_component("a&b=c"), "a%26b%3Dc");
+        // Unreserved characters pass through untouched.
+        assert_eq!(
+            encode_component("daily-report_v2.1~x"),
+            "daily-report_v2.1~x"
+        );
+        // Non-ASCII is UTF-8 percent-encoded.
+        assert_eq!(encode_component("café"), "caf%C3%A9");
+    }
+}

--- a/crates/mcp-core/src/projection.rs
+++ b/crates/mcp-core/src/projection.rs
@@ -1,20 +1,22 @@
 //! Projection of the enriched pipeline inventory into MCP tool definitions.
 //! Pure functions — everything here is unit-testable without a server.
+//! Shared by the CLI's stdio bridge and the server's `/mcp` handler, so the
+//! two bindings cannot drift apart on the tool surface.
 
 use std::collections::{HashMap, HashSet};
 
 use rmcp::model::{JsonObject, Tool};
 use serde_json::{Value, json};
 
-/// The built-in tool names. `builtin_tools()` and the bridge's dispatch
+/// The built-in tool names. `builtin_tools()` and each binding's dispatch
 /// match use these same constants, and `RESERVED_NAMES` is built from them,
-/// so the three sites cannot drift apart.
-pub(crate) const QUERY: &str = "query";
-pub(crate) const LIST_DATA_SOURCES: &str = "list_data_sources";
+/// so the sites cannot drift apart.
+pub const QUERY: &str = "query";
+pub const LIST_DATA_SOURCES: &str = "list_data_sources";
 
 /// Tool names claimed by the built-ins; a pipeline sanitizing to one of
 /// these is renamed with a `_pipeline` suffix.
-pub(crate) const RESERVED_NAMES: [&str; 2] = [QUERY, LIST_DATA_SOURCES];
+pub const RESERVED_NAMES: [&str; 2] = [QUERY, LIST_DATA_SOURCES];
 
 /// MCP clients commonly enforce `^[a-zA-Z0-9_-]{1,64}$` for tool names.
 const MAX_TOOL_NAME: usize = 64;
@@ -147,7 +149,7 @@ fn pipeline_tool(tool_name: &str, pipeline_name: &str, entry: &Value) -> Tool {
     )
 }
 
-pub(crate) fn builtin_tools() -> Vec<Tool> {
+pub fn builtin_tools() -> Vec<Tool> {
     let query_schema = object_schema(
         json!({
             "sql": {"type": "string"},
@@ -186,7 +188,7 @@ pub(crate) fn builtin_tools() -> Vec<Tool> {
 /// Project the enriched `GET /pipelines` body into (tools, tool → pipeline
 /// name map). The built-ins are appended after the pipeline tools; the map
 /// covers pipeline tools only.
-pub(crate) fn project(inventory: &Value) -> (Vec<Tool>, HashMap<String, String>) {
+pub fn project(inventory: &Value) -> (Vec<Tool>, HashMap<String, String>) {
     let entries: HashMap<&str, &Value> = inventory["pipelines"]
         .as_array()
         .map(|entries| {

--- a/crates/mcp-core/src/projection.rs
+++ b/crates/mcp-core/src/projection.rs
@@ -54,14 +54,14 @@ fn assign_tool_names(original_names: &[&str]) -> Vec<(String, String)> {
     for original in sorted {
         let mut candidate = sanitize(original);
         if candidate.is_empty() {
-            eprintln!(
-                "warning: pipeline name '{original}' sanitizes to an empty MCP tool name; exposing it as `pipeline`"
+            tracing::warn!(
+                "pipeline name '{original}' sanitizes to an empty MCP tool name; exposing it as `pipeline`"
             );
             candidate = "pipeline".to_string();
         }
         if RESERVED_NAMES.contains(&candidate.as_str()) {
-            eprintln!(
-                "warning: pipeline '{original}' collides with the built-in `{candidate}` tool; exposing it as `{candidate}_pipeline`"
+            tracing::warn!(
+                "pipeline '{original}' collides with the built-in `{candidate}` tool; exposing it as `{candidate}_pipeline`"
             );
             candidate = format!("{candidate}_pipeline");
             candidate.truncate(MAX_TOOL_NAME);
@@ -115,8 +115,8 @@ fn pipeline_tool(tool_name: &str, pipeline_name: &str, entry: &Value) -> Tool {
     // `parameters: []` is a real zero-parameter pipeline and keeps the
     // closed empty schema below.
     let Some(params) = entry.get("parameters").and_then(Value::as_array) else {
-        eprintln!(
-            "warning: pipeline '{pipeline_name}' carries no `parameters` in the inventory \
+        tracing::warn!(
+            "pipeline '{pipeline_name}' carries no `parameters` in the inventory \
              (skardi-server older than the CLI?); publishing an open input schema"
         );
         let open_schema: JsonObject = serde_json::from_value(json!({

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -89,6 +89,13 @@ url = { workspace = true }
 arrow = { workspace = true }
 datafusion = { workspace = true }
 http-body-util = "0.1"
+# Client half of the /mcp end-to-end suite (tests/mcp_http.rs): a real rmcp
+# client over HTTP against the served router. Same pin as the main
+# dependency; features union in test builds.
+rmcp = { version = "=3.1.4", default-features = false, features = ["client", "transport-streamable-http-client-reqwest"] }
+# Raw HTTP probes for what the rmcp client can't express (an invented
+# Mcp-Session-Id). Loopback plain-HTTP only, so no TLS backend.
+reqwest = { version = "0.12", default-features = false }
 skardi = { path = "../skardi" }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -60,11 +60,21 @@ serde_yaml = { workspace = true }
 skardi = { path = "../skardi" }
 anyhow = "1.0"
 base64 = "0.22"
+# The /mcp streamable-HTTP binding. default-features = false mirrors the
+# CLI's pin; the transport feature brings rmcp's tower service (no runtime
+# axum dependency — verified against the 3.1.4 source).
+rmcp = { version = "=3.1.4", default-features = false, features = ["server", "transport-streamable-http-server"] }
+skardi-mcp-core = { path = "../mcp-core" }
 thiserror = "1.0"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "sync", "time"] }
 tokio-rusqlite = { workspace = true }
 skardi-query-audit = { path = "../query-audit" }
-tower = { workspace = true }
+# `util` is explicit: production code (the /mcp handler's self-dispatch)
+# uses tower::ServiceExt::oneshot, which must not lean on the feature
+# arriving transitively via axum/tower-http.
+tower = { workspace = true, features = ["util"] }
+# One v4 UUID per stateless MCP request: the audit-attribution fallback id.
+uuid = { workspace = true }
 tower-http = { workspace = true, features = ["fs", "trace", "cors"] }
 tracing = { workspace = true }
 tracing-opentelemetry = "0.28"

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -384,6 +384,7 @@ mod tests {
                 port: 8080,
                 query_audit_db: None,
                 query_audit_retention_days: None,
+                mcp_allowed_hosts: vec![],
             },
         };
         let session_ctx = Arc::new(SessionContext::new());
@@ -444,6 +445,7 @@ mod tests {
                 port: 8080,
                 query_audit_db: None,
                 query_audit_retention_days: None,
+                mcp_allowed_hosts: vec![],
             },
         };
         let session_ctx = Arc::new(SessionContext::new());

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -114,6 +114,19 @@ pub struct CliArgs {
         help = "Prune /query audit records older than N days (default: keep forever)"
     )]
     pub query_audit_retention_days: Option<u32>,
+
+    /// Extra `Host` header values `/mcp` accepts, appended to the
+    /// always-allowed loopback trio (localhost / 127.0.0.1 / ::1). rmcp's
+    /// loopback-only default is a DNS-rebinding defense; a remote deployment
+    /// declares its public hostnames here — deliberately no allow-any escape
+    /// hatch. An entry with a port matches that port exactly; without one it
+    /// matches any port. Repeatable.
+    #[arg(
+        long = "mcp-allowed-host",
+        help = "Allow this Host header value on /mcp, in addition to loopback \
+                (repeatable; host or host:port)"
+    )]
+    pub mcp_allowed_hosts: Vec<String>,
 }
 
 /// Main server configuration containing pipelines and data sources
@@ -2339,6 +2352,7 @@ spec:
             port: 8080,
             query_audit_db: None,
             query_audit_retention_days: None,
+            mcp_allowed_hosts: vec![],
         };
 
         let config = load_server_config(args).await.unwrap();
@@ -2366,6 +2380,7 @@ spec:
             port: 3000,
             query_audit_db: None,
             query_audit_retention_days: None,
+            mcp_allowed_hosts: vec![],
         };
 
         let config = load_server_config(args).await.unwrap();
@@ -2422,6 +2437,7 @@ spec:
             port: 3000,
             query_audit_db: None,
             query_audit_retention_days: None,
+            mcp_allowed_hosts: vec![],
         };
 
         let config = load_server_config(args).await.unwrap();
@@ -2452,6 +2468,7 @@ spec:
             port: 8080,
             query_audit_db: None,
             query_audit_retention_days: None,
+            mcp_allowed_hosts: vec![],
         };
 
         let result = load_server_config(args).await;
@@ -2478,6 +2495,7 @@ spec:
             port: 8080,
             query_audit_db: None,
             query_audit_retention_days: None,
+            mcp_allowed_hosts: vec![],
         };
 
         let config = load_server_config(args).await.unwrap();
@@ -2735,6 +2753,30 @@ spec:
         assert!(args.pipeline_path.is_none());
         assert_eq!(args.ctx_file, None);
         assert_eq!(args.port, 8080); // default value
+    }
+
+    #[test]
+    fn mcp_allowed_host_is_repeatable_and_defaults_empty() {
+        use clap::Parser;
+
+        let args = CliArgs::try_parse_from([
+            "skardi-server",
+            "--mcp-allowed-host",
+            "api.example.com",
+            "--mcp-allowed-host",
+            "skardi.internal:8443",
+        ])
+        .unwrap();
+        assert_eq!(
+            args.mcp_allowed_hosts,
+            vec![
+                "api.example.com".to_string(),
+                "skardi.internal:8443".to_string()
+            ]
+        );
+
+        let args = CliArgs::try_parse_from(["skardi-server"]).unwrap();
+        assert!(args.mcp_allowed_hosts.is_empty());
     }
 
     #[test]

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -720,6 +720,17 @@ fn extract_pipeline_sql(path: &Path) -> Result<(String, String)> {
     let pipeline: MinimalPipeline = serde_yaml::from_str(&content)
         .with_context(|| format!("Failed to parse pipeline YAML: {:?}", path))?;
 
+    // The name is the URL segment of `/<name>/execute` (and the identity every
+    // MCP binding dispatches on), so an empty one is unreachable everywhere.
+    // Reject it here, before SQL validation and the full load.
+    if pipeline.metadata.name.trim().is_empty() {
+        anyhow::bail!(
+            "Pipeline {:?} has an empty metadata.name; every pipeline needs a \
+             non-empty name — it is the URL segment of /<name>/execute",
+            path
+        );
+    }
+
     Ok((pipeline.metadata.name, pipeline.spec.query))
 }
 
@@ -2480,6 +2491,48 @@ spec:
         assert!(
             error_string.contains("Pipeline file not found"),
             "Expected error to contain 'Pipeline file not found', got: {}",
+            error_string
+        );
+    }
+
+    /// An empty `metadata.name` is unreachable on every surface — it is the
+    /// `:name` segment of `/:name/execute`, which cannot bind an empty string,
+    /// and both MCP bindings dispatch on the same path — so the loader rejects
+    /// it up front instead of advertising a tool that can only 404.
+    #[tokio::test]
+    async fn test_load_server_config_rejects_empty_pipeline_name() {
+        let temp_dir = TempDir::new().unwrap();
+        let pipeline_path = temp_dir.path().join("unnamed.yaml");
+        fs::write(
+            &pipeline_path,
+            r#"
+kind: pipeline
+metadata:
+  name: ""
+  version: "1.0.0"
+spec:
+  query: "SELECT 1"
+"#,
+        )
+        .unwrap();
+
+        let args = CliArgs {
+            pipeline_path: Some(pipeline_path),
+            jobs_path: None,
+            jobs_db_path: None,
+            ctx_file: None,
+            semantics_path: None,
+            port: 8080,
+            query_audit_db: None,
+            query_audit_retention_days: None,
+            mcp_allowed_hosts: vec![],
+        };
+
+        let error = load_server_config(args).await.unwrap_err();
+        let error_string = format!("{:?}", error);
+        assert!(
+            error_string.contains("empty metadata.name"),
+            "Expected the empty-name rejection, got: {}",
             error_string
         );
     }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -4,6 +4,7 @@ pub mod gui;
 pub mod handlers;
 pub mod jobs_handlers;
 pub mod logging;
+pub(crate) mod mcp;
 pub mod metrics;
 pub mod optimizer_registry;
 pub(crate) mod param_schema;

--- a/crates/server/src/mcp/gate.rs
+++ b/crates/server/src/mcp/gate.rs
@@ -1,0 +1,74 @@
+//! `/mcp`-specific transport middleware: every inbound request authenticates
+//! via `verify_session` BEFORE rmcp creates any session state — an anonymous
+//! `initialize` is a transport-level 401, not a retained session, and missing
+//! credentials surface as the 401 host credential flows key on (not as tool
+//! errors inside HTTP 200s). Wraps only the nested MCP service; synthetic
+//! dispatches never traverse it.
+//!
+//! Bearer only: `verify_session`'s cookie fallback would admit callers whose
+//! every tool call then fails handler-level auth (synthetic requests forward
+//! only `Authorization`), so the gate strips `cookie` before the check —
+//! token validation stays single-home while the accepted carrier narrows to
+//! the one MCP hosts actually send. This is also what keeps the open
+//! `allowed_origins` posture honest: a browser's ambient cookie cannot
+//! authenticate `/mcp`, so there is no CSRF-shaped surface for Origin to
+//! guard. On a no-auth deployment `verify_session` always allows and the
+//! gate is a no-op.
+
+use std::convert::Infallible;
+use std::task::{Context, Poll};
+
+use axum::body::Body;
+use axum::http::{Request, header};
+use axum::response::{IntoResponse, Response};
+use futures::future::BoxFuture;
+
+use crate::auth::routes::verify_session;
+use crate::server::AppState;
+
+#[derive(Clone)]
+pub(crate) struct SessionGate<S> {
+    inner: S,
+    state: AppState,
+}
+
+impl<S> SessionGate<S> {
+    pub(crate) fn new(inner: S, state: AppState) -> Self {
+        SessionGate { inner, state }
+    }
+}
+
+impl<S> tower::Service<Request<Body>> for SessionGate<S>
+where
+    S: tower::Service<Request<Body>, Error = Infallible> + Clone + Send + 'static,
+    S::Response: IntoResponse,
+    S::Future: Send,
+{
+    type Response = Response;
+    type Error = Infallible;
+    type Future = BoxFuture<'static, Result<Response, Infallible>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Infallible>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        // Standard tower pattern: take the service that was polled ready,
+        // leave a fresh clone behind.
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+        let state = self.state.clone();
+        Box::pin(async move {
+            let mut headers = req.headers().clone();
+            headers.remove(header::COOKIE);
+            if let Err(unauthorized) = verify_session(&state, &headers).await {
+                return Ok(unauthorized.into_response());
+            }
+            Ok(inner
+                .call(req)
+                .await
+                .unwrap_or_else(|infallible| match infallible {})
+                .into_response())
+        })
+    }
+}

--- a/crates/server/src/mcp/handler.rs
+++ b/crates/server/src/mcp/handler.rs
@@ -1,0 +1,556 @@
+//! MCP ⇄ REST protocol adapter: a stateless `ServerHandler` whose every tool
+//! call becomes a synthetic HTTP request dispatched in-process against the
+//! server's own REST router (`tower::ServiceExt::oneshot`) — the same
+//! mechanism the HTTP tests use. The captured router is the pre-middleware
+//! one; see `configure_routes` for the transport-vs-execution boundary.
+//!
+//! Stateless by protocol: MCP `2026-07-28` removes sessions (SEP-2567) and
+//! rmcp constructs this handler once per request on that path, so it owns
+//! only the Arc-cheap `Router` clone — no tool map, no per-session state.
+//! Pipeline tool names are resolved per call.
+//!
+//! The MCP trait methods are thin wrappers over inherent `do_*` methods
+//! (taking the inbound headers as a plain parameter): `RequestContext` is
+//! `#[non_exhaustive]`, so tests drive the `do_*` methods directly.
+
+use std::collections::HashMap;
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{HeaderMap, Method, Request, StatusCode, header};
+use rmcp::ServerHandler;
+use rmcp::model::{
+    CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ErrorData,
+    Implementation, JsonObject, ListToolsResult, PaginatedRequestParams, ServerCapabilities,
+    ServerInfo, Tool,
+};
+use rmcp::service::{RequestContext, RoleServer};
+use serde_json::Value;
+use skardi_mcp_core::{encode_component, projection};
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use crate::session_header::{SESSION_ID_HEADER, validate_session_id};
+
+/// Same wording as the stdio bridge (`crates/cli/src/mcp/bridge.rs`) — the
+/// two bindings present one product to hosts. Kept per-binding rather than
+/// in skardi-mcp-core so either side can diverge deliberately.
+const INSTRUCTIONS: &str = "Skardi is a federated SQL data plane: operator-defined \
+pipelines plus an ad-hoc SQL engine over the configured data sources. Prefer the \
+pipeline tools for tasks they cover. Before writing ad-hoc SQL with `query`, call \
+`list_data_sources` to see tables, schemas, and their plain-English descriptions.";
+
+/// Ceiling on a synthetic response body — the same 256 MB the stdio bridge
+/// inherits from the CLI client (`crates/cli/src/client.rs`), kept as a
+/// constant so one pipeline behaves identically through both bindings (not
+/// shared because the CLI's ceiling is client-wide, not MCP-specific).
+/// In-process this bounds only the MCP layer's own copy of the result: the
+/// REST handler has already materialized the full result before the
+/// collector sees a byte — execution-layer resource governance is a
+/// recorded server-wide non-goal, not this cap's job.
+const MAX_RESPONSE_BYTES: usize = 256 * 1024 * 1024;
+
+/// The legacy-protocol session header rmcp echoes on every request of a
+/// managed session (`legacy_session_mode`). Stateless-protocol requests
+/// (`2026-07-28` and later) don't carry it.
+const MCP_SESSION_ID: &str = "mcp-session-id";
+
+#[derive(Clone)]
+pub(crate) struct McpHandler {
+    /// Pre-middleware capture of the REST router (routing table + handlers,
+    /// where every execution concern lives: `require_session`, parameter
+    /// validation, audit recording). Arc-cheap to clone; the service factory
+    /// clones it per request.
+    rest: Router,
+}
+
+impl McpHandler {
+    pub(crate) fn new(rest: Router) -> Self {
+        McpHandler { rest }
+    }
+
+    /// The audit id for this request, layered: a valid legacy
+    /// `Mcp-Session-Id` groups the session's calls together (matching the
+    /// stdio bridge's per-connection grouping); anything else — a stateless
+    /// request, or a malformed value — gets a per-request UUID, so
+    /// attribution stays intact and grouping granularity is honestly
+    /// per-request. rmcp mints UUIDs, which always pass the validator, but
+    /// the fallback must not lean on that invisible coupling: a malformed
+    /// value would otherwise 400 the whole execute at the forwarding
+    /// target's strict validator (`session_id_from_headers`).
+    fn request_session_id(headers: &HeaderMap) -> String {
+        headers
+            .get(MCP_SESSION_ID)
+            .and_then(|v| v.to_str().ok())
+            .filter(|s| validate_session_id(s).is_ok())
+            .map(str::to_string)
+            .unwrap_or_else(|| Uuid::new_v4().to_string())
+    }
+
+    /// Build and dispatch one synthetic request against the captured REST
+    /// router. Forwards the inbound `Authorization` verbatim (omitted when
+    /// the caller sent none) so handler-level enforcement, authorization
+    /// errors, and ledger recording are exactly the REST semantics; sets
+    /// `content-type: application/json` when there is a body.
+    async fn dispatch(
+        &self,
+        method: Method,
+        path: &str,
+        inbound: &HeaderMap,
+        extra_headers: &[(&str, &str)],
+        body: Option<Value>,
+    ) -> Result<(StatusCode, String), ErrorData> {
+        let mut builder = Request::builder().method(method).uri(path);
+        if let Some(auth) = inbound.get(header::AUTHORIZATION) {
+            builder = builder.header(header::AUTHORIZATION, auth.clone());
+        }
+        for (name, value) in extra_headers {
+            builder = builder.header(*name, *value);
+        }
+        let request = match body {
+            Some(v) => builder
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(v.to_string())),
+            None => builder.body(Body::empty()),
+        }
+        .map_err(|e| ErrorData::internal_error(format!("synthetic request: {e}"), None))?;
+        // In-process: a dispatch failure is a bug, not a network condition.
+        let response = self
+            .rest
+            .clone()
+            .oneshot(request)
+            .await
+            .map_err(|e| ErrorData::internal_error(format!("synthetic dispatch: {e}"), None))?;
+        let status = response.status();
+        let bytes = axum::body::to_bytes(response.into_body(), MAX_RESPONSE_BYTES)
+            .await
+            .map_err(|e| {
+                ErrorData::internal_error(format!("collecting synthetic response: {e}"), None)
+            })?;
+        Ok((status, String::from_utf8_lossy(&bytes).into_owned()))
+    }
+
+    /// Fetch and project the live inventory. Used by `tools/list` and by
+    /// every pipeline `tools/call` — per-call name resolution: one extra
+    /// in-process dispatch buys correctness in both protocol modes and
+    /// freshness by construction (a stale-map "unknown tool" cannot exist).
+    async fn project_inventory(
+        &self,
+        headers: &HeaderMap,
+    ) -> Result<(Vec<Tool>, HashMap<String, String>), ErrorData> {
+        let (status, body) = self
+            .dispatch(Method::GET, "/pipelines", headers, &[], None)
+            .await?;
+        if !status.is_success() {
+            return Err(ErrorData::internal_error(
+                format!("GET /pipelines answered {status}: {body}"),
+                None,
+            ));
+        }
+        let inventory: Value = serde_json::from_str(&body).map_err(|e| {
+            ErrorData::internal_error(format!("GET /pipelines returned non-JSON: {e}"), None)
+        })?;
+        Ok(projection::project(&inventory))
+    }
+
+    pub(crate) async fn do_list_tools(
+        &self,
+        headers: &HeaderMap,
+    ) -> Result<ListToolsResult, ErrorData> {
+        let (tools, _) = self.project_inventory(headers).await?;
+        Ok(ListToolsResult::with_all_items(tools))
+    }
+
+    pub(crate) async fn do_call_tool(
+        &self,
+        name: &str,
+        args: Option<JsonObject>,
+        headers: &HeaderMap,
+    ) -> Result<CallToolResult, ErrorData> {
+        let session_id = Self::request_session_id(headers);
+        let (status, body) = match name {
+            projection::QUERY => {
+                let body = Self::query_body(args, &session_id);
+                self.dispatch(Method::POST, "/query", headers, &[], Some(body))
+                    .await?
+            }
+            projection::LIST_DATA_SOURCES => {
+                self.dispatch(Method::GET, "/data_source", headers, &[], None)
+                    .await?
+            }
+            _ => {
+                let (_, map) = self.project_inventory(headers).await?;
+                let Some(pipeline) = map.get(name) else {
+                    // Protocol-level: covers host bugs and a server
+                    // re-configured since the host last listed.
+                    return Err(ErrorData::invalid_params(
+                        format!(
+                            "unknown tool '{name}' — the pipeline inventory may have \
+                             changed; re-issue tools/list to refresh it"
+                        ),
+                        None,
+                    ));
+                };
+                // Arguments pass through as the flat execute body — the
+                // server is the validator. The session header gives pipeline
+                // runs the same ledger attribution as `query`'s
+                // ai_context.session_id.
+                let body = Value::Object(args.unwrap_or_default());
+                let path = format!("/{}/execute", encode_component(pipeline));
+                self.dispatch(
+                    Method::POST,
+                    &path,
+                    headers,
+                    &[(SESSION_ID_HEADER, &session_id)],
+                    Some(body),
+                )
+                .await?
+            }
+        };
+        Ok(if status.is_success() {
+            // The response JSON verbatim, no reshaping.
+            CallToolResult::success(vec![ContentBlock::text(body)])
+        } else {
+            // Execution errors are for the model to see and react to (fix a
+            // parameter, pick another tool), not protocol errors.
+            CallToolResult::error(vec![ContentBlock::text(body)])
+        })
+    }
+
+    /// The one choke-point that assembles the `/query` body. When `purpose`
+    /// is absent, ai_context is omitted entirely — the server rejects a
+    /// partial object.
+    fn query_body(args: Option<JsonObject>, session_id: &str) -> Value {
+        let args = args.unwrap_or_default();
+        let mut body = serde_json::Map::new();
+        for key in ["sql", "max_rows"] {
+            if let Some(value) = args.get(key) {
+                body.insert(key.to_string(), value.clone());
+            }
+        }
+        if let Some(purpose) = args.get("purpose").and_then(Value::as_str) {
+            let purpose = purpose.trim();
+            if !purpose.is_empty() {
+                body.insert(
+                    "ai_context".to_string(),
+                    serde_json::json!({"purpose": purpose, "session_id": session_id}),
+                );
+            }
+        }
+        Value::Object(body)
+    }
+
+    /// The inbound request's headers, from the `http::request::Parts` rmcp
+    /// injects into every request's extensions (stateless mode included;
+    /// verified against the 3.1.4 source).
+    fn inbound_headers(context: &RequestContext<RoleServer>) -> HeaderMap {
+        context
+            .extensions
+            .get::<axum::http::request::Parts>()
+            .map(|parts| parts.headers.clone())
+            .unwrap_or_default()
+    }
+}
+
+impl ServerHandler for McpHandler {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::new("skardi", env!("CARGO_PKG_VERSION")))
+            .with_instructions(INSTRUCTIONS)
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, ErrorData> {
+        self.do_list_tools(&Self::inbound_headers(&context)).await
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResponse, ErrorData> {
+        self.do_call_tool(
+            &request.name,
+            request.arguments,
+            &Self::inbound_headers(&context),
+        )
+        .await
+        .map(CallToolResponse::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::extract::State;
+    use axum::response::IntoResponse;
+    use axum::routing::{get, post};
+    use serde_json::json;
+    use std::sync::{Arc, Mutex};
+
+    /// What one synthetic request carried, as the REST layer would see it.
+    #[derive(Debug)]
+    struct SeenRequest {
+        path: String,
+        authorization: Option<String>,
+        session_header: Option<String>,
+        body: Value,
+    }
+
+    /// A stand-in for the REST router that records what the handler
+    /// dispatched — the in-process analogue of the bridge's wiremock tests.
+    #[derive(Clone)]
+    struct Probe {
+        seen: Arc<Mutex<Vec<SeenRequest>>>,
+        inventory: Value,
+        respond_status: StatusCode,
+        respond_body: Value,
+    }
+
+    impl Probe {
+        fn new(inventory: Value) -> Self {
+            Probe {
+                seen: Arc::new(Mutex::new(Vec::new())),
+                inventory,
+                respond_status: StatusCode::OK,
+                respond_body: json!({"success": true}),
+            }
+        }
+
+        fn take_seen(&self) -> Vec<SeenRequest> {
+            std::mem::take(&mut self.seen.lock().unwrap())
+        }
+    }
+
+    async fn record(State(probe): State<Probe>, req: axum::extract::Request) -> impl IntoResponse {
+        let (parts, body) = req.into_parts();
+        let bytes = axum::body::to_bytes(body, 1 << 20).await.unwrap();
+        let header = |name: &str| {
+            parts
+                .headers
+                .get(name)
+                .and_then(|v| v.to_str().ok())
+                .map(String::from)
+        };
+        probe.seen.lock().unwrap().push(SeenRequest {
+            path: parts.uri.path().to_string(),
+            authorization: header("authorization"),
+            session_header: header(SESSION_ID_HEADER),
+            body: if bytes.is_empty() {
+                Value::Null
+            } else {
+                serde_json::from_slice(&bytes).unwrap()
+            },
+        });
+        (probe.respond_status, axum::Json(probe.respond_body.clone()))
+    }
+
+    async fn serve_inventory(State(probe): State<Probe>) -> impl IntoResponse {
+        axum::Json(probe.inventory.clone())
+    }
+
+    fn probe_router(probe: Probe) -> Router {
+        Router::new()
+            .route("/pipelines", get(serve_inventory))
+            .route("/query", post(record))
+            .route("/data_source", get(record))
+            .route("/:name/execute", post(record))
+            .with_state(probe)
+    }
+
+    fn inventory() -> Value {
+        json!({"success": true, "count": 1, "data_sources": 0,
+               "pipelines": [{"name": "product-search", "version": "1.0.0",
+                 "endpoint": "/product-search/execute",
+                 "description": "Filter products",
+                 "parameters": [{"name": "brand", "data_type": "Utf8",
+                                 "json_schema": {"type": ["string", "null"]}}]}]})
+    }
+
+    fn handler_with_probe() -> (McpHandler, Probe) {
+        let probe = Probe::new(inventory());
+        (McpHandler::new(probe_router(probe.clone())), probe)
+    }
+
+    fn args(v: Value) -> Option<JsonObject> {
+        v.as_object().cloned()
+    }
+
+    #[tokio::test]
+    async fn list_tools_projects_pipelines_and_builtins() {
+        let (handler, _) = handler_with_probe();
+        let result = handler.do_list_tools(&HeaderMap::new()).await.unwrap();
+        let names: Vec<&str> = result.tools.iter().map(|t| t.name.as_ref()).collect();
+        assert!(names.contains(&"product-search"), "{names:?}");
+        assert!(names.contains(&"query"), "{names:?}");
+        assert!(names.contains(&"list_data_sources"), "{names:?}");
+    }
+
+    #[tokio::test]
+    async fn pipeline_call_resolves_per_call_and_posts_flat_body() {
+        // Deliberately NO prior do_list_tools: per-call resolution is the
+        // point — a stateless request's handler instance has never listed.
+        let (handler, probe) = handler_with_probe();
+        let result = handler
+            .do_call_tool(
+                "product-search",
+                args(json!({"brand": "acme"})),
+                &HeaderMap::new(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.is_error, Some(false));
+        let seen = probe.take_seen();
+        assert_eq!(seen.len(), 1, "{seen:?}");
+        assert_eq!(seen[0].path, "/product-search/execute");
+        assert_eq!(seen[0].body, json!({"brand": "acme"}));
+    }
+
+    #[tokio::test]
+    async fn authorization_is_forwarded_verbatim_and_absent_when_missing() {
+        let (handler, probe) = handler_with_probe();
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", "Bearer tok-1".parse().unwrap());
+        handler
+            .do_call_tool("query", args(json!({"sql": "select 1"})), &headers)
+            .await
+            .unwrap();
+        handler
+            .do_call_tool("query", args(json!({"sql": "select 1"})), &HeaderMap::new())
+            .await
+            .unwrap();
+        let seen = probe.take_seen();
+        assert_eq!(seen[0].authorization.as_deref(), Some("Bearer tok-1"));
+        assert_eq!(seen[1].authorization, None);
+    }
+
+    #[tokio::test]
+    async fn legacy_mcp_session_id_is_echoed_as_the_audit_id() {
+        let (handler, probe) = handler_with_probe();
+        let mut headers = HeaderMap::new();
+        headers.insert(MCP_SESSION_ID, "legacy-42".parse().unwrap());
+        handler
+            .do_call_tool("product-search", args(json!({"brand": "x"})), &headers)
+            .await
+            .unwrap();
+        handler
+            .do_call_tool(
+                "query",
+                args(json!({"sql": "select 1", "purpose": "why"})),
+                &headers,
+            )
+            .await
+            .unwrap();
+        let seen = probe.take_seen();
+        assert_eq!(seen[0].session_header.as_deref(), Some("legacy-42"));
+        assert_eq!(seen[1].body["ai_context"]["session_id"], json!("legacy-42"));
+        assert_eq!(seen[1].body["ai_context"]["purpose"], json!("why"));
+    }
+
+    #[tokio::test]
+    async fn malformed_mcp_session_id_falls_back_to_a_minted_uuid() {
+        // The forwarding target 400s a malformed x-skardi-session-id
+        // (session_id_from_headers); the handler must not propagate a
+        // caller-minted bad value into that — it loses the grouping, not
+        // the call.
+        let (handler, probe) = handler_with_probe();
+        let mut headers = HeaderMap::new();
+        headers.insert(MCP_SESSION_ID, "has space".parse().unwrap());
+        let result = handler
+            .do_call_tool("product-search", args(json!({"brand": "x"})), &headers)
+            .await
+            .unwrap();
+        assert_eq!(result.is_error, Some(false));
+        let seen = probe.take_seen();
+        let forwarded = seen[0].session_header.as_deref().unwrap();
+        assert!(
+            Uuid::parse_str(forwarded).is_ok(),
+            "expected a minted UUID, got {forwarded:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn stateless_request_mints_a_uuid_per_request() {
+        let (handler, probe) = handler_with_probe();
+        for _ in 0..2 {
+            handler
+                .do_call_tool(
+                    "product-search",
+                    args(json!({"brand": "x"})),
+                    &HeaderMap::new(),
+                )
+                .await
+                .unwrap();
+        }
+        let seen = probe.take_seen();
+        let first = seen[0].session_header.as_deref().unwrap();
+        let second = seen[1].session_header.as_deref().unwrap();
+        assert!(Uuid::parse_str(first).is_ok(), "{first:?}");
+        assert!(Uuid::parse_str(second).is_ok(), "{second:?}");
+        assert_ne!(
+            first, second,
+            "stateless grouping is honestly per-request — ids must differ"
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_tool_is_invalid_params_nudging_a_relist() {
+        let (handler, _) = handler_with_probe();
+        let err = handler
+            .do_call_tool("nope", None, &HeaderMap::new())
+            .await
+            .unwrap_err();
+        assert!(err.message.contains("unknown tool"), "{}", err.message);
+        assert!(err.message.contains("tools/list"), "{}", err.message);
+    }
+
+    #[tokio::test]
+    async fn non_2xx_becomes_is_error_with_the_body_text() {
+        let mut probe = Probe::new(inventory());
+        probe.respond_status = StatusCode::BAD_REQUEST;
+        probe.respond_body = json!({
+            "success": false,
+            "error": "Missing required parameters: brand",
+            "error_type": "parameter_validation_error"
+        });
+        let handler = McpHandler::new(probe_router(probe.clone()));
+        let result = handler
+            .do_call_tool("query", args(json!({"sql": "select 1"})), &HeaderMap::new())
+            .await
+            .unwrap();
+        assert_eq!(result.is_error, Some(true));
+        let text = serde_json::to_string(&result.content).unwrap();
+        assert!(text.contains("parameter_validation_error"), "{text}");
+        assert!(text.contains("Missing required parameters"), "{text}");
+    }
+
+    #[tokio::test]
+    async fn query_without_purpose_omits_ai_context_entirely() {
+        let (handler, probe) = handler_with_probe();
+        handler
+            .do_call_tool(
+                "query",
+                args(json!({"sql": "select 1", "max_rows": 5})),
+                &HeaderMap::new(),
+            )
+            .await
+            .unwrap();
+        let seen = probe.take_seen();
+        assert_eq!(seen[0].body, json!({"sql": "select 1", "max_rows": 5}));
+    }
+
+    #[tokio::test]
+    async fn list_data_sources_proxies_get_data_source() {
+        let (handler, probe) = handler_with_probe();
+        let result = handler
+            .do_call_tool("list_data_sources", None, &HeaderMap::new())
+            .await
+            .unwrap();
+        assert_eq!(result.is_error, Some(false));
+        let seen = probe.take_seen();
+        assert_eq!(seen[0].path, "/data_source");
+    }
+}

--- a/crates/server/src/mcp/mod.rs
+++ b/crates/server/src/mcp/mod.rs
@@ -2,4 +2,329 @@
 //! server's own router, not a second execution path. Design:
 //! `docs/superpowers/specs/2026-08-28-mcp-http-transport-design.md`.
 
+mod gate;
 pub(crate) mod handler;
+
+use std::sync::Arc;
+
+use axum::Router;
+use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use rmcp::transport::{StreamableHttpServerConfig, StreamableHttpService};
+
+use crate::server::AppState;
+use gate::SessionGate;
+use handler::McpHandler;
+
+/// Nest the gated MCP service at `/mcp`. `rest` is deliberately the
+/// pre-middleware router: transport middleware (CORS today) applies exactly
+/// once, to the inbound `/mcp` request — capturing the post-middleware
+/// router would run it a second time on every synthetic dispatch. Dispatch
+/// only ever targets REST paths, so no recursion into `/mcp` is possible.
+///
+/// Known, accepted shadow: the nest hides REST's `/:name/execute` from
+/// every URL-borne caller for a pipeline literally named `mcp`; only `/mcp`
+/// itself still reaches it, via this pre-nest capture.
+pub(crate) fn attach(rest: Router, state: AppState) -> Router {
+    let allowed_hosts = allowed_hosts(&state);
+    let handler_rest = rest.clone();
+    let service = StreamableHttpService::new(
+        move || Ok(McpHandler::new(handler_rest.clone())),
+        Arc::new(LocalSessionManager::default()),
+        StreamableHttpServerConfig {
+            allowed_hosts,
+            // Everything else stays at rmcp's defaults, each one a spec
+            // decision: sse_keep_alive 15s (bytes keep flowing during long
+            // tool calls, resetting reverse-proxy idle timers well under
+            // nginx's 60s proxy_read_timeout default), legacy_session_mode
+            // true (legacy-protocol clients keep the session behavior they
+            // expect; the gate guards the state they create), json_response
+            // false (SSE responses, so the keep-alive applies), and
+            // allowed_origins empty (MCP hosts are not browsers; the
+            // Bearer-only gate is the actual barrier, so there is no
+            // CSRF-shaped surface for Origin to guard).
+            ..Default::default()
+        },
+    );
+    rest.nest_service("/mcp", SessionGate::new(service, state))
+}
+
+/// Additive host allowlist: the loopback trio is always allowed (rmcp's
+/// DNS-rebinding default, which protects developers running on loopback),
+/// declared `--mcp-allowed-host` values are appended. Deliberately no
+/// allow-any escape hatch — a public deployment names its hostnames.
+fn allowed_hosts(state: &AppState) -> Vec<String> {
+    let mut hosts = vec![
+        "localhost".to_string(),
+        "127.0.0.1".to_string(),
+        "::1".to_string(),
+    ];
+    hosts.extend(
+        state
+            .config
+            .read()
+            .unwrap()
+            .args
+            .mcp_allowed_hosts
+            .iter()
+            .cloned(),
+    );
+    hosts
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use axum::body::Body;
+    use axum::http::{HeaderMap, Request, StatusCode};
+    use datafusion::prelude::SessionContext;
+    use serde_json::json;
+    use skardi::engine::datafusion::DataFusionEngine;
+    use tower::ServiceExt;
+
+    use crate::auth::layer::AuthLayer;
+    use crate::auth::mode::AuthMode;
+    use crate::config::{CliArgs, ServerConfig};
+    use crate::mcp::handler::McpHandler;
+    use crate::semantics::SemanticsRegistry;
+    use crate::server::{AppState, configure_middleware, configure_routes, rest_router};
+
+    fn make_state(auth_layer: AuthLayer, mcp_allowed_hosts: Vec<String>) -> AppState {
+        let config = ServerConfig {
+            pipelines: HashMap::new(),
+            jobs: HashMap::new(),
+            data_sources: vec![],
+            semantics: SemanticsRegistry::default(),
+            args: CliArgs {
+                pipeline_path: None,
+                jobs_path: None,
+                jobs_db_path: None,
+                ctx_file: None,
+                semantics_path: None,
+                port: 0,
+                query_audit_db: None,
+                query_audit_retention_days: None,
+                mcp_allowed_hosts,
+            },
+        };
+        let session_ctx = Arc::new(SessionContext::new());
+        let engine = Arc::new(DataFusionEngine::new_with_arc(session_ctx.clone()));
+        AppState::new(
+            config,
+            engine,
+            session_ctx,
+            auth_layer,
+            None,
+            None,
+            Default::default(),
+        )
+    }
+
+    async fn better_auth_layer() -> AuthLayer {
+        // Held only across the env mutation + `build` below: once the layer
+        // exists it no longer reads the environment.
+        let _env = crate::auth::test_env::lock().await;
+        unsafe {
+            std::env::set_var("AUTH_SECRET", "test-secret-that-is-at-least-32-characters!");
+            std::env::set_var("AUTH_DB_PATH", ":memory:");
+            std::env::remove_var("AUTH_BASE_URL");
+        }
+        AuthLayer::build(&AuthMode::BetterAuthDieselSqlite)
+            .await
+            .unwrap()
+    }
+
+    /// Mint a real user + session and return the Bearer token (and the
+    /// cookie name for the cookie-only case).
+    async fn bearer_session(state: &AppState) -> (String, String) {
+        use better_auth::{SessionOps, UserOps};
+        let auth = state.auth_layer.as_better_auth().unwrap();
+        let user = auth
+            .database()
+            .create_user(better_auth::types_mod::CreateUser {
+                name: Some("mcp".into()),
+                email: Some("mcp@test.com".into()),
+                password: Some("password123".into()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let session = auth
+            .database()
+            .create_session(better_auth::types_mod::CreateSession {
+                user_id: user.id.clone(),
+                expires_at: chrono::Utc::now() + chrono::Duration::hours(1),
+                ip_address: None,
+                user_agent: None,
+                impersonated_by: None,
+                active_organization_id: None,
+            })
+            .await
+            .unwrap();
+        let cookie_name = auth.config().session.cookie_name.clone();
+        (session.token, cookie_name)
+    }
+
+    fn initialize_body() -> String {
+        json!({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "0"}
+            }
+        })
+        .to_string()
+    }
+
+    /// POST an `initialize` to `/mcp` on the given router. `Host` is set
+    /// explicitly: synthetic `oneshot` requests carry no `Host`, which
+    /// rmcp's DNS-rebinding validation rejects with 400 before anything
+    /// else runs.
+    async fn post_initialize(
+        app: axum::Router,
+        host: &str,
+        extra_headers: &[(&str, &str)],
+    ) -> axum::response::Response {
+        let mut builder = Request::builder()
+            .method("POST")
+            .uri("/mcp")
+            .header("host", host)
+            .header("content-type", "application/json")
+            .header("accept", "application/json, text/event-stream");
+        for (name, value) in extra_headers {
+            builder = builder.header(*name, *value);
+        }
+        app.oneshot(builder.body(Body::from(initialize_body())).unwrap())
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn session_gate_is_bearer_only_and_precedes_session_creation() {
+        let state = make_state(better_auth_layer().await, vec![]);
+        let (token, cookie_name) = bearer_session(&state).await;
+
+        // Anonymous initialize: transport-level 401 — rmcp never runs, so
+        // no session state is created for the caller.
+        let resp = post_initialize(configure_routes(state.clone()), "127.0.0.1", &[]).await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        // Cookie-only: a valid session cookie must NOT pass — synthetic
+        // requests forward only Authorization, so admitting it would trade
+        // this 401 for every tool call failing inside HTTP 200s.
+        let cookie = format!("{cookie_name}={token}");
+        let resp = post_initialize(
+            configure_routes(state.clone()),
+            "127.0.0.1",
+            &[("cookie", cookie.as_str())],
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        // The same initialize with the Bearer token passes the gate.
+        let auth = format!("Bearer {token}");
+        let resp = post_initialize(
+            configure_routes(state),
+            "127.0.0.1",
+            &[("authorization", auth.as_str())],
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn session_gate_is_a_noop_without_auth() {
+        let state = make_state(AuthLayer::None, vec![]);
+        let resp = post_initialize(configure_routes(state), "127.0.0.1", &[]).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn host_allowlist_is_loopback_plus_declared() {
+        // Default configuration: loopback only.
+        let state = make_state(AuthLayer::None, vec![]);
+        let resp = post_initialize(configure_routes(state.clone()), "api.example.com", &[]).await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        let resp = post_initialize(configure_routes(state), "127.0.0.1", &[]).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Declared host: allowed, loopback still allowed (additive).
+        let state = make_state(AuthLayer::None, vec!["api.example.com".to_string()]);
+        let resp = post_initialize(configure_routes(state.clone()), "api.example.com", &[]).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let resp = post_initialize(configure_routes(state.clone()), "localhost", &[]).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        // Undeclared non-loopback host stays rejected — no allow-any.
+        let resp = post_initialize(configure_routes(state), "evil.example", &[]).await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    /// The transport-vs-execution middleware boundary, pinned two-sided:
+    /// transport middleware (CORS) wraps the nested MCP service exactly
+    /// once, and the captured router the handler dispatches through is the
+    /// pre-middleware one. The second half is a direct pin — the handler
+    /// consumes synthetic responses body-only, so a double-wrapped capture
+    /// would never show up in `/mcp` response headers.
+    #[tokio::test]
+    async fn middleware_wraps_mcp_once_and_synthetic_dispatch_not_at_all() {
+        let state = make_state(AuthLayer::None, vec![]);
+
+        let app = configure_middleware(configure_routes(state.clone()));
+        let resp = post_initialize(app, "127.0.0.1", &[("origin", "https://example.com")]).await;
+        let acao: Vec<_> = resp
+            .headers()
+            .get_all("access-control-allow-origin")
+            .iter()
+            .collect();
+        assert_eq!(
+            acao.len(),
+            1,
+            "transport middleware must wrap /mcp exactly once: {acao:?}"
+        );
+
+        let rest = rest_router(state);
+        let resp = rest
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/pipelines")
+                    .header("origin", "https://example.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            resp.headers().get("access-control-allow-origin").is_none(),
+            "the captured router must be the pre-middleware one"
+        );
+    }
+
+    /// The second layer of defense, tested directly: the session gate makes
+    /// the no-credential path unreachable end-to-end, so handler-level
+    /// `require_session` (reached via synthetic dispatch) needs its own
+    /// regression test. If auth ever migrated into `configure_middleware`,
+    /// this call would start succeeding — the tripwire for the
+    /// middleware-boundary constraint the design depends on.
+    #[tokio::test]
+    async fn do_call_tool_hits_handler_level_auth_without_a_bearer() {
+        let state = make_state(better_auth_layer().await, vec![]);
+        let handler = McpHandler::new(rest_router(state));
+        let result = handler
+            .do_call_tool(
+                "query",
+                json!({"sql": "select 1"}).as_object().cloned(),
+                &HeaderMap::new(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.is_error, Some(true));
+        let text = serde_json::to_string(&result.content).unwrap();
+        assert!(
+            text.contains("unauthorized") || text.contains("Authentication required"),
+            "expected the handler-level 401 to surface in the tool result: {text}"
+        );
+    }
+}

--- a/crates/server/src/mcp/mod.rs
+++ b/crates/server/src/mcp/mod.rs
@@ -1,0 +1,5 @@
+//! MCP over streamable HTTP at `/mcp` — a protocol adapter over the
+//! server's own router, not a second execution path. Design:
+//! `docs/superpowers/specs/2026-08-28-mcp-http-transport-design.md`.
+
+pub(crate) mod handler;

--- a/crates/server/src/mcp/mod.rs
+++ b/crates/server/src/mcp/mod.rs
@@ -15,15 +15,17 @@ use crate::server::AppState;
 use gate::SessionGate;
 use handler::McpHandler;
 
-/// Nest the gated MCP service at `/mcp`. `rest` is deliberately the
+/// Mount the gated MCP service at exactly `/mcp`. `rest` is deliberately the
 /// pre-middleware router: transport middleware (CORS today) applies exactly
 /// once, to the inbound `/mcp` request — capturing the post-middleware
 /// router would run it a second time on every synthetic dispatch. Dispatch
 /// only ever targets REST paths, so no recursion into `/mcp` is possible.
 ///
-/// Known, accepted shadow: the nest hides REST's `/:name/execute` from
-/// every URL-borne caller for a pipeline literally named `mcp`; only `/mcp`
-/// itself still reaches it, via this pre-nest capture.
+/// The mount is `route_service` (exact path), not `nest_service` (prefix):
+/// streamable HTTP is a single-endpoint protocol (rmcp dispatches on method
+/// alone — POST/GET/DELETE against one URL), and a prefix mount would shadow
+/// REST's `/:name/execute` for a pipeline literally named `mcp` from every
+/// URL-borne caller — REST, the CLI, and the stdio bridge alike.
 pub(crate) fn attach(rest: Router, state: AppState) -> Router {
     let allowed_hosts = allowed_hosts(&state);
     let handler_rest = rest.clone();
@@ -43,7 +45,12 @@ pub(crate) fn attach(rest: Router, state: AppState) -> Router {
         // CSRF-shaped surface for Origin to guard).
         StreamableHttpServerConfig::default().with_allowed_hosts(allowed_hosts),
     );
-    rest.nest_service("/mcp", SessionGate::new(service, state))
+    let gate = SessionGate::new(service, state);
+    // `/mcp/` is registered too: the prefix mount used to accept it, and a
+    // host configured with a trailing slash should not 404. Only these two
+    // exact paths — nothing deeper — so `/mcp/execute` stays REST's.
+    rest.route_service("/mcp", gate.clone())
+        .route_service("/mcp/", gate)
 }
 
 /// Additive host allowlist: the loopback trio is always allowed (rmcp's
@@ -229,6 +236,25 @@ mod tests {
             &[("authorization", auth.as_str())],
         )
         .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    /// The mount is exact, but a trailing slash still reaches the service —
+    /// the prefix mount accepted `/mcp/`, and a host URL configured that way
+    /// should not 404. Nothing deeper is claimed: `/mcp/execute` is REST's,
+    /// covered end-to-end in `tests/mcp_http.rs`.
+    #[tokio::test]
+    async fn trailing_slash_also_reaches_the_mcp_service() {
+        let state = make_state(AuthLayer::None, vec![]);
+        let request = Request::builder()
+            .method("POST")
+            .uri("/mcp/")
+            .header("host", "127.0.0.1")
+            .header("content-type", "application/json")
+            .header("accept", "application/json, text/event-stream")
+            .body(Body::from(initialize_body()))
+            .unwrap();
+        let resp = configure_routes(state).oneshot(request).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
     }
 

--- a/crates/server/src/mcp/mod.rs
+++ b/crates/server/src/mcp/mod.rs
@@ -60,7 +60,7 @@ fn allowed_hosts(state: &AppState) -> Vec<String> {
         state
             .config
             .read()
-            .unwrap()
+            .unwrap_or_else(|p| p.into_inner())
             .args
             .mcp_allowed_hosts
             .iter()

--- a/crates/server/src/mcp/mod.rs
+++ b/crates/server/src/mcp/mod.rs
@@ -30,20 +30,18 @@ pub(crate) fn attach(rest: Router, state: AppState) -> Router {
     let service = StreamableHttpService::new(
         move || Ok(McpHandler::new(handler_rest.clone())),
         Arc::new(LocalSessionManager::default()),
-        StreamableHttpServerConfig {
-            allowed_hosts,
-            // Everything else stays at rmcp's defaults, each one a spec
-            // decision: sse_keep_alive 15s (bytes keep flowing during long
-            // tool calls, resetting reverse-proxy idle timers well under
-            // nginx's 60s proxy_read_timeout default), legacy_session_mode
-            // true (legacy-protocol clients keep the session behavior they
-            // expect; the gate guards the state they create), json_response
-            // false (SSE responses, so the keep-alive applies), and
-            // allowed_origins empty (MCP hosts are not browsers; the
-            // Bearer-only gate is the actual barrier, so there is no
-            // CSRF-shaped surface for Origin to guard).
-            ..Default::default()
-        },
+        // The config is #[non_exhaustive], so it's built from the defaults
+        // via the builder. Everything except allowed_hosts stays at rmcp's
+        // defaults, each one a spec decision: sse_keep_alive 15s (bytes
+        // keep flowing during long tool calls, resetting reverse-proxy
+        // idle timers well under nginx's 60s proxy_read_timeout default),
+        // legacy_session_mode true (legacy-protocol clients keep the
+        // session behavior they expect; the gate guards the state they
+        // create), json_response false (SSE responses, so the keep-alive
+        // applies), and allowed_origins empty (MCP hosts are not browsers;
+        // the Bearer-only gate is the actual barrier, so there is no
+        // CSRF-shaped surface for Origin to guard).
+        StreamableHttpServerConfig::default().with_allowed_hosts(allowed_hosts),
     );
     rest.nest_service("/mcp", SessionGate::new(service, state))
 }

--- a/crates/server/src/pipeline_handlers.rs
+++ b/crates/server/src/pipeline_handlers.rs
@@ -1283,6 +1283,7 @@ spec:
             port: 8080,
             query_audit_db: None,
             query_audit_retention_days: None,
+            mcp_allowed_hosts: vec![],
         };
 
         let config = ServerConfig {
@@ -1373,6 +1374,7 @@ spec:
             port: 8080,
             query_audit_db: None,
             query_audit_retention_days: None,
+            mcp_allowed_hosts: vec![],
         };
 
         let config = ServerConfig {
@@ -2111,6 +2113,7 @@ spec:
             port: 8080,
             query_audit_db: None,
             query_audit_retention_days: None,
+            mcp_allowed_hosts: vec![],
         };
         let config = ServerConfig {
             pipelines: HashMap::new(),

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -537,8 +537,24 @@ fn resolve_jobs_db_path(explicit: Option<&PathBuf>) -> Result<PathBuf> {
     Ok(home.join(".skardi").join("jobs.db"))
 }
 
-/// Configure all application routes
+/// Configure all application routes: the REST router exactly as before,
+/// plus the MCP service nested at `/mcp`. The MCP handler captures the
+/// PRE-middleware REST router — `configure_middleware` wraps the final
+/// router (transport middleware, applied once to the inbound `/mcp`
+/// request), while synthetic dispatches traverse routing + handlers only,
+/// which is where every execution concern lives (`require_session`,
+/// parameter validation, audit recording). If auth ever moved into
+/// `configure_middleware`, synthetic dispatch would bypass it — see the
+/// tripwire test on the MCP handler.
 pub fn configure_routes(state: AppState) -> Router {
+    let rest = rest_router(state.clone());
+    crate::mcp::attach(rest, state)
+}
+
+/// The REST routing table + handlers, without the `/mcp` nest and without
+/// transport middleware. `pub(crate)` so the MCP tests can pin that the
+/// captured router really is this pre-middleware one.
+pub(crate) fn rest_router(state: AppState) -> Router {
     tracing::info!("Configuring HTTP routes");
 
     let mut router = Router::new()

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -697,6 +697,7 @@ spec:
                 port: 8080,
                 query_audit_db: None,
                 query_audit_retention_days: None,
+                mcp_allowed_hosts: vec![],
             },
         };
 
@@ -722,6 +723,7 @@ spec:
                 port: 8080,
                 query_audit_db: None,
                 query_audit_retention_days: None,
+                mcp_allowed_hosts: vec![],
             },
         }
     }
@@ -765,6 +767,7 @@ spec:
             port: 8080,
             query_audit_db: None,
             query_audit_retention_days: None,
+            mcp_allowed_hosts: vec![],
         };
         let config = crate::config::load_server_config(args)
             .await

--- a/crates/server/src/session_header.rs
+++ b/crates/server/src/session_header.rs
@@ -57,6 +57,16 @@ pub fn session_id_from_headers(headers: &HeaderMap) -> Result<Option<String>, St
     let s = value
         .to_str()
         .map_err(|_| format!("{SESSION_ID_HEADER} must contain only visible ASCII characters"))?;
+    validate_session_id(s)?;
+    Ok(Some(s.to_string()))
+}
+
+/// Validate one session-id VALUE against the rules above, independent of the
+/// header plumbing. Public so the server's `/mcp` handler can vet a
+/// caller-minted `Mcp-Session-Id` against the same predicate before
+/// forwarding it as `x-skardi-session-id` (falling back to a minted UUID on
+/// mismatch — losing that call's session grouping, not the call).
+pub fn validate_session_id(s: &str) -> Result<(), String> {
     if !s.chars().all(|c| c.is_ascii_graphic() && c != ',') {
         return Err(format!(
             "{SESSION_ID_HEADER} must contain only visible ASCII characters, \
@@ -72,5 +82,20 @@ pub fn session_id_from_headers(headers: &HeaderMap) -> Result<Option<String>, St
             "{SESSION_ID_HEADER} must be at most {MAX_SESSION_ID_CHARS} characters"
         ));
     }
-    Ok(Some(s.to_string()))
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_session_id_matches_the_header_rules() {
+        assert!(validate_session_id("sess-1").is_ok());
+        assert!(validate_session_id("").is_err());
+        assert!(validate_session_id("has space").is_err());
+        assert!(validate_session_id("a,b").is_err());
+        assert!(validate_session_id(&"x".repeat(MAX_SESSION_ID_CHARS + 1)).is_err());
+        assert!(validate_session_id(&"x".repeat(MAX_SESSION_ID_CHARS)).is_ok());
+    }
 }

--- a/crates/server/tests/graph_views.rs
+++ b/crates/server/tests/graph_views.rs
@@ -55,6 +55,7 @@ fn args_with_ctx(ctx_path: std::path::PathBuf) -> CliArgs {
         port: 8080,
         query_audit_db: None,
         query_audit_retention_days: None,
+        mcp_allowed_hosts: vec![],
     }
 }
 

--- a/crates/server/tests/jobs_audit_http.rs
+++ b/crates/server/tests/jobs_audit_http.rs
@@ -154,6 +154,7 @@ spec:
             port: 0,
             query_audit_db: None,
             query_audit_retention_days: None,
+            mcp_allowed_hosts: vec![],
         },
     };
     let state = AppState::new(

--- a/crates/server/tests/jobs_auth_http.rs
+++ b/crates/server/tests/jobs_auth_http.rs
@@ -122,6 +122,7 @@ spec:
             port: 0,
             query_audit_db: None,
             query_audit_retention_days: None,
+            mcp_allowed_hosts: vec![],
         },
     };
     let state = AppState::new(

--- a/crates/server/tests/jobs_bridge_startup.rs
+++ b/crates/server/tests/jobs_bridge_startup.rs
@@ -35,6 +35,7 @@ fn args(jobs_path: PathBuf, jobs_db: PathBuf, audit_db: PathBuf) -> CliArgs {
         port: 8080,
         query_audit_db: Some(audit_db),
         query_audit_retention_days: None,
+        mcp_allowed_hosts: vec![],
     }
 }
 

--- a/crates/server/tests/jobs_http.rs
+++ b/crates/server/tests/jobs_http.rs
@@ -105,6 +105,7 @@ spec:
             port: 0,
             query_audit_db: None,
             query_audit_retention_days: None,
+            mcp_allowed_hosts: vec![],
         },
     };
     let state = AppState::new(

--- a/crates/server/tests/mcp_http.rs
+++ b/crates/server/tests/mcp_http.rs
@@ -20,7 +20,9 @@ use datafusion::prelude::SessionContext;
 use rmcp::model::{CallToolRequestParams, CallToolResult, ClientInfo, ProtocolVersion};
 use rmcp::transport::StreamableHttpClientTransport;
 use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
-use rmcp::{RoleClient, ServiceExt, service::RunningService};
+use rmcp::{
+    ClientLifecycleMode, ClientServiceExt, RoleClient, ServiceExt, service::RunningService,
+};
 use serde_json::{Value, json};
 use skardi::pipeline::pipeline::{Pipeline, StandardPipeline};
 use tempfile::TempDir;
@@ -365,6 +367,15 @@ async fn anonymous_initialize_is_a_transport_401() {
     assert_eq!(resp.status(), reqwest::StatusCode::UNAUTHORIZED);
 }
 
+/// rmcp's stateless client is the Discover lifecycle: no `initialize`
+/// handshake, no session — `server/discover` negotiates the version and
+/// every request carries self-contained `_meta` (SEP-2575).
+fn discover_2026_07_28() -> ClientLifecycleMode {
+    ClientLifecycleMode::Discover {
+        preferred_versions: vec![ProtocolVersion::V_2026_07_28],
+    }
+}
+
 /// The stateless-protocol regression test: a 2026-07-28 client carries no
 /// session, so every request stands alone — `tools/call` must resolve the
 /// pipeline per-call with no `tools/list` state to lean on.
@@ -375,10 +386,9 @@ async fn stateless_2026_07_28_client_lists_and_calls() {
 
     let transport = StreamableHttpClientTransport::from_uri(mcp_uri(addr));
     let client = ClientInfo::default()
-        .with_protocol_version(ProtocolVersion::V_2026_07_28)
-        .serve(transport)
+        .serve_with_lifecycle(transport, discover_2026_07_28())
         .await
-        .expect("stateless initialize");
+        .expect("discover startup");
     // Guard the premise: the negotiated version is the stateless protocol
     // (rmcp serves >= 2026-07-28 statelessly regardless of session config).
     assert_eq!(
@@ -418,10 +428,9 @@ async fn stateless_pipeline_call_records_a_uuid_audit_session_id() {
     // the handler's minted per-request UUID.
     let transport = StreamableHttpClientTransport::from_uri(mcp_uri(addr));
     let client = ClientInfo::default()
-        .with_protocol_version(ProtocolVersion::V_2026_07_28)
-        .serve(transport)
+        .serve_with_lifecycle(transport, discover_2026_07_28())
         .await
-        .expect("stateless initialize");
+        .expect("discover startup");
     let result = client
         .call_tool(call_params(
             "product-search",

--- a/crates/server/tests/mcp_http.rs
+++ b/crates/server/tests/mcp_http.rs
@@ -99,6 +99,29 @@ spec:
     let mut pipelines: HashMap<String, StandardPipeline> = HashMap::new();
     pipelines.insert(pipeline.name().to_string(), pipeline);
 
+    // A pipeline literally named `mcp`: its REST route is `/mcp/execute`,
+    // one path segment below the MCP mount — the worst-case name for the
+    // exact-mount regression test below.
+    let mcp_yaml_path = tmp.path().join("mcp.yaml");
+    let mut f = std::fs::File::create(&mcp_yaml_path).unwrap();
+    f.write_all(
+        br#"
+kind: pipeline
+metadata:
+  name: "mcp"
+  version: "1.0.0"
+  description: "Deliberately named after the MCP mount point"
+spec:
+  query: |
+    SELECT COUNT(*) AS n FROM products WHERE price <= {max_price}
+"#,
+    )
+    .unwrap();
+    let mcp_pipeline = StandardPipeline::load_from_file(&mcp_yaml_path, Arc::clone(&ctx))
+        .await
+        .unwrap();
+    pipelines.insert(mcp_pipeline.name().to_string(), mcp_pipeline);
+
     let engine = Arc::new(skardi::engine::datafusion::DataFusionEngine::new_with_arc(
         Arc::clone(&ctx),
     ));
@@ -365,6 +388,29 @@ async fn anonymous_initialize_is_a_transport_401() {
         .await
         .unwrap();
     assert_eq!(resp.status(), reqwest::StatusCode::UNAUTHORIZED);
+}
+
+/// Regression: the MCP service is mounted at exactly `/mcp`, so a pipeline
+/// literally named `mcp` keeps its REST surface at `/mcp/execute`. A prefix
+/// mount (`nest_service`) would shadow that route from every URL-borne
+/// caller — REST, the CLI, and the stdio bridge alike.
+#[tokio::test]
+async fn pipeline_named_mcp_is_not_shadowed_by_the_mount() {
+    let (state, _tmp) = make_app_state(AuthLayer::None, None).await;
+    let addr = serve(state).await;
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/mcp/execute"))
+        .header("content-type", "application/json")
+        .body(json!({"max_price": 1000.0}).to_string())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = serde_json::from_slice(&resp.bytes().await.unwrap()).unwrap();
+    assert_eq!(body["success"], json!(true), "{body}");
+    // Three products at or under 1000: Sony 199, Samsung 599, Apple 999.
+    assert_eq!(body["data"][0]["n"], json!(3), "{body}");
 }
 
 /// rmcp's stateless client is the Discover lifecycle: no `initialize`

--- a/crates/server/tests/mcp_http.rs
+++ b/crates/server/tests/mcp_http.rs
@@ -1,0 +1,464 @@
+//! End-to-end tests for the `/mcp` streamable-HTTP binding: a real rmcp
+//! client over a real TCP socket against the same middleware-wrapped router
+//! the binary serves. The transport-level pieces (gate ordering, host
+//! allowlist, middleware boundary) are pinned in-crate by `src/mcp/mod.rs`;
+//! this suite proves the full stack — rmcp client transport → gate → rmcp
+//! server → handler → synthetic dispatch → REST handlers — agrees with it.
+//!
+//! Harness mirrors `pipelines_http.rs` (products MemTable + one real
+//! pipeline) and `jobs_auth_http.rs` (better-auth env lock).
+
+use std::collections::HashMap;
+use std::io::Write;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use arrow::array::{Float64Array, Int64Array, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use datafusion::prelude::SessionContext;
+use rmcp::model::{CallToolRequestParams, CallToolResult, ClientInfo, ProtocolVersion};
+use rmcp::transport::StreamableHttpClientTransport;
+use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+use rmcp::{RoleClient, ServiceExt, service::RunningService};
+use serde_json::{Value, json};
+use skardi::pipeline::pipeline::{Pipeline, StandardPipeline};
+use tempfile::TempDir;
+
+use skardi_server::auth::layer::AuthLayer;
+use skardi_server::auth::mode::AuthMode;
+use skardi_server::config::{CliArgs, ServerConfig};
+use skardi_server::query_audit::QueryAuditStore;
+use skardi_server::semantics::SemanticsRegistry;
+use skardi_server::server::{AppState, configure_middleware, configure_routes};
+
+fn products_batch() -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("brand", DataType::Utf8, false),
+        Field::new("price", DataType::Float64, false),
+        Field::new("category", DataType::Utf8, false),
+    ]));
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(vec![1i64, 2, 3, 4, 5])),
+            Arc::new(StringArray::from(vec![
+                "Apple", "Sony", "Apple", "Samsung", "Apple",
+            ])),
+            Arc::new(Float64Array::from(vec![
+                1299.0, 199.0, 999.0, 599.0, 2499.0,
+            ])),
+            Arc::new(StringArray::from(vec![
+                "Electronics",
+                "Audio",
+                "Electronics",
+                "Electronics",
+                "Electronics",
+            ])),
+        ],
+    )
+    .unwrap()
+}
+
+/// `AppState` with a `products` MemTable and a real `product-search`
+/// pipeline, so `/mcp` tool calls run actual SQL end-to-end.
+async fn make_app_state(
+    auth_layer: AuthLayer,
+    query_audit: Option<Arc<QueryAuditStore>>,
+) -> (AppState, TempDir) {
+    let tmp = TempDir::new().unwrap();
+    let ctx = Arc::new(SessionContext::new());
+    ctx.register_batch("products", products_batch()).unwrap();
+
+    let yaml_path = tmp.path().join("product-search.yaml");
+    let mut f = std::fs::File::create(&yaml_path).unwrap();
+    f.write_all(
+        br#"
+kind: pipeline
+metadata:
+  name: "product-search"
+  version: "1.0.0"
+  description: "Filter products by brand + max price"
+spec:
+  parameters:
+    brand: "Exact brand name; null matches every brand"
+  query: |
+    SELECT id, brand, price, category
+    FROM products
+    WHERE brand = {brand} AND price <= {max_price}
+    ORDER BY price DESC
+"#,
+    )
+    .unwrap();
+    let pipeline = StandardPipeline::load_from_file(&yaml_path, Arc::clone(&ctx))
+        .await
+        .unwrap();
+    let mut pipelines: HashMap<String, StandardPipeline> = HashMap::new();
+    pipelines.insert(pipeline.name().to_string(), pipeline);
+
+    let engine = Arc::new(skardi::engine::datafusion::DataFusionEngine::new_with_arc(
+        Arc::clone(&ctx),
+    ));
+    let config = ServerConfig {
+        pipelines,
+        jobs: HashMap::new(),
+        data_sources: vec![],
+        semantics: SemanticsRegistry::default(),
+        args: CliArgs {
+            pipeline_path: None,
+            jobs_path: None,
+            jobs_db_path: None,
+            ctx_file: None,
+            semantics_path: None,
+            port: 0,
+            query_audit_db: None,
+            query_audit_retention_days: None,
+            mcp_allowed_hosts: vec![],
+        },
+    };
+    let state = AppState::new(
+        config,
+        engine,
+        Arc::clone(&ctx),
+        auth_layer,
+        None,
+        query_audit,
+        Default::default(),
+    );
+    (state, tmp)
+}
+
+/// Serve the full app (routes + middleware, exactly what the binary runs) on
+/// an ephemeral loopback port. The rmcp client sends `Host: 127.0.0.1:<port>`,
+/// which the portless loopback allowlist entry matches.
+async fn serve(state: AppState) -> SocketAddr {
+    let app = configure_middleware(configure_routes(state));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    addr
+}
+
+fn mcp_uri(addr: SocketAddr) -> String {
+    format!("http://{addr}/mcp")
+}
+
+/// Default rmcp client: negotiates `ProtocolVersion::LATEST` (2025-11-25),
+/// so the server serves it in legacy session mode.
+async fn connect(addr: SocketAddr) -> RunningService<RoleClient, ()> {
+    let transport = StreamableHttpClientTransport::from_uri(mcp_uri(addr));
+    ().serve(transport).await.expect("initialize handshake")
+}
+
+/// Tool results carry the REST response JSON verbatim as one text block;
+/// parse it back out for row-level assertions.
+fn result_json(result: &CallToolResult) -> Value {
+    let content = serde_json::to_value(&result.content).unwrap();
+    let text = content[0]["text"]
+        .as_str()
+        .unwrap_or_else(|| panic!("expected a text content block: {content}"));
+    serde_json::from_str(text)
+        .unwrap_or_else(|e| panic!("tool result text is not the REST JSON body ({e}): {text}"))
+}
+
+fn call_params(name: &'static str, args: Value) -> CallToolRequestParams {
+    CallToolRequestParams::new(name)
+        .with_arguments(args.as_object().cloned().expect("literal is an object"))
+}
+
+/// Serialized with the same discipline as `jobs_auth_http.rs`: `AuthLayer::
+/// build` reads process-global env vars, and `auth::test_env::lock` is
+/// `#[cfg(test)]` on the lib, invisible to integration-test binaries.
+static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+async fn better_auth_layer() -> AuthLayer {
+    let _env = ENV_LOCK.lock().await;
+    unsafe {
+        std::env::set_var("AUTH_SECRET", "test-secret-that-is-at-least-32-characters!");
+        std::env::set_var("AUTH_DB_PATH", ":memory:");
+        std::env::remove_var("AUTH_BASE_URL");
+    }
+    AuthLayer::build(&AuthMode::BetterAuthDieselSqlite)
+        .await
+        .unwrap()
+}
+
+/// Mint a real user + session, returning the Bearer token.
+async fn bearer_token(state: &AppState) -> String {
+    use better_auth::{SessionOps, UserOps};
+    let auth = state.auth_layer.as_better_auth().unwrap();
+    let user = auth
+        .database()
+        .create_user(better_auth::types_mod::CreateUser {
+            name: Some("mcp-e2e".into()),
+            email: Some("mcp-e2e@test.com".into()),
+            password: Some("password123".into()),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    let session = auth
+        .database()
+        .create_session(better_auth::types_mod::CreateSession {
+            user_id: user.id.clone(),
+            expires_at: chrono::Utc::now() + chrono::Duration::hours(1),
+            ip_address: None,
+            user_agent: None,
+            impersonated_by: None,
+            active_organization_id: None,
+        })
+        .await
+        .unwrap();
+    session.token
+}
+
+#[tokio::test]
+async fn tools_list_contains_seeded_pipelines_and_builtins() {
+    let (state, _tmp) = make_app_state(AuthLayer::None, None).await;
+    let client = connect(serve(state).await).await;
+
+    let info = client.peer_info().expect("server info");
+    assert!(info.capabilities.tools.is_some(), "tools capability");
+    assert!(
+        info.instructions.as_deref().is_some_and(|i| !i.is_empty()),
+        "instructions should be set"
+    );
+
+    let tools = client.list_all_tools().await.unwrap();
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+    assert!(names.contains(&"product-search"), "{names:?}");
+    assert!(names.contains(&"query"), "{names:?}");
+    assert!(names.contains(&"list_data_sources"), "{names:?}");
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn pipeline_call_executes_and_returns_rows() {
+    let (state, _tmp) = make_app_state(AuthLayer::None, None).await;
+    let client = connect(serve(state).await).await;
+
+    // No tools/list first: per-call name resolution must hold on its own.
+    let result = client
+        .call_tool(call_params(
+            "product-search",
+            json!({"brand": "Apple", "max_price": 1500.0}),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(result.is_error, Some(false), "{result:?}");
+    let body = result_json(&result);
+    assert_eq!(body["success"], json!(true), "{body}");
+    // Two Apple rows are <= 1500 (ids 1 and 3); id=5 at 2499 is filtered out.
+    assert_eq!(body["rows"].as_u64(), Some(2), "{body}");
+    assert_eq!(body["data"][0]["id"], json!(1), "{body}");
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn query_round_trips() {
+    let (state, _tmp) = make_app_state(AuthLayer::None, None).await;
+    let client = connect(serve(state).await).await;
+
+    let result = client
+        .call_tool(call_params(
+            "query",
+            json!({"sql": "SELECT count(*) AS n FROM products"}),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(result.is_error, Some(false), "{result:?}");
+    let body = result_json(&result);
+    assert_eq!(body["data"][0]["n"], json!(5), "{body}");
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn unknown_tool_is_invalid_params() {
+    let (state, _tmp) = make_app_state(AuthLayer::None, None).await;
+    let client = connect(serve(state).await).await;
+
+    let err = client
+        .call_tool(CallToolRequestParams::new("nope"))
+        .await
+        .unwrap_err();
+    let msg = format!("{err}");
+    assert!(msg.contains("unknown tool 'nope'"), "{msg}");
+    assert!(msg.contains("tools/list"), "should nudge a re-list: {msg}");
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn failing_sql_surfaces_as_is_error_tool_result() {
+    let (state, _tmp) = make_app_state(AuthLayer::None, None).await;
+    let client = connect(serve(state).await).await;
+
+    // Passes statement validation, fails in the engine — an execution
+    // error the model should see and react to, not a protocol error.
+    let result = client
+        .call_tool(call_params(
+            "query",
+            json!({"sql": "SELECT * FROM no_such_table"}),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(result.is_error, Some(true), "{result:?}");
+    let content = serde_json::to_string(&result.content).unwrap();
+    assert!(content.contains("no_such_table"), "{content}");
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn auth_forwarding_reaches_the_handlers() {
+    let (state, _tmp) = make_app_state(better_auth_layer().await, None).await;
+    let token = bearer_token(&state).await;
+    let addr = serve(state).await;
+
+    let transport = StreamableHttpClientTransport::from_config(
+        StreamableHttpClientTransportConfig::with_uri(mcp_uri(addr)).auth_header(token),
+    );
+    let client = ().serve(transport).await.expect("bearer initialize");
+
+    // A succeeding query proves `Authorization` survives synthetic dispatch:
+    // a dropped header would pass the gate but 401 at handler-level
+    // `require_session`, surfacing here as `is_error == Some(true)`.
+    let result = client
+        .call_tool(call_params("query", json!({"sql": "SELECT 1 AS one"})))
+        .await
+        .unwrap();
+    assert_eq!(result.is_error, Some(false), "{result:?}");
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn anonymous_initialize_is_a_transport_401() {
+    let (state, _tmp) = make_app_state(better_auth_layer().await, None).await;
+    let addr = serve(state).await;
+
+    // No credential: the handshake itself fails — a transport-level 401,
+    // not an open session whose every call errors.
+    let transport = StreamableHttpClientTransport::from_uri(mcp_uri(addr));
+    assert!(
+        ().serve(transport).await.is_err(),
+        "anonymous initialize must fail the handshake"
+    );
+
+    // An invented Mcp-Session-Id changes nothing: the gate runs before
+    // rmcp's session manager, so this is a 401, not a session-lookup error.
+    let resp = reqwest::Client::new()
+        .post(mcp_uri(addr))
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream")
+        .header("mcp-session-id", "11111111-2222-3333-4444-555555555555")
+        .body(json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}).to_string())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::UNAUTHORIZED);
+}
+
+/// The stateless-protocol regression test: a 2026-07-28 client carries no
+/// session, so every request stands alone — `tools/call` must resolve the
+/// pipeline per-call with no `tools/list` state to lean on.
+#[tokio::test]
+async fn stateless_2026_07_28_client_lists_and_calls() {
+    let (state, _tmp) = make_app_state(AuthLayer::None, None).await;
+    let addr = serve(state).await;
+
+    let transport = StreamableHttpClientTransport::from_uri(mcp_uri(addr));
+    let client = ClientInfo::default()
+        .with_protocol_version(ProtocolVersion::V_2026_07_28)
+        .serve(transport)
+        .await
+        .expect("stateless initialize");
+    // Guard the premise: the negotiated version is the stateless protocol
+    // (rmcp serves >= 2026-07-28 statelessly regardless of session config).
+    assert_eq!(
+        client.peer_info().expect("server info").protocol_version,
+        ProtocolVersion::V_2026_07_28
+    );
+
+    let tools = client.list_all_tools().await.unwrap();
+    assert!(
+        tools.iter().any(|t| t.name == "product-search"),
+        "{tools:?}"
+    );
+
+    let result = client
+        .call_tool(call_params(
+            "product-search",
+            json!({"brand": "Sony", "max_price": 500.0}),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(result.is_error, Some(false), "{result:?}");
+    let body = result_json(&result);
+    assert_eq!(body["rows"].as_u64(), Some(1), "{body}");
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn stateless_pipeline_call_records_a_uuid_audit_session_id() {
+    let audit_tmp = TempDir::new().unwrap();
+    let db_path = audit_tmp.path().join("audit.db");
+    let store = Arc::new(QueryAuditStore::open(&db_path).await.unwrap());
+    let (state, _tmp) = make_app_state(AuthLayer::None, Some(Arc::clone(&store))).await;
+    let addr = serve(state).await;
+
+    // Stateless client: no Mcp-Session-Id anywhere, so the audit id must be
+    // the handler's minted per-request UUID.
+    let transport = StreamableHttpClientTransport::from_uri(mcp_uri(addr));
+    let client = ClientInfo::default()
+        .with_protocol_version(ProtocolVersion::V_2026_07_28)
+        .serve(transport)
+        .await
+        .expect("stateless initialize");
+    let result = client
+        .call_tool(call_params(
+            "product-search",
+            json!({"brand": "Apple", "max_price": 1500.0}),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(result.is_error, Some(false), "{result:?}");
+    client.cancel().await.unwrap();
+
+    // The ledger's read API is keyed by an already-known session id, and the
+    // minted id is exactly what's under test — so read the column raw.
+    let conn = tokio_rusqlite::Connection::open(&db_path).await.unwrap();
+    let session_ids = conn
+        .call(
+            |conn| -> Result<Vec<Option<String>>, tokio_rusqlite::rusqlite::Error> {
+                let mut stmt = conn.prepare("SELECT session_id FROM query_audit")?;
+                let ids = stmt
+                    .query_map([], |row| row.get::<_, Option<String>>(0))?
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(ids)
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(session_ids.len(), 1, "{session_ids:?}");
+    let sid = session_ids[0]
+        .as_deref()
+        .expect("the pipeline run must be attributed, not NULL");
+    uuid::Uuid::parse_str(sid)
+        .unwrap_or_else(|e| panic!("stateless audit id should be a minted UUID ({e}): {sid}"));
+
+    // And it groups: the public read path finds the run under that id.
+    let rows = store.list_by_session(sid).await.unwrap();
+    assert_eq!(rows.len(), 1, "{rows:?}");
+    assert_eq!(
+        rows[0]["statement_kind"],
+        json!("pipeline"),
+        "{:?}",
+        rows[0]
+    );
+}

--- a/crates/server/tests/mcp_http.rs
+++ b/crates/server/tests/mcp_http.rs
@@ -298,7 +298,9 @@ async fn failing_sql_surfaces_as_is_error_tool_result() {
     let client = connect(serve(state).await).await;
 
     // Passes statement validation, fails in the engine — an execution
-    // error the model should see and react to, not a protocol error.
+    // error the model should see and react to, not a protocol error. The
+    // REST error envelope arrives verbatim; the engine's own message stays
+    // in the server logs by design, so the envelope is what's pinned here.
     let result = client
         .call_tool(call_params(
             "query",
@@ -308,7 +310,7 @@ async fn failing_sql_surfaces_as_is_error_tool_result() {
         .unwrap();
     assert_eq!(result.is_error, Some(true), "{result:?}");
     let content = serde_json::to_string(&result.content).unwrap();
-    assert!(content.contains("no_such_table"), "{content}");
+    assert!(content.contains("query_execution_error"), "{content}");
 
     client.cancel().await.unwrap();
 }

--- a/crates/server/tests/pipeline_audit_http.rs
+++ b/crates/server/tests/pipeline_audit_http.rs
@@ -198,6 +198,7 @@ spec:
             port: 0,
             query_audit_db: None,
             query_audit_retention_days: None,
+            mcp_allowed_hosts: vec![],
         },
     };
     let state = AppState::new(

--- a/crates/server/tests/pipelines_http.rs
+++ b/crates/server/tests/pipelines_http.rs
@@ -111,6 +111,7 @@ spec:
             port: 0,
             query_audit_db: None,
             query_audit_retention_days: None,
+            mcp_allowed_hosts: vec![],
         },
     };
     let state = AppState::new(

--- a/crates/server/tests/query_http.rs
+++ b/crates/server/tests/query_http.rs
@@ -93,6 +93,7 @@ fn make_state_with_audit(query_audit: Option<Arc<QueryAuditStore>>) -> AppState 
             port: 0,
             query_audit_db: None,
             query_audit_retention_days: None,
+            mcp_allowed_hosts: vec![],
         },
     };
     AppState::new(

--- a/crates/server/tests/semantics_endpoint.rs
+++ b/crates/server/tests/semantics_endpoint.rs
@@ -94,6 +94,7 @@ async fn make_state(data_sources: Vec<DataSource>, semantics: SemanticsRegistry)
             port: 0,
             query_audit_db: None,
             query_audit_retention_days: None,
+            mcp_allowed_hosts: vec![],
         },
     };
     AppState::new(

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -126,11 +126,14 @@ pipelines should still check proxy read timeouts (nginx's
 proxy counts any bytes as liveness).
 
 **Audit grouping.** A legacy-protocol session (2025-11-25 and earlier)
-groups its queries and pipeline runs in the query-audit ledger under the
-transport's `Mcp-Session-Id`. Stateless-protocol requests (2026-07-28 and
-later) are attributed per-request with a minted UUID — that protocol
-revision removed the conversation-level handle, so there is nothing durable
-to group by.
+groups its pipeline runs — and the queries that carry `purpose` — in the
+query-audit ledger under the transport's `Mcp-Session-Id`. Stateless-protocol
+requests (2026-07-28 and later) are attributed per-request with a minted
+UUID — that protocol revision removed the conversation-level handle, so
+there is nothing durable to group by. On either protocol the id reaches a
+`query` audit row only inside `ai_context`, which is omitted when `purpose`
+is absent: a purpose-less query is recorded with no session id at all.
+Pipeline runs always carry the id, via `X-Skardi-Session-Id`.
 
 ---
 
@@ -163,10 +166,12 @@ schema as the standard `description` keyword, so the model no longer has
 to guess semantics from the parameter name alone.
 
 Every pipeline call carries a session id as `X-Skardi-Session-Id` — the
-same id `query` sends in `ai_context.session_id` — so an MCP session's
-pipeline runs and ad-hoc queries group together in the query audit ledger.
-On the stdio bridge that id is one UUID per MCP connection; on `/mcp` see
-audit grouping under [Remote (streamable HTTP)](#remote-streamable-http).
+same id `query` sends in `ai_context.session_id` when `purpose` is given —
+so an MCP session's pipeline runs and purposeful ad-hoc queries group
+together in the query audit ledger. A query without `purpose` sends no
+`ai_context` and is audited without a session id, so it stands outside the
+group. On the stdio bridge the id is one UUID per MCP connection; on `/mcp`
+see audit grouping under [Remote (streamable HTTP)](#remote-streamable-http).
 
 ### `query`
 
@@ -176,7 +181,7 @@ Ad-hoc SQL against the federated engine — the MCP face of `POST /query`.
 |---|---|---|
 | `sql` | string, **required** | One statement. DML only on `access_mode: read_write` sources; DDL is always rejected. |
 | `max_rows` | integer, optional | Result row cap; server default 1000. |
-| `purpose` | string, optional | One line on why you are running this query. Sent as `ai_context: {purpose, session_id}` and recorded in the server's query audit log; the `session_id` is the same per-connection (bridge) or per-session/per-request (`/mcp`) id pipeline calls carry, so related calls group together in the ledger. Omitted entirely when not provided. |
+| `purpose` | string, optional | One line on why you are running this query. Sent as `ai_context: {purpose, session_id}` and recorded in the server's query audit log; the `session_id` is the same per-connection (bridge) or per-session/per-request (`/mcp`) id pipeline calls carry, so related calls group together in the ledger. Omitted entirely when not provided — a query without `purpose` is audited without a session id and does not group with the session's other calls. |
 
 ### `list_data_sources`
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,15 +1,26 @@
-# MCP Binding — `skardi mcp`
+# MCP Binding
 
-`skardi mcp` serves the [Model Context Protocol](https://modelcontextprotocol.io)
-over stdio, making Skardi's pipelines and ad-hoc query surface available to
-any MCP host — Claude Desktop, Cursor, or your own agent loop. It is the
-third agent-facing binding of the same pipeline YAML, next to the shell verb
-(`skardi run`) and REST (`POST /<name>/execute`).
+Skardi serves the [Model Context Protocol](https://modelcontextprotocol.io)
+over two transports of the same tool surface — pipelines, ad-hoc `query`,
+and `list_data_sources`:
 
-The subcommand is a transport bridge, not a second engine: the host spawns
-`skardi mcp` as a long-lived child process and speaks JSON-RPC to it over
-stdin/stdout; every tool call is proxied to a running `skardi-server` over
-REST and the response is returned verbatim.
+- **Local (stdio)** — `skardi mcp`, a CLI subcommand the host spawns as a
+  child process. For hosts that run a local binary: Claude Desktop, Cursor,
+  your own agent loop.
+- **Remote (streamable HTTP)** — `/mcp` on skardi-server itself. For hosts
+  that cannot spawn one: claude.ai, mobile clients, hosted agent platforms.
+  See [Remote (streamable HTTP)](#remote-streamable-http).
+
+Both are the same agent-facing binding of the same pipeline YAML, next to
+the shell verb (`skardi run`) and REST (`POST /<name>/execute`). The stdio
+bridge is not retired by the HTTP endpoint.
+
+Neither transport is a second engine. The bridge is a long-lived child
+process speaking JSON-RPC over stdin/stdout that proxies every tool call to
+a running `skardi-server` over REST and returns the response verbatim; the
+HTTP endpoint is a protocol adapter inside the server that dispatches each
+tool call to its own REST routes in-process — same handlers, same
+validation, same audit path.
 
 ```
 ┌──────────────┐  stdio (JSON-RPC)  ┌────────────────────┐  HTTP (REST)  ┌───────────────┐
@@ -17,11 +28,17 @@ REST and the response is returned verbatim.
 │ (Claude       │  spawned as a     │  (CLI subcommand:   │  ApiClient,  │  (executes     │
 │  Desktop, …)  │  child process    │   MCP ⇄ REST bridge)│  Bearer auth │   SQL)         │
 └──────────────┘                    └────────────────────┘               └───────────────┘
+
+┌──────────────┐  streamable HTTP (JSON-RPC over POST + SSE)  ┌────────────────────────┐
+│  MCP host     │ ◄──────────────────────────────────────────► │  skardi-server /mcp     │
+│ (claude.ai,   │  Authorization: Bearer <token>               │  (in-process dispatch   │
+│  hosted, …)   │                                              │   to its REST handlers) │
+└──────────────┘                                               └────────────────────────┘
 ```
 
 ---
 
-## Host setup
+## Host setup (stdio bridge)
 
 Claude Desktop (`claude_desktop_config.json`):
 
@@ -63,6 +80,60 @@ before serving instead of offering tools that would all fail.
 
 ---
 
+## Remote (streamable HTTP)
+
+skardi-server serves the same MCP tool surface at `http://<server>/mcp` —
+default-on, no config flag. Hosts that take a URL instead of a command
+connect directly:
+
+```json
+{
+  "mcpServers": {
+    "skardi": {
+      "url": "http://localhost:8080/mcp"
+    }
+  }
+}
+```
+
+**Auth is Bearer-only and covers everything.** With auth enabled, every
+`/mcp` request — `initialize` and `tools/list` included — requires
+`Authorization: Bearer <token>`. This is a deliberate divergence from REST,
+where `GET /pipelines` is readable without a token: on `/mcp` the tool
+inventory sits behind the same credential as execution. Session cookies are
+never accepted on `/mcp`.
+
+**Host allowlist.** As DNS-rebinding protection, a request is accepted only
+when its `Host` header is on the allowlist: loopback (`localhost`,
+`127.0.0.1`, `::1`) by default, plus any values declared with the
+repeatable server flag:
+
+```bash
+skardi-server --mcp-allowed-host api.example.com --mcp-allowed-host api.example.com:8443
+```
+
+An entry with a port matches that port exactly; a portless entry matches
+the host on any port. There is deliberately no allow-any option — a public
+deployment names its hostnames.
+
+**Reverse proxies.** Either forward the public `Host` and declare it via
+`--mcp-allowed-host`, or rewrite `Host` to the upstream loopback authority.
+A mismatch presents as `403 Forbidden: Host header is not allowed`. Long
+tool calls hold their POST open for the whole run; responses are SSE with a
+15 s keep-alive so bytes keep flowing, but deployments running long
+pipelines should still check proxy read timeouts (nginx's
+`proxy_read_timeout` defaults to 60 s, and a keep-alive only helps when the
+proxy counts any bytes as liveness).
+
+**Audit grouping.** A legacy-protocol session (2025-11-25 and earlier)
+groups its queries and pipeline runs in the query-audit ledger under the
+transport's `Mcp-Session-Id`. Stateless-protocol requests (2026-07-28 and
+later) are attributed per-request with a minted UUID — that protocol
+revision removed the conversation-level handle, so there is nothing durable
+to group by.
+
+---
+
 ## Tool surface
 
 ### Pipeline tools
@@ -91,10 +162,11 @@ description to any parameter via `spec.parameters` in the pipeline YAML
 schema as the standard `description` keyword, so the model no longer has
 to guess semantics from the parameter name alone.
 
-Every pipeline call carries the connection's session id as
-`X-Skardi-Session-Id` — the same id `query` sends in
-`ai_context.session_id` — so one MCP session's pipeline runs and ad-hoc
-queries group together in the query audit ledger.
+Every pipeline call carries a session id as `X-Skardi-Session-Id` — the
+same id `query` sends in `ai_context.session_id` — so an MCP session's
+pipeline runs and ad-hoc queries group together in the query audit ledger.
+On the stdio bridge that id is one UUID per MCP connection; on `/mcp` see
+audit grouping under [Remote (streamable HTTP)](#remote-streamable-http).
 
 ### `query`
 
@@ -104,7 +176,7 @@ Ad-hoc SQL against the federated engine — the MCP face of `POST /query`.
 |---|---|---|
 | `sql` | string, **required** | One statement. DML only on `access_mode: read_write` sources; DDL is always rejected. |
 | `max_rows` | integer, optional | Result row cap; server default 1000. |
-| `purpose` | string, optional | One line on why you are running this query. Sent as `ai_context: {purpose, session_id}` and recorded in the server's query audit log; the `session_id` is one UUID per MCP connection, so a session's queries group together in the ledger. Omitted entirely when not provided. |
+| `purpose` | string, optional | One line on why you are running this query. Sent as `ai_context: {purpose, session_id}` and recorded in the server's query audit log; the `session_id` is the same per-connection (bridge) or per-session/per-request (`/mcp`) id pipeline calls carry, so related calls group together in the ledger. Omitted entirely when not provided. |
 
 ### `list_data_sources`
 
@@ -118,24 +190,34 @@ Call it before writing ad-hoc SQL with `query`.
 
 The pipeline inventory is fetched from `GET /pipelines` on **every**
 `tools/list` request — a pipeline added to the server appears as soon as the
-host re-lists. Hosts that list once at connect time and never again keep
-their snapshot until reconnect. The bridge does not emit `listChanged`
-notifications in v1.
+host re-lists. (`/mcp` goes one further and re-resolves the inventory on
+every pipeline `tools/call` too, so a rename between list and call is an
+in-band "unknown tool" nudge to re-list, never a stale dispatch.) Hosts
+that list once at connect time and never again keep their snapshot until
+reconnect. Neither binding emits `listChanged` notifications in v1.
 
 ---
 
 ## Auth notes
 
-The bridge sends the Bearer token it inherits from normal CLI config
-resolution on every REST call. Note that on today's server, `GET /pipelines`
-(the tool inventory) and `GET /data_source` are readable without a token —
-existing REST behavior, not something the bridge adds. Deployments whose
-table names or column semantics are sensitive should weigh access to
-`/data_source` and `/pipelines` together.
+Per binding:
+
+- **stdio bridge** — sends the Bearer token it inherits from normal CLI
+  config resolution on every REST call. Note that on today's server,
+  `GET /pipelines` (the tool inventory) and `GET /data_source` are readable
+  without a token — existing REST behavior, not something the bridge adds.
+  Deployments whose table names or column semantics are sensitive should
+  weigh access to `/data_source` and `/pipelines` together.
+- **`/mcp`** — once auth is on, the Bearer token is required for every
+  request, tool inventory included, and cookies are never accepted; see
+  [Remote (streamable HTTP)](#remote-streamable-http). The REST inventory
+  exception above does not extend here.
 
 ---
 
 ## Timeouts & lifecycle
+
+Stdio bridge:
 
 - **No bridge-side request timeout.** A hung server hangs the tool call
   until the MCP host's own tool-call timeout fires — every mainstream host
@@ -146,12 +228,27 @@ table names or column semantics are sensitive should weigh access to
 - **Lifecycle is host-driven.** When the host closes stdin, the bridge exits
   `0`; in-flight REST calls die with the process.
 
-REST failures during serving are reported in-band, not as crashes: any
-failed tool call — a 4xx/5xx from the server or an unreachable server —
-becomes a tool result with `isError: true` carrying the error text (the same
-"cannot reach skardi-server" wording the CLI prints). A `tools/list` that
-can't reach the server is the one JSON-RPC-level error, since there is no
-tool result to attach it to.
+`/mcp`:
+
+- **Per-request lifecycle — there is no process to exit.** Each JSON-RPC
+  request is one HTTP exchange; a host that disconnects simply stops
+  sending requests.
+- **Disconnect semantics follow the SSE response mode.** A tool call's
+  response is an SSE stream with a 15 s keep-alive; a client that drops the
+  connection abandons that response.
+- **The host's tool-call timeout remains the backstop.** The endpoint adds
+  no timeout of its own; the keep-alive exists so reverse proxies don't
+  fire theirs first (see the reverse-proxy notes above).
+
+Execution failures are reported in-band on both transports: a 4xx/5xx from
+the REST handlers becomes a tool result with `isError: true` carrying the
+error text, for the model to see and react to. On the bridge, an
+unreachable server surfaces the same way (the "cannot reach skardi-server"
+wording the CLI prints), and a `tools/list` that can't reach the server is
+the one JSON-RPC-level error, since there is no tool result to attach it
+to; in-process dispatch on `/mcp` has no unreachable-server case, and its
+one JSON-RPC-level tool-call error is an unknown tool name (with a nudge to
+re-issue `tools/list`).
 
 ---
 
@@ -171,5 +268,6 @@ tool result to attach it to.
   collision rules above; the original pipeline name is always echoed in the
   tool description.
 - **Result size** — `query` results are capped by `max_rows` (default
-  1000). Pipeline executions are not row-capped server-side; the bridge
-  refuses response bodies over 256 MB (the CLI-wide client ceiling).
+  1000). Pipeline executions are not row-capped server-side; both bindings
+  refuse response bodies over 256 MB (the CLI-wide client ceiling, restated
+  by the `/mcp` handler).

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -54,8 +54,10 @@ spec:
 ```
 
 The loader is strict — a file without `kind: pipeline` at the root is
-rejected at startup, and a pipeline file under a `--jobs` directory is
-silently skipped.
+rejected at startup, and so is one with an empty `metadata.name` (the name
+is the `<name>` segment of `POST /<name>/execute`, so an empty one could
+never be called); a pipeline file under a `--jobs` directory is silently
+skipped.
 
 ### Parameter placeholders
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -15,8 +15,10 @@ One pipeline YAML drives every agent-facing surface:
 - **Shell** — `skardi run <name> --param=…` from the CLI today.
 - **Claude skills** — auto-generated Markdown under `.claude/skills/` (v1.1
   roadmap).
-- **MCP tools** — same YAML projected to MCP tools for non-Claude hosts via
-  `skardi mcp` — see [mcp.md](mcp.md).
+- **MCP tools** — same YAML projected to MCP tools, over two transports:
+  the `skardi mcp` stdio bridge for hosts that spawn a local binary, and
+  the server's `/mcp` streamable-HTTP endpoint for hosts that can't — see
+  [mcp.md](mcp.md).
 
 This page covers the pipeline YAML shape, parameter inference, invocation,
 and response format. For the HTTP binding and shared concerns (context
@@ -88,7 +90,7 @@ comes from the SQL, and every key under `spec.parameters` must name a
 load, and so does a blank description. Text is trimmed on load, so block
 scalars (`>`) publish without their trailing newline. Each description is published as the standard `description` keyword
 inside that parameter's `json_schema` in the enriched `GET /pipelines`
-inventory, which `skardi mcp` projects verbatim into MCP tool input
+inventory, which both MCP bindings project verbatim into MCP tool input
 schemas — the sentence written here is exactly what a model reads before
 filling the parameter.
 

--- a/docs/superpowers/plans/2026-09-01-mcp-http-transport.md
+++ b/docs/superpowers/plans/2026-09-01-mcp-http-transport.md
@@ -1,0 +1,1016 @@
+# MCP Streamable HTTP Transport (`/mcp`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** skardi-server speaks MCP over streamable HTTP at `/mcp` — a protocol adapter that translates every tool call into a synthetic in-process request against the server's own REST router.
+
+**Architecture:** A new `skardi-mcp-core` crate holds the projection layer shared with the stdio bridge; a new `crates/server/src/mcp/` module implements a stateless `ServerHandler` that self-dispatches via `tower::ServiceExt::oneshot` over a pre-middleware capture of the REST router, wrapped by a Bearer-only session gate and rmcp's streamable-HTTP service nested at `/mcp`.
+
+**Tech Stack:** Rust, axum 0.7, tower 0.4 (`util`), rmcp `=3.1.4` (`server`, `transport-streamable-http-server`), uuid, percent-encoding.
+
+**Spec:** `docs/superpowers/specs/2026-08-28-mcp-http-transport-design.md` — the plan argues from the spec; executors read both.
+
+## Global Constraints
+
+- **No local test runs** (repo policy): verification is GitHub CI only. Before every push run `cargo fmt` — nothing else. Task-level "verify" steps mean "will be verified by CI on the PR"; write the tests, don't run them.
+- CI runs all `#[ignore]` tests bare — nothing in this plan needs `#[ignore]` (spec: all tests self-contained).
+- rmcp is pinned `=3.1.4` everywhere; `default-features = false` on every rmcp dependency entry.
+- The CLI refactor must be behavior-neutral: existing bridge unit tests and `mcp_e2e` pass unchanged (except import paths).
+- All work lands on branch `mcp-http-transport` (created from `main`); commits per task; draft PR at the end.
+- Commit messages in English, ending with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+Verified API facts (from rmcp 3.1.4 source, so tasks don't re-derive them):
+
+- `StreamableHttpService::new(factory: impl Fn() -> Result<S, io::Error>, Arc<LocalSessionManager>, StreamableHttpServerConfig)`; the service implements `tower_service::Service<http::Request<B>>` with `Response = BoxResponse` (`http::Response<BoxBody<Bytes, Infallible>>`), `Error = Infallible`, and is `Clone`.
+- `StreamableHttpServerConfig::default()`: `sse_keep_alive: Some(15s)`, `legacy_session_mode: true`, `json_response: false`, `allowed_hosts: ["localhost", "127.0.0.1", "::1"]`, `allowed_origins: []` (empty = Origin validation disabled).
+- `with_allowed_hosts` **replaces** the list — additive semantics means we build `loopback trio + declared` ourselves.
+- Host validation: missing `Host` header AND no `:authority` → 400; disallowed → 403. Tests driving `/mcp` via `oneshot` must set a `Host` header explicitly.
+- rmcp injects `http::request::Parts` into `RequestContext::extensions` (`ctx.extensions.get::<http::request::Parts>()`) on every request, stateless mode included.
+- Client side for tests: features `client` + `transport-streamable-http-client-reqwest`; `StreamableHttpClientTransport::from_uri(...)` / `StreamableHttpClientTransport::with_client(reqwest::Client, StreamableHttpClientTransportConfig::with_uri(...).auth_header(token))`.
+- Legacy session header name is `mcp-session-id` (`rmcp::transport::common::http_header::HEADER_SESSION_ID`).
+
+---
+
+### Task 1: Extract `crates/mcp-core` (package `skardi-mcp-core`) and rewire the CLI
+
+**Files:**
+- Create: `crates/mcp-core/Cargo.toml`
+- Create: `crates/mcp-core/src/lib.rs`
+- Create: `crates/mcp-core/src/projection.rs` (moved from `crates/cli/src/mcp/projection.rs`)
+- Modify: `Cargo.toml` (workspace members)
+- Modify: `crates/cli/Cargo.toml` (add `skardi-mcp-core`; fix the falsified rmcp comment)
+- Delete: `crates/cli/src/mcp/projection.rs`
+- Modify: `crates/cli/src/mcp/mod.rs`, `crates/cli/src/mcp/bridge.rs` (imports)
+- Modify: `crates/cli/src/client.rs` (drop `encode_component` + `URL_COMPONENT` + their test; re-export from the crate)
+
+**Interfaces:**
+- Produces: `skardi_mcp_core::projection::{project, builtin_tools, QUERY, LIST_DATA_SOURCES, RESERVED_NAMES}` (all `pub`), `skardi_mcp_core::encode_component` — signatures unchanged from today: `pub fn project(inventory: &Value) -> (Vec<Tool>, HashMap<String, String>)`, `pub fn builtin_tools() -> Vec<Tool>`, `pub fn encode_component(raw: &str) -> String`.
+
+- [ ] **Step 1: Create the crate**
+
+`crates/mcp-core/Cargo.toml`:
+
+```toml
+[package]
+name = "skardi-mcp-core"
+version.workspace = true
+edition.workspace = true
+description = "Shared MCP projection layer: pipeline inventory -> MCP tool definitions"
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+
+[dependencies]
+# Model types only — no features. Preserves the intent behind the CLI's
+# deliberate default-features = false pin (rmcp's transports stay out of
+# this crate's own graph; each binding picks its transport itself).
+rmcp = { version = "=3.1.4", default-features = false }
+percent-encoding = "2.3"
+serde_json = { workspace = true }
+
+[lints]
+workspace = true
+```
+
+`crates/mcp-core/src/lib.rs`:
+
+```rust
+//! The knowledge shared by every Skardi MCP binding: projecting the enriched
+//! `GET /pipelines` inventory into MCP tool definitions, the built-in tool
+//! names, and the pipeline-name -> URL path encoding of the tool->REST
+//! translation contract. The dispatch matches themselves deliberately stay
+//! per-binding (stdio bridge, server `/mcp`): same shape, different error
+//! types and identity carriers.
+
+pub mod projection;
+
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
+
+/// Characters percent-encoded by [`encode_component`]: everything except
+/// ASCII alphanumerics and the RFC 3986 "unreserved" marks (`-`, `.`, `_`,
+/// `~`). Deliberately conservative — over-encoding is always valid, while
+/// missing a reserved character (`/`, `?`, `#`, `%`, space, …) mis-routes
+/// the request.
+const URL_COMPONENT: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~');
+
+/// Percent-encode one URL path segment or query value (user-supplied
+/// pipeline/job names, run ids) so characters like `/`, `?`, `#`, `%`, and
+/// spaces cannot alter the request route.
+pub fn encode_component(raw: &str) -> String {
+    utf8_percent_encode(raw, URL_COMPONENT).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn encode_component_escapes_reserved_and_keeps_unreserved() {
+        use super::encode_component;
+        assert_eq!(encode_component("simple-name_1.2~x"), "simple-name_1.2~x");
+        assert_eq!(encode_component("a/b"), "a%2Fb");
+        assert_eq!(encode_component("a b?c#d%e"), "a%20b%3Fc%23d%25e");
+    }
+}
+```
+
+(The `encode_component` test body must match what `crates/cli/src/client.rs` has today — copy it verbatim when deleting it there, don't retype from this plan.)
+
+- [ ] **Step 2: Move projection.rs wholesale**
+
+Copy `crates/cli/src/mcp/projection.rs` → `crates/mcp-core/src/projection.rs` with exactly two mechanical transformations, nothing else:
+- every `pub(crate)` → `pub` (items: `QUERY`, `LIST_DATA_SOURCES`, `RESERVED_NAMES`, `builtin_tools`, `project`)
+- module doc comment gains one line noting it is shared by the stdio bridge and the server's `/mcp` handler.
+
+All unit tests move with the file unchanged. Delete the original.
+
+- [ ] **Step 3: Workspace + CLI wiring**
+
+`Cargo.toml` (root): add `"crates/mcp-core"` to `[workspace] members`.
+
+`crates/cli/Cargo.toml`: add `skardi-mcp-core = { path = "../mcp-core" }`; replace the rmcp comment (falsified by feature unification once the server pulls rmcp's HTTP stack into workspace builds) with:
+
+```toml
+# The MCP-over-stdio bridge (`skardi mcp`). default-features = false keeps
+# rmcp's optional stacks out of THIS crate's own dependency graph;
+# `transport-io` is the server-side stdio transport. Note: with resolver = "2",
+# a whole-workspace build unifies features across members, so skardi-server's
+# rmcp HTTP features do get compiled into that build graph — the pin here
+# governs what `cargo build -p skardi-cli` alone pulls in. rmcp has no runtime
+# axum dependency (verified against the 3.1.4 source), so no axum skew either way.
+```
+
+`crates/cli/src/mcp/mod.rs`: drop `mod projection;`.
+
+`crates/cli/src/mcp/bridge.rs`: replace `use crate::mcp::projection;` with `use skardi_mcp_core::projection;` and `use crate::client::{ApiClient, ApiError, encode_component};` stays (re-export below keeps it working).
+
+`crates/cli/src/client.rs`: delete `URL_COMPONENT`, `encode_component`, the `percent_encoding` import, and the `encode_component_escapes_reserved_and_keeps_unreserved` test (moved in Step 1); add near the top:
+
+```rust
+// The pipeline-name -> URL path encoding is part of the tool->REST
+// translation contract shared with the server's /mcp binding; the CLI
+// re-exports it so command modules keep importing from crate::client.
+pub use skardi_mcp_core::encode_component;
+```
+
+- [ ] **Step 4: `cargo fmt`**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(mcp): extract skardi-mcp-core — shared projection + encode_component"
+```
+
+---
+
+### Task 2: `validate_session_id` — the shared predicate, callable on a plain value
+
+**Files:**
+- Modify: `crates/server/src/session_header.rs`
+
+**Interfaces:**
+- Produces: `pub fn validate_session_id(s: &str) -> Result<(), String>` — same rules `session_id_from_headers` enforces today (visible ASCII, no comma, non-empty, ≤ `MAX_SESSION_ID_CHARS`). Task 4's handler validates inbound `Mcp-Session-Id` values against it (the third mirror, after the server's header path and the CLI's `crates/cli/src/session.rs`).
+
+- [ ] **Step 1: Extract the predicate**
+
+Refactor `session_id_from_headers` so the value checks live in a new function it calls (header-shape checks — duplicate header, non-ASCII encoding — stay where they are):
+
+```rust
+/// Validate one session-id VALUE against the rules above, independent of the
+/// header plumbing. Public so the server's `/mcp` handler can vet a
+/// caller-minted `Mcp-Session-Id` against the same predicate before
+/// forwarding it as `x-skardi-session-id` (falling back to a minted UUID on
+/// mismatch — losing that call's session grouping, not the call).
+pub fn validate_session_id(s: &str) -> Result<(), String> {
+    if !s.chars().all(|c| c.is_ascii_graphic() && c != ',') {
+        return Err(format!(
+            "{SESSION_ID_HEADER} must contain only visible ASCII characters, \
+             with no spaces and no commas (proxies may merge repeated header \
+             lines into one comma-separated value)"
+        ));
+    }
+    if s.is_empty() {
+        return Err(format!("{SESSION_ID_HEADER} must not be empty"));
+    }
+    if s.chars().count() > MAX_SESSION_ID_CHARS {
+        return Err(format!(
+            "{SESSION_ID_HEADER} must be at most {MAX_SESSION_ID_CHARS} characters"
+        ));
+    }
+    Ok(())
+}
+```
+
+`session_id_from_headers` keeps its exact behavior by delegating: after `to_str()`, call `validate_session_id(s)?` and return `Ok(Some(s.to_string()))`. (Note today's check order is charset → empty → length; keep that order so error messages don't change.)
+
+- [ ] **Step 2: Unit test**
+
+Add to the existing test module (or create one if the file has none — check first):
+
+```rust
+#[test]
+fn validate_session_id_matches_the_header_rules() {
+    assert!(validate_session_id("sess-1").is_ok());
+    assert!(validate_session_id("").is_err());
+    assert!(validate_session_id("has space").is_err());
+    assert!(validate_session_id("a,b").is_err());
+    assert!(validate_session_id(&"x".repeat(201)).is_err());
+    assert!(validate_session_id(&"x".repeat(200)).is_ok());
+}
+```
+
+- [ ] **Step 3: `cargo fmt`, commit**
+
+```bash
+git add crates/server/src/session_header.rs
+git commit -m "refactor(server): extract validate_session_id from the header path"
+```
+
+---
+
+### Task 3: Server dependencies + `--mcp-allowed-host` flag
+
+**Files:**
+- Modify: `crates/server/Cargo.toml`
+- Modify: `crates/server/src/config.rs` (CliArgs)
+- Modify: every `CliArgs { ... }` struct literal (grep `CliArgs {`): `crates/server/src/server.rs`, `crates/server/src/config.rs`, `crates/server/src/auth/routes.rs`, `crates/server/src/pipeline_handlers.rs`, `crates/server/tests/{pipelines_http,query_http,jobs_http,jobs_auth_http,jobs_audit_http,pipeline_audit_http,jobs_bridge_startup,graph_views,semantics_endpoint}.rs`
+
+**Interfaces:**
+- Produces: `CliArgs.mcp_allowed_hosts: Vec<String>` (empty by default), read by Task 5's service construction.
+
+- [ ] **Step 1: Cargo changes**
+
+In `crates/server/Cargo.toml` `[dependencies]`:
+
+```toml
+rmcp = { version = "=3.1.4", default-features = false, features = ["server", "transport-streamable-http-server"] }
+skardi-mcp-core = { path = "../mcp-core" }
+uuid = { workspace = true }
+```
+
+and change the tower entry to promote `oneshot` to production code explicitly rather than leaning on feature unification:
+
+```toml
+tower = { workspace = true, features = ["util"] }
+```
+
+- [ ] **Step 2: The flag**
+
+Append to `CliArgs` in `crates/server/src/config.rs`:
+
+```rust
+/// Extra `Host` header values `/mcp` accepts, appended to the always-allowed
+/// loopback trio (localhost / 127.0.0.1 / ::1). rmcp's loopback-only default
+/// is a DNS-rebinding defense; a remote deployment declares its public
+/// hostnames here instead of an allow-any escape hatch. An entry with a port
+/// matches that port exactly; without one it matches any port. Repeatable.
+#[arg(
+    long = "mcp-allowed-host",
+    help = "Allow this Host header value on /mcp, in addition to loopback \
+            (repeatable; host or host:port)"
+)]
+pub mcp_allowed_hosts: Vec<String>,
+```
+
+- [ ] **Step 3: Fix every struct literal**
+
+Add `mcp_allowed_hosts: vec![],` to every `CliArgs { ... }` literal found by `grep -rn "CliArgs {" crates`.
+
+- [ ] **Step 4: Clap parse test**
+
+In `crates/server/src/config.rs`'s existing CLI-parse test module (near the `CliArgs::try_parse_from` tests around line 2700):
+
+```rust
+#[test]
+fn mcp_allowed_host_is_repeatable_and_defaults_empty() {
+    let args = CliArgs::try_parse_from([
+        "skardi-server",
+        "--mcp-allowed-host",
+        "api.example.com",
+        "--mcp-allowed-host",
+        "skardi.internal:8443",
+    ])
+    .unwrap();
+    assert_eq!(
+        args.mcp_allowed_hosts,
+        vec!["api.example.com".to_string(), "skardi.internal:8443".to_string()]
+    );
+    let args = CliArgs::try_parse_from(["skardi-server"]).unwrap();
+    assert!(args.mcp_allowed_hosts.is_empty());
+}
+```
+
+- [ ] **Step 5: `cargo fmt`, commit**
+
+```bash
+git add -A
+git commit -m "feat(server): rmcp + mcp-core deps, --mcp-allowed-host flag"
+```
+
+---
+
+### Task 4: The MCP handler (`crates/server/src/mcp/handler.rs`)
+
+**Files:**
+- Create: `crates/server/src/mcp/handler.rs`
+- Create: `crates/server/src/mcp/mod.rs` (minimal: `pub(crate) mod handler;` — grows in Task 5)
+- Modify: `crates/server/src/lib.rs` (`pub(crate) mod mcp;`)
+
+**Interfaces:**
+- Consumes: `skardi_mcp_core::{projection, encode_component}` (Task 1), `crate::session_header::validate_session_id` (Task 2).
+- Produces: `pub(crate) struct McpHandler` with `pub(crate) fn new(rest: Router) -> Self`, `pub(crate) async fn do_list_tools(&self, headers: &HeaderMap) -> Result<ListToolsResult, ErrorData>`, `pub(crate) async fn do_call_tool(&self, name: &str, args: Option<JsonObject>, headers: &HeaderMap) -> Result<CallToolResult, ErrorData>`; implements `rmcp::ServerHandler`. Task 5 wraps it in the service factory.
+
+- [ ] **Step 1: Write the handler**
+
+```rust
+//! MCP ⇄ REST protocol adapter: a stateless `ServerHandler` whose every tool
+//! call becomes a synthetic HTTP request dispatched in-process against the
+//! server's own REST router (`tower::ServiceExt::oneshot`) — the same
+//! mechanism the HTTP tests use. The captured router is the pre-middleware
+//! one; see `configure_routes` for the transport-vs-execution boundary.
+//!
+//! Stateless by protocol: MCP `2026-07-28` removes sessions (SEP-2567) and
+//! rmcp constructs this handler once per request on that path, so it owns
+//! only the Arc-cheap `Router` clone — no tool map, no per-session state.
+//! Pipeline tool names are resolved per call.
+//!
+//! The MCP trait methods are thin wrappers over inherent `do_*` methods
+//! (taking the inbound headers as a plain parameter): `RequestContext` is
+//! `#[non_exhaustive]`, so tests drive the `do_*` methods directly.
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{HeaderMap, Method, Request, StatusCode, header};
+use rmcp::ServerHandler;
+use rmcp::model::{
+    CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ErrorData,
+    Implementation, JsonObject, ListToolsResult, PaginatedRequestParams, ServerCapabilities,
+    ServerInfo,
+};
+use rmcp::service::{RequestContext, RoleServer};
+use serde_json::Value;
+use skardi_mcp_core::{encode_component, projection};
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use crate::session_header::{SESSION_ID_HEADER, validate_session_id};
+
+/// Same wording as the stdio bridge (`crates/cli/src/mcp/bridge.rs`) — the
+/// two bindings present one product to hosts. Kept per-binding (not in
+/// skardi-mcp-core) so either side can diverge deliberately.
+const INSTRUCTIONS: &str = "Skardi is a federated SQL data plane: operator-defined \
+pipelines plus an ad-hoc SQL engine over the configured data sources. Prefer the \
+pipeline tools for tasks they cover. Before writing ad-hoc SQL with `query`, call \
+`list_data_sources` to see tables, schemas, and their plain-English descriptions.";
+
+/// Ceiling on a synthetic response body — the same 256 MB the stdio bridge
+/// inherits from the CLI client (`crates/cli/src/client.rs`), kept as a
+/// constant so one pipeline behaves identically through both bindings.
+/// In-process this bounds only the MCP layer's own copy of the result; the
+/// REST handler has already materialized the full result before the
+/// collector sees a byte (execution-layer resource governance is a recorded
+/// server-wide non-goal).
+const MAX_RESPONSE_BYTES: usize = 256 * 1024 * 1024;
+
+/// The legacy-protocol session header rmcp echoes on every request of a
+/// managed session (`legacy_session_mode`). Stateless-protocol requests
+/// don't carry it.
+const MCP_SESSION_ID: &str = "mcp-session-id";
+
+#[derive(Clone)]
+pub(crate) struct McpHandler {
+    /// Pre-middleware capture of the REST router (routing table + handlers,
+    /// where every execution concern lives: `require_session`, validation,
+    /// audit). Arc-cheap to clone; the service factory clones it per request.
+    rest: Router,
+}
+
+impl McpHandler {
+    pub(crate) fn new(rest: Router) -> Self {
+        McpHandler { rest }
+    }
+
+    /// The audit id for this request, layered: a valid legacy
+    /// `Mcp-Session-Id` groups the session's calls together; anything else
+    /// (stateless protocol, malformed value) gets a per-request UUID —
+    /// attribution stays intact, grouping granularity is honestly
+    /// per-request.
+    fn request_session_id(headers: &HeaderMap) -> String {
+        headers
+            .get(MCP_SESSION_ID)
+            .and_then(|v| v.to_str().ok())
+            .filter(|s| validate_session_id(s).is_ok())
+            .map(str::to_string)
+            .unwrap_or_else(|| Uuid::new_v4().to_string())
+    }
+
+    /// Build and dispatch one synthetic request against the captured REST
+    /// router. Forwards the inbound `Authorization` verbatim (omitted when
+    /// the caller sent none) so handler-level enforcement and ledger
+    /// recording are exactly the REST semantics; sets
+    /// `content-type: application/json` when there is a body.
+    async fn dispatch(
+        &self,
+        method: Method,
+        path: &str,
+        inbound: &HeaderMap,
+        extra_headers: &[(&str, &str)],
+        body: Option<Value>,
+    ) -> Result<(StatusCode, String), ErrorData> {
+        let mut builder = Request::builder().method(method).uri(path);
+        if let Some(auth) = inbound.get(header::AUTHORIZATION) {
+            builder = builder.header(header::AUTHORIZATION, auth.clone());
+        }
+        for (name, value) in extra_headers {
+            builder = builder.header(*name, *value);
+        }
+        let request = match body {
+            Some(v) => builder
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(v.to_string())),
+            None => builder.body(Body::empty()),
+        }
+        .map_err(|e| ErrorData::internal_error(format!("synthetic request: {e}"), None))?;
+        // In-process: a dispatch failure is a bug, not a network condition.
+        let response = self
+            .rest
+            .clone()
+            .oneshot(request)
+            .await
+            .map_err(|e| ErrorData::internal_error(format!("synthetic dispatch: {e}"), None))?;
+        let status = response.status();
+        let bytes = axum::body::to_bytes(response.into_body(), MAX_RESPONSE_BYTES)
+            .await
+            .map_err(|e| {
+                ErrorData::internal_error(format!("collecting synthetic response: {e}"), None)
+            })?;
+        Ok((status, String::from_utf8_lossy(&bytes).into_owned()))
+    }
+
+    /// Fetch + project the live inventory. Used by `tools/list` and by every
+    /// pipeline `tools/call` (per-call name resolution: one extra in-process
+    /// dispatch buys correctness in both protocol modes and freshness by
+    /// construction — a stale-map "unknown tool" cannot exist).
+    async fn project_inventory(
+        &self,
+        headers: &HeaderMap,
+    ) -> Result<(Vec<rmcp::model::Tool>, std::collections::HashMap<String, String>), ErrorData>
+    {
+        let (status, body) = self
+            .dispatch(Method::GET, "/pipelines", headers, &[], None)
+            .await?;
+        if !status.is_success() {
+            return Err(ErrorData::internal_error(
+                format!("GET /pipelines answered {status}: {body}"),
+                None,
+            ));
+        }
+        let inventory: Value = serde_json::from_str(&body).map_err(|e| {
+            ErrorData::internal_error(format!("GET /pipelines returned non-JSON: {e}"), None)
+        })?;
+        Ok(projection::project(&inventory))
+    }
+
+    pub(crate) async fn do_list_tools(
+        &self,
+        headers: &HeaderMap,
+    ) -> Result<ListToolsResult, ErrorData> {
+        let (tools, _) = self.project_inventory(headers).await?;
+        Ok(ListToolsResult::with_all_items(tools))
+    }
+
+    pub(crate) async fn do_call_tool(
+        &self,
+        name: &str,
+        args: Option<JsonObject>,
+        headers: &HeaderMap,
+    ) -> Result<CallToolResult, ErrorData> {
+        let session_id = Self::request_session_id(headers);
+        let (status, body) = match name {
+            projection::QUERY => {
+                let body = Self::query_body(args, &session_id);
+                self.dispatch(Method::POST, "/query", headers, &[], Some(body))
+                    .await?
+            }
+            projection::LIST_DATA_SOURCES => {
+                self.dispatch(Method::GET, "/data_source", headers, &[], None)
+                    .await?
+            }
+            _ => {
+                let (_, map) = self.project_inventory(headers).await?;
+                let Some(pipeline) = map.get(name) else {
+                    // Protocol-level: covers host bugs and a server
+                    // re-configured since the host last listed.
+                    return Err(ErrorData::invalid_params(
+                        format!(
+                            "unknown tool '{name}' — the pipeline inventory may have \
+                             changed; re-issue tools/list to refresh it"
+                        ),
+                        None,
+                    ));
+                };
+                // Arguments pass through as the flat execute body — the
+                // server is the validator. The session header gives pipeline
+                // runs the same ledger attribution as `query`'s
+                // ai_context.session_id.
+                let body = Value::Object(args.unwrap_or_default());
+                let path = format!("/{}/execute", encode_component(pipeline));
+                self.dispatch(
+                    Method::POST,
+                    &path,
+                    headers,
+                    &[(SESSION_ID_HEADER, &session_id)],
+                    Some(body),
+                )
+                .await?
+            }
+        };
+        Ok(if status.is_success() {
+            // The response JSON verbatim, no reshaping.
+            CallToolResult::success(vec![ContentBlock::text(body)])
+        } else {
+            // Execution errors are for the model to see and react to (fix a
+            // parameter, pick another tool), not protocol errors.
+            CallToolResult::error(vec![ContentBlock::text(body)])
+        })
+    }
+
+    /// The one choke-point that assembles the `/query` body. When `purpose`
+    /// is absent, ai_context is omitted entirely — the server rejects a
+    /// partial object.
+    fn query_body(args: Option<JsonObject>, session_id: &str) -> Value {
+        let args = args.unwrap_or_default();
+        let mut body = serde_json::Map::new();
+        for key in ["sql", "max_rows"] {
+            if let Some(value) = args.get(key) {
+                body.insert(key.to_string(), value.clone());
+            }
+        }
+        if let Some(purpose) = args.get("purpose").and_then(Value::as_str) {
+            let purpose = purpose.trim();
+            if !purpose.is_empty() {
+                body.insert(
+                    "ai_context".to_string(),
+                    serde_json::json!({"purpose": purpose, "session_id": session_id}),
+                );
+            }
+        }
+        Value::Object(body)
+    }
+
+    /// The inbound request's headers, from the `http::request::Parts` rmcp
+    /// injects into every request's extensions (stateless mode included;
+    /// verified against the 3.1.4 source).
+    fn inbound_headers(context: &RequestContext<RoleServer>) -> HeaderMap {
+        context
+            .extensions
+            .get::<axum::http::request::Parts>()
+            .map(|parts| parts.headers.clone())
+            .unwrap_or_default()
+    }
+}
+
+impl ServerHandler for McpHandler {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::new("skardi", env!("CARGO_PKG_VERSION")))
+            .with_instructions(INSTRUCTIONS)
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, ErrorData> {
+        self.do_list_tools(&Self::inbound_headers(&context)).await
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResponse, ErrorData> {
+        self.do_call_tool(
+            &request.name,
+            request.arguments,
+            &Self::inbound_headers(&context),
+        )
+        .await
+        .map(CallToolResponse::from)
+    }
+}
+```
+
+(Adjust names against the real rmcp 3.1.4 API while implementing — e.g. `CallToolRequestParams`/`CallToolResponse` are what the bridge imports today, keep identical imports.)
+
+- [ ] **Step 2: Unit tests in the same file** (`#[cfg(test)] mod tests`)
+
+Test doubles: a **probe router** — a tiny axum `Router` standing in for the REST router, recording what the synthetic request carried. Pattern:
+
+```rust
+use axum::routing::{get, post};
+use axum::extract::Request as AxumRequest;
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, Default)]
+struct Seen(Arc<Mutex<Vec<(String, Option<String>, Option<String>, String)>>>);
+// (path, authorization, x-skardi-session-id, body)
+
+fn probe_router(seen: Seen, inventory: Value) -> Router {
+    let record = |seen: Seen| {
+        move |req: AxumRequest| {
+            let seen = seen.clone();
+            async move {
+                let (parts, body) = req.into_parts();
+                let hdr = |name: &str| {
+                    parts.headers.get(name).and_then(|v| v.to_str().ok()).map(String::from)
+                };
+                let auth = hdr("authorization");
+                let sid = hdr("x-skardi-session-id");
+                let bytes = axum::body::to_bytes(body, 1 << 20).await.unwrap();
+                seen.0.lock().unwrap().push((
+                    parts.uri.path().to_string(),
+                    auth,
+                    sid,
+                    String::from_utf8_lossy(&bytes).into_owned(),
+                ));
+                axum::Json(serde_json::json!({"success": true}))
+            }
+        }
+    };
+    Router::new()
+        .route("/pipelines", get(move || {
+            let inventory = inventory.clone();
+            async move { axum::Json(inventory) }
+        }))
+        .route("/query", post(record(seen.clone())))
+        .route("/data_source", get(record(seen.clone())))
+        .route("/:name/execute", post(record(seen)))
+}
+```
+
+Tests (each one bite-sized; write, then move on — CI verifies):
+
+1. `list_tools_projects_pipelines_and_builtins` — probe router with a one-pipeline inventory (same JSON shape as the bridge test's `inventory()`); `do_list_tools(&HeaderMap::new())` contains the pipeline tool + `query` + `list_data_sources`.
+2. `pipeline_call_resolves_per_call_and_posts_flat_body` — **no prior `do_list_tools`**: `do_call_tool("product-search", {"brand":"acme"}, empty headers)` succeeds (per-call resolution is the point), probe saw `/product-search/execute` with body `{"brand":"acme"}`.
+3. `authorization_is_forwarded_verbatim_and_absent_when_missing` — headers with `authorization: Bearer tok-1` → probe records it on the synthetic request; empty headers → probe records `None`.
+4. `legacy_mcp_session_id_is_echoed_as_the_audit_id` — headers with `mcp-session-id: legacy-42` → pipeline call's `x-skardi-session-id` is `legacy-42`; query call with `purpose` gets `ai_context.session_id == "legacy-42"`.
+5. `malformed_mcp_session_id_falls_back_to_a_minted_uuid` — `mcp-session-id: "has space"` (build via `HeaderValue::from_static`) → forwarded id parses as a UUID (`Uuid::parse_str` ok), the call succeeds (400 must not propagate).
+6. `stateless_request_mints_a_uuid_per_request` — no `mcp-session-id`: two pipeline calls record two DIFFERENT valid UUIDs.
+7. `unknown_tool_is_invalid_params_nudging_a_relist` — same assertion text as the bridge test.
+8. `non_2xx_becomes_is_error_with_the_body_text` — probe route answering 400 with a JSON error body → `is_error == Some(true)`, content contains the body text.
+9. `query_without_purpose_omits_ai_context` — probe body has no `ai_context` key.
+10. **The negative-auth tripwire** — `do_call_tool_hits_handler_level_auth_without_a_bearer`: build a REAL auth-enabled AppState (reuse the in-crate pattern from `crates/server/src/auth/routes.rs` tests: `make_better_auth_state` + `auth::test_env::lock`-style env guard), `configure_routes`-style REST router via `crate::server::rest_router(state)` (Task 5) or a locally-built router with the real `/query` handler; `do_call_tool("query", {"sql": "select 1"}, empty headers)` → `is_error == Some(true)` and content contains `"unauthorized"` / 401 wording. Comment: *if auth ever migrated into `configure_middleware`, this call would start succeeding — the tripwire for the middleware-boundary constraint.* (Depends on Task 5's `rest_router`; if writing tests before Task 5, gate on the locally-built real-handler router instead. Prefer landing this test in the same commit as Task 5.)
+
+- [ ] **Step 3: `cargo fmt`, commit**
+
+```bash
+git add -A
+git commit -m "feat(server): MCP handler — stateless protocol adapter over the REST router"
+```
+
+---
+
+### Task 5: Session gate + service construction + router wiring
+
+**Files:**
+- Create: `crates/server/src/mcp/gate.rs`
+- Modify: `crates/server/src/mcp/mod.rs`
+- Modify: `crates/server/src/server.rs` (`configure_routes` split + nest)
+
+**Interfaces:**
+- Consumes: `McpHandler` (Task 4), `CliArgs.mcp_allowed_hosts` (Task 3), `crate::auth::routes::verify_session`.
+- Produces: `pub(crate) fn attach(rest: Router, state: AppState) -> Router` (nests the gated MCP service at `/mcp`); `pub(crate) fn rest_router(state: AppState) -> Router` in server.rs (today's `configure_routes` body). `configure_routes` public signature unchanged: `pub fn configure_routes(state: AppState) -> Router`.
+
+- [ ] **Step 1: The session gate** (`crates/server/src/mcp/gate.rs`)
+
+```rust
+//! `/mcp`-specific transport middleware: every inbound request authenticates
+//! via `verify_session` BEFORE rmcp creates any session state — an anonymous
+//! `initialize` is a transport-level 401, not a retained session, and missing
+//! credentials surface as the 401 host credential flows key on (not as tool
+//! errors inside HTTP 200s). Never runs on synthetic dispatches.
+//!
+//! Bearer only: `verify_session`'s cookie fallback would admit callers whose
+//! every tool call then fails handler-level auth (synthetic requests forward
+//! only `Authorization`), so the gate strips `cookie` before the check —
+//! token validation stays single-home, the accepted carrier narrows to the
+//! one MCP hosts actually send. This is also what keeps the open
+//! `allowed_origins` posture honest: a browser's ambient cookie cannot
+//! authenticate `/mcp`, so there is no CSRF-shaped surface for Origin to
+//! guard. On a no-auth deployment `verify_session` always allows and the
+//! gate is a no-op.
+
+use std::convert::Infallible;
+use std::task::{Context, Poll};
+
+use axum::body::Body;
+use axum::http::{Request, header};
+use axum::response::{IntoResponse, Response};
+use futures::future::BoxFuture;
+
+use crate::server::AppState;
+
+#[derive(Clone)]
+pub(crate) struct SessionGate<S> {
+    inner: S,
+    state: AppState,
+}
+
+impl<S> SessionGate<S> {
+    pub(crate) fn new(inner: S, state: AppState) -> Self {
+        SessionGate { inner, state }
+    }
+}
+
+impl<S, B> tower::Service<Request<Body>> for SessionGate<S>
+where
+    S: tower::Service<Request<Body>, Response = axum::http::Response<B>, Error = Infallible>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send,
+    B: http_body::Body<Data = bytes::Bytes> + Send + 'static,
+    B::Error: Into<axum::BoxError>,
+{
+    type Response = Response;
+    type Error = Infallible;
+    type Future = BoxFuture<'static, Result<Response, Infallible>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Infallible>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        // Standard tower pattern: take the ready inner, leave a fresh clone.
+        let inner = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, inner);
+        let state = self.state.clone();
+        Box::pin(async move {
+            let mut headers = req.headers().clone();
+            headers.remove(header::COOKIE);
+            if let Err(unauthorized) = crate::auth::routes::verify_session(&state, &headers).await
+            {
+                return Ok(unauthorized.into_response());
+            }
+            Ok(inner.call(req).await.expect("Infallible").into_response())
+        })
+    }
+}
+```
+
+(Dependency note: `http_body` / `bytes` are already in the server's graph transitively via axum; if the trait bounds need them as direct deps, prefer bounding on `S::Response: IntoResponse` instead — implementer's choice, whichever compiles cleanly with rmcp's `BoxResponse`.)
+
+- [ ] **Step 2: Service construction + attach** (`crates/server/src/mcp/mod.rs`)
+
+```rust
+//! MCP over streamable HTTP at `/mcp` — a protocol adapter, not a second
+//! execution path. See docs/superpowers/specs/2026-08-28-mcp-http-transport-design.md.
+
+mod gate;
+pub(crate) mod handler;
+
+use std::sync::Arc;
+
+use axum::Router;
+use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use rmcp::transport::streamable_http_server::tower::{
+    StreamableHttpServerConfig, StreamableHttpService,
+};
+
+use crate::server::AppState;
+use gate::SessionGate;
+use handler::McpHandler;
+
+/// Nest the gated MCP service at `/mcp`. `rest` is deliberately the
+/// pre-middleware router (transport middleware — CORS today — applies
+/// exactly once, to the inbound `/mcp` request; capturing post-middleware
+/// would run it a second time on every synthetic dispatch). Dispatch only
+/// ever targets REST paths, so no recursion into `/mcp` is possible.
+///
+/// Known, accepted shadow: the nest hides REST's `/:name/execute` for a
+/// pipeline literally named `mcp` from every URL-borne caller; only `/mcp`
+/// itself still reaches it via this pre-nest capture.
+pub(crate) fn attach(rest: Router, state: AppState) -> Router {
+    let allowed_hosts = allowed_hosts(&state);
+    let handler_rest = rest.clone();
+    let service = StreamableHttpService::new(
+        move || Ok(McpHandler::new(handler_rest.clone())),
+        Arc::new(LocalSessionManager::default()),
+        StreamableHttpServerConfig {
+            allowed_hosts,
+            // Everything else stays at rmcp's defaults, each one a spec
+            // decision: sse_keep_alive 15s (bytes keep flowing during long
+            // tool calls, resetting reverse-proxy idle timers well under
+            // nginx's 60s default), legacy_session_mode true (legacy clients
+            // keep the session behavior they expect; the gate guards the
+            // state they create), json_response false (SSE responses so the
+            // keep-alive applies), allowed_origins empty (MCP hosts are not
+            // browsers; the Bearer-only gate is the actual barrier).
+            ..Default::default()
+        },
+    );
+    rest.nest_service("/mcp", SessionGate::new(service, state))
+}
+
+/// Additive host allowlist: the loopback trio is always allowed (rmcp's
+/// DNS-rebinding default), declared `--mcp-allowed-host` values are
+/// appended. Deliberately no allow-any escape hatch.
+fn allowed_hosts(state: &AppState) -> Vec<String> {
+    let mut hosts = vec!["localhost".to_string(), "127.0.0.1".to_string(), "::1".to_string()];
+    hosts.extend(
+        state
+            .config
+            .read()
+            .expect("config lock")
+            .args
+            .mcp_allowed_hosts
+            .iter()
+            .cloned(),
+    );
+    hosts
+}
+```
+
+(Import paths for `StreamableHttpService` etc.: check rmcp 3.1.4's re-exports — `rmcp::transport::StreamableHttpService` may be the public path; use whatever the crate exports.)
+
+- [ ] **Step 3: Split `configure_routes`** in `crates/server/src/server.rs`
+
+Rename today's body to `pub(crate) fn rest_router(state: AppState) -> Router` (identical content, still ends `.with_state(state)` — keep the `state.auth_layer.is_enabled()` branch working by cloning what it needs), and:
+
+```rust
+/// Configure all application routes: the REST router exactly as before,
+/// plus the MCP service nested at /mcp. The MCP handler captures the
+/// PRE-middleware REST router — `configure_middleware` wraps the final
+/// router (transport middleware, applied once), while synthetic dispatches
+/// traverse routing + handlers only, where every execution concern
+/// (require_session, validation, audit) lives. If auth ever moved into
+/// configure_middleware, synthetic dispatch would bypass it — see the
+/// tripwire test on the MCP handler.
+pub fn configure_routes(state: AppState) -> Router {
+    let rest = rest_router(state.clone());
+    crate::mcp::attach(rest, state)
+}
+```
+
+- [ ] **Step 4: In-crate wiring tests** (server.rs or mcp/mod.rs test module; reuse the existing test-state builders)
+
+1. `session_gate_returns_401_before_rmcp_sees_an_anonymous_initialize` — auth-enabled AppState; `configure_routes(state)` oneshot `POST /mcp` (`Host: 127.0.0.1`, `content-type: application/json`, `accept: application/json, text/event-stream`, body = a JSON-RPC `initialize` request) with no Authorization → 401. Same with only a valid session **cookie** (create user+session as `verify_session_cookie_fallback` does, send `cookie: {name}={token}`) → 401 (Bearer-only carrier pinned). Same with `authorization: Bearer {token}` → NOT 401.
+2. `session_gate_is_a_noop_without_auth` — no-auth AppState: anonymous initialize on `/mcp` is not 401.
+3. `mcp_host_allowlist_is_loopback_plus_declared` — no-auth AppState with `mcp_allowed_hosts: vec!["api.example.com".into()]`; oneshot initialize with `Host: evil.example` → 403; `Host: api.example.com` → not 403; `Host: 127.0.0.1` → not 403. And a default state (`vec![]`): `Host: api.example.com` → 403.
+4. `middleware_boundary_is_pinned_two_sided` — (a) full app = `configure_middleware(configure_routes(state))`, oneshot initialize on `/mcp` with an `Origin` header: exactly ONE `access-control-allow-origin` value in the response; (b) `rest_router(state)` oneshot `GET /pipelines` with the same `Origin`: NO `access-control-allow-origin` header (the capture is pre-middleware).
+5. The Task 4 negative-auth tripwire test lands here if it needed `rest_router`.
+
+A JSON-RPC initialize body for these raw-HTTP tests:
+
+```rust
+fn initialize_body() -> String {
+    serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-03-26",
+            "capabilities": {},
+            "clientInfo": {"name": "test", "version": "0"}
+        }
+    })
+    .to_string()
+}
+```
+
+- [ ] **Step 5: `cargo fmt`, commit**
+
+```bash
+git add -A
+git commit -m "feat(server): /mcp — session gate, host allowlist, router nesting"
+```
+
+---
+
+### Task 6: End-to-end integration tests (`crates/server/tests/mcp_http.rs`)
+
+**Files:**
+- Modify: `crates/server/Cargo.toml` (`[dev-dependencies]`)
+- Create: `crates/server/tests/mcp_http.rs`
+
+**Interfaces:**
+- Consumes: `configure_routes`, `configure_middleware`, `AppState` (all pub), rmcp client transport.
+
+- [ ] **Step 1: dev-deps**
+
+```toml
+[dev-dependencies]
+rmcp = { version = "=3.1.4", default-features = false, features = ["client", "transport-streamable-http-client-reqwest"] }
+```
+
+(plus whatever the reqwest transport needs to build plain-HTTP requests — if the feature alone doesn't compile against localhost HTTP, add `reqwest = { version = "0.12", default-features = false }` as a dev-dep; decide at implementation.)
+
+- [ ] **Step 2: Harness**
+
+Test-local `make_app_state` modeled on `crates/server/tests/pipelines_http.rs` (in-memory batch `products`, one real `StandardPipeline` from YAML with a `{brand}`-style parameter, optional query-audit SQLite in a TempDir, optional better-auth layer modeled on `jobs_auth_http.rs` including the `ENV_LOCK` pattern), plus:
+
+```rust
+async fn serve(state: AppState) -> std::net::SocketAddr {
+    let app = skardi_server::server::configure_middleware(
+        skardi_server::server::configure_routes(state),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    addr
+}
+
+async fn connect(addr: std::net::SocketAddr) -> rmcp::service::RunningService<rmcp::RoleClient, ()> {
+    let transport = rmcp::transport::StreamableHttpClientTransport::from_uri(
+        format!("http://{addr}/mcp"),
+    );
+    rmcp::ServiceExt::serve((), transport).await.unwrap()
+}
+```
+
+(Exact client-side types per rmcp 3.1.4 — the CLI's `tests/mcp_e2e.rs` already drives an rmcp client over a child process; mirror its idioms for `list_tools` / `call_tool` and adapt the transport.)
+
+- [ ] **Step 3: The tests**
+
+1. `tools_list_contains_seeded_pipelines_and_builtins` — via rmcp client.
+2. `pipeline_call_executes_and_returns_rows` — `call_tool` on the seeded pipeline with its parameter; result `is_error != Some(true)`, content text parses as JSON with `success: true` and row data.
+3. `query_round_trips` — `call_tool("query", {"sql": "SELECT count(*) AS n FROM products"})`.
+4. `unknown_tool_is_invalid_params` — `call_tool("nope", ...)` errors at the protocol level with the re-list hint.
+5. `failing_sql_surfaces_as_is_error_tool_result` — bad SQL → `is_error == Some(true)`.
+6. `auth_forwarding_reaches_the_handlers` — auth-enabled state; client transport built with `.auth_header(token)`(via `StreamableHttpClientTransportConfig`); a `query` call succeeds — proving `Authorization` survives synthetic dispatch (a dropped header would 401 at handler-level `require_session` despite the gate having passed).
+7. `anonymous_and_cookie_only_initialize_are_transport_401s` — raw `reqwest` (or oneshot in Task 5 covers this; keep here only the end-to-end anonymous case: rmcp client `.serve()` against auth-enabled server fails; and a follow-up raw POST claiming an invented `Mcp-Session-Id` also gets 401).
+8. `stateless_protocol_regression` — drive `/mcp` as a stateless `2026-07-28` client (rmcp client with `allow_stateless: true` config / no session; consult rmcp's own stateless client tests for the exact knob): `tools/list` then `tools/call` as independent requests must still resolve and execute — the direct regression test for per-call resolution.
+9. `pipeline_call_records_an_audit_id` — state with query-audit SQLite in a TempDir; pipeline call via `/mcp`; open the ledger (`skardi_server::query_audit::QueryAuditStore`) and assert the recorded `session_id` is a valid UUID (stateless path). The legacy `Mcp-Session-Id` echo is already pinned at the `do_*` level (Task 4 test 4).
+
+- [ ] **Step 4: `cargo fmt`, commit**
+
+```bash
+git add -A
+git commit -m "test(server): /mcp end-to-end — rmcp client, auth, allowlist, stateless"
+```
+
+---
+
+### Task 7: Documentation
+
+**Files:**
+- Modify: `docs/mcp.md`
+- Modify: `docs/pipelines.md`
+
+- [ ] **Step 1: `docs/mcp.md`**
+
+Per the spec's Documentation section, this is a rewrite of existing prose plus a new section:
+
+- Title: `# MCP Binding — \`skardi mcp\`` → `# MCP Binding` (page covers both bindings now). Opening paragraphs state the local-vs-remote split: stdio bridge for hosts that spawn a local binary; `/mcp` for hosts that cannot (claude.ai, mobile, hosted platforms). The stdio bridge is not retired.
+- Architecture diagram gains the second path (HTTP: host → `/mcp` on skardi-server directly).
+- New section `## Remote (streamable HTTP)` after Host setup:
+  - The endpoint: `http://<server>/mcp`, default-on, no config flag; URL-based MCP host configuration example.
+  - Bearer guidance: send `Authorization: Bearer <token>`; with auth enabled every `/mcp` request — `initialize` and `tools/list` included — requires the token (deliberate divergence from REST's tokenless `GET /pipelines`, stated). Cookies are never accepted on `/mcp`.
+  - Host allowlist: loopback allowed by default; remote deployments declare public hostnames via repeatable `--mcp-allowed-host api.example.com` / `host:port` (port entry matches exactly; portless matches any port). No allow-any option.
+  - Reverse proxies: either forward the public `Host` and declare it, or rewrite `Host` to the upstream loopback authority; a mismatch presents as `403 Forbidden: Host header is not allowed`. Proxy read/idle timeouts: long tool calls hold their POST open for the whole run; responses are SSE with a 15 s keep-alive so bytes keep flowing, but deployments running long pipelines should still check proxy read timeouts (nginx `proxy_read_timeout` defaults to 60 s and only helps if it counts any bytes as liveness).
+  - Audit grouping: legacy-protocol sessions group by `Mcp-Session-Id`; stateless-protocol (2026-07-28+) requests are attributed per-request with a minted UUID — the protocol removed the conversation-level handle.
+- `## Auth notes` gains the per-binding split: bridge REST calls keep today's tokenless `GET /pipelines` note; `/mcp` requires the token for everything once auth is on.
+- `## Timeouts & lifecycle` gains the HTTP lifecycle: per-request, no process to exit; disconnect semantics per the SSE response mode; the host's tool-call timeout remains the backstop and the keep-alive is what keeps proxies from firing first.
+
+- [ ] **Step 2: `docs/pipelines.md`**
+
+Find the surface-list MCP bullet reading "via `skardi mcp`" and broaden it to name both bindings (the stdio bridge and the server's `/mcp` endpoint).
+
+- [ ] **Step 3: `cargo fmt` (no-op for docs), commit**
+
+```bash
+git add docs/mcp.md docs/pipelines.md
+git commit -m "docs(mcp): /mcp remote binding — manual covers both bindings"
+```
+
+---
+
+### Task 8: Plan/spec housekeeping, push, draft PR
+
+- [ ] **Step 1:** Commit this plan file (`docs/superpowers/plans/2026-09-01-mcp-http-transport.md`).
+- [ ] **Step 2:** `cargo fmt` (final check), verify branch is `mcp-http-transport`, push:
+
+```bash
+git push -u origin mcp-http-transport
+```
+
+- [ ] **Step 3:** Draft PR against `main`:
+
+```bash
+gh pr create --draft --title "feat(server): MCP streamable HTTP transport — /mcp" --body "..."
+```
+
+Body: implements the spec (`docs/superpowers/specs/2026-08-28-mcp-http-transport-design.md`, PR #234); summary of the four pieces (mcp-core extraction, handler, gate+wiring, tests+docs); note that R2's "routine CI build is the only remaining confirmation" is confirmed by this PR's CI. End with the standard generation footer.
+
+- [ ] **Step 4:** Watch CI; fix failures on the branch. (rmcp client API details in Task 6 are the most likely to need iteration — that's expected, tests are CI-verified by policy.)
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage**: shared crate (T1), session gate Bearer-only (T5), host allowlist (T3+T5), stateless handler + per-call resolution (T4), audit layering + validator mirror (T2+T4), SSE keep-alive (T5, rmcp default 15 s), response cap (T4), error mapping (T4), all named tests (T4–T6), docs (T7), CLI Cargo comment (T1), tower util promotion (T3). Non-goals untouched.
+- **Types**: `McpHandler::new(Router)`; `attach(Router, AppState) -> Router`; `rest_router(AppState) -> Router`; `validate_session_id(&str) -> Result<(), String>` — consistent across tasks.
+- **Known implementation-time checks** (not placeholders — verify against the crate while coding): exact rmcp public re-export paths, client-side stateless knob, `SessionGate` trait-bound form.

--- a/docs/superpowers/plans/2026-09-01-mcp-http-transport.md
+++ b/docs/superpowers/plans/2026-09-01-mcp-http-transport.md
@@ -814,7 +814,13 @@ pub(crate) fn attach(rest: Router, state: AppState) -> Router {
             ..Default::default()
         },
     );
-    rest.nest_service("/mcp", SessionGate::new(service, state))
+    // Exact mount, not `nest_service`: streamable HTTP is a single-endpoint
+    // protocol, and a prefix mount would shadow REST's `/:name/execute` for
+    // a pipeline literally named `mcp`. `/mcp/` is kept for hosts configured
+    // with a trailing slash.
+    let gate = SessionGate::new(service, state);
+    rest.route_service("/mcp", gate.clone())
+        .route_service("/mcp/", gate)
 }
 
 /// Additive host allowlist: the loopback trio is always allowed (rmcp's


### PR DESCRIPTION
Implements the merged design `docs/superpowers/specs/2026-08-28-mcp-http-transport-design.md` (#234): the server's own MCP binding at `/mcp`, for hosts that can't spawn the stdio bridge (claude.ai, mobile, hosted platforms). The stdio bridge is not retired.

## What's here

- **`crates/mcp-core`** (`skardi-mcp-core`) — the tool projection and `encode_component` extracted from the CLI bridge, now shared by both bindings. Dispatch matches stay deliberately per-binding.
- **Handler** (`crates/server/src/mcp/handler.rs`) — a stateless protocol adapter over the server's own REST router via `tower::ServiceExt::oneshot` self-dispatch: per-call pipeline name resolution (correct under the 2026-07-28 stateless protocol, fresh by construction), `Authorization` forwarded verbatim, layered audit ids (valid `Mcp-Session-Id` echoed, else a minted per-request UUID), 256 MB response cap, non-2xx → `isError` tool results.
- **Gate + wiring** (`gate.rs`, `mod.rs`) — Bearer-only `verify_session` before rmcp sees the request (cookies stripped; anonymous `initialize` is a transport-level 401, no session state created), additive `--mcp-allowed-host` over rmcp's loopback-only Host allowlist (no allow-any), nested on the pre-middleware router so transport middleware applies exactly once.
- **Tests** — handler-level unit tests (probe router), in-crate transport tests (gate order, allowlist, middleware boundary, handler-auth tripwire), and an end-to-end suite driving `/mcp` with a real rmcp client over TCP: tools projection, per-call resolution, auth forwarding, anonymous 401, stateless 2026-07-28 regression, and UUID audit attribution in the query-audit ledger.
- **Docs** — `docs/mcp.md` covers both bindings (remote section: host config, Bearer guidance, reverse proxies, audit grouping); `docs/pipelines.md` names both transports.

rmcp is pinned `=3.1.4`, `default-features = false`, mirroring the CLI.

The spec's R2 left one open confirmation — "the routine CI build is the only remaining confirmation" for the rmcp server feature set — which this PR's CI settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)