### PR TITLE
feat(query-audit): best-effort query ledger module, downstreamed from skardi-cloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -612,8 +612,9 @@ jobs:
       - name: Execute Integration tests
         env:
           # The query-audit Postgres-backend live suite
-          # (crates/query-audit/tests/pg_live.rs) — pointed at the job's
-          # postgres service; each test creates its own throwaway database.
+          # (crates/query-audit/tests/pg_live.rs and ledger_live.rs) —
+          # pointed at the job's postgres service; each test creates its own
+          # throwaway database.
           SKARDI_QUERY_AUDIT_LIVE_URL: postgres://skardi_user:skardi_pass@127.0.0.1:5432/mydb
         run: cargo llvm-cov --no-report nextest --all-features -- --ignored
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9740,10 +9740,12 @@ name = "skardi-query-audit"
 version = "0.5.0"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "chrono",
  "futures",
  "serde_json",
  "sqlx",
+ "sqlx-postgres",
  "tempfile",
  "tokio",
  "tokio-rusqlite",
@@ -9951,6 +9953,7 @@ checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "chrono",
  "crc",
  "crossbeam-queue",
  "either",
@@ -10025,6 +10028,7 @@ dependencies = [
  "base64 0.22.1",
  "bitflags 2.13.0",
  "byteorder",
+ "chrono",
  "crc",
  "dotenvy",
  "etcetera",

--- a/README.md
+++ b/README.md
@@ -128,9 +128,11 @@ acting on *intentions*: when every weekday morning ends with the same GitHub +
 Slack queries, each declaring `purpose: "daily standup"`, the pattern isn't a
 pipeline — it's a routine, and any harness that can run an agent on a schedule
 (Claude Code routines, a cron-driven CLI run) can have the standup drafted
-before anyone asks. And because the ledger is one SQLite file, you can hand a
-window of it to an LLM and ask what keeps being needed that nobody turned into a
-tool — recurring intentions the user hasn't noticed yet. One boundary is yours
+before anyone asks. And because the ledger is one SQLite file (or one
+Postgres database, via `SKARDI_QUERY_AUDIT_PG_DSN` — same fail-closed
+contract, storage swapped), you can hand a window of it to an LLM and ask
+what keeps being needed that nobody turned into a tool — recurring
+intentions the user hasn't noticed yet. One boundary is yours
 to set: ledger rows carry raw SQL, literals included, so keep that analysis on a
 local model or redact first — sending a window to a hosted LLM should be a
 deliberate opt-in, not a default. Both land as skills on

--- a/crates/query-audit/Cargo.toml
+++ b/crates/query-audit/Cargo.toml
@@ -17,7 +17,18 @@ tokio-rusqlite = { workspace = true }
 # arrived with that change while this crate was being extracted, so they are
 # declared here rather than inherited from the server that used to host the
 # module.
-tokio = { workspace = true, features = ["time"] }
+tokio = { workspace = true, features = ["time", "sync", "rt"] }
+# The best-effort ledger module's opaque read cursor (`ledger::read`).
+base64 = "0.22"
+# chrono/json Encode/Decode for the ledger module's TIMESTAMPTZ + JSONB
+# columns, enabled on sqlx's INTERNAL postgres node rather than the facade:
+# the facade's `chrono`/`json` features textually reference
+# `sqlx-sqlite?/...`, which makes the resolver pull sqlx-sqlite into the
+# lock, whose libsqlite3-sys (0.30) `links`-conflicts with tokio-rusqlite's
+# (0.35). Feature unification lands these on the same node the facade
+# re-exports, so `sqlx::query` sees the impls; the version range must keep
+# resolving to the facade's pinned sqlx-postgres.
+sqlx-postgres = { version = "0.8", default-features = false, features = ["chrono", "json"] }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/query-audit/src/ledger/mod.rs
+++ b/crates/query-audit/src/ledger/mod.rs
@@ -29,16 +29,20 @@ pub mod queries;
 pub mod read;
 pub mod writer;
 
+use std::panic::catch_unwind;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 use anyhow::Context as _;
 use chrono::{DateTime, Utc};
 use serde_json::Value;
+use sqlx::PgPool;
 use sqlx::postgres::PgPoolOptions;
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::{Notify, mpsc, watch};
+use tokio::time::sleep;
 
 /// `sql` is truncated to this at ROW ASSEMBLY: the learn loop wants
 /// patterns, not megabyte literals, and bounding at ingestion is what keeps
@@ -139,7 +143,7 @@ pub const FLUSH_BATCH_ROWS: usize = 64;
 
 /// Wall-clock bound on one flush. A slow PG drops the batch (counted),
 /// never stalls the writer behind an unbounded await.
-pub const FLUSH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+pub const FLUSH_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Loss accounting: dropped is never silent. The consumer renders this into
 /// its own metrics surface.
@@ -394,7 +398,7 @@ fn truncate_utf8(s: &str, max: usize) -> (String, bool) {
 #[derive(Clone)]
 pub struct PgLedger {
     tx: mpsc::Sender<LedgerRow>,
-    pool: sqlx::PgPool,
+    pool: PgPool,
     writer: Arc<WriterControl>,
 }
 
@@ -439,6 +443,22 @@ impl PgLedger {
             "the ledger writer needs a running Tokio runtime; construct the \
              ledger from within one",
         )?;
+        // A current handle proves a RUNTIME, not a TIMER: a runtime built
+        // without `enable_time` lets construction succeed and then panics at
+        // the writer's first `timeout` — inside the detached task, killing
+        // it and losing accepted rows with neither counter touched. Probe
+        // the timer here by creating (never awaiting) a zero Sleep,
+        // converting tokio's panic into this constructor's Result. The one
+        // stderr panic line in the misconfigured case accompanies an actual
+        // configuration error being reported.
+        if catch_unwind(|| drop(sleep(Duration::ZERO))).is_err() {
+            anyhow::bail!(
+                "the ledger writer needs a Tokio runtime with its timer \
+                 enabled (enable_time / enable_all); this one has no timer \
+                 driver, and the flush deadline would panic inside the \
+                 writer task"
+            );
+        }
         let pool = PgPoolOptions::new().max_connections(2).connect_lazy(dsn)?;
         let (tx, rx) = mpsc::channel(capacity);
         let (done_tx, done_rx) = watch::channel(false);
@@ -488,7 +508,7 @@ impl PgLedger {
         }
     }
 
-    pub fn pool(&self) -> &sqlx::PgPool {
+    pub fn pool(&self) -> &PgPool {
         &self.pool
     }
 }
@@ -606,6 +626,24 @@ mod tests {
         assert_eq!(decimal_len_estimate("42"), 2);
         assert_eq!(decimal_len_estimate("-3.25"), 5);
         assert!(decimal_len_estimate("1e18446744073709551615") > 1_000_000);
+    }
+
+    /// A runtime WITHOUT `enable_time` passes the handle check but would
+    /// panic at the writer's first flush deadline — construction must
+    /// refuse it instead (the panic would land inside the detached task,
+    /// losing rows uncounted).
+    #[test]
+    fn a_runtime_without_a_timer_is_refused() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("runtime without enable_time");
+        let err = rt.block_on(async {
+            match PgLedger::spawn("postgres://u:p@192.0.2.1:5432/x") {
+                Ok(_) => panic!("must refuse a timerless runtime"),
+                Err(e) => e,
+            }
+        });
+        assert!(err.to_string().contains("timer"), "{err}");
     }
 
     /// `tokio::spawn` panics outside a runtime; the synchronous constructor

--- a/crates/query-audit/src/ledger/mod.rs
+++ b/crates/query-audit/src/ledger/mod.rs
@@ -48,6 +48,13 @@ pub const ERROR_MAX_BYTES: usize = 4 * 1024;
 /// worst case is ~40 MiB per process.
 pub const QUEUE_CAPACITY: usize = 1024;
 
+/// Bound on each identity field (`org_id`, `workspace_id`, `user_id`,
+/// `request_id`) at assembly. Production values are gate-validated slugs a
+/// few dozen bytes long; the cap exists because the ~40 MiB queue worst
+/// case is only true if EVERY field is bounded — an unbounded identity
+/// string would let 1,024 queued rows hold arbitrarily more.
+pub const IDENTITY_MAX_BYTES: usize = 4 * 1024;
+
 /// Rows per multi-row INSERT flush.
 pub const FLUSH_BATCH_ROWS: usize = 64;
 
