### PR TITLE
docs(readme): build the server without cmake by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,9 +226,20 @@ sudo mv skardi /usr/local/bin/
 
 ```bash
 git clone https://github.com/SkardiLabs/skardi.git && cd skardi
-cargo build --release -p skardi-server     # add --features rag for embedding + chunk UDFs
-cargo install --locked --path crates/cli   # the CLI, from the same checkout
+cargo build --release -p skardi-server --features candle,chunking   # local embeddings + chunk(); pure Rust
+cargo install --locked --path crates/cli                            # the CLI, from the same checkout
 ```
+
+That gives the retrieval skills what they need — `chunk()` plus a local
+embedding UDF — and builds with cargo alone. (`chunking` is already a default
+server feature; naming it keeps the line correct against older tags.)
+
+**`--features rag` widens that to all four embedding backends, and one of them
+— `gguf` — compiles llama.cpp through `cmake`, so that build needs `cmake` and a
+C++ toolchain on the machine.** Reach for `rag` when you want `gguf`, `onnx` or
+`remote_embed`; otherwise the line above is the cheaper build. Or skip building
+altogether and run a published server image that ships the embedding backends
+(see **Docker & cloud** under More).
 
 ---
 


### PR DESCRIPTION
## What this fixes

The source-build line offered `--features rag` as the way to get the embedding and chunk UDFs. `rag` expands to `embedding + chunking`, and `embedding` bundles all four backends — including `gguf`, whose build script compiles llama.cpp through cmake.

So **every reader following that line needed cmake and a C++ toolchain**, whether or not they ever intended to use gguf. And the local-SQLite storage path — the default one — cannot use a published image (`--backend sqlite --runtime docker` is refused: no Linux sqlite-vec in the image), so it is exactly the users on the default path who hit this.

## Evidence

From the dependency graph, so it does not depend on one machine's state:

```
cargo tree -p skardi-server --no-default-features -e normal \
  --features candle,chunking    # no llama-cpp-*, no ort
  --features rag                # llama-cpp-4 -> llama-cpp-sys-4, and ort
```

Measured 2026-09-02 on macOS arm64, before cmake was installed:

- `--features rag` → fails in `llama-cpp-sys-4`'s build script, `is 'cmake' not installed?`, exit 101
- `--features candle,chunking` → builds clean in 73m34s. The binary carries `chunk()` and `candle()`, carries none of `gguf` / `onnx` / `remote_embed`, and `otool -L` shows no non-system libraries.

That binary then ran the auto-context flow end to end on a real 111-document corpus: render workspace, start server (5/5 pipelines), ingest 111/111 in 81.6s, and all three search pipelines answering. So the narrower build is not merely compilable — it is the build the retrieval skills need.

## The change

One line in the Install section, plus the trade-off spelled out. `rag` stays documented as the wider build, with its prerequisite stated where someone about to run it will read it.

There is no smaller published feature name for `candle + chunking`, so the line spells the pair out. `chunking` is already a default server feature on `main`; naming it explicitly keeps the command correct against `v0.5.0`, where it is not.

## Scope

Docs only — no feature or workflow change. Two adjacent things this deliberately does **not** do:

- **It does not add a feature alias.** #237's stance is to pin feature lists explicitly rather than grow umbrellas, and a new umbrella would cut against that.
- **It does not touch the Docker section**, which #237 rewrites. Different part of the file; no overlap. The sentence about published images is worded to stay true after the `-lite` / `-full` rename lands.

## Possible follow-up, not in this PR

The release workflow builds `-p skardi-cli` only, so there is no pre-built `skardi-server` on any platform and the default local path always means a Rust build. The measurement above suggests a cheap middle: `candle,chunking` pulls no native dependency, so it is the feature set most likely to cross-compile as cleanly as the CLI already does. Whether that is worth a release artifact is a call for whoever owns the release workflow — flagging it rather than assuming.

## Testing

`cargo check --release -p skardi-server --features candle,chunking` passes on this commit.


---

## Verified after opening: the fold makes this line the only one people read

Two facts checked on `origin/main` on 2026-09-03, after this PR was already open. They do not change the diff, but they sharpen why the line matters.

**The Docker command is not next to this one.** The Server paragraph says "a Docker image, or a source build", but the command block under it contains only the source build. `docker run` lives at line 304, inside a `<details>` fold titled "Docker & cloud" that opens at line 300 — about eighty lines below Install, collapsed by default. So someone following Install top-down sees exactly one way to get a server: clone and compile. The prose offers a choice the layout does not.

**And the source build is not always the slower path.** On a machine where `docker` is on PATH from homebrew but no container runtime is installed — an ordinary state on macOS — reaching for the image means first pulling down a multi-GB Linux VM. Compiling can finish first. So "just use the image" is not a universally cheaper answer either, which is another reason the source-build line should be correct rather than merely present.

Both of those are arguments for a separate change — promoting the Docker command out of the fold, which is a layout decision for whoever owns the README's shape. This PR does not touch it. It only makes the command that people actually reach today one that builds without a C++ toolchain.