@@ -197,11 +204,12 @@ impl RowDraft {
         Self {
             // Identity values arrive gate-validated in production, but
             // assembly is the single bounding point and must not trust that:
-            // one NUL here would still poison the batch.
-            org_id: scrub_nul(org_id),
-            workspace_id: scrub_nul(workspace_id),
-            user_id: scrub_nul(user_id),
-            request_id: scrub_nul(request_id),
+            // one NUL here would still poison the batch, and one unbounded
+            // string would void the queue's ~40 MiB worst case.
+            org_id: bound_text(org_id, IDENTITY_MAX_BYTES).0,
+            workspace_id: bound_text(workspace_id, IDENTITY_MAX_BYTES).0,
+            user_id: bound_text(user_id, IDENTITY_MAX_BYTES).0,
+            request_id: bound_text(request_id, IDENTITY_MAX_BYTES).0,
             session_id,
             created_at: Utc::now(),
             sql,
@@ -419,6 +427,48 @@ mod tests {
         let ai = json!({"session_id": "s".repeat(201)});
         let draft = RowDraft::capture("o", "w", "u", "r", "SELECT 1", Some(&ai), None, 1000);
         assert!(draft.session_id.is_none());
+    }
+
+    /// The queue's ~40 MiB worst case requires EVERY field bounded — an
+    /// oversized identity string must cap at assembly like everything else.
+    #[test]
+    fn identity_fields_are_bounded_at_assembly() {
+        let huge = "x".repeat(1024 * 1024);
+        let draft = RowDraft::capture(&huge, &huge, &huge, &huge, "SELECT 1", None, None, 1000);
+        for v in [
+            &draft.org_id,
+            &draft.workspace_id,
+            &draft.user_id,
+            &draft.request_id,
+        ] {
+            assert_eq!(v.len(), IDENTITY_MAX_BYTES);
+        }
+    }
+
+    /// The SELECT bounds fields server-side so `fetch_all` cannot
+    /// materialize unbounded rows; its hardcoded literals must track the
+    /// Rust consts, or the two layers drift.
+    #[test]
+    fn select_page_literals_track_the_rust_bounds() {
+        let q = queries::SELECT_PAGE;
+        assert!(q.contains(&format!("left(sql, {SQL_MAX_BYTES})")));
+        assert!(q.contains(&format!("octet_length(sql) > {SQL_MAX_BYTES}")));
+        assert!(q.contains(&format!("left(error, {ERROR_MAX_BYTES})")));
+        assert!(q.contains(&format!(
+            "octet_length(ai_context::text) <= {ERROR_MAX_BYTES}"
+        )));
+        for col in [
+            "org_id",
+            "workspace_id",
+            "user_id",
+            "request_id",
+            "session_id",
+        ] {
+            assert!(
+                q.contains(&format!("left({col}, {IDENTITY_MAX_BYTES})")),
+                "{col} must be bounded in the SELECT"
+            );
+        }
     }
 
     /// U+0000 is legal in a Rust String but unstorable in Postgres TEXT and

--- a/crates/query-audit/src/ledger/mod.rs
+++ b/crates/query-audit/src/ledger/mod.rs
@@ -29,10 +29,13 @@ pub mod queries;
 pub mod read;
 pub mod writer;
 
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use chrono::{DateTime, Utc};
 use serde_json::Value;
+use tokio::sync::mpsc::error::TrySendError;
+use tokio::sync::{Notify, mpsc, watch};
 
 /// `sql` is truncated to this at ROW ASSEMBLY: the learn loop wants
 /// patterns, not megabyte literals, and bounding at ingestion is what keeps
@@ -308,19 +311,22 @@ fn truncate_utf8(s: &str, max: usize) -> (String, bool) {
 /// (see [`Self::shutdown`]).
 #[derive(Clone)]
 pub struct PgLedger {
-    tx: tokio::sync::mpsc::Sender<LedgerRow>,
+    tx: mpsc::Sender<LedgerRow>,
     pool: sqlx::PgPool,
-    writer: std::sync::Arc<WriterControl>,
+    writer: Arc<WriterControl>,
 }
 
 /// The writer task's shutdown plumbing. Held behind an `Arc` so every clone
 /// of the handle can trigger and await the same drain.
 pub(crate) struct WriterControl {
     /// Signals the writer to close its receiver and drain what is buffered.
-    pub(crate) drain: tokio::sync::Notify,
-    /// The writer's JoinHandle, kept — a detached task dies WITH the runtime,
-    /// mid-flush, and rows lost that way would be counted by nobody.
-    handle: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
+    pub(crate) drain: Notify,
+    /// Becomes `true` when the writer task has exited — set by a drop guard
+    /// inside the task, so it fires on the graceful path, on a panic, and on
+    /// an abort alike. SHARED completion state, not a taken JoinHandle:
+    /// every concurrent shutdown caller awaits the same signal, and a
+    /// cancelled waiter cancels only itself.
+    done: watch::Receiver<bool>,
 }
 
 impl PgLedger {
@@ -339,13 +345,19 @@ impl PgLedger {
         let pool = sqlx::postgres::PgPoolOptions::new()
             .max_connections(2)
             .connect_lazy(dsn)?;
-        let (tx, rx) = tokio::sync::mpsc::channel(capacity);
-        let writer = std::sync::Arc::new(WriterControl {
-            drain: tokio::sync::Notify::new(),
-            handle: std::sync::Mutex::new(None),
+        if capacity == 0 {
+            // tokio's bounded channel PANICS on zero; this constructor
+            // advertises Result, so invalid configuration must not be able
+            // to take the process down.
+            anyhow::bail!("ledger queue capacity must be >= 1 (got 0)");
+        }
+        let (tx, rx) = mpsc::channel(capacity);
+        let (done_tx, done_rx) = watch::channel(false);
+        let writer = Arc::new(WriterControl {
+            drain: Notify::new(),
+            done: done_rx,
         });
-        let handle = tokio::spawn(writer::run(pool.clone(), rx, writer.clone()));
-        *writer.handle.lock().expect("fresh mutex") = Some(handle);
+        tokio::spawn(writer::run(pool.clone(), rx, writer.clone(), done_tx));
         Ok(Self { tx, pool, writer })
     }
 
@@ -360,17 +372,17 @@ impl PgLedger {
     /// Unbounded by design — the drain is at most `capacity / FLUSH_BATCH`
     /// flushes of [`FLUSH_TIMEOUT`] each; a caller with a deadline wraps
     /// this in `tokio::time::timeout`, and rows still queued at a HARD
-    /// abort remain the accepted pod-crash loss class. Concurrent callers:
-    /// the first drives the drain; later calls return once it is done (the
-    /// handle is taken exactly once).
+    /// abort remain the accepted pod-crash loss class. Concurrent callers
+    /// all await the SAME completion state (a watch the writer's drop guard
+    /// sets on every exit path, panic included), so whichever caller
+    /// controls teardown holds it open until the drain is really done, and
+    /// one cancelled waiter cancels nobody else.
     pub async fn shutdown(&self) {
         self.writer.drain.notify_one();
-        let handle = self.writer.handle.lock().expect("writer mutex").take();
-        if let Some(handle) = handle {
-            // A panicked writer is already logged by the runtime; shutdown's
-            // job is only to not leave rows behind silently.
-            let _ = handle.await;
-        }
+        let mut done = self.writer.done.clone();
+        // Err = the sender dropped, which only happens when the task is
+        // gone; either way, the writer is no longer running.
+        let _ = done.wait_for(|finished| *finished).await;
     }
 
     /// Enqueue one decided row. Never waits, never errors to the caller: a
@@ -381,8 +393,7 @@ impl PgLedger {
                 .insert_failures_channel_full
                 .fetch_add(1, Ordering::Relaxed);
             let request_id = match &e {
-                tokio::sync::mpsc::error::TrySendError::Full(r)
-                | tokio::sync::mpsc::error::TrySendError::Closed(r) => r.request_id.clone(),
+                TrySendError::Full(r) | TrySendError::Closed(r) => r.request_id.clone(),
             };
             tracing::warn!(%request_id, "ledger row dropped: queue full or writer gone");
         }
@@ -468,6 +479,17 @@ mod tests {
         let ai = json!({"session_id": "s".repeat(201)});
         let draft = RowDraft::capture("o", "w", "u", "r", "SELECT 1", Some(&ai), None, 1000);
         assert!(draft.session_id.is_none());
+    }
+
+    /// tokio's bounded channel panics on zero; the Result-returning
+    /// constructor must refuse instead (AGENTS.md: no panics in production).
+    #[tokio::test]
+    async fn zero_capacity_is_an_error_not_a_panic() {
+        let err = match PgLedger::spawn_with_capacity("postgres://u:p@192.0.2.1:5432/x", 0) {
+            Ok(_) => panic!("zero capacity must refuse"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("capacity"), "{err}");
     }
 
     /// The queue's ~40 MiB worst case requires EVERY field bounded — an

--- a/crates/query-audit/src/ledger/mod.rs
+++ b/crates/query-audit/src/ledger/mod.rs
@@ -32,8 +32,10 @@ pub mod writer;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use anyhow::Context as _;
 use chrono::{DateTime, Utc};
 use serde_json::Value;
+use tokio::runtime::Handle;
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::{Notify, mpsc, watch};
 
@@ -342,22 +344,31 @@ impl PgLedger {
     /// queue-full contract — drop + count, never block — is testable without
     /// enqueueing a thousand rows against a hung writer.
     pub fn spawn_with_capacity(dsn: &str, capacity: usize) -> anyhow::Result<Self> {
-        let pool = sqlx::postgres::PgPoolOptions::new()
-            .max_connections(2)
-            .connect_lazy(dsn)?;
         if capacity == 0 {
             // tokio's bounded channel PANICS on zero; this constructor
             // advertises Result, so invalid configuration must not be able
             // to take the process down.
             anyhow::bail!("ledger queue capacity must be >= 1 (got 0)");
         }
+        // Same reasoning as the capacity check, and it must come BEFORE the
+        // pool: `tokio::spawn` AND sqlx's `connect_lazy` (whose pool spawns
+        // its reaper) both PANIC outside a runtime, and a synchronous
+        // Result-returning constructor must refuse invalid initialization,
+        // not abort the process.
+        let runtime = Handle::try_current().context(
+            "the ledger writer needs a running Tokio runtime; construct the \
+             ledger from within one",
+        )?;
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .max_connections(2)
+            .connect_lazy(dsn)?;
         let (tx, rx) = mpsc::channel(capacity);
         let (done_tx, done_rx) = watch::channel(false);
         let writer = Arc::new(WriterControl {
             drain: Notify::new(),
             done: done_rx,
         });
-        tokio::spawn(writer::run(pool.clone(), rx, writer.clone(), done_tx));
+        runtime.spawn(writer::run(pool.clone(), rx, writer.clone(), done_tx));
         Ok(Self { tx, pool, writer })
     }
 
@@ -481,6 +492,18 @@ mod tests {
         assert!(draft.session_id.is_none());
     }
 
+    /// `tokio::spawn` panics outside a runtime; the synchronous constructor
+    /// must refuse instead — a plain #[test] has no ambient runtime, which
+    /// is exactly the failing caller.
+    #[test]
+    fn constructing_outside_a_runtime_is_an_error_not_a_panic() {
+        let err = match PgLedger::spawn("postgres://u:p@192.0.2.1:5432/x") {
+            Ok(_) => panic!("must refuse without a runtime"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("Tokio runtime"), "{err}");
+    }
+
     /// tokio's bounded channel panics on zero; the Result-returning
     /// constructor must refuse instead (AGENTS.md: no panics in production).
     #[tokio::test]
@@ -517,8 +540,11 @@ mod tests {
         assert!(q.contains(&format!("left(sql, {SQL_MAX_BYTES})")));
         assert!(q.contains(&format!("octet_length(sql) > {SQL_MAX_BYTES}")));
         assert!(q.contains(&format!("left(error, {ERROR_MAX_BYTES})")));
+        // TRANSPORT bound: 2× ingestion, because jsonb::text re-adds
+        // whitespace the compact form (which ingestion measured) lacks.
         assert!(q.contains(&format!(
-            "octet_length(ai_context::text) <= {ERROR_MAX_BYTES}"
+            "octet_length(ai_context::text) <= {}",
+            2 * ERROR_MAX_BYTES
         )));
         for col in [
             "org_id",

--- a/crates/query-audit/src/ledger/mod.rs
+++ b/crates/query-audit/src/ledger/mod.rs
@@ -292,6 +292,19 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    /// The metrics text the consumer splices into its /metrics endpoint:
+    /// both loss reasons render, with live counter values.
+    #[test]
+    fn metrics_render_names_both_loss_reasons() {
+        let m = Metrics::default();
+        m.insert_failures_pg.store(3, Ordering::Relaxed);
+        m.insert_failures_channel_full.store(7, Ordering::Relaxed);
+        let text = m.render();
+        assert!(text.contains("ledger_insert_failures_total{reason=\"pg\"} 3"));
+        assert!(text.contains("ledger_insert_failures_total{reason=\"channel_full\"} 7"));
+        assert!(text.starts_with("# TYPE ledger_insert_failures_total counter"));
+    }
+
     #[test]
     fn assembly_bounds_every_field() {
         // An 8 MiB statement lands truncated at 32 KiB with the flag set.

--- a/crates/query-audit/src/ledger/mod.rs
+++ b/crates/query-audit/src/ledger/mod.rs
@@ -29,9 +29,9 @@ pub mod queries;
 pub mod read;
 pub mod writer;
 
-use std::panic::catch_unwind;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread;
 use std::time::Duration;
 
 use anyhow::Context as _;
@@ -39,10 +39,9 @@ use chrono::{DateTime, Utc};
 use serde_json::Value;
 use sqlx::PgPool;
 use sqlx::postgres::PgPoolOptions;
-use tokio::runtime::Handle;
+use tokio::runtime::Builder;
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::{Notify, mpsc, watch};
-use tokio::time::sleep;
 
 /// `sql` is truncated to this at ROW ASSEMBLY: the learn loop wants
 /// patterns, not megabyte literals, and bounding at ingestion is what keeps
@@ -427,6 +426,17 @@ impl PgLedger {
     /// goes through `spawn` ([`QUEUE_CAPACITY`]); this seam exists so the
     /// queue-full contract — drop + count, never block — is testable without
     /// enqueueing a thousand rows against a hung writer.
+    ///
+    /// The writer runs on its OWN single-thread Tokio runtime, on a
+    /// dedicated OS thread, with the timer enabled — so construction needs
+    /// no ambient runtime at all, and the caller's runtime configuration
+    /// (present or not, timer or not, `panic = "abort"` or not) can never
+    /// panic the write pipeline: earlier designs probed the ambient timer
+    /// by catching a deliberate panic, which an abort profile turns into a
+    /// process abort. The pool is created inside that runtime too, so its
+    /// internal tasks and deadlines live where the timer is. The READ path
+    /// ([`read::list_page`]) runs on the caller's runtime and needs it
+    /// sqlx-capable (timer enabled), like any sqlx call.
     pub fn spawn_with_capacity(dsn: &str, capacity: usize) -> anyhow::Result<Self> {
         if capacity == 0 {
             // tokio's bounded channel PANICS on zero; this constructor
@@ -434,39 +444,29 @@ impl PgLedger {
             // to take the process down.
             anyhow::bail!("ledger queue capacity must be >= 1 (got 0)");
         }
-        // Same reasoning as the capacity check, and it must come BEFORE the
-        // pool: `tokio::spawn` AND sqlx's `connect_lazy` (whose pool spawns
-        // its reaper) both PANIC outside a runtime, and a synchronous
-        // Result-returning constructor must refuse invalid initialization,
-        // not abort the process.
-        let runtime = Handle::try_current().context(
-            "the ledger writer needs a running Tokio runtime; construct the \
-             ledger from within one",
-        )?;
-        // A current handle proves a RUNTIME, not a TIMER: a runtime built
-        // without `enable_time` lets construction succeed and then panics at
-        // the writer's first `timeout` — inside the detached task, killing
-        // it and losing accepted rows with neither counter touched. Probe
-        // the timer here by creating (never awaiting) a zero Sleep,
-        // converting tokio's panic into this constructor's Result. The one
-        // stderr panic line in the misconfigured case accompanies an actual
-        // configuration error being reported.
-        if catch_unwind(|| drop(sleep(Duration::ZERO))).is_err() {
-            anyhow::bail!(
-                "the ledger writer needs a Tokio runtime with its timer \
-                 enabled (enable_time / enable_all); this one has no timer \
-                 driver, and the flush deadline would panic inside the \
-                 writer task"
-            );
-        }
-        let pool = PgPoolOptions::new().max_connections(2).connect_lazy(dsn)?;
+        let runtime = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("build the ledger writer's runtime")?;
+        // Created under the writer runtime's context: sqlx's pool spawns
+        // internal tasks and takes deadlines from the runtime that is
+        // CURRENT at creation, and those must not depend on the caller's.
+        let pool = {
+            let _entered = runtime.enter();
+            PgPoolOptions::new().max_connections(2).connect_lazy(dsn)?
+        };
         let (tx, rx) = mpsc::channel(capacity);
         let (done_tx, done_rx) = watch::channel(false);
         let writer = Arc::new(WriterControl {
             drain: Notify::new(),
             done: done_rx,
         });
-        runtime.spawn(writer::run(pool.clone(), rx, writer.clone(), done_tx));
+        let writer_pool = pool.clone();
+        let writer_control = writer.clone();
+        thread::Builder::new()
+            .name("skardi-ledger-writer".to_string())
+            .spawn(move || runtime.block_on(writer::run(writer_pool, rx, writer_control, done_tx)))
+            .context("spawn the ledger writer thread")?;
         Ok(Self { tx, pool, writer })
     }
 
@@ -628,34 +628,40 @@ mod tests {
         assert!(decimal_len_estimate("1e18446744073709551615") > 1_000_000);
     }
 
-    /// A runtime WITHOUT `enable_time` passes the handle check but would
-    /// panic at the writer's first flush deadline — construction must
-    /// refuse it instead (the panic would land inside the detached task,
-    /// losing rows uncounted).
+    /// The writer owns its runtime, so the ambient one is irrelevant: a
+    /// plain #[test] (no runtime at all) can construct and record, the
+    /// writer's OWN timer bounds the doomed flush and counts the loss, and
+    /// a TIMERLESS caller runtime can still drive shutdown (a watch await
+    /// needs no timer). This is the panic-free answer to both "no runtime"
+    /// and "runtime without enable_time" — including under panic = "abort",
+    /// where the previous catch_unwind probe would itself abort.
     #[test]
-    fn a_runtime_without_a_timer_is_refused() {
+    fn ambient_runtime_configuration_cannot_panic_the_write_pipeline() {
+        let pg =
+            PgLedger::spawn("postgres://u:p@192.0.2.1:5432/x").expect("no ambient runtime needed");
+        let before = METRICS.insert_failures_pg.load(Ordering::Relaxed);
+        pg.record(
+            RowDraft::capture("o", "w", "u", "r-own-rt", "SELECT 1", None, None, 1000).finish(
+                RowStatus::Succeeded,
+                Some(1),
+                None,
+            ),
+        );
+        // The writer's own timer pays the flush bound and counts the loss;
+        // poll with std sleeps — deliberately no async here.
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        while METRICS.insert_failures_pg.load(Ordering::Relaxed) == before {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the writer's own timer must bound the flush and count the loss"
+            );
+            thread::sleep(Duration::from_millis(200));
+        }
+        // A timerless caller runtime is enough to drive shutdown.
         let rt = tokio::runtime::Builder::new_current_thread()
             .build()
-            .expect("runtime without enable_time");
-        let err = rt.block_on(async {
-            match PgLedger::spawn("postgres://u:p@192.0.2.1:5432/x") {
-                Ok(_) => panic!("must refuse a timerless runtime"),
-                Err(e) => e,
-            }
-        });
-        assert!(err.to_string().contains("timer"), "{err}");
-    }
-
-    /// `tokio::spawn` panics outside a runtime; the synchronous constructor
-    /// must refuse instead — a plain #[test] has no ambient runtime, which
-    /// is exactly the failing caller.
-    #[test]
-    fn constructing_outside_a_runtime_is_an_error_not_a_panic() {
-        let err = match PgLedger::spawn("postgres://u:p@192.0.2.1:5432/x") {
-            Ok(_) => panic!("must refuse without a runtime"),
-            Err(e) => e,
-        };
-        assert!(err.to_string().contains("Tokio runtime"), "{err}");
+            .expect("timerless runtime");
+        rt.block_on(pg.shutdown());
     }
 
     /// tokio's bounded channel panics on zero; the Result-returning

--- a/crates/query-audit/src/ledger/mod.rs
+++ b/crates/query-audit/src/ledger/mod.rs
@@ -357,7 +357,7 @@ fn scrub_nul(s: &str) -> String {
 
 /// True when any string in the document — values or object KEYS — contains
 /// U+0000, which JSONB cannot represent.
-fn json_contains_nul(v: &serde_json::Value) -> bool {
+fn json_contains_nul(v: &Value) -> bool {
     match v {
         Value::String(s) => s.contains('\0'),
         Value::Array(a) => a.iter().any(json_contains_nul),

--- a/crates/query-audit/src/ledger/mod.rs
+++ b/crates/query-audit/src/ledger/mod.rs
@@ -35,6 +35,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use anyhow::Context as _;
 use chrono::{DateTime, Utc};
 use serde_json::Value;
+use sqlx::postgres::PgPoolOptions;
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::{Notify, mpsc, watch};
@@ -52,6 +53,79 @@ pub const ERROR_MAX_BYTES: usize = 4 * 1024;
 /// Queue capacity in ROWS; with every field bounded at assembly the byte
 /// worst case is ~40 MiB per process.
 pub const QUEUE_CAPACITY: usize = 1024;
+
+/// The transport bound the read path's SELECT enforces on
+/// `ai_context::text` (2× [`ERROR_MAX_BYTES`]). Ingestion guarantees it:
+/// [`RowDraft::capture`] drops any document whose PG-CANONICAL text form
+/// (estimated by [`jsonb_text_len_estimate`]) exceeds this, so the SELECT's
+/// CASE can only ever null out-of-band writes, never a row this module
+/// accepted.
+pub const AI_CONTEXT_TRANSPORT_MAX_BYTES: usize = 2 * ERROR_MAX_BYTES;
+
+/// Estimate the length of Postgres's `jsonb::text` rendering of `v`. Two
+/// things grow past the compact serde form and both are covered: a space
+/// after every `:` and `,`, and NUMERIC CANONICALIZATION — jsonb stores
+/// numbers as `numeric` and prints them as plain decimals, so a 5-byte
+/// `1e300` becomes 301 digits, which no fixed multiplier on the compact
+/// length can bound. Escapes and key ordering only shrink or hold, so the
+/// estimate upper-bounds the real rendering for ingestion's purposes.
+fn jsonb_text_len_estimate(v: &Value) -> usize {
+    match v {
+        Value::Null => 4,
+        Value::Bool(b) => {
+            if *b {
+                4
+            } else {
+                5
+            }
+        }
+        Value::Number(n) => decimal_len_estimate(&n.to_string()),
+        Value::String(s) => serde_json::to_string(s).map(|t| t.len()).unwrap_or(2),
+        Value::Array(a) => {
+            let inner: usize = a.iter().map(jsonb_text_len_estimate).sum();
+            2 + inner + a.len().saturating_sub(1) * 2
+        }
+        Value::Object(o) => {
+            let inner: usize = o
+                .iter()
+                .map(|(k, val)| {
+                    serde_json::to_string(k).map(|t| t.len()).unwrap_or(2)
+                        + 2
+                        + jsonb_text_len_estimate(val)
+                })
+                .sum();
+            2 + inner + o.len().saturating_sub(1) * 2
+        }
+    }
+}
+
+/// Length of the plain-decimal expansion of a JSON number given its compact
+/// (ryu) rendering. `1e300` → 301, `1.5e-7` → 9-ish (`0.00000015`); plain
+/// forms pass through. Saturating, so absurd exponents cannot overflow.
+fn decimal_len_estimate(compact: &str) -> usize {
+    let lower = compact.to_ascii_lowercase();
+    let Some((mantissa, exp)) = lower.split_once('e') else {
+        return compact.len();
+    };
+    let Ok(exp) = exp.parse::<i64>() else {
+        // An exponent too large for i64 could not be a finite f64 anyway;
+        // if one ever appears, erring HUGE drops the document — the safe
+        // direction for a bound.
+        return usize::MAX;
+    };
+    let sign = usize::from(mantissa.starts_with('-'));
+    let digits = mantissa.chars().filter(|c| c.is_ascii_digit()).count();
+    if exp >= 0 {
+        let exp = usize::try_from(exp).unwrap_or(usize::MAX);
+        // Integer part grows to exp+1 digits (or keeps its own), plus room
+        // for a fraction remainder and its dot.
+        sign + digits.max(exp.saturating_add(1)).saturating_add(2)
+    } else {
+        let exp = usize::try_from(-exp).unwrap_or(usize::MAX);
+        // 0.<zeros><digits>
+        sign + 2usize.saturating_add(exp).saturating_add(digits)
+    }
+}
 
 /// Bound on each identity field (`org_id`, `workspace_id`, `user_id`,
 /// `request_id`) at assembly. Production values are gate-validated slugs a
@@ -204,6 +278,12 @@ impl RowDraft {
                     // WHOLE document rather than mutating it — an edited JSON
                     // document is a different document.
                     && !json_contains_nul(c)
+                    // The PG-canonical rendering must fit the read path's
+                    // transport bound: jsonb numeric canonicalization can
+                    // expand a compact-legal document without limit (1e300
+                    // is 5 bytes compact, 301 canonical), and a document the
+                    // read path would have to null was never worth queueing.
+                    && jsonb_text_len_estimate(c) <= AI_CONTEXT_TRANSPORT_MAX_BYTES
             })
             .cloned();
         Self {
@@ -359,9 +439,7 @@ impl PgLedger {
             "the ledger writer needs a running Tokio runtime; construct the \
              ledger from within one",
         )?;
-        let pool = sqlx::postgres::PgPoolOptions::new()
-            .max_connections(2)
-            .connect_lazy(dsn)?;
+        let pool = PgPoolOptions::new().max_connections(2).connect_lazy(dsn)?;
         let (tx, rx) = mpsc::channel(capacity);
         let (done_tx, done_rx) = watch::channel(false);
         let writer = Arc::new(WriterControl {
@@ -490,6 +568,44 @@ mod tests {
         let ai = json!({"session_id": "s".repeat(201)});
         let draft = RowDraft::capture("o", "w", "u", "r", "SELECT 1", Some(&ai), None, 1000);
         assert!(draft.session_id.is_none());
+    }
+
+    /// jsonb numeric canonicalization defeats any fixed multiplier: 1e300 is
+    /// 5 compact bytes and 301 canonical digits. Ingestion must drop what
+    /// the transport bound would null, so the read path never silently
+    /// loses an accepted document.
+    #[test]
+    fn exponent_heavy_ai_context_is_dropped_at_ingestion() {
+        // 500 × "1e300," ≈ 3.5 KB compact (passes the compact bound),
+        // canonical ≈ 150 KB (fails transport).
+        let bomb = Value::Array(vec![serde_json::json!(1e300); 500]);
+        assert!(serde_json::to_vec(&bomb).unwrap().len() <= ERROR_MAX_BYTES);
+        let draft = RowDraft::capture("o", "w", "u", "r", "SELECT 1", Some(&bomb), None, 1000);
+        assert!(
+            draft.ai_context.is_none(),
+            "canonical form exceeds transport"
+        );
+
+        // A normal near-limit document still passes (its whitespace-only
+        // expansion fits the 2x transport bound).
+        let mut obj = serde_json::Map::new();
+        for i in 0..330 {
+            obj.insert(format!("key{i:04}"), serde_json::json!(1));
+        }
+        let ok = Value::Object(obj);
+        let draft = RowDraft::capture("o", "w", "u", "r", "SELECT 1", Some(&ok), None, 1000);
+        assert!(draft.ai_context.is_some());
+    }
+
+    /// The decimal estimator upper-bounds PG's rendering for the shapes
+    /// that matter.
+    #[test]
+    fn decimal_estimates_cover_canonical_expansion() {
+        assert!(decimal_len_estimate("1e300") >= 301);
+        assert!(decimal_len_estimate("1.5e-7") >= "0.00000015".len());
+        assert_eq!(decimal_len_estimate("42"), 2);
+        assert_eq!(decimal_len_estimate("-3.25"), 5);
+        assert!(decimal_len_estimate("1e18446744073709551615") > 1_000_000);
     }
 
     /// `tokio::spawn` panics outside a runtime; the synchronous constructor

--- a/crates/query-audit/src/ledger/mod.rs
+++ b/crates/query-audit/src/ledger/mod.rs
@@ -304,11 +304,23 @@ fn truncate_utf8(s: &str, max: usize) -> (String, bool) {
 }
 
 /// The queued recorder: a bounded queue into the writer task and the lazy
-/// pool the read path shares. Cloning shares both.
+/// pool the read path shares. Cloning shares both, and the writer's handle
+/// (see [`Self::shutdown`]).
 #[derive(Clone)]
 pub struct PgLedger {
     tx: tokio::sync::mpsc::Sender<LedgerRow>,
     pool: sqlx::PgPool,
+    writer: std::sync::Arc<WriterControl>,
+}
+
+/// The writer task's shutdown plumbing. Held behind an `Arc` so every clone
+/// of the handle can trigger and await the same drain.
+pub(crate) struct WriterControl {
+    /// Signals the writer to close its receiver and drain what is buffered.
+    pub(crate) drain: tokio::sync::Notify,
+    /// The writer's JoinHandle, kept — a detached task dies WITH the runtime,
+    /// mid-flush, and rows lost that way would be counted by nobody.
+    handle: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 impl PgLedger {
@@ -328,8 +340,37 @@ impl PgLedger {
             .max_connections(2)
             .connect_lazy(dsn)?;
         let (tx, rx) = tokio::sync::mpsc::channel(capacity);
-        tokio::spawn(writer::run(pool.clone(), rx));
-        Ok(Self { tx, pool })
+        let writer = std::sync::Arc::new(WriterControl {
+            drain: tokio::sync::Notify::new(),
+            handle: std::sync::Mutex::new(None),
+        });
+        let handle = tokio::spawn(writer::run(pool.clone(), rx, writer.clone()));
+        *writer.handle.lock().expect("fresh mutex") = Some(handle);
+        Ok(Self { tx, pool, writer })
+    }
+
+    /// Graceful shutdown: signal the writer to stop accepting rows, drain and
+    /// flush everything already queued, and wait for it to finish. Call this
+    /// before letting the Tokio runtime wind down — a detached writer is
+    /// aborted WITH the runtime, mid-flush, and rows lost that way are
+    /// counted by nobody, which would break the loss-is-never-silent
+    /// contract. After shutdown, [`Self::record`] counts every further row
+    /// as a channel loss (the same accounting as a full queue).
+    ///
+    /// Unbounded by design — the drain is at most `capacity / FLUSH_BATCH`
+    /// flushes of [`FLUSH_TIMEOUT`] each; a caller with a deadline wraps
+    /// this in `tokio::time::timeout`, and rows still queued at a HARD
+    /// abort remain the accepted pod-crash loss class. Concurrent callers:
+    /// the first drives the drain; later calls return once it is done (the
+    /// handle is taken exactly once).
+    pub async fn shutdown(&self) {
+        self.writer.drain.notify_one();
+        let handle = self.writer.handle.lock().expect("writer mutex").take();
+        if let Some(handle) = handle {
+            // A panicked writer is already logged by the runtime; shutdown's
+            // job is only to not leave rows behind silently.
+            let _ = handle.await;
+        }
     }
 
     /// Enqueue one decided row. Never waits, never errors to the caller: a

--- a/crates/query-audit/src/ledger/mod.rs
+++ b/crates/query-audit/src/ledger/mod.rs
@@ -159,13 +159,15 @@ impl RowDraft {
         requested_max_rows: Option<usize>,
         default_max_rows: usize,
     ) -> Self {
-        let (sql, sql_truncated) = truncate_utf8(sql, SQL_MAX_BYTES);
+        let (sql, sql_truncated) = bound_text(sql, SQL_MAX_BYTES);
         let session_id = ai_context
             .and_then(|c| c.get("session_id"))
             .and_then(Value::as_str)
             // A longer value is a malformed caller assertion, dropped rather
-            // than truncated into a different-looking session.
-            .filter(|s| s.chars().count() <= crate::MAX_SESSION_ID_CHARS)
+            // than truncated into a different-looking session — and one
+            // carrying U+0000 (unstorable in TEXT) is dropped for the same
+            // reason: scrubbing would make it a different-looking session.
+            .filter(|s| s.chars().count() <= crate::MAX_SESSION_ID_CHARS && !s.contains('\0'))
             .map(str::to_string);
         // The column bound (≤ 4 KiB) is enforced HERE, not only by a route's
         // own refusal: a refused row for an oversized ai_context must not
@@ -176,13 +178,21 @@ impl RowDraft {
                 serde_json::to_vec(c)
                     .map(|v| v.len() <= ERROR_MAX_BYTES)
                     .unwrap_or(false)
+                    // JSONB cannot represent U+0000 anywhere in the document
+                    // (keys included); like the oversize case this drops the
+                    // WHOLE document rather than mutating it — an edited JSON
+                    // document is a different document.
+                    && !json_contains_nul(c)
             })
             .cloned();
         Self {
-            org_id: org_id.to_string(),
-            workspace_id: workspace_id.to_string(),
-            user_id: user_id.to_string(),
-            request_id: request_id.to_string(),
+            // Identity values arrive gate-validated in production, but
+            // assembly is the single bounding point and must not trust that:
+            // one NUL here would still poison the batch.
+            org_id: scrub_nul(org_id),
+            workspace_id: scrub_nul(workspace_id),
+            user_id: scrub_nul(user_id),
+            request_id: scrub_nul(request_id),
             session_id,
             created_at: Utc::now(),
             sql,
@@ -220,9 +230,47 @@ impl RowDraft {
             max_rows: self.max_rows,
             status,
             row_count: row_count.map(|n| i64::try_from(n).unwrap_or(i64::MAX)),
-            error: error.map(|e| truncate_utf8(&e, ERROR_MAX_BYTES).0),
+            error: error.map(|e| bound_text(&e, ERROR_MAX_BYTES).0),
         }
     }
+}
+
+/// U+0000 cannot be stored in Postgres TEXT or JSONB — one NUL in one
+/// field would reject the INSERT and poison the row's whole flush batch
+/// (up to [`FLUSH_BATCH_ROWS`] of OTHER callers' rows), which is exactly
+/// what assembly-time bounding exists to prevent. Scrubbed to U+FFFD, the
+/// standard replacement character, so the row still records that a value
+/// was there and was altered.
+fn scrub_nul(s: &str) -> String {
+    if s.contains('\0') {
+        s.replace('\0', "\u{FFFD}")
+    } else {
+        s.to_string()
+    }
+}
+
+/// True when any string in the document — values or object KEYS — contains
+/// U+0000, which JSONB cannot represent.
+fn json_contains_nul(v: &serde_json::Value) -> bool {
+    match v {
+        Value::String(s) => s.contains('\0'),
+        Value::Array(a) => a.iter().any(json_contains_nul),
+        Value::Object(o) => o
+            .iter()
+            .any(|(k, val)| k.contains('\0') || json_contains_nul(val)),
+        _ => false,
+    }
+}
+
+/// Scrub then truncate to at most `max` bytes on a char boundary. Returns
+/// the (possibly shortened) string and whether TRUNCATION happened (the NUL
+/// scrub is not flagged — a NUL was never valid content to preserve).
+/// Scrub first: the replacement char is 3 bytes where NUL was 1, so the
+/// byte bound must be applied to the final text.
+fn bound_text(s: &str, max: usize) -> (String, bool) {
+    let scrubbed = scrub_nul(s);
+    let (t, truncated) = truncate_utf8(&scrubbed, max);
+    (t, truncated)
 }
 
 /// Truncate to at most `max` bytes on a char boundary. Returns the (possibly
@@ -362,6 +410,53 @@ mod tests {
         let ai = json!({"session_id": "s".repeat(201)});
         let draft = RowDraft::capture("o", "w", "u", "r", "SELECT 1", Some(&ai), None, 1000);
         assert!(draft.session_id.is_none());
+    }
+
+    /// U+0000 is legal in a Rust String but unstorable in Postgres TEXT and
+    /// JSONB — one NUL would reject the INSERT and poison the row's whole
+    /// flush batch. Assembly scrubs text fields (U+FFFD), drops a NUL-bearing
+    /// session_id (scrubbing would rename the session), and drops a
+    /// NUL-bearing ai_context whole, keys included.
+    #[test]
+    fn nul_never_survives_assembly() {
+        let ai = json!({"session_id": "s\u{0}1", "purpose": "p"});
+        let draft = RowDraft::capture(
+            "o\u{0}rg",
+            "w",
+            "u",
+            "r",
+            "SELECT '\u{0}'",
+            Some(&ai),
+            None,
+            1000,
+        );
+        assert_eq!(draft.sql, "SELECT '\u{FFFD}'");
+        assert!(!draft.sql_truncated, "a scrub is not a truncation");
+        assert_eq!(draft.org_id, "o\u{FFFD}rg");
+        assert!(draft.session_id.is_none(), "a NUL session id is dropped");
+        assert!(
+            draft.ai_context.is_none(),
+            "a NUL-bearing document is dropped"
+        );
+
+        // NUL hiding in an object KEY is caught too.
+        let keyed = json!({"purpose": "p", "me\u{0}ta": {"x": 1}});
+        let draft = RowDraft::capture("o", "w", "u", "r", "SELECT 1", Some(&keyed), None, 1000);
+        assert!(draft.ai_context.is_none());
+
+        // A nested NUL in an array value is caught.
+        let nested = json!({"purpose": "p", "tags": ["ok", "ba\u{0}d"]});
+        let draft = RowDraft::capture("o", "w", "u", "r", "SELECT 1", Some(&nested), None, 1000);
+        assert!(draft.ai_context.is_none());
+
+        // A clean document still travels.
+        let clean = json!({"session_id": "s-1", "purpose": "p"});
+        let draft = RowDraft::capture("o", "w", "u", "r", "SELECT 1", Some(&clean), None, 1000);
+        assert!(draft.ai_context.is_some());
+
+        // The error text is scrubbed at finish.
+        let row = draft.finish(RowStatus::Failed, None, Some("boom\u{0}!".into()));
+        assert_eq!(row.error.as_deref(), Some("boom\u{FFFD}!"));
     }
 
     /// The 200 bound is CHARACTERS, the unit the wire validation counts in —

--- a/crates/query-audit/src/ledger/mod.rs
+++ b/crates/query-audit/src/ledger/mod.rs
@@ -20,8 +20,9 @@
 //! [`QueryAuditStore`]; if you want "learn-loop analytics that never costs a
 //! query", you want this.
 //!
-//! Schema: the [`queries::QUERY_LEDGER_DDL`] table (`query_ledger`), applied
-//! by the DOWNSTREAM deployment's migration path — this module runs no DDL
+//! Schema: the `query_ledger` table, versioned migration constants in
+//! [`queries`] (`QUERY_LEDGER_MIGRATION_0001`, …), applied by the DOWNSTREAM
+//! deployment's migration path — this module runs no DDL
 //! (its writers connect as roles that deliberately cannot).
 
 pub mod queries;
@@ -106,40 +107,48 @@ impl RowStatus {
 /// field is bounded and coerced**: `sql` truncated to [`SQL_MAX_BYTES`],
 /// `error` to [`ERROR_MAX_BYTES`], `max_rows` clamped into `i64` — so a batch
 /// can never be poisoned by one row.
+/// Fields are deliberately NOT public: the bound is a TYPE invariant.
+/// The only way to obtain a `LedgerRow` is [`RowDraft::capture`] →
+/// [`RowDraft::finish`], so a row handed to [`PgLedger::record`] is bounded
+/// by construction — public fields would let any caller bypass assembly and
+/// break both the ~40 MiB queue worst case and the no-poisoned-batch
+/// guarantee.
 #[derive(Debug, Clone)]
 pub struct LedgerRow {
-    pub org_id: String,
-    pub workspace_id: String,
-    pub user_id: String,
-    pub request_id: String,
-    pub session_id: Option<String>,
-    pub created_at: DateTime<Utc>,
-    pub finished_at: DateTime<Utc>,
-    pub sql: String,
-    pub sql_truncated: bool,
-    pub ai_context: Option<Value>,
-    pub statement_kind: &'static str,
-    pub max_rows: i64,
-    pub status: RowStatus,
-    pub row_count: Option<i64>,
-    pub error: Option<String>,
+    pub(crate) org_id: String,
+    pub(crate) workspace_id: String,
+    pub(crate) user_id: String,
+    pub(crate) request_id: String,
+    pub(crate) session_id: Option<String>,
+    pub(crate) created_at: DateTime<Utc>,
+    pub(crate) finished_at: DateTime<Utc>,
+    pub(crate) sql: String,
+    pub(crate) sql_truncated: bool,
+    pub(crate) ai_context: Option<Value>,
+    pub(crate) statement_kind: &'static str,
+    pub(crate) max_rows: i64,
+    pub(crate) status: RowStatus,
+    pub(crate) row_count: Option<i64>,
+    pub(crate) error: Option<String>,
 }
 
 /// The identity + request facts captured once the caller's identity gate has
 /// passed. The `sql` snapshot is truncated at capture, so a pending context
 /// never pins a multi-MiB statement.
+/// Same visibility rule as [`LedgerRow`]: constructed only by
+/// [`RowDraft::capture`], so the bounds cannot be bypassed.
 #[derive(Debug, Clone)]
 pub struct RowDraft {
-    pub org_id: String,
-    pub workspace_id: String,
-    pub user_id: String,
-    pub request_id: String,
-    pub session_id: Option<String>,
-    pub created_at: DateTime<Utc>,
-    pub sql: String,
-    pub sql_truncated: bool,
-    pub ai_context: Option<Value>,
-    pub max_rows: i64,
+    pub(crate) org_id: String,
+    pub(crate) workspace_id: String,
+    pub(crate) user_id: String,
+    pub(crate) request_id: String,
+    pub(crate) session_id: Option<String>,
+    pub(crate) created_at: DateTime<Utc>,
+    pub(crate) sql: String,
+    pub(crate) sql_truncated: bool,
+    pub(crate) ai_context: Option<Value>,
+    pub(crate) max_rows: i64,
 }
 
 impl RowDraft {

--- a/crates/query-audit/src/ledger/mod.rs
+++ b/crates/query-audit/src/ledger/mod.rs
@@ -29,8 +29,10 @@ pub mod queries;
 pub mod read;
 pub mod writer;
 
+use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::sync_channel;
 use std::thread;
 use std::time::Duration;
 
@@ -38,8 +40,9 @@ use anyhow::Context as _;
 use chrono::{DateTime, Utc};
 use serde_json::Value;
 use sqlx::PgPool;
-use sqlx::postgres::PgPoolOptions;
+use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 use tokio::runtime::Builder;
+use tokio::sync::Semaphore;
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::{Notify, mpsc, watch};
 
@@ -444,29 +447,64 @@ impl PgLedger {
             // to take the process down.
             anyhow::bail!("ledger queue capacity must be >= 1 (got 0)");
         }
-        let runtime = Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .context("build the ledger writer's runtime")?;
-        // Created under the writer runtime's context: sqlx's pool spawns
-        // internal tasks and takes deadlines from the runtime that is
-        // CURRENT at creation, and those must not depend on the caller's.
-        let pool = {
-            let _entered = runtime.enter();
-            PgPoolOptions::new().max_connections(2).connect_lazy(dsn)?
-        };
+        // The channel PANICS above the semaphore's permit ceiling too — the
+        // upper twin of the zero check.
+        if capacity > Semaphore::MAX_PERMITS {
+            anyhow::bail!(
+                "ledger queue capacity must be <= {} (got {capacity})",
+                Semaphore::MAX_PERMITS
+            );
+        }
+        // Parsed HERE, the only fallible piece of pool construction: a bad
+        // DSN must be an ordinary Err before any runtime exists — an error
+        // path that drops a Runtime on an async caller's stack panics
+        // instead of returning.
+        let options = PgConnectOptions::from_str(dsn).context("parse the ledger DSN")?;
         let (tx, rx) = mpsc::channel(capacity);
         let (done_tx, done_rx) = watch::channel(false);
         let writer = Arc::new(WriterControl {
             drain: Notify::new(),
             done: done_rx,
         });
-        let writer_pool = pool.clone();
+        // The runtime is built, used, and DROPPED entirely on the dedicated
+        // thread: tokio prohibits dropping a Runtime in async context, so no
+        // constructor error path may ever hold one on the caller's stack
+        // (the earlier shape dropped it there on connect/spawn failures).
+        // The startup handshake hands back the pool — created under the
+        // writer runtime so sqlx's internal tasks and deadlines live where
+        // the timer is — or the build error; connect_lazy_with itself is
+        // infallible and does no I/O, so the recv is microseconds.
+        let (pool_tx, pool_rx) = sync_channel::<anyhow::Result<PgPool>>(1);
         let writer_control = writer.clone();
         thread::Builder::new()
             .name("skardi-ledger-writer".to_string())
-            .spawn(move || runtime.block_on(writer::run(writer_pool, rx, writer_control, done_tx)))
+            .spawn(move || {
+                let runtime = match Builder::new_current_thread().enable_all().build() {
+                    Ok(runtime) => runtime,
+                    Err(e) => {
+                        let _ =
+                            pool_tx
+                                .send(Err(anyhow::Error::from(e)
+                                    .context("build the ledger writer's runtime")));
+                        return;
+                    }
+                };
+                let pool = {
+                    let _entered = runtime.enter();
+                    PgPoolOptions::new()
+                        .max_connections(2)
+                        .connect_lazy_with(options)
+                };
+                if pool_tx.send(Ok(pool.clone())).is_err() {
+                    // The constructor gave up; nothing to run for.
+                    return;
+                }
+                runtime.block_on(writer::run(pool, rx, writer_control, done_tx));
+            })
             .context("spawn the ledger writer thread")?;
+        let pool = pool_rx
+            .recv()
+            .context("the ledger writer thread died during startup")??;
         Ok(Self { tx, pool, writer })
     }
 
@@ -626,6 +664,25 @@ mod tests {
         assert_eq!(decimal_len_estimate("42"), 2);
         assert_eq!(decimal_len_estimate("-3.25"), 5);
         assert!(decimal_len_estimate("1e18446744073709551615") > 1_000_000);
+    }
+
+    /// Both channel-capacity panics are refused as errors: zero, and the
+    /// semaphore permit ceiling the bounded channel asserts against.
+    #[test]
+    fn out_of_range_capacities_are_errors_not_panics() {
+        for capacity in [0, Semaphore::MAX_PERMITS + 1] {
+            let result = PgLedger::spawn_with_capacity("postgres://u:p@192.0.2.1:5432/x", capacity);
+            assert!(result.is_err(), "capacity {capacity} must refuse");
+        }
+    }
+
+    /// A malformed DSN from an ASYNC caller must be an ordinary Err: the
+    /// earlier shape built the runtime first and the error path dropped it
+    /// on the async stack, which tokio answers with a panic, not our Result.
+    #[tokio::test]
+    async fn a_bad_dsn_from_async_context_is_an_error_not_a_panic() {
+        let result = PgLedger::spawn("definitely not a dsn");
+        assert!(result.is_err());
     }
 
     /// The writer owns its runtime, so the ambient one is irrelevant: a

--- a/crates/query-audit/src/ledger/mod.rs
+++ b/crates/query-audit/src/ledger/mod.rs
@@ -1,0 +1,370 @@
+//! The best-effort query ledger — the SECOND contract this crate hosts, and
+//! deliberately not a storage backend of [`QueryAuditStore`].
+//!
+//! [`QueryAuditStore`](crate::QueryAuditStore) is a **compliance record**:
+//! durable before execution, fail-closed (a statement that cannot be
+//! recorded does not run), two-phase (`started` → outcome, with startup
+//! reconciliation). This module is an **analytics ledger**: one row per
+//! DECIDED statement (`succeeded` / `failed` / `refused`), written
+//! best-effort AFTER the outcome is known, on a bounded queue the caller
+//! never waits for. A Postgres outage degrades the ledger and never the
+//! query path; loss is counted ([`METRICS`]), never silent.
+//!
+//! The OSS server does not wire this module; its consumer is the governed
+//! cloud engine (skardi-cloud's `2026-08-30-query-ledger-postgres-design.md`),
+//! whose N per-workspace pods share one Postgres and write as RLS-pinned
+//! per-workspace roles. It lives here so the audit domain has one home and
+//! the shared vocabulary (identity columns, `MAX_SESSION_ID_CHARS`) cannot
+//! drift — NOT because the two contracts are interchangeable. If you want
+//! "audit that refuses to run unrecorded statements", you want
+//! [`QueryAuditStore`]; if you want "learn-loop analytics that never costs a
+//! query", you want this.
+//!
+//! Schema: the [`queries::QUERY_LEDGER_DDL`] table (`query_ledger`), applied
+//! by the DOWNSTREAM deployment's migration path — this module runs no DDL
+//! (its writers connect as roles that deliberately cannot).
+
+pub mod queries;
+pub mod read;
+pub mod writer;
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+
+/// `sql` is truncated to this at ROW ASSEMBLY: the learn loop wants
+/// patterns, not megabyte literals, and bounding at ingestion is what keeps
+/// the queue's worst case ~40 MiB instead of ~8 GiB (1024 rows × an 8 MiB
+/// statement ceiling).
+pub const SQL_MAX_BYTES: usize = 32 * 1024;
+
+/// `error` shares `ai_context`'s 4 KiB bound: failures and refusals are the
+/// most instructive rows, but they carry engine text, not documents.
+pub const ERROR_MAX_BYTES: usize = 4 * 1024;
+
+/// Queue capacity in ROWS; with every field bounded at assembly the byte
+/// worst case is ~40 MiB per process.
+pub const QUEUE_CAPACITY: usize = 1024;
+
+/// Rows per multi-row INSERT flush.
+pub const FLUSH_BATCH_ROWS: usize = 64;
+
+/// Wall-clock bound on one flush. A slow PG drops the batch (counted),
+/// never stalls the writer behind an unbounded await.
+pub const FLUSH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Loss accounting: dropped is never silent. The consumer renders this into
+/// its own metrics surface.
+#[derive(Debug, Default)]
+pub struct Metrics {
+    /// A flush failed or timed out; the whole batch was dropped (logged with
+    /// its request ids).
+    pub insert_failures_pg: AtomicU64,
+    /// `try_send` refused — the channel was full; the row was dropped.
+    pub insert_failures_channel_full: AtomicU64,
+}
+
+pub static METRICS: Metrics = Metrics {
+    insert_failures_pg: AtomicU64::new(0),
+    insert_failures_channel_full: AtomicU64::new(0),
+};
+
+impl Metrics {
+    pub fn render(&self) -> String {
+        format!(
+            "# TYPE ledger_insert_failures_total counter\n\
+             ledger_insert_failures_total{{reason=\"pg\"}} {}\n\
+             ledger_insert_failures_total{{reason=\"channel_full\"}} {}\n",
+            self.insert_failures_pg.load(Ordering::Relaxed),
+            self.insert_failures_channel_full.load(Ordering::Relaxed),
+        )
+    }
+}
+
+/// Row status vocabulary. `refused` is this ledger's extension to the
+/// [`QueryAuditStatus`](crate::QueryAuditStatus) set; `started`/`unknown`
+/// have no counterpart here because there is no two-phase write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RowStatus {
+    Succeeded,
+    Failed,
+    Refused,
+}
+
+impl RowStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            RowStatus::Succeeded => "succeeded",
+            RowStatus::Failed => "failed",
+            RowStatus::Refused => "refused",
+        }
+    }
+}
+
+/// One fully-bounded, insert-ready row. **Assembly is the single place every
+/// field is bounded and coerced**: `sql` truncated to [`SQL_MAX_BYTES`],
+/// `error` to [`ERROR_MAX_BYTES`], `max_rows` clamped into `i64` — so a batch
+/// can never be poisoned by one row.
+#[derive(Debug, Clone)]
+pub struct LedgerRow {
+    pub org_id: String,
+    pub workspace_id: String,
+    pub user_id: String,
+    pub request_id: String,
+    pub session_id: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub finished_at: DateTime<Utc>,
+    pub sql: String,
+    pub sql_truncated: bool,
+    pub ai_context: Option<Value>,
+    pub statement_kind: &'static str,
+    pub max_rows: i64,
+    pub status: RowStatus,
+    pub row_count: Option<i64>,
+    pub error: Option<String>,
+}
+
+/// The identity + request facts captured once the caller's identity gate has
+/// passed. The `sql` snapshot is truncated at capture, so a pending context
+/// never pins a multi-MiB statement.
+#[derive(Debug, Clone)]
+pub struct RowDraft {
+    pub org_id: String,
+    pub workspace_id: String,
+    pub user_id: String,
+    pub request_id: String,
+    pub session_id: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub sql: String,
+    pub sql_truncated: bool,
+    pub ai_context: Option<Value>,
+    pub max_rows: i64,
+}
+
+impl RowDraft {
+    /// Capture the bounded draft. `session_id` is denormalized out of
+    /// `ai_context` exactly as [`QueryAuditStore`](crate::QueryAuditStore)
+    /// does, so session lookups keep working on the same key — and the bound
+    /// is [`MAX_SESSION_ID_CHARS`](crate::MAX_SESSION_ID_CHARS) in
+    /// CHARACTERS, the same unit the wire validation counts in.
+    #[allow(clippy::too_many_arguments)] // mirrors the row's identity columns
+    pub fn capture(
+        org_id: &str,
+        workspace_id: &str,
+        user_id: &str,
+        request_id: &str,
+        sql: &str,
+        ai_context: Option<&Value>,
+        requested_max_rows: Option<usize>,
+        default_max_rows: usize,
+    ) -> Self {
+        let (sql, sql_truncated) = truncate_utf8(sql, SQL_MAX_BYTES);
+        let session_id = ai_context
+            .and_then(|c| c.get("session_id"))
+            .and_then(Value::as_str)
+            // A longer value is a malformed caller assertion, dropped rather
+            // than truncated into a different-looking session.
+            .filter(|s| s.chars().count() <= crate::MAX_SESSION_ID_CHARS)
+            .map(str::to_string);
+        // The column bound (≤ 4 KiB) is enforced HERE, not only by a route's
+        // own refusal: a refused row for an oversized ai_context must not
+        // smuggle the very payload the refusal exists to bound. Dropped, not
+        // truncated — a truncated JSON document is not a JSON document.
+        let ai_context = ai_context
+            .filter(|c| {
+                serde_json::to_vec(c)
+                    .map(|v| v.len() <= ERROR_MAX_BYTES)
+                    .unwrap_or(false)
+            })
+            .cloned();
+        Self {
+            org_id: org_id.to_string(),
+            workspace_id: workspace_id.to_string(),
+            user_id: user_id.to_string(),
+            request_id: request_id.to_string(),
+            session_id,
+            created_at: Utc::now(),
+            sql,
+            sql_truncated,
+            ai_context,
+            // Clamped into i64 at assembly: a refused row's requested value
+            // may exceed any ceiling — a 3,000,000,000 must land clamped,
+            // not sink its batch.
+            max_rows: requested_max_rows
+                .unwrap_or(default_max_rows)
+                .try_into()
+                .unwrap_or(i64::MAX),
+        }
+    }
+
+    /// Finish the draft into an insert-ready row.
+    pub fn finish(
+        self,
+        status: RowStatus,
+        row_count: Option<usize>,
+        error: Option<String>,
+    ) -> LedgerRow {
+        LedgerRow {
+            org_id: self.org_id,
+            workspace_id: self.workspace_id,
+            user_id: self.user_id,
+            request_id: self.request_id,
+            session_id: self.session_id,
+            created_at: self.created_at,
+            finished_at: Utc::now(),
+            sql: self.sql,
+            sql_truncated: self.sql_truncated,
+            ai_context: self.ai_context,
+            statement_kind: "query",
+            max_rows: self.max_rows,
+            status,
+            row_count: row_count.map(|n| i64::try_from(n).unwrap_or(i64::MAX)),
+            error: error.map(|e| truncate_utf8(&e, ERROR_MAX_BYTES).0),
+        }
+    }
+}
+
+/// Truncate to at most `max` bytes on a char boundary. Returns the (possibly
+/// shortened) string and whether truncation happened.
+fn truncate_utf8(s: &str, max: usize) -> (String, bool) {
+    if s.len() <= max {
+        return (s.to_string(), false);
+    }
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    (s[..end].to_string(), true)
+}
+
+/// The queued recorder: a bounded queue into the writer task and the lazy
+/// pool the read path shares. Cloning shares both.
+#[derive(Clone)]
+pub struct PgLedger {
+    tx: tokio::sync::mpsc::Sender<LedgerRow>,
+    pool: sqlx::PgPool,
+}
+
+impl PgLedger {
+    /// Construct the lazy pool (max 2 connections — the consumer's many
+    /// processes share one PG) and spawn the writer. Makes NO connection:
+    /// nothing about the ledger is boot-fatal.
+    pub fn spawn(dsn: &str) -> anyhow::Result<Self> {
+        Self::spawn_with_capacity(dsn, QUEUE_CAPACITY)
+    }
+
+    /// [`spawn`](Self::spawn) with an explicit queue bound. Production always
+    /// goes through `spawn` ([`QUEUE_CAPACITY`]); this seam exists so the
+    /// queue-full contract — drop + count, never block — is testable without
+    /// enqueueing a thousand rows against a hung writer.
+    pub fn spawn_with_capacity(dsn: &str, capacity: usize) -> anyhow::Result<Self> {
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .max_connections(2)
+            .connect_lazy(dsn)?;
+        let (tx, rx) = tokio::sync::mpsc::channel(capacity);
+        tokio::spawn(writer::run(pool.clone(), rx));
+        Ok(Self { tx, pool })
+    }
+
+    /// Enqueue one decided row. Never waits, never errors to the caller: a
+    /// full channel drops the row and counts it.
+    pub fn record(&self, row: LedgerRow) {
+        if let Err(e) = self.tx.try_send(row) {
+            METRICS
+                .insert_failures_channel_full
+                .fetch_add(1, Ordering::Relaxed);
+            let request_id = match &e {
+                tokio::sync::mpsc::error::TrySendError::Full(r)
+                | tokio::sync::mpsc::error::TrySendError::Closed(r) => r.request_id.clone(),
+            };
+            tracing::warn!(%request_id, "ledger row dropped: queue full or writer gone");
+        }
+    }
+
+    pub fn pool(&self) -> &sqlx::PgPool {
+        &self.pool
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn assembly_bounds_every_field() {
+        // An 8 MiB statement lands truncated at 32 KiB with the flag set.
+        let big_sql = "S".repeat(8 * 1024 * 1024);
+        let draft = RowDraft::capture(
+            "acme",
+            "acme-prod",
+            "user:acme/u1",
+            "req-1",
+            &big_sql,
+            Some(&json!({"session_id": "s-1", "purpose": "test"})),
+            // The poison case: a refused row whose requested max_rows
+            // exceeds i64 must clamp, not sink its batch.
+            Some(usize::MAX),
+            1000,
+        );
+        assert_eq!(draft.sql.len(), SQL_MAX_BYTES);
+        assert!(draft.sql_truncated);
+        assert_eq!(draft.max_rows, i64::MAX);
+        assert_eq!(draft.session_id.as_deref(), Some("s-1"));
+
+        let row = draft.finish(
+            RowStatus::Refused,
+            None,
+            Some("plan-error: ".to_string() + &"x".repeat(64 * 1024)),
+        );
+        assert_eq!(row.status.as_str(), "refused");
+        assert!(row.error.as_ref().unwrap().len() <= ERROR_MAX_BYTES);
+        assert!(row.row_count.is_none());
+        assert!(row.finished_at >= row.created_at);
+    }
+
+    #[test]
+    fn truncation_respects_char_boundaries() {
+        // A multi-byte char straddling the cut must not split.
+        let s = format!("{}文", "a".repeat(SQL_MAX_BYTES - 1));
+        let (t, truncated) = truncate_utf8(&s, SQL_MAX_BYTES);
+        assert!(truncated);
+        assert!(t.len() <= SQL_MAX_BYTES);
+        assert!(std::str::from_utf8(t.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn oversized_ai_context_never_reaches_a_row() {
+        // The refused row for an oversized ai_context must not carry it.
+        let big = json!({"session_id": "s-1", "blob": "x".repeat(64 * 1024)});
+        let draft = RowDraft::capture("o", "w", "u", "r", "SELECT 1", Some(&big), None, 1000);
+        assert!(draft.ai_context.is_none());
+        // session_id extraction still happened before the drop.
+        assert_eq!(draft.session_id.as_deref(), Some("s-1"));
+    }
+
+    #[test]
+    fn overlong_session_ids_are_dropped_not_truncated() {
+        let ai = json!({"session_id": "s".repeat(201)});
+        let draft = RowDraft::capture("o", "w", "u", "r", "SELECT 1", Some(&ai), None, 1000);
+        assert!(draft.session_id.is_none());
+    }
+
+    /// The 200 bound is CHARACTERS, the unit the wire validation counts in —
+    /// a 150-char CJK id is 450 UTF-8 bytes and contract-valid, and a
+    /// byte-counted filter would silently drop it, breaking its own session
+    /// filter. 201 chars stays dropped in any alphabet.
+    #[test]
+    fn session_id_bound_counts_characters_not_bytes() {
+        let cjk = "审".repeat(150);
+        assert_eq!(cjk.len(), 450, "the fixture must be multi-byte");
+        let ai = json!({ "session_id": cjk.clone() });
+        let draft = RowDraft::capture("o", "w", "u", "r", "SELECT 1", Some(&ai), None, 1000);
+        assert_eq!(draft.session_id.as_deref(), Some(cjk.as_str()));
+
+        let too_long = json!({ "session_id": "审".repeat(201) });
+        let draft = RowDraft::capture("o", "w", "u", "r", "SELECT 1", Some(&too_long), None, 1000);
+        assert!(draft.session_id.is_none());
+    }
+}

--- a/crates/query-audit/src/ledger/mod.rs
+++ b/crates/query-audit/src/ledger/mod.rs
@@ -36,7 +36,7 @@ use std::sync::mpsc::sync_channel;
 use std::thread;
 use std::time::Duration;
 
-use anyhow::Context as _;
+use anyhow::{Context as _, Error, Result, bail};
 use chrono::{DateTime, Utc};
 use serde_json::Value;
 use sqlx::PgPool;
@@ -421,7 +421,7 @@ impl PgLedger {
     /// Construct the lazy pool (max 2 connections — the consumer's many
     /// processes share one PG) and spawn the writer. Makes NO connection:
     /// nothing about the ledger is boot-fatal.
-    pub fn spawn(dsn: &str) -> anyhow::Result<Self> {
+    pub fn spawn(dsn: &str) -> Result<Self> {
         Self::spawn_with_capacity(dsn, QUEUE_CAPACITY)
     }
 
@@ -440,17 +440,17 @@ impl PgLedger {
     /// internal tasks and deadlines live where the timer is. The READ path
     /// ([`read::list_page`]) runs on the caller's runtime and needs it
     /// sqlx-capable (timer enabled), like any sqlx call.
-    pub fn spawn_with_capacity(dsn: &str, capacity: usize) -> anyhow::Result<Self> {
+    pub fn spawn_with_capacity(dsn: &str, capacity: usize) -> Result<Self> {
         if capacity == 0 {
             // tokio's bounded channel PANICS on zero; this constructor
             // advertises Result, so invalid configuration must not be able
             // to take the process down.
-            anyhow::bail!("ledger queue capacity must be >= 1 (got 0)");
+            bail!("ledger queue capacity must be >= 1 (got 0)");
         }
         // The channel PANICS above the semaphore's permit ceiling too — the
         // upper twin of the zero check.
         if capacity > Semaphore::MAX_PERMITS {
-            anyhow::bail!(
+            bail!(
                 "ledger queue capacity must be <= {} (got {capacity})",
                 Semaphore::MAX_PERMITS
             );
@@ -474,7 +474,7 @@ impl PgLedger {
         // writer runtime so sqlx's internal tasks and deadlines live where
         // the timer is — or the build error; connect_lazy_with itself is
         // infallible and does no I/O, so the recv is microseconds.
-        let (pool_tx, pool_rx) = sync_channel::<anyhow::Result<PgPool>>(1);
+        let (pool_tx, pool_rx) = sync_channel::<Result<PgPool>>(1);
         let writer_control = writer.clone();
         thread::Builder::new()
             .name("skardi-ledger-writer".to_string())
@@ -482,10 +482,9 @@ impl PgLedger {
                 let runtime = match Builder::new_current_thread().enable_all().build() {
                     Ok(runtime) => runtime,
                     Err(e) => {
-                        let _ =
-                            pool_tx
-                                .send(Err(anyhow::Error::from(e)
-                                    .context("build the ledger writer's runtime")));
+                        let _ = pool_tx.send(Err(
+                            Error::from(e).context("build the ledger writer's runtime")
+                        ));
                         return;
                     }
                 };

--- a/crates/query-audit/src/ledger/queries.rs
+++ b/crates/query-audit/src/ledger/queries.rs
@@ -21,9 +21,30 @@ pub const INSERT_HEAD: &str = "INSERT INTO query_ledger \
 /// `$4`/`$5` are `since`/`until` (NULL = unbounded), `$6` the optional
 /// `session_id`, `$7` the optional `status`, `$8` the LIMIT (already capped
 /// at 500 by the route).
-pub const SELECT_PAGE: &str = "SELECT id, org_id, workspace_id, user_id, request_id, session_id, \
-            created_at, finished_at, sql, sql_truncated, ai_context, \
-            statement_kind, max_rows, status, row_count, error \
+/// Text fields are BOUNDED IN THE SELECT (`left(...)`), not only at Rust
+/// serialization: a row written past the assembly can be arbitrarily large,
+/// and `fetch_all` materializes up to 500 whole rows before Rust sees one —
+/// unbounded fields there are an OOM, not a formatting problem. `left`
+/// counts characters (so a multi-byte page may still exceed the BYTE bound
+/// by ~4x); the Rust side re-applies the byte-precise bounds, and the
+/// `sql_truncated` flag is computed here from `octet_length` so a SQL-side
+/// cut is still declared to the reader. The literals must equal
+/// `SQL_MAX_BYTES` / `ERROR_MAX_BYTES` / the read field bound — pinned by a
+/// unit test.
+pub const SELECT_PAGE: &str = "SELECT id, \
+            left(org_id, 4096) AS org_id, \
+            left(workspace_id, 4096) AS workspace_id, \
+            left(user_id, 4096) AS user_id, \
+            left(request_id, 4096) AS request_id, \
+            left(session_id, 4096) AS session_id, \
+            created_at, finished_at, \
+            left(sql, 32768) AS sql, \
+            (sql_truncated OR octet_length(sql) > 32768) AS sql_truncated, \
+            CASE WHEN octet_length(ai_context::text) <= 4096 THEN ai_context \
+                 ELSE NULL END AS ai_context, \
+            left(statement_kind, 4096) AS statement_kind, \
+            max_rows, status, row_count, \
+            left(error, 4096) AS error \
      FROM query_ledger \
      WHERE workspace_id = $1 \
        AND (created_at, id) < ($2, $3) \

--- a/crates/query-audit/src/ledger/queries.rs
+++ b/crates/query-audit/src/ledger/queries.rs
@@ -31,6 +31,15 @@ pub const INSERT_HEAD: &str = "INSERT INTO query_ledger \
 /// cut is still declared to the reader. The literals must equal
 /// `SQL_MAX_BYTES` / `ERROR_MAX_BYTES` / the read field bound — pinned by a
 /// unit test.
+///
+/// The `ai_context` CASE is a TRANSPORT bound at 2× the ingestion limit,
+/// not the limit itself: Postgres renders `jsonb::text` with spaces after
+/// `:` and `,`, so a document whose COMPACT form fits 4096 bytes (which is
+/// what ingestion accepted) can measure larger here — nulling at 4096 would
+/// silently lose valid context. 2× safely covers the expansion (a compact
+/// 4096-byte document holds < 2048 separators, so < +2048 bytes of
+/// whitespace); the byte-precise compact check re-runs in Rust after
+/// decoding, which stays the authority.
 pub const SELECT_PAGE: &str = "SELECT id, \
             left(org_id, 4096) AS org_id, \
             left(workspace_id, 4096) AS workspace_id, \
@@ -40,7 +49,7 @@ pub const SELECT_PAGE: &str = "SELECT id, \
             created_at, finished_at, \
             left(sql, 32768) AS sql, \
             (sql_truncated OR octet_length(sql) > 32768) AS sql_truncated, \
-            CASE WHEN octet_length(ai_context::text) <= 4096 THEN ai_context \
+            CASE WHEN octet_length(ai_context::text) <= 8192 THEN ai_context \
                  ELSE NULL END AS ai_context, \
             left(statement_kind, 4096) AS statement_kind, \
             max_rows, status, row_count, \

--- a/crates/query-audit/src/ledger/queries.rs
+++ b/crates/query-audit/src/ledger/queries.rs
@@ -49,14 +49,21 @@ pub const DATABASE_EXISTS: &str = "SELECT EXISTS (SELECT 1 FROM pg_database WHER
 /// See [`LEDGER_DB_NAME`] for why the name is spelled twice.
 pub const CREATE_DATABASE: &str = r#"CREATE DATABASE "skardi_ledger""#;
 
-/// The `query_ledger` schema — the SINGLE SOURCE OF TRUTH. This module runs
-/// no DDL itself (its writers connect as roles that deliberately cannot);
-/// the consumer's migration path applies it, and the consumer's migration
-/// file must stay BYTE-IDENTICAL to this constant (skardi-cloud pins that
-/// with a test against its sqlx migration, whose checksum is itself locked).
-/// Changing this string is a schema migration: coordinate with every
-/// consumer before touching it.
-pub const QUERY_LEDGER_DDL: &str = r#"-- The cloud query ledger (design: 2026-08-30-query-ledger-postgres-design.md §3).
+/// Migration 0001 — the `query_ledger` schema's first (and so far only)
+/// migration, and the single source of truth for it. This module runs no
+/// DDL itself (its writers connect as roles that deliberately cannot); the
+/// consumer's migration path applies it, and each consumer migration file
+/// must stay BYTE-IDENTICAL to its versioned constant here (skardi-cloud
+/// pins that with a test against its sqlx migration, whose checksum is
+/// itself locked and append-only).
+///
+/// **This constant is IMMUTABLE once a consumer has shipped it** — exactly
+/// like the migration files it feeds. A schema change is a NEW versioned
+/// constant (`QUERY_LEDGER_MIGRATION_0002`, …) that consumers append as a
+/// new migration and pin the same way; the full schema is the ordered
+/// application of every constant. Editing an existing constant would break
+/// every consumer's locked checksum and is never the answer.
+pub const QUERY_LEDGER_MIGRATION_0001: &str = r#"-- The cloud query ledger (design: 2026-08-30-query-ledger-postgres-design.md §3).
 --
 -- One row per DECIDED statement — status ∈ (succeeded, failed, refused);
 -- there is no `started` phase and no orphan reconciliation, because the
@@ -95,7 +102,7 @@ CREATE TABLE query_ledger (
 ALTER TABLE query_ledger ENABLE ROW LEVEL SECURITY;
 ALTER TABLE query_ledger FORCE ROW LEVEL SECURITY;
 
-CREATE INDEX ledger_ws_created_idx  ON query_ledger (workspace_id, created_at DESC);
-CREATE INDEX ledger_ws_session_idx  ON query_ledger (workspace_id, session_id, created_at DESC);
+CREATE INDEX ledger_ws_created_idx  ON query_ledger (workspace_id, created_at DESC, id DESC);
+CREATE INDEX ledger_ws_session_idx  ON query_ledger (workspace_id, session_id, created_at DESC, id DESC);
 CREATE INDEX ledger_org_created_idx ON query_ledger (org_id, created_at DESC);
 "#;

--- a/crates/query-audit/src/ledger/queries.rs
+++ b/crates/query-audit/src/ledger/queries.rs
@@ -1,0 +1,101 @@
+//! Every SQL statement the best-effort ledger runs, as documented constants
+//! (SQL lives in `pub const` strings, never inline in call sites) — plus the
+//! table's DDL, of which this file is the single source of truth.
+
+/// One batch INSERT row's worth of placeholders is appended per queued row
+/// by the writer ([`super::writer`]); this is the fixed head. Column order
+/// is the binding order in `writer::flush` — the two are one file apart on
+/// purpose, and the store integration test round-trips every column.
+pub const INSERT_HEAD: &str = "INSERT INTO query_ledger \
+     (org_id, workspace_id, user_id, request_id, session_id, \
+      created_at, finished_at, sql, sql_truncated, ai_context, \
+      statement_kind, max_rows, status, row_count, error) ";
+
+/// The read page (§5): the deployment's own workspace only — `$1` comes from
+/// the envelope, never the query string — newest-first over the stable
+/// `(created_at, id)` keyset. The cursor keys land in `$2`/`$3`: rows
+/// strictly below `(cursor_created_at, cursor_id)` in that order. For the
+/// first page the caller passes `(infinity, i64::MAX)` so the predicate is
+/// vacuously true — one statement, no dynamic SQL.
+///
+/// `$4`/`$5` are `since`/`until` (NULL = unbounded), `$6` the optional
+/// `session_id`, `$7` the optional `status`, `$8` the LIMIT (already capped
+/// at 500 by the route).
+pub const SELECT_PAGE: &str = "SELECT id, org_id, workspace_id, user_id, request_id, session_id, \
+            created_at, finished_at, sql, sql_truncated, ai_context, \
+            statement_kind, max_rows, status, row_count, error \
+     FROM query_ledger \
+     WHERE workspace_id = $1 \
+       AND (created_at, id) < ($2, $3) \
+       AND ($4::timestamptz IS NULL OR created_at >= $4) \
+       AND ($5::timestamptz IS NULL OR created_at <= $5) \
+       AND ($6::text IS NULL OR session_id = $6) \
+       AND ($7::text IS NULL OR status = $7) \
+     ORDER BY created_at DESC, id DESC \
+     LIMIT $8";
+
+/// The one database the ledger lives in (2026-08-30 design §3). Kept
+/// adjacent to [`CREATE_DATABASE`], which spells the same name as a literal:
+/// sqlx 0.9's `SqlSafeStr` audit gate accepts only literals, so the pair is
+/// co-located here where a rename cannot drift them apart silently.
+pub const LEDGER_DB_NAME: &str = "skardi_ledger";
+
+/// The migrate job's existence probe (`skardi-ledger-migrate` step 1):
+/// `CREATE DATABASE` cannot run inside a transaction and has no
+/// `IF NOT EXISTS`, so the binary probes first and treats a raced duplicate
+/// create (42P04) as success.
+pub const DATABASE_EXISTS: &str = "SELECT EXISTS (SELECT 1 FROM pg_database WHERE datname = $1)";
+
+/// See [`LEDGER_DB_NAME`] for why the name is spelled twice.
+pub const CREATE_DATABASE: &str = r#"CREATE DATABASE "skardi_ledger""#;
+
+/// The `query_ledger` schema — the SINGLE SOURCE OF TRUTH. This module runs
+/// no DDL itself (its writers connect as roles that deliberately cannot);
+/// the consumer's migration path applies it, and the consumer's migration
+/// file must stay BYTE-IDENTICAL to this constant (skardi-cloud pins that
+/// with a test against its sqlx migration, whose checksum is itself locked).
+/// Changing this string is a schema migration: coordinate with every
+/// consumer before touching it.
+pub const QUERY_LEDGER_DDL: &str = r#"-- The cloud query ledger (design: 2026-08-30-query-ledger-postgres-design.md §3).
+--
+-- One row per DECIDED statement — status ∈ (succeeded, failed, refused);
+-- there is no `started` phase and no orphan reconciliation, because the
+-- cloud ledger records completed attempts best-effort (§2), which is what
+-- permits N engine pods to share this table.
+--
+-- Applied ONLY by the `skardi-ledger-migrate` job binary (§6) with a
+-- superuser-capable DSN; engine pods never run DDL here. Row-level security
+-- is FORCED so even a future table owner is policy-bound; per-workspace
+-- roles and their policies are minted by the operator, not this migration.
+--
+-- `org_id`/`workspace_id` are TEXT slugs — the envelope deliberately carries
+-- slugs, never row uuids (§3). `org_id` is write-time attribution and is
+-- never rewritten; `workspace_id` is ownership (RLS, reads, retention,
+-- teardown all pivot on it).
+
+CREATE TABLE query_ledger (
+    id             BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    org_id         TEXT NOT NULL,
+    workspace_id   TEXT NOT NULL,
+    user_id        TEXT NOT NULL,
+    request_id     TEXT NOT NULL,
+    session_id     TEXT,
+    created_at     TIMESTAMPTZ NOT NULL,
+    finished_at    TIMESTAMPTZ NOT NULL,
+    sql            TEXT NOT NULL,
+    sql_truncated  BOOLEAN NOT NULL DEFAULT FALSE,
+    ai_context     JSONB,
+    statement_kind TEXT NOT NULL,
+    max_rows       BIGINT NOT NULL,
+    status         TEXT NOT NULL CHECK (status IN ('succeeded', 'failed', 'refused')),
+    row_count      BIGINT,
+    error          TEXT
+);
+
+ALTER TABLE query_ledger ENABLE ROW LEVEL SECURITY;
+ALTER TABLE query_ledger FORCE ROW LEVEL SECURITY;
+
+CREATE INDEX ledger_ws_created_idx  ON query_ledger (workspace_id, created_at DESC);
+CREATE INDEX ledger_ws_session_idx  ON query_ledger (workspace_id, session_id, created_at DESC);
+CREATE INDEX ledger_org_created_idx ON query_ledger (org_id, created_at DESC);
+"#;

--- a/crates/query-audit/src/ledger/read.rs
+++ b/crates/query-audit/src/ledger/read.rs
@@ -7,6 +7,9 @@
 //! response says so (`truncated: true` + `next_cursor`), because 500 rows of
 //! even ingestion-bounded fields can pass the `/data_source` budget.
 
+use std::error::Error;
+use std::fmt;
+
 use base64::Engine as _;
 use chrono::{DateTime, Utc};
 use serde_json::{Value, json};
@@ -68,8 +71,8 @@ pub enum ReadError {
     Unavailable(SqlxError),
 }
 
-impl std::fmt::Display for ReadError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for ReadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ReadError::BadRequest(m) => write!(f, "{m}"),
             ReadError::Unavailable(_) => write!(f, "ledger read failed"),
@@ -77,8 +80,8 @@ impl std::fmt::Display for ReadError {
     }
 }
 
-impl std::error::Error for ReadError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl Error for ReadError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             ReadError::BadRequest(_) => None,
             ReadError::Unavailable(e) => Some(e),
@@ -260,11 +263,11 @@ mod tests {
     fn read_error_display_and_source() {
         let bad = ReadError::BadRequest("limit must be >= 1".into());
         assert_eq!(bad.to_string(), "limit must be >= 1");
-        assert!(std::error::Error::source(&bad).is_none());
+        assert!(Error::source(&bad).is_none());
 
         let unavailable = ReadError::Unavailable(SqlxError::PoolClosed);
         assert_eq!(unavailable.to_string(), "ledger read failed");
-        let src = std::error::Error::source(&unavailable).expect("driver cause");
+        let src = Error::source(&unavailable).expect("driver cause");
         assert!(src.to_string().contains("closed"), "{src}");
     }
 

--- a/crates/query-audit/src/ledger/read.rs
+++ b/crates/query-audit/src/ledger/read.rs
@@ -12,7 +12,7 @@ use chrono::{DateTime, Utc};
 use serde_json::{Value, json};
 use sqlx::{PgPool, Row};
 
-use super::queries;
+use super::{ERROR_MAX_BYTES, SQL_MAX_BYTES, queries};
 
 pub const LIMIT_DEFAULT: i64 = 100;
 pub const LIMIT_MAX: i64 = 500;
@@ -23,6 +23,16 @@ pub const LIMIT_MAX: i64 = 500;
 /// turns into a deterministic 413 — and the same cursor fetches the same
 /// page, so the caller is livelocked until the rows age out.
 pub const RESPONSE_MAX_BYTES: usize = 8 * 1024 * 1024;
+
+/// Read-side bound on any single text field. The DDL deliberately carries
+/// no length constraints (ingestion bounds live at assembly), so a row
+/// written PAST the assembly — by hand, by another tool, by a future writer
+/// with a bug — can be arbitrarily large. The read path re-applies the
+/// ingestion bounds when serializing, which makes the 8 MiB body budget
+/// STRUCTURAL: every emitted row is ≤ ~50 KiB, so even the page's first row
+/// can never overflow the budget, and the keyset always advances past a
+/// monster row instead of livelocking the cursor on it.
+const READ_FIELD_MAX_BYTES: usize = 4 * 1024;
 
 /// Headroom [`list_page`] holds back from [`RESPONSE_MAX_BYTES`] for
 /// everything that is not a row: the envelope framing
@@ -134,34 +144,25 @@ pub async fn list_page(pool: &PgPool, workspace: &str, q: PageQuery) -> Result<V
     let mut last_key: Option<(DateTime<Utc>, i64)> = None;
     let fetched = rows.len();
     for row in rows {
-        let id: i64 = row.get("id");
-        let created_at: DateTime<Utc> = row.get("created_at");
-        let finished_at: DateTime<Utc> = row.get("finished_at");
-        let obj = json!({
-            "id": id,
-            "org_id": row.get::<String, _>("org_id"),
-            "workspace_id": row.get::<String, _>("workspace_id"),
-            "user_id": row.get::<String, _>("user_id"),
-            "request_id": row.get::<String, _>("request_id"),
-            "session_id": row.get::<Option<String>, _>("session_id"),
-            "created_at": created_at.to_rfc3339(),
-            "finished_at": finished_at.to_rfc3339(),
-            "sql": row.get::<String, _>("sql"),
-            "sql_truncated": row.get::<bool, _>("sql_truncated"),
-            "ai_context": row.get::<Option<Value>, _>("ai_context"),
-            "statement_kind": row.get::<String, _>("statement_kind"),
-            "max_rows": row.get::<i64, _>("max_rows"),
-            "status": row.get::<String, _>("status"),
-            "row_count": row.get::<Option<i64>, _>("row_count"),
-            "error": row.get::<Option<String>, _>("error"),
-        });
+        // `try_get`, never `get`: `get` PANICS on a missing column, a type
+        // mismatch, or a decode failure — a momentary migration/engine skew
+        // downstream must surface as the designed 503, not kill the task.
+        let obj = serialize_row(&row).map_err(ReadError::Unavailable)?;
+        let id = obj["id"].as_i64().expect("serialize_row sets id");
+        let created_at = obj["__created_at_key"]
+            .as_i64()
+            .expect("serialize_row sets the key");
+        let created_at =
+            DateTime::<Utc>::from_timestamp_micros(created_at).expect("stored timestamp");
+        let obj = strip_key(obj);
         // Byte cap: elide from the tail once the budget is spent. The
-        // budget is the WHOLE body's, not the rows': the gateway 413s one
-        // byte over `RESPONSE_MAX_BYTES` and the same cursor re-fetches the
-        // same page, so under-counting the envelope turns a full page into
-        // a permanent 413 (a ~226-row page of 32 KiB-sql rows gets there in
-        // ordinary use). Each row is charged its serialized length plus its
+        // budget is the WHOLE body's, not the rows': the consumer's relay
+        // 413s one byte over `RESPONSE_MAX_BYTES` and the same cursor
+        // re-fetches the same page, so an over-budget body is a permanent
+        // 413. Each row is charged its serialized length plus its
         // separating comma; the fixed framing comes out of the reserve.
+        // `serialize_row` bounds every field ([`READ_FIELD_MAX_BYTES`]), so
+        // even the FIRST row fits and the loop always makes progress.
         let row_bytes = obj.to_string().len() + 1;
         if bytes + row_bytes > RESPONSE_MAX_BYTES - ENVELOPE_RESERVE_BYTES && !out.is_empty() {
             truncated = true;
@@ -184,6 +185,67 @@ pub async fn list_page(pool: &PgPool, workspace: &str, q: PageQuery) -> Result<V
         "truncated": truncated,
         "next_cursor": next_cursor,
     }))
+}
+
+/// One row → the wire object, every step fallible and every text field
+/// bounded (see [`READ_FIELD_MAX_BYTES`]). Carries the keyset key in a
+/// private `__created_at_key` member that [`strip_key`] removes, so the
+/// caller never sees it and the loop never re-parses RFC 3339.
+fn serialize_row(row: &sqlx::postgres::PgRow) -> Result<Value, sqlx::Error> {
+    fn bound(s: String, max: usize) -> String {
+        if s.len() <= max {
+            return s;
+        }
+        let mut end = max;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        s[..end].to_string()
+    }
+    let created_at: DateTime<Utc> = row.try_get("created_at")?;
+    let finished_at: DateTime<Utc> = row.try_get("finished_at")?;
+    let sql: String = row.try_get("sql")?;
+    let sql_over = sql.len() > SQL_MAX_BYTES;
+    let ai_context: Option<Value> = row.try_get("ai_context")?;
+    // The same drop-not-truncate rule as ingestion: an over-bound document
+    // (only writable past the assembly) is elided whole.
+    let ai_context = ai_context.filter(|c| {
+        serde_json::to_vec(c)
+            .map(|v| v.len() <= ERROR_MAX_BYTES)
+            .unwrap_or(false)
+    });
+    Ok(json!({
+        "id": row.try_get::<i64, _>("id")?,
+        "org_id": bound(row.try_get("org_id")?, READ_FIELD_MAX_BYTES),
+        "workspace_id": bound(row.try_get("workspace_id")?, READ_FIELD_MAX_BYTES),
+        "user_id": bound(row.try_get("user_id")?, READ_FIELD_MAX_BYTES),
+        "request_id": bound(row.try_get("request_id")?, READ_FIELD_MAX_BYTES),
+        "session_id": row
+            .try_get::<Option<String>, _>("session_id")?
+            .map(|s| bound(s, READ_FIELD_MAX_BYTES)),
+        "created_at": created_at.to_rfc3339(),
+        "finished_at": finished_at.to_rfc3339(),
+        "sql": bound(sql, SQL_MAX_BYTES),
+        // True when ingestion truncated it OR the read had to: either way
+        // the reader is told the text is not the whole statement.
+        "sql_truncated": row.try_get::<bool, _>("sql_truncated")? || sql_over,
+        "ai_context": ai_context,
+        "statement_kind": bound(row.try_get("statement_kind")?, READ_FIELD_MAX_BYTES),
+        "max_rows": row.try_get::<i64, _>("max_rows")?,
+        "status": bound(row.try_get("status")?, READ_FIELD_MAX_BYTES),
+        "row_count": row.try_get::<Option<i64>, _>("row_count")?,
+        "error": row
+            .try_get::<Option<String>, _>("error")?
+            .map(|e| bound(e, ERROR_MAX_BYTES)),
+        "__created_at_key": created_at.timestamp_micros(),
+    }))
+}
+
+fn strip_key(mut obj: Value) -> Value {
+    obj.as_object_mut()
+        .expect("serialize_row emits an object")
+        .remove("__created_at_key");
+    obj
 }
 
 #[cfg(test)]

--- a/crates/query-audit/src/ledger/read.rs
+++ b/crates/query-audit/src/ledger/read.rs
@@ -190,6 +190,43 @@ pub async fn list_page(pool: &PgPool, workspace: &str, q: PageQuery) -> Result<V
 mod tests {
     use super::*;
 
+    /// The hand-rolled error impls (no `thiserror` in this crate): Display
+    /// keeps driver detail out of the caller-facing variant, and source()
+    /// exposes it for operators.
+    #[test]
+    fn read_error_display_and_source() {
+        let bad = ReadError::BadRequest("limit must be >= 1".into());
+        assert_eq!(bad.to_string(), "limit must be >= 1");
+        assert!(std::error::Error::source(&bad).is_none());
+
+        let unavailable = ReadError::Unavailable(sqlx::Error::PoolClosed);
+        assert_eq!(unavailable.to_string(), "ledger read failed");
+        let src = std::error::Error::source(&unavailable).expect("driver cause");
+        assert!(src.to_string().contains("closed"), "{src}");
+    }
+
+    /// `limit < 1` refuses BEFORE any query: a lazy pool to a blackhole
+    /// address proves no connection is attempted.
+    #[tokio::test]
+    async fn non_positive_limits_refuse_before_any_query() {
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://u:p@192.0.2.1:5432/nowhere")
+            .expect("lazy");
+        for n in [0, -5] {
+            let err = list_page(
+                &pool,
+                "ws",
+                PageQuery {
+                    limit: Some(n),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("must refuse");
+            assert!(matches!(err, ReadError::BadRequest(_)), "{err}");
+        }
+    }
+
     #[test]
     fn cursor_round_trips() {
         let at = Utc::now();

--- a/crates/query-audit/src/ledger/read.rs
+++ b/crates/query-audit/src/ledger/read.rs
@@ -1,0 +1,208 @@
+//! The read half: one page of one workspace's rows, newest-first over the
+//! stable `(created_at, id)` keyset.
+//!
+//! The route owns authorization (envelope + admin re-check); this module
+//! owns semantics: filters, the cursor, the row cap (≤ 500, default 100),
+//! and the 8 MiB response byte cap — rows are elided from the tail and the
+//! response says so (`truncated: true` + `next_cursor`), because 500 rows of
+//! even ingestion-bounded fields can pass the `/data_source` budget.
+
+use base64::Engine as _;
+use chrono::{DateTime, Utc};
+use serde_json::{Value, json};
+use sqlx::{PgPool, Row};
+
+use super::queries;
+
+pub const LIMIT_DEFAULT: i64 = 100;
+pub const LIMIT_MAX: i64 = 500;
+
+/// The whole response body stays under this. The consumer's relay enforces
+/// the same 8 MiB as a hard cap and answers 413 above it, so this is a HARD
+/// wire contract, not a soft target: a body that lands even one byte over
+/// turns into a deterministic 413 — and the same cursor fetches the same
+/// page, so the caller is livelocked until the rows age out.
+pub const RESPONSE_MAX_BYTES: usize = 8 * 1024 * 1024;
+
+/// Headroom [`list_page`] holds back from [`RESPONSE_MAX_BYTES`] for
+/// everything that is not a row: the envelope framing
+/// (`{"success":…,"rows":[…],"truncated":…,"next_cursor":"…"}`, with the
+/// cursor well under 100 bytes) plus the `rows` array's brackets. The
+/// per-row comma is counted per row instead, so this only has to cover the
+/// fixed part — 1 KiB is an order of magnitude more than it needs, and one
+/// elided row against a 32 KiB-sql worst case is noise.
+const ENVELOPE_RESERVE_BYTES: usize = 1024;
+
+/// Parsed, validated query inputs. The route builds this from the query
+/// string; `workspace` always comes from the envelope.
+#[derive(Debug, Default)]
+pub struct PageQuery {
+    pub session_id: Option<String>,
+    pub status: Option<String>,
+    pub since: Option<DateTime<Utc>>,
+    pub until: Option<DateTime<Utc>>,
+    pub limit: Option<i64>,
+    pub cursor: Option<String>,
+}
+
+/// Hand-rolled rather than derived: this crate deliberately carries no
+/// `thiserror` (its only other error surface is `anyhow` + one bespoke
+/// timeout enum), and two variants do not justify the dependency.
+#[derive(Debug)]
+pub enum ReadError {
+    /// Caller-shaped: a malformed filter/cursor (400).
+    BadRequest(String),
+    /// Backend-shaped: PG unreachable or the query failed (503; the ledger
+    /// is degraded, the caller should retry).
+    Unavailable(sqlx::Error),
+}
+
+impl std::fmt::Display for ReadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReadError::BadRequest(m) => write!(f, "{m}"),
+            ReadError::Unavailable(_) => write!(f, "ledger read failed"),
+        }
+    }
+}
+
+impl std::error::Error for ReadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ReadError::BadRequest(_) => None,
+            ReadError::Unavailable(e) => Some(e),
+        }
+    }
+}
+
+/// The opaque cursor: base64 of `<created_at micros>:<id>`. Opaque to
+/// callers by contract — the encoding may change; only round-tripping a
+/// returned value is supported.
+fn encode_cursor(created_at: DateTime<Utc>, id: i64) -> String {
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(format!(
+        "{}:{}",
+        created_at.timestamp_micros(),
+        id
+    ))
+}
+
+fn decode_cursor(cursor: &str) -> Result<(DateTime<Utc>, i64), ReadError> {
+    let bad = || ReadError::BadRequest("cursor is not a value a prior response returned".into());
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(cursor)
+        .map_err(|_| bad())?;
+    let s = String::from_utf8(bytes).map_err(|_| bad())?;
+    let (t, id) = s.split_once(':').ok_or_else(bad)?;
+    let micros: i64 = t.parse().map_err(|_| bad())?;
+    let id: i64 = id.parse().map_err(|_| bad())?;
+    let created_at = DateTime::<Utc>::from_timestamp_micros(micros).ok_or_else(bad)?;
+    Ok((created_at, id))
+}
+
+/// One page. Returns the JSON body the consumer's route serves verbatim.
+pub async fn list_page(pool: &PgPool, workspace: &str, q: PageQuery) -> Result<Value, ReadError> {
+    let limit = match q.limit {
+        None => LIMIT_DEFAULT,
+        Some(n) if n < 1 => {
+            return Err(ReadError::BadRequest("limit must be >= 1".into()));
+        }
+        Some(n) => n.min(LIMIT_MAX),
+    };
+    let (cursor_at, cursor_id) = match &q.cursor {
+        Some(c) => decode_cursor(c)?,
+        // First page: a keyset upper bound above every real row, so the one
+        // prepared statement serves both cases (queries::SELECT_PAGE).
+        None => (DateTime::<Utc>::MAX_UTC, i64::MAX),
+    };
+
+    let rows = sqlx::query(queries::SELECT_PAGE)
+        .bind(workspace)
+        .bind(cursor_at)
+        .bind(cursor_id)
+        .bind(q.since)
+        .bind(q.until)
+        .bind(&q.session_id)
+        .bind(&q.status)
+        .bind(limit)
+        .fetch_all(pool)
+        .await
+        .map_err(ReadError::Unavailable)?;
+
+    let mut out: Vec<Value> = Vec::with_capacity(rows.len());
+    let mut bytes = 0usize;
+    let mut truncated = false;
+    let mut last_key: Option<(DateTime<Utc>, i64)> = None;
+    let fetched = rows.len();
+    for row in rows {
+        let id: i64 = row.get("id");
+        let created_at: DateTime<Utc> = row.get("created_at");
+        let finished_at: DateTime<Utc> = row.get("finished_at");
+        let obj = json!({
+            "id": id,
+            "org_id": row.get::<String, _>("org_id"),
+            "workspace_id": row.get::<String, _>("workspace_id"),
+            "user_id": row.get::<String, _>("user_id"),
+            "request_id": row.get::<String, _>("request_id"),
+            "session_id": row.get::<Option<String>, _>("session_id"),
+            "created_at": created_at.to_rfc3339(),
+            "finished_at": finished_at.to_rfc3339(),
+            "sql": row.get::<String, _>("sql"),
+            "sql_truncated": row.get::<bool, _>("sql_truncated"),
+            "ai_context": row.get::<Option<Value>, _>("ai_context"),
+            "statement_kind": row.get::<String, _>("statement_kind"),
+            "max_rows": row.get::<i64, _>("max_rows"),
+            "status": row.get::<String, _>("status"),
+            "row_count": row.get::<Option<i64>, _>("row_count"),
+            "error": row.get::<Option<String>, _>("error"),
+        });
+        // Byte cap: elide from the tail once the budget is spent. The
+        // budget is the WHOLE body's, not the rows': the gateway 413s one
+        // byte over `RESPONSE_MAX_BYTES` and the same cursor re-fetches the
+        // same page, so under-counting the envelope turns a full page into
+        // a permanent 413 (a ~226-row page of 32 KiB-sql rows gets there in
+        // ordinary use). Each row is charged its serialized length plus its
+        // separating comma; the fixed framing comes out of the reserve.
+        let row_bytes = obj.to_string().len() + 1;
+        if bytes + row_bytes > RESPONSE_MAX_BYTES - ENVELOPE_RESERVE_BYTES && !out.is_empty() {
+            truncated = true;
+            break;
+        }
+        bytes += row_bytes;
+        last_key = Some((created_at, id));
+        out.push(obj);
+    }
+    // A full fetch means the keyset may continue; an elided tail always does.
+    let more_may_exist = truncated || fetched == limit as usize;
+    let next_cursor = match (more_may_exist, last_key) {
+        (true, Some((at, id))) => Some(encode_cursor(at, id)),
+        _ => None,
+    };
+
+    Ok(json!({
+        "success": true,
+        "rows": out,
+        "truncated": truncated,
+        "next_cursor": next_cursor,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cursor_round_trips() {
+        let at = Utc::now();
+        let enc = encode_cursor(at, 42);
+        let (back_at, back_id) = decode_cursor(&enc).expect("round trip");
+        assert_eq!(back_id, 42);
+        assert_eq!(back_at.timestamp_micros(), at.timestamp_micros());
+    }
+
+    #[test]
+    fn garbage_cursors_are_bad_requests() {
+        for c in ["", "!!!", "bm9jb2xvbg", "MTIz"] {
+            assert!(matches!(decode_cursor(c), Err(ReadError::BadRequest(_))));
+        }
+    }
+}

--- a/crates/query-audit/src/ledger/read.rs
+++ b/crates/query-audit/src/ledger/read.rs
@@ -10,7 +10,8 @@
 use base64::Engine as _;
 use chrono::{DateTime, Utc};
 use serde_json::{Value, json};
-use sqlx::{PgPool, Row};
+use sqlx::postgres::PgRow;
+use sqlx::{Error as SqlxError, PgPool, Row};
 
 use super::{ERROR_MAX_BYTES, SQL_MAX_BYTES, queries};
 
@@ -64,7 +65,7 @@ pub enum ReadError {
     BadRequest(String),
     /// Backend-shaped: PG unreachable or the query failed (503; the ledger
     /// is degraded, the caller should retry).
-    Unavailable(sqlx::Error),
+    Unavailable(SqlxError),
 }
 
 impl std::fmt::Display for ReadError {
@@ -191,7 +192,7 @@ pub async fn list_page(pool: &PgPool, workspace: &str, q: PageQuery) -> Result<V
 /// bounded (see [`READ_FIELD_MAX_BYTES`]). Carries the keyset key in a
 /// private `__created_at_key` member that [`strip_key`] removes, so the
 /// caller never sees it and the loop never re-parses RFC 3339.
-fn serialize_row(row: &sqlx::postgres::PgRow) -> Result<Value, sqlx::Error> {
+fn serialize_row(row: &PgRow) -> Result<Value, SqlxError> {
     fn bound(s: String, max: usize) -> String {
         if s.len() <= max {
             return s;
@@ -261,7 +262,7 @@ mod tests {
         assert_eq!(bad.to_string(), "limit must be >= 1");
         assert!(std::error::Error::source(&bad).is_none());
 
-        let unavailable = ReadError::Unavailable(sqlx::Error::PoolClosed);
+        let unavailable = ReadError::Unavailable(SqlxError::PoolClosed);
         assert_eq!(unavailable.to_string(), "ledger read failed");
         let src = std::error::Error::source(&unavailable).expect("driver cause");
         assert!(src.to_string().contains("closed"), "{src}");

--- a/crates/query-audit/src/ledger/writer.rs
+++ b/crates/query-audit/src/ledger/writer.rs
@@ -11,6 +11,7 @@ use std::sync::atomic::Ordering;
 use sqlx::{PgPool, Postgres, QueryBuilder};
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::watch;
+use tokio::time::timeout;
 
 use super::{FLUSH_BATCH_ROWS, FLUSH_TIMEOUT, LedgerRow, METRICS, WriterControl, queries};
 
@@ -76,7 +77,7 @@ async fn flush(pool: &PgPool, batch: &[LedgerRow]) {
             .push_bind(&row.error);
     });
     let fut = qb.build().execute(pool);
-    let outcome = tokio::time::timeout(FLUSH_TIMEOUT, fut).await;
+    let outcome = timeout(FLUSH_TIMEOUT, fut).await;
     let err: Option<String> = match outcome {
         Ok(Ok(_)) => None,
         Ok(Err(e)) => Some(e.to_string()),

--- a/crates/query-audit/src/ledger/writer.rs
+++ b/crates/query-audit/src/ledger/writer.rs
@@ -8,7 +8,7 @@
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
-use sqlx::PgPool;
+use sqlx::{PgPool, Postgres, QueryBuilder};
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::watch;
 
@@ -56,7 +56,7 @@ pub(crate) async fn run(
 }
 
 async fn flush(pool: &PgPool, batch: &[LedgerRow]) {
-    let mut qb: sqlx::QueryBuilder<sqlx::Postgres> = sqlx::QueryBuilder::new(queries::INSERT_HEAD);
+    let mut qb: QueryBuilder<Postgres> = QueryBuilder::new(queries::INSERT_HEAD);
     qb.push_values(batch, |mut b, row| {
         // Binding order = queries::INSERT_HEAD column order.
         b.push_bind(&row.org_id)

--- a/crates/query-audit/src/ledger/writer.rs
+++ b/crates/query-audit/src/ledger/writer.rs
@@ -5,18 +5,31 @@
 //! loss is accepted by design and never silent (see the module doc for the
 //! contract).
 
+use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 use sqlx::PgPool;
 use tokio::sync::mpsc::Receiver;
+use tokio::sync::watch;
 
 use super::{FLUSH_BATCH_ROWS, FLUSH_TIMEOUT, LedgerRow, METRICS, WriterControl, queries};
 
 pub(crate) async fn run(
     pool: PgPool,
     mut rx: Receiver<LedgerRow>,
-    control: std::sync::Arc<WriterControl>,
+    control: Arc<WriterControl>,
+    done: watch::Sender<bool>,
 ) {
+    // The completion latch every shutdown() caller awaits. A drop guard,
+    // not a final statement, so it fires on EVERY exit: graceful return,
+    // panic unwind, and task drop at runtime teardown.
+    struct Done(watch::Sender<bool>);
+    impl Drop for Done {
+        fn drop(&mut self) {
+            let _ = self.0.send(true);
+        }
+    }
+    let _done = Done(done);
     let mut batch: Vec<LedgerRow> = Vec::with_capacity(FLUSH_BATCH_ROWS);
     loop {
         batch.clear();

--- a/crates/query-audit/src/ledger/writer.rs
+++ b/crates/query-audit/src/ledger/writer.rs
@@ -10,20 +10,35 @@ use std::sync::atomic::Ordering;
 use sqlx::PgPool;
 use tokio::sync::mpsc::Receiver;
 
-use super::{FLUSH_BATCH_ROWS, FLUSH_TIMEOUT, LedgerRow, METRICS, queries};
+use super::{FLUSH_BATCH_ROWS, FLUSH_TIMEOUT, LedgerRow, METRICS, WriterControl, queries};
 
-pub async fn run(pool: PgPool, mut rx: Receiver<LedgerRow>) {
+pub(crate) async fn run(
+    pool: PgPool,
+    mut rx: Receiver<LedgerRow>,
+    control: std::sync::Arc<WriterControl>,
+) {
     let mut batch: Vec<LedgerRow> = Vec::with_capacity(FLUSH_BATCH_ROWS);
     loop {
         batch.clear();
         // Block for the first row, then drain whatever else is queued up to
         // the batch bound — natural batching under load, no ticker at rest.
-        let n = rx.recv_many(&mut batch, FLUSH_BATCH_ROWS).await;
-        if n == 0 {
-            // Channel closed: the handle is gone, the process is winding down.
-            return;
+        // The drain signal closes the receiver: senders start failing fast
+        // (counted by `record` as channel losses) while recv_many hands over
+        // everything already buffered, then returns 0 and the task exits —
+        // the graceful path never abandons an accepted row.
+        tokio::select! {
+            n = rx.recv_many(&mut batch, FLUSH_BATCH_ROWS) => {
+                if n == 0 {
+                    // Channel closed and drained: every sender is gone, or a
+                    // shutdown finished handing over the backlog.
+                    return;
+                }
+                flush(&pool, &batch).await;
+            }
+            _ = control.drain.notified() => {
+                rx.close();
+            }
         }
-        flush(&pool, &batch).await;
     }
 }
 

--- a/crates/query-audit/src/ledger/writer.rs
+++ b/crates/query-audit/src/ledger/writer.rs
@@ -1,0 +1,70 @@
+//! The dedicated writer task: drains the bounded channel, batching up
+//! to [`FLUSH_BATCH_ROWS`] rows per multi-row INSERT, each flush bounded at
+//! [`FLUSH_TIMEOUT`]. A failed or timed-out flush drops its batch, counts it
+//! (`ledger_insert_failures_total{reason="pg"}`), and logs the request ids —
+//! loss is accepted by design and never silent (see the module doc for the
+//! contract).
+
+use std::sync::atomic::Ordering;
+
+use sqlx::PgPool;
+use tokio::sync::mpsc::Receiver;
+
+use super::{FLUSH_BATCH_ROWS, FLUSH_TIMEOUT, LedgerRow, METRICS, queries};
+
+pub async fn run(pool: PgPool, mut rx: Receiver<LedgerRow>) {
+    let mut batch: Vec<LedgerRow> = Vec::with_capacity(FLUSH_BATCH_ROWS);
+    loop {
+        batch.clear();
+        // Block for the first row, then drain whatever else is queued up to
+        // the batch bound — natural batching under load, no ticker at rest.
+        let n = rx.recv_many(&mut batch, FLUSH_BATCH_ROWS).await;
+        if n == 0 {
+            // Channel closed: the handle is gone, the process is winding down.
+            return;
+        }
+        flush(&pool, &batch).await;
+    }
+}
+
+async fn flush(pool: &PgPool, batch: &[LedgerRow]) {
+    let mut qb: sqlx::QueryBuilder<sqlx::Postgres> = sqlx::QueryBuilder::new(queries::INSERT_HEAD);
+    qb.push_values(batch, |mut b, row| {
+        // Binding order = queries::INSERT_HEAD column order.
+        b.push_bind(&row.org_id)
+            .push_bind(&row.workspace_id)
+            .push_bind(&row.user_id)
+            .push_bind(&row.request_id)
+            .push_bind(&row.session_id)
+            .push_bind(row.created_at)
+            .push_bind(row.finished_at)
+            .push_bind(&row.sql)
+            .push_bind(row.sql_truncated)
+            .push_bind(&row.ai_context)
+            .push_bind(row.statement_kind)
+            .push_bind(row.max_rows)
+            .push_bind(row.status.as_str())
+            .push_bind(row.row_count)
+            .push_bind(&row.error);
+    });
+    let fut = qb.build().execute(pool);
+    let outcome = tokio::time::timeout(FLUSH_TIMEOUT, fut).await;
+    let err: Option<String> = match outcome {
+        Ok(Ok(_)) => None,
+        Ok(Err(e)) => Some(e.to_string()),
+        Err(_) => Some(format!("flush timed out after {FLUSH_TIMEOUT:?}")),
+    };
+    if let Some(err) = err {
+        METRICS
+            .insert_failures_pg
+            .fetch_add(batch.len() as u64, Ordering::Relaxed);
+        let request_ids: Vec<&str> = batch.iter().map(|r| r.request_id.as_str()).collect();
+        // The error string is a driver/connectivity message, not row content;
+        // request ids are gateway-minted UUIDs. Nothing caller-supplied here.
+        tracing::warn!(
+            dropped = batch.len(),
+            request_ids = ?request_ids,
+            "ledger flush failed; batch dropped: {err}"
+        );
+    }
+}

--- a/crates/query-audit/src/lib.rs
+++ b/crates/query-audit/src/lib.rs
@@ -43,6 +43,8 @@ use anyhow::{Context, Result, anyhow};
 mod postgres;
 pub use postgres::PG_DSN_ENV;
 
+pub mod ledger;
+
 /// Overrides the writer identity every `started` row is stamped with (see
 /// [`QueryAuditStore::with_writer_identity`]). Resolution:
 /// this variable → `HOSTNAME` (set by Kubernetes and Docker, exactly the

--- a/crates/query-audit/tests/ledger_live.rs
+++ b/crates/query-audit/tests/ledger_live.rs
@@ -5,7 +5,7 @@
 //! Gated exactly like `pg_live.rs`: `#[ignore]` by default, run with
 //! `SKARDI_QUERY_AUDIT_LIVE_URL=postgres://… cargo test -- --ignored`.
 //! Each test creates its own throwaway database and applies
-//! [`queries::QUERY_LEDGER_DDL`] — the module runs no DDL itself.
+//! [`queries::QUERY_LEDGER_MIGRATION_0001`] — the module runs no DDL itself.
 
 use serde_json::{Value, json};
 use skardi_query_audit::ledger::{self, PgLedger, RowDraft, RowStatus, queries, read};
@@ -52,7 +52,7 @@ async fn fresh_db(url: &str) -> (String, sqlx::PgPool) {
     parsed.set_path(&format!("/{db}"));
     let dsn = parsed.to_string();
     let pool = sqlx::PgPool::connect(&dsn).await.expect("connect test db");
-    sqlx::raw_sql(queries::QUERY_LEDGER_DDL)
+    sqlx::raw_sql(queries::QUERY_LEDGER_MIGRATION_0001)
         .execute(&pool)
         .await
         .expect("apply the ledger DDL");
@@ -519,4 +519,114 @@ async fn a_nul_bearing_row_cannot_poison_its_batch() {
     assert_eq!(sql, "SELECT '\u{FFFD}'");
     assert_eq!(err, "bad\u{FFFD}input");
     assert!(session.is_none(), "the NUL session id was dropped");
+}
+
+/// The P1 regression: a row written PAST the assembly (DDL has no length
+/// constraints) with a body far over the 8 MiB budget must not livelock the
+/// cursor. The read path re-applies the ingestion bounds, so the monster
+/// row comes back bounded (sql cut to 32 KiB with the flag forced true,
+/// oversized ai_context elided), the page stays under budget, and the
+/// keyset advances to the rows behind it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs SKARDI_QUERY_AUDIT_LIVE_URL"]
+async fn a_monster_row_reads_back_bounded_and_never_livelocks() {
+    let Some(url) = live_url() else { return };
+    let (_dsn, pool) = fresh_db(&url).await;
+    // Newest first: the monster is the FIRST row of the page.
+    sqlx::query(
+        "INSERT INTO query_ledger (org_id, workspace_id, user_id, request_id, \
+         created_at, finished_at, sql, statement_kind, max_rows, status, error, ai_context) \
+         VALUES ('acme', $1, 'u', 'r-old', now() - interval '1 hour', now(), \
+                 'SELECT 1', 'query', 10, 'succeeded', NULL, NULL)",
+    )
+    .bind(WS)
+    .execute(&pool)
+    .await
+    .expect("normal row");
+    sqlx::query(
+        "INSERT INTO query_ledger (org_id, workspace_id, user_id, request_id, \
+         created_at, finished_at, sql, statement_kind, max_rows, status, error, ai_context) \
+         VALUES ('acme', $1, 'u', 'r-monster', now(), now(), \
+                 repeat('m', 10 * 1024 * 1024), 'query', 10, 'failed', \
+                 repeat('e', 9 * 1024 * 1024), \
+                 jsonb_build_object('blob', repeat('b', 64 * 1024)))",
+    )
+    .bind(WS)
+    .execute(&pool)
+    .await
+    .expect("monster row");
+
+    let page = read::list_page(&pool, WS, read::PageQuery::default())
+        .await
+        .expect("the monster must not fail the page");
+    assert!(
+        page.to_string().len() <= read::RESPONSE_MAX_BYTES,
+        "the body must fit the budget even with the monster first"
+    );
+    let rows = page["rows"].as_array().unwrap();
+    assert_eq!(rows.len(), 2, "the page advances past the monster");
+    assert_eq!(rows[0]["request_id"], "r-monster");
+    assert!(rows[0]["sql"].as_str().unwrap().len() <= 32 * 1024);
+    assert_eq!(rows[0]["sql_truncated"], json!(true), "the cut is declared");
+    assert!(
+        rows[0]["ai_context"].is_null(),
+        "over-bound document elided"
+    );
+    assert!(rows[0]["error"].as_str().unwrap().len() <= 4 * 1024);
+    assert_eq!(rows[1]["request_id"], "r-old");
+}
+
+/// The P2 regression: schema drift (here: a mutant table whose max_rows is
+/// TEXT) must surface as ReadError::Unavailable — the designed 503 — never
+/// a decode panic that kills the request task.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs SKARDI_QUERY_AUDIT_LIVE_URL"]
+async fn schema_drift_is_a_read_error_not_a_panic() {
+    let Some(url) = live_url() else { return };
+    // A bare database WITHOUT the real DDL: build a mutant query_ledger
+    // whose columns exist but max_rows decodes as TEXT.
+    let (_dsn, pool) = {
+        // fresh_db applies the real DDL; make our own db instead.
+        static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let db = format!(
+            "lgrmut_{}_{}_{}",
+            std::process::id(),
+            std::time::UNIX_EPOCH.elapsed().unwrap().as_nanos(),
+            SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        );
+        let boot = sqlx::PgPool::connect(&url).await.expect("connect server");
+        sqlx::raw_sql(&format!(r#"CREATE DATABASE "{db}""#))
+            .execute(&boot)
+            .await
+            .expect("create");
+        boot.close().await;
+        let mut parsed = url::Url::parse(&url).expect("url");
+        parsed.set_path(&format!("/{db}"));
+        let dsn = parsed.to_string();
+        let pool = sqlx::PgPool::connect(&dsn).await.expect("connect");
+        (dsn, pool)
+    };
+    sqlx::raw_sql(
+        "CREATE TABLE query_ledger (
+            id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+            org_id TEXT NOT NULL, workspace_id TEXT NOT NULL,
+            user_id TEXT NOT NULL, request_id TEXT NOT NULL, session_id TEXT,
+            created_at TIMESTAMPTZ NOT NULL, finished_at TIMESTAMPTZ NOT NULL,
+            sql TEXT NOT NULL, sql_truncated BOOLEAN NOT NULL DEFAULT FALSE,
+            ai_context JSONB, statement_kind TEXT NOT NULL,
+            max_rows TEXT NOT NULL, status TEXT NOT NULL,
+            row_count BIGINT, error TEXT);
+         INSERT INTO query_ledger (org_id, workspace_id, user_id, request_id,
+            created_at, finished_at, sql, statement_kind, max_rows, status)
+         VALUES ('acme', 'ws-core', 'u', 'r-drift', now(), now(),
+                 'SELECT 1', 'query', 'not-a-number', 'succeeded');",
+    )
+    .execute(&pool)
+    .await
+    .expect("mutant schema");
+
+    let err = read::list_page(&pool, WS, read::PageQuery::default())
+        .await
+        .expect_err("drift must be an error, not a panic");
+    assert!(matches!(err, read::ReadError::Unavailable(_)), "got {err}");
 }

--- a/crates/query-audit/tests/ledger_live.rs
+++ b/crates/query-audit/tests/ledger_live.rs
@@ -346,3 +346,122 @@ async fn ai_context_lands_as_jsonb_and_reads_back() {
     assert_eq!(row["session_id"], json!("s-1"));
     assert_eq!(row["status"], json!("succeeded"));
 }
+
+/// The writer's loss accounting, no server needed: a blackholed DSN makes
+/// the first flush fail (connect timeout inside the 5 s flush bound), the
+/// batch is dropped, and `insert_failures_total{reason="pg"}` counts it —
+/// the caller saw none of this. Also pins the pool accessor and that a
+/// dropped handle shuts the writer down rather than leaking it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_failed_flush_counts_its_losses() {
+    let pg = PgLedger::spawn("postgres://u:p@192.0.2.1:5432/skardi_ledger").expect("lazy pool");
+    assert!(!pg.pool().is_closed(), "lazy pool, no connection yet");
+    let before = ledger::METRICS
+        .insert_failures_pg
+        .load(std::sync::atomic::Ordering::Relaxed);
+
+    pg.record(draft(WS, "SELECT 1", "r-flush-fail").finish(RowStatus::Succeeded, Some(1), None));
+
+    // The flush pays its 5 s bound (plus the doomed connect) before counting.
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let now = ledger::METRICS
+            .insert_failures_pg
+            .load(std::sync::atomic::Ordering::Relaxed);
+        if now > before {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the dropped batch was never counted"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    // Dropping the handle closes the channel; the writer's recv sees it and
+    // exits. Nothing to assert beyond "this does not hang or panic" — the
+    // yield gives the writer task a turn to observe the close.
+    drop(pg);
+    tokio::time::sleep(Duration::from_millis(50)).await;
+}
+
+/// The read page's byte budget elides from the tail and pages on: ~300
+/// worst-case rows (32 KiB sql each) cannot fit the 8 MiB body, so the page
+/// ends early with `truncated: true` and a cursor — never an over-budget
+/// body (the consumer's relay 413s one byte over).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs SKARDI_QUERY_AUDIT_LIVE_URL"]
+async fn the_byte_budget_elides_the_tail_and_pages_on() {
+    let Some(url) = live_url() else { return };
+    let (_dsn, pool) = fresh_db(&url).await;
+    sqlx::query(
+        "INSERT INTO query_ledger (org_id, workspace_id, user_id, request_id, \
+         created_at, finished_at, sql, sql_truncated, statement_kind, max_rows, \
+         status, error) \
+         SELECT 'acme', $1, 'user:acme/u1', 'req-' || n, now(), now(), \
+                repeat('x', 32768), true, 'query', 100, 'failed', \
+                'execution-failed: ' || repeat('e', 4096) \
+         FROM generate_series(1, 300) AS n",
+    )
+    .bind(WS)
+    .execute(&pool)
+    .await
+    .expect("seed 300 worst-case rows");
+
+    let page = read::list_page(
+        &pool,
+        WS,
+        read::PageQuery {
+            limit: Some(500),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("page");
+    let rows = page["rows"].as_array().unwrap();
+    assert!(
+        !rows.is_empty() && rows.len() < 300,
+        "the byte cap, not the row limit, must end this page (got {})",
+        rows.len()
+    );
+    assert_eq!(page["truncated"], json!(true));
+    assert!(page["next_cursor"].as_str().is_some());
+    assert!(
+        page.to_string().len() <= read::RESPONSE_MAX_BYTES,
+        "the whole body must fit the budget"
+    );
+}
+
+/// The flush-error arm that is NOT a timeout: the server answers and says
+/// no (here: the table is gone). The batch drops, the loss is counted, the
+/// caller never heard about any of it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs SKARDI_QUERY_AUDIT_LIVE_URL"]
+async fn a_rejected_insert_counts_its_losses() {
+    let Some(url) = live_url() else { return };
+    let (dsn, pool) = fresh_db(&url).await;
+    sqlx::raw_sql("DROP TABLE query_ledger")
+        .execute(&pool)
+        .await
+        .expect("sabotage");
+    let pg = PgLedger::spawn(&dsn).expect("pool");
+    let before = ledger::METRICS
+        .insert_failures_pg
+        .load(std::sync::atomic::Ordering::Relaxed);
+    pg.record(draft(WS, "SELECT 1", "r-rejected").finish(RowStatus::Succeeded, Some(1), None));
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        if ledger::METRICS
+            .insert_failures_pg
+            .load(std::sync::atomic::Ordering::Relaxed)
+            > before
+        {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the rejected batch was never counted"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}

--- a/crates/query-audit/tests/ledger_live.rs
+++ b/crates/query-audit/tests/ledger_live.rs
@@ -720,3 +720,60 @@ async fn concurrent_shutdown_callers_all_await_the_drain() {
         .load(std::sync::atomic::Ordering::Relaxed);
     assert!(after > before, "the drain completed before either returned");
 }
+
+/// The ai_context transport bound (review): Postgres renders jsonb::text
+/// with whitespace the compact form lacks, so a document that PASSED the
+/// 4 KiB compact ingestion bound can measure larger in SQL — it must still
+/// read back, not silently null. Built with enough small members that the
+/// jsonb::text form crosses 4096 while the compact form stays under.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs SKARDI_QUERY_AUDIT_LIVE_URL"]
+async fn near_limit_ai_context_survives_the_read_bound() {
+    let Some(url) = live_url() else { return };
+    let (dsn, pool) = fresh_db(&url).await;
+    // ~330 members of "keyNNNN":1 — compact ≈ 3960 bytes (< 4096), while
+    // jsonb::text adds a space after every ':' and ',' ≈ +660 (> 4096).
+    let mut obj = serde_json::Map::new();
+    for i in 0..330 {
+        obj.insert(format!("key{i:04}"), json!(1));
+    }
+    let ctx = Value::Object(obj);
+    let compact = serde_json::to_vec(&ctx).unwrap().len();
+    assert!(compact <= 4096, "fixture must pass ingestion: {compact}");
+
+    let pg = PgLedger::spawn(&dsn).expect("pool");
+    let draft = RowDraft::capture(
+        "acme",
+        WS,
+        "user:acme/u1",
+        "r-near",
+        "SELECT 1",
+        Some(&ctx),
+        None,
+        1000,
+    );
+    pg.record(draft.finish(RowStatus::Succeeded, Some(1), None));
+    pg.shutdown().await;
+
+    // Prove the premise: the stored jsonb's text form exceeds the old bound.
+    let text_len: i32 =
+        sqlx::query_scalar("SELECT octet_length(ai_context::text) FROM query_ledger")
+            .fetch_one(&pool)
+            .await
+            .expect("len");
+    assert!(
+        text_len > 4096,
+        "fixture must exercise the expansion: {text_len}"
+    );
+
+    let page = read::list_page(&pool, WS, read::PageQuery::default())
+        .await
+        .expect("page");
+    let row = &page["rows"].as_array().unwrap()[0];
+    assert!(
+        row["ai_context"].is_object(),
+        "valid near-limit context must survive the read: {}",
+        row["ai_context"]
+    );
+    assert_eq!(row["ai_context"]["key0000"], json!(1));
+}

--- a/crates/query-audit/tests/ledger_live.rs
+++ b/crates/query-audit/tests/ledger_live.rs
@@ -465,3 +465,58 @@ async fn a_rejected_insert_counts_its_losses() {
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 }
+
+/// The P1 regression against real Postgres: a row whose caller-supplied
+/// text carried U+0000 lands IN THE SAME BATCH as clean rows, and every row
+/// survives — before assembly scrubbed NULs, that one row rejected the
+/// whole multi-row INSERT and up to 63 other callers' rows were lost.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs SKARDI_QUERY_AUDIT_LIVE_URL"]
+async fn a_nul_bearing_row_cannot_poison_its_batch() {
+    let Some(url) = live_url() else { return };
+    let (dsn, pool) = fresh_db(&url).await;
+    let pg = PgLedger::spawn(&dsn).expect("pool");
+
+    // Enqueued back-to-back so the writer drains them as ONE batch.
+    pg.record(draft(WS, "SELECT 1", "r-clean-1").finish(RowStatus::Succeeded, Some(1), None));
+    pg.record(
+        RowDraft::capture(
+            "acme",
+            WS,
+            "user:acme/u1",
+            "r-poison",
+            "SELECT '\u{0}'",
+            Some(&json!({"session_id": "s\u{0}", "purpose": "p"})),
+            None,
+            1000,
+        )
+        .finish(RowStatus::Failed, None, Some("bad\u{0}input".into())),
+    );
+    pg.record(draft(WS, "SELECT 2", "r-clean-2").finish(RowStatus::Succeeded, Some(1), None));
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let n: i64 = sqlx::query_scalar("SELECT count(*) FROM query_ledger")
+            .fetch_one(&pool)
+            .await
+            .expect("count");
+        if n == 3 {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the batch was poisoned: only {n} of 3 rows landed"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    let (sql, err, session): (String, String, Option<String>) = sqlx::query_as(
+        "SELECT sql, error, session_id FROM query_ledger WHERE request_id = 'r-poison'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("poisoned row landed");
+    assert_eq!(sql, "SELECT '\u{FFFD}'");
+    assert_eq!(err, "bad\u{FFFD}input");
+    assert!(session.is_none(), "the NUL session id was dropped");
+}

--- a/crates/query-audit/tests/ledger_live.rs
+++ b/crates/query-audit/tests/ledger_live.rs
@@ -1,0 +1,348 @@
+//! Live-Postgres tests for the best-effort ledger module (`ledger::*`) —
+//! the queued writer, the read page, and the RLS posture its consumer's
+//! per-workspace roles rely on, against a real server.
+//!
+//! Gated exactly like `pg_live.rs`: `#[ignore]` by default, run with
+//! `SKARDI_QUERY_AUDIT_LIVE_URL=postgres://… cargo test -- --ignored`.
+//! Each test creates its own throwaway database and applies
+//! [`queries::QUERY_LEDGER_DDL`] — the module runs no DDL itself.
+
+use serde_json::{Value, json};
+use skardi_query_audit::ledger::{self, PgLedger, RowDraft, RowStatus, queries, read};
+use std::time::{Duration, Instant};
+
+const LIVE_URL_ENV: &str = "SKARDI_QUERY_AUDIT_LIVE_URL";
+const WS: &str = "ws-core";
+
+fn live_url() -> Option<String> {
+    std::env::var(LIVE_URL_ENV)
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+}
+
+/// A fresh database with the ledger DDL applied. Same three-axis unique
+/// name as `pg_live.rs`'s, for the same reasons.
+async fn fresh_db(url: &str) -> (String, sqlx::PgPool) {
+    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let db = format!(
+        "lgr_{}_{}_{}",
+        std::process::id(),
+        std::time::UNIX_EPOCH.elapsed().unwrap().as_nanos(),
+        SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    );
+    let boot = sqlx::PgPool::connect(url).await.expect("connect server");
+    let mut attempts = 0;
+    loop {
+        match sqlx::raw_sql(&format!(r#"CREATE DATABASE "{db}""#))
+            .execute(&boot)
+            .await
+        {
+            Ok(_) => break,
+            Err(e)
+                if attempts < 50 && e.to_string().contains("is being accessed by other users") =>
+            {
+                attempts += 1;
+                tokio::time::sleep(Duration::from_millis(200)).await;
+            }
+            Err(e) => panic!("create test db: {e}"),
+        }
+    }
+    boot.close().await;
+    let mut parsed = url::Url::parse(url).expect("url");
+    parsed.set_path(&format!("/{db}"));
+    let dsn = parsed.to_string();
+    let pool = sqlx::PgPool::connect(&dsn).await.expect("connect test db");
+    sqlx::raw_sql(queries::QUERY_LEDGER_DDL)
+        .execute(&pool)
+        .await
+        .expect("apply the ledger DDL");
+    (dsn, pool)
+}
+
+fn draft(ws: &str, sql: &str, request_id: &str) -> RowDraft {
+    RowDraft::capture(
+        "acme",
+        ws,
+        "user:acme/u1",
+        request_id,
+        sql,
+        Some(&json!({"session_id": "s-1", "purpose": "test"})),
+        Some(100),
+        1000,
+    )
+}
+
+/// Queue-full contract, no server needed: a full channel DROPS the row and
+/// COUNTS it — `record` never waits and never errors to the caller.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_full_queue_drops_and_counts_instead_of_blocking() {
+    let pg = PgLedger::spawn_with_capacity("postgres://u:p@192.0.2.1:5432/skardi_ledger", 1)
+        .expect("lazy pool");
+    let before = ledger::METRICS
+        .insert_failures_channel_full
+        .load(std::sync::atomic::Ordering::Relaxed);
+
+    let started = Instant::now();
+    for i in 0..200 {
+        let d = draft(WS, "SELECT 1", &format!("r-full-{i}"));
+        pg.record(d.finish(RowStatus::Succeeded, Some(1), None));
+    }
+    assert!(
+        started.elapsed() < Duration::from_secs(1),
+        "record must never block, even with the queue full"
+    );
+    let dropped = ledger::METRICS
+        .insert_failures_channel_full
+        .load(std::sync::atomic::Ordering::Relaxed)
+        - before;
+    assert!(dropped >= 100, "losses must be counted; got {dropped}");
+}
+
+/// Store round trip through the real writer: all three statuses land and
+/// read back with filter semantics; the poisoned-batch clamp holds; an
+/// 8 MiB statement is stored truncated.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs SKARDI_QUERY_AUDIT_LIVE_URL"]
+async fn store_round_trip_and_filters() {
+    let Some(url) = live_url() else { return };
+    let (dsn, pool) = fresh_db(&url).await;
+    let pg = PgLedger::spawn(&dsn).expect("pool");
+
+    pg.record(draft(WS, "SELECT 1", "r-ok").finish(RowStatus::Succeeded, Some(3), None));
+    pg.record(draft(WS, "SELECT boom", "r-fail").finish(
+        RowStatus::Failed,
+        None,
+        Some("execution-failed: boom".into()),
+    ));
+    // The poison case: max_rows beyond i32, plus an 8 MiB statement.
+    let big = "S".repeat(8 * 1024 * 1024);
+    let poison = RowDraft::capture(
+        "acme",
+        WS,
+        "user:acme/u1",
+        "r-refused",
+        &big,
+        None,
+        Some(3_000_000_000),
+        1000,
+    );
+    pg.record(poison.finish(RowStatus::Refused, None, Some("plan-error: nope".into())));
+
+    // Drain: the first flush pays the batch window plus the lazy pool's
+    // first real connect.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let n: i64 = sqlx::query_scalar("SELECT count(*) FROM query_ledger")
+            .fetch_one(&pool)
+            .await
+            .expect("count");
+        if n == 3 {
+            break;
+        }
+        assert!(Instant::now() < deadline, "rows never landed (n={n})");
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    let page = read::list_page(&pool, WS, read::PageQuery::default())
+        .await
+        .expect("page");
+    assert_eq!(page["rows"].as_array().unwrap().len(), 3);
+
+    let refused_only = read::list_page(
+        &pool,
+        WS,
+        read::PageQuery {
+            status: Some("refused".into()),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("page");
+    let rows = refused_only["rows"].as_array().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["request_id"], "r-refused");
+    assert_eq!(rows[0]["max_rows"], json!(3_000_000_000i64));
+    assert_eq!(rows[0]["sql_truncated"], json!(true));
+    assert!(rows[0]["sql"].as_str().unwrap().len() <= 32 * 1024);
+
+    let by_session = read::list_page(
+        &pool,
+        WS,
+        read::PageQuery {
+            session_id: Some("s-1".into()),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("page");
+    assert_eq!(by_session["rows"].as_array().unwrap().len(), 2);
+}
+
+/// Keyset pagination: rows sharing ONE created_at paginate without skips or
+/// repeats, and a returned `next_cursor` fed back yields the tail.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs SKARDI_QUERY_AUDIT_LIVE_URL"]
+async fn pagination_is_stable_across_shared_timestamps() {
+    let Some(url) = live_url() else { return };
+    let (_dsn, pool) = fresh_db(&url).await;
+    let at = chrono::Utc::now();
+    for i in 0..5 {
+        sqlx::query(
+            "INSERT INTO query_ledger (org_id, workspace_id, user_id, request_id, \
+             created_at, finished_at, sql, statement_kind, max_rows, status) \
+             VALUES ('acme', $1, 'u', $2, $3, $3, 'SELECT 1', 'query', 100, 'succeeded')",
+        )
+        .bind(WS)
+        .bind(format!("r-{i}"))
+        .bind(at)
+        .execute(&pool)
+        .await
+        .expect("insert");
+    }
+
+    let mut seen: Vec<String> = Vec::new();
+    let mut cursor: Option<String> = None;
+    loop {
+        let page = read::list_page(
+            &pool,
+            WS,
+            read::PageQuery {
+                limit: Some(2),
+                cursor: cursor.clone(),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("page");
+        for r in page["rows"].as_array().unwrap() {
+            seen.push(r["request_id"].as_str().unwrap().to_string());
+        }
+        match page["next_cursor"].as_str() {
+            Some(c) => cursor = Some(c.to_string()),
+            None => break,
+        }
+    }
+    seen.sort();
+    seen.dedup();
+    assert_eq!(seen.len(), 5, "every row exactly once: {seen:?}");
+}
+
+/// Two workspace roles under FORCE RLS — role A cannot read or write role
+/// B's rows even with a deliberately unscoped statement — and the grant set
+/// a workspace role needs (schema USAGE + identity-sequence USAGE/SELECT)
+/// is proven by an INSERT *through* the role. This is the database half of
+/// the consumer's isolation story; the roles are provisioned here exactly
+/// as its operator does.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs SKARDI_QUERY_AUDIT_LIVE_URL"]
+async fn rls_isolates_workspace_roles() {
+    let Some(url) = live_url() else { return };
+    let (dsn, pool) = fresh_db(&url).await;
+
+    // Roles are cluster-wide: unique per run so reruns cannot collide.
+    let tag = format!(
+        "{}_{}",
+        std::process::id(),
+        std::time::UNIX_EPOCH.elapsed().unwrap().as_millis()
+    );
+    let role_a = format!("lgr_a_{tag}");
+    let role_b = format!("lgr_b_{tag}");
+    for (role, ws) in [(&role_a, "ws-a"), (&role_b, "ws-b")] {
+        for stmt in [
+            format!("CREATE ROLE {role} LOGIN PASSWORD 'pw' NOBYPASSRLS"),
+            format!("GRANT USAGE ON SCHEMA public TO {role}"),
+            format!("GRANT INSERT, SELECT ON query_ledger TO {role}"),
+            format!("GRANT USAGE, SELECT ON SEQUENCE query_ledger_id_seq TO {role}"),
+            format!(
+                "CREATE POLICY ws_{role} ON query_ledger FOR ALL TO {role} \
+                 USING (workspace_id = '{ws}') WITH CHECK (workspace_id = '{ws}')"
+            ),
+        ] {
+            sqlx::raw_sql(&stmt)
+                .execute(&pool)
+                .await
+                .expect("provision");
+        }
+    }
+
+    let base = dsn.rsplit_once('@').expect("dsn").1;
+    let dsn_a = format!("postgres://{role_a}:pw@{base}");
+    let pool_a = sqlx::PgPool::connect(&dsn_a).await.expect("connect as A");
+
+    sqlx::query(
+        "INSERT INTO query_ledger (org_id, workspace_id, user_id, request_id, \
+         created_at, finished_at, sql, statement_kind, max_rows, status) \
+         VALUES ('acme', 'ws-a', 'u', 'r-a', now(), now(), 'SELECT 1', 'query', 10, 'succeeded')",
+    )
+    .execute(&pool_a)
+    .await
+    .expect("insert through role A must succeed (grants incomplete otherwise)");
+
+    sqlx::query(
+        "INSERT INTO query_ledger (org_id, workspace_id, user_id, request_id, \
+         created_at, finished_at, sql, statement_kind, max_rows, status) \
+         VALUES ('acme', 'ws-b', 'u', 'r-b', now(), now(), 'SECRET OF B', 'query', 10, 'succeeded')",
+    )
+    .execute(&pool)
+    .await
+    .expect("admin insert");
+
+    let visible: Vec<String> = sqlx::query_scalar("SELECT request_id FROM query_ledger")
+        .fetch_all(&pool_a)
+        .await
+        .expect("select as A");
+    assert_eq!(visible, vec!["r-a".to_string()], "RLS must hide B's rows");
+
+    let smuggle = sqlx::query(
+        "INSERT INTO query_ledger (org_id, workspace_id, user_id, request_id, \
+         created_at, finished_at, sql, statement_kind, max_rows, status) \
+         VALUES ('acme', 'ws-b', 'u', 'r-smuggle', now(), now(), 'x', 'query', 10, 'succeeded')",
+    )
+    .execute(&pool_a)
+    .await;
+    assert!(
+        smuggle.is_err(),
+        "WITH CHECK must refuse cross-workspace writes"
+    );
+
+    let del = sqlx::query("DELETE FROM query_ledger")
+        .execute(&pool_a)
+        .await;
+    assert!(del.is_err(), "the workspace role must hold no DELETE");
+
+    // Cleanup: roles are cluster-wide and would otherwise outlive the db.
+    drop(pool_a);
+    for role in [&role_a, &role_b] {
+        let _ = sqlx::raw_sql(&format!("DROP OWNED BY {role}"))
+            .execute(&pool)
+            .await;
+        let _ = sqlx::raw_sql(&format!("DROP ROLE {role}"))
+            .execute(&pool)
+            .await;
+    }
+}
+
+/// One ai_context/session/status shape lands typed (JSONB in, JSON out) —
+/// the field the learn loop reads.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs SKARDI_QUERY_AUDIT_LIVE_URL"]
+async fn ai_context_lands_as_jsonb_and_reads_back() {
+    let Some(url) = live_url() else { return };
+    let (dsn, pool) = fresh_db(&url).await;
+    let pg = PgLedger::spawn(&dsn).expect("pool");
+    pg.record(draft(WS, "SELECT 1", "r-ctx").finish(RowStatus::Succeeded, Some(1), None));
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let row: Value = loop {
+        let page = read::list_page(&pool, WS, read::PageQuery::default())
+            .await
+            .expect("page");
+        if let Some(r) = page["rows"].as_array().unwrap().first() {
+            break r.clone();
+        }
+        assert!(Instant::now() < deadline, "row never landed");
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    };
+    assert_eq!(row["ai_context"]["purpose"], json!("test"));
+    assert_eq!(row["session_id"], json!("s-1"));
+    assert_eq!(row["status"], json!("succeeded"));
+}

--- a/crates/query-audit/tests/ledger_live.rs
+++ b/crates/query-audit/tests/ledger_live.rs
@@ -630,3 +630,63 @@ async fn schema_drift_is_a_read_error_not_a_panic() {
         .expect_err("drift must be an error, not a panic");
     assert!(matches!(err, read::ReadError::Unavailable(_)), "got {err}");
 }
+
+/// Graceful shutdown drains: rows enqueued before shutdown() LAND (the
+/// drain hands the backlog to a final flush instead of dying with the
+/// runtime), and rows recorded after are counted as channel losses — the
+/// loss-is-never-silent contract survives a restart.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs SKARDI_QUERY_AUDIT_LIVE_URL"]
+async fn shutdown_drains_the_queue_before_exiting() {
+    let Some(url) = live_url() else { return };
+    let (dsn, pool) = fresh_db(&url).await;
+    let pg = PgLedger::spawn(&dsn).expect("pool");
+    for i in 0..10 {
+        pg.record(draft(WS, "SELECT 1", &format!("r-drain-{i}")).finish(
+            RowStatus::Succeeded,
+            Some(1),
+            None,
+        ));
+    }
+    pg.shutdown().await;
+    let n: i64 = sqlx::query_scalar("SELECT count(*) FROM query_ledger")
+        .fetch_one(&pool)
+        .await
+        .expect("count");
+    assert_eq!(
+        n, 10,
+        "every accepted row must land before shutdown returns"
+    );
+
+    // Post-shutdown rows are refused by the closed channel and COUNTED.
+    let before = ledger::METRICS
+        .insert_failures_channel_full
+        .load(std::sync::atomic::Ordering::Relaxed);
+    pg.record(draft(WS, "SELECT 1", "r-late").finish(RowStatus::Succeeded, Some(1), None));
+    let after = ledger::METRICS
+        .insert_failures_channel_full
+        .load(std::sync::atomic::Ordering::Relaxed);
+    assert_eq!(after - before, 1, "a post-shutdown row is a counted loss");
+}
+
+/// Shutdown against an unreachable server still terminates (the drain's
+/// final flush pays its bound, fails, COUNTS the batch) — a stalled PG must
+/// not turn graceful shutdown into a hang.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn shutdown_with_a_dead_server_counts_and_returns() {
+    let pg = PgLedger::spawn("postgres://u:p@192.0.2.1:5432/skardi_ledger").expect("lazy pool");
+    let before = ledger::METRICS
+        .insert_failures_pg
+        .load(std::sync::atomic::Ordering::Relaxed);
+    pg.record(draft(WS, "SELECT 1", "r-dead-drain").finish(RowStatus::Succeeded, Some(1), None));
+    tokio::time::timeout(Duration::from_secs(20), pg.shutdown())
+        .await
+        .expect("shutdown must complete within the flush bound, not hang");
+    let after = ledger::METRICS
+        .insert_failures_pg
+        .load(std::sync::atomic::Ordering::Relaxed);
+    assert!(
+        after > before,
+        "the drained-but-unflushable batch is counted"
+    );
+}

--- a/crates/query-audit/tests/ledger_live.rs
+++ b/crates/query-audit/tests/ledger_live.rs
@@ -690,3 +690,33 @@ async fn shutdown_with_a_dead_server_counts_and_returns() {
         "the drained-but-unflushable batch is counted"
     );
 }
+
+/// EVERY concurrent shutdown caller awaits the same drain (review): the
+/// completion latch is shared watch state, so a second caller — even one
+/// that controls runtime teardown — holds until the writer has really
+/// exited, and no caller's return depends on being "first".
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_shutdown_callers_all_await_the_drain() {
+    let pg = PgLedger::spawn("postgres://u:p@192.0.2.1:5432/skardi_ledger").expect("lazy pool");
+    pg.record(draft(WS, "SELECT 1", "r-cc").finish(RowStatus::Succeeded, Some(1), None));
+    let before = ledger::METRICS
+        .insert_failures_pg
+        .load(std::sync::atomic::Ordering::Relaxed);
+
+    let a = pg.clone();
+    let b = pg.clone();
+    let (ra, rb) = tokio::join!(
+        tokio::time::timeout(Duration::from_secs(20), async move { a.shutdown().await }),
+        tokio::time::timeout(Duration::from_secs(20), async move { b.shutdown().await }),
+    );
+    ra.expect("caller A completes");
+    rb.expect("caller B completes");
+
+    // BOTH returned only after the drain finished — by then the doomed
+    // batch has been counted, so a caller that tears the runtime down next
+    // cannot be racing an in-flight flush.
+    let after = ledger::METRICS
+        .insert_failures_pg
+        .load(std::sync::atomic::Ordering::Relaxed);
+    assert!(after > before, "the drain completed before either returned");
+}

--- a/docs/server.md
+++ b/docs/server.md
@@ -216,6 +216,28 @@ kind selected — with plain SQL. `job_run_id` carries its own partial index
 `GET /jobs/runs`, which session submitted it — does not scan a table that is
 append-only and has retention off by default.
 
+#### A second ledger contract, library-only: the best-effort query ledger
+
+The `skardi-query-audit` crate also hosts `ledger::*` — a **different
+contract** from the audit ledger above, for downstream distributions whose
+many server processes share one Postgres and treat the record as analytics
+rather than compliance. Where the audit ledger is fail-closed (durable
+before execution; a statement that cannot be recorded does not run,
+two-phase with startup reconciliation), the best-effort ledger writes one
+row per DECIDED statement (`succeeded`/`failed`/`refused`) AFTER the
+outcome, on a bounded queue the query path never waits for: a Postgres
+outage degrades the ledger and never a query, and loss is counted
+(`ledger::METRICS`), never silent. Its schema (`query_ledger`) ships as
+versioned migration constants (`ledger::queries::QUERY_LEDGER_MIGRATION_*`)
+that the consumer's own migration path applies — the module runs no DDL.
+
+**This server does not wire it.** Nothing here reads or writes
+`query_ledger`; the OSS flags above always drive the fail-closed audit
+ledger. The consumer is the governed cloud engine (skardi-cloud), whose
+deployment docs own the operational story (per-workspace roles, RLS,
+retention). It lives in this crate so the audit domain has one home and the
+shared vocabulary (identity columns, session-id bounds) cannot drift.
+
 What is **not** here: job runs. `POST /jobs/:name/run` executes its own SQL
 through the same engine but is recorded in the separate jobs run ledger (see
 [jobs.md](jobs.md)), not in `query_audit`. An operator reasoning about


### PR DESCRIPTION
Downstreams skardi-cloud's `query_ledger` machinery into this crate as `skardi_query_audit::ledger`, per the decision that the ledger logic should live in OSS and the cloud engine should reference it rather than implement it. The consuming change is skardi-cloud#407, which becomes a thin re-export + route wiring once this merges.

## What moves in

- **`ledger::RowDraft` / `LedgerRow`** — bounded row assembly: sql truncated at 32 KiB (+flag), error ≤4 KiB, oversized `ai_context` dropped whole, `max_rows` clamped into i64, `session_id` char-counted against `MAX_SESSION_ID_CHARS` — now consumed **directly from this crate**, killing the cross-repo drift class that produced the char-vs-bytes review bug in #407.
- **`ledger::PgLedger` + `writer`** — the bounded mpsc queue (1024) drained by a batching writer (64 rows/flush, 5 s bound, `connect_lazy`, `try_send` never blocks); loss counted in `ledger::METRICS`, never silent.
- **`ledger::read`** — the keyset `(created_at, id)` page with opaque cursor, limit ≤500, and the 8 MiB body budget with envelope reserve.
- **`ledger::queries`** — every SQL statement as documented consts, plus **`QUERY_LEDGER_DDL`: the schema's single source of truth**. The module runs no DDL (its writers connect as roles that deliberately cannot); the consumer's migration path applies it and pins its migration file byte-identical.

## What this is NOT

Not a storage backend of `QueryAuditStore` — the module doc leads with the distinction. `QueryAuditStore` is the compliance record (durable before execution, fail-closed, two-phase, startup reconcile); `ledger` is analytics (one row per DECIDED statement — `succeeded`/`failed`/`refused` — best-effort after the outcome, on a queue the caller never waits for). Co-hosting buys one home for the audit domain and shared vocabulary, not interchangeable contracts.

## Dependency note

sqlx's facade-level `chrono`/`json` features textually reference `sqlx-sqlite?/…`, which makes the resolver pull `sqlx-sqlite` into the lock and `links`-conflict its libsqlite3-sys (0.30) against tokio-rusqlite's (0.35). The features are therefore enabled on the **internal `sqlx-postgres` node**, which feature-unifies with the facade's — no facade feature change, no sqlite anywhere.

## Tests

- Unit suite moves in (assembly bounds, char-counted session ids, cursor codec): **39 passed**.
- `tests/ledger_live.rs` behind the same `SKARDI_QUERY_AUDIT_LIVE_URL` gate CI already runs: queue-full drop+count (no server needed), writer round trip with truncation + i64 clamp, keyset pagination across shared timestamps, RLS isolation (WITH CHECK + no DELETE) through roles provisioned exactly as the consumer's operator does, JSONB round trip. Live: **5/5** (+ existing `pg_live` 10/10) against `postgres:11-alpine`.
- Verified the suites consume the gate (wrong-password probe fails them, not skips them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
