### PR TITLE
fix(sqlite): sqlite_fts takes what the user typed, like pg_fts does

### DIFF
--- a/crates/skardi/src/sources/providers/sqlite/fts_exec.rs
+++ b/crates/skardi/src/sources/providers/sqlite/fts_exec.rs
@@ -1,6 +1,6 @@
 //! Physical execution plan for SQLite FTS5 full-text search.
 
-use arrow::array::{ArrayRef, RecordBatch};
+use arrow::array::{ArrayRef, RecordBatch, RecordBatchOptions, new_empty_array};
 use arrow::datatypes::{DataType, SchemaRef};
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
@@ -16,6 +16,7 @@ use std::fmt;
 use std::sync::Arc;
 use tokio_rusqlite::Connection;
 
+use super::fts_query::websearch_to_fts5;
 use super::{quote_sqlite_ident, sqlite_values_to_arrow};
 
 /// Physical execution plan that runs a SQLite FTS5 full-text search query using
@@ -35,6 +36,12 @@ use super::{quote_sqlite_ident, sqlite_values_to_arrow};
 /// Note: FTS5's `rank` is equivalent to `bm25(table)` and is negative (more
 /// negative = better match). We negate it so `_score` is positive and higher
 /// means more relevant, consistent with `pg_fts`.
+///
+/// `query` is what the user typed, not an FTS5 expression: it is translated by
+/// [`websearch_to_fts5`] on the way in, so the same parameter means the same
+/// thing here as it does in `pg_fts` behind `websearch_to_tsquery`. Text with
+/// nothing to search for returns no rows without reaching SQLite, because FTS5
+/// rejects an empty match string as a syntax error.
 #[derive(Debug, Clone)]
 pub struct SqliteFtsExec {
     conn: Arc<Connection>,
@@ -42,7 +49,9 @@ pub struct SqliteFtsExec {
     table_name: String,
     /// Name of the text column to search.
     text_col: String,
-    /// The user's search query string.
+    /// The user's search text, verbatim — translated to an FTS5 expression at
+    /// execution time rather than stored translated, so `EXPLAIN` output and
+    /// error messages keep showing what was actually asked.
     query: String,
     /// Maximum number of results to return.
     limit: usize,
@@ -141,12 +150,31 @@ impl SqliteFtsExec {
 
     /// Execute the query and return all rows as a single `RecordBatch`.
     async fn run(&self) -> DFResult<RecordBatch> {
+        let schema = self.schema.clone();
+
+        // No searchable term — an empty or punctuation-only question. FTS5
+        // treats an empty match string as a syntax error, so answer it here
+        // instead of letting a blank question come back as an execution
+        // failure (or, worse, as arbitrary rows).
+        let Some(match_expr) = websearch_to_fts5(&self.query) else {
+            tracing::debug!("sqlite_fts: query has no searchable term; returning no rows");
+            return RecordBatch::try_new_with_options(
+                schema.clone(),
+                schema
+                    .fields()
+                    .iter()
+                    .map(|f| new_empty_array(f.data_type()))
+                    .collect(),
+                &RecordBatchOptions::new().with_row_count(Some(0)),
+            )
+            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None));
+        };
+
         let sql = self.build_query();
         tracing::debug!("sqlite_fts SQL: {}", sql);
 
         let conn = Arc::clone(&self.conn);
-        let schema = self.schema.clone();
-        let query = self.query.clone();
+        let query = match_expr;
         let num_cols = schema.fields().len();
         let field_types: Vec<DataType> = schema
             .fields()

--- a/crates/skardi/src/sources/providers/sqlite/fts_query.rs
+++ b/crates/skardi/src/sources/providers/sqlite/fts_query.rs
@@ -1,0 +1,361 @@
+//! Translate what a person typed into an FTS5 `MATCH` expression.
+//!
+//! `pg_fts` hands its `query` argument to PostgreSQL's
+//! `websearch_to_tsquery`, whose whole purpose is to accept the contents of a
+//! search box: apostrophes, colons and hyphens are ordinary characters to it,
+//! and no user text can make it raise a parse error. `sqlite_fts` used to hand
+//! the same argument straight to FTS5's `MATCH` grammar, which has no such
+//! forgiving entry point — so `read-only`, `doesn't` and `note:` each turned an
+//! ordinary question into an execution error naming a column the user never
+//! wrote. Two backends, one documented parameter, two contracts.
+//!
+//! [`websearch_to_fts5`] closes that gap on the SQLite side by parsing the
+//! text here and emitting an expression FTS5 can always parse.
+
+/// One parsed search term.
+struct Term {
+    negated: bool,
+    /// The term's literal text, before FTS5 phrase quoting.
+    text: String,
+}
+
+/// True when a term carries something FTS5 could tokenize. A run of pure
+/// punctuation (`---`, `:::`) has no tokens, and an empty phrase pair
+/// contributes nothing to the match, so such terms are dropped rather than
+/// emitted.
+fn is_searchable(text: &str) -> bool {
+    text.chars().any(char::is_alphanumeric)
+}
+
+/// Wrap a term as an FTS5 phrase, doubling any embedded double quote.
+///
+/// Quoting is what makes the translation total: inside a phrase, every
+/// character except `"` is literal, so a colon cannot start a column filter, a
+/// hyphen cannot split the word, and an apostrophe cannot open a string. FTS5
+/// still applies the table's own tokenizer inside the phrase, so `"read-only"`
+/// matches text indexed as `read` followed by `only` — the hyphenated term is
+/// found, not merely tolerated.
+fn as_phrase(text: &str) -> String {
+    format!("\"{}\"", text.replace('"', "\"\""))
+}
+
+/// Parse `input` into terms plus the positions where the user wrote a bare
+/// `or`. Returns the terms and, for each term after the first, whether an `or`
+/// joined it to the previous one.
+fn parse(input: &str) -> Vec<(Term, bool)> {
+    let chars: Vec<char> = input.chars().collect();
+    let mut out: Vec<(Term, bool)> = Vec::new();
+    let mut i = 0;
+    // Set by a bare `or`, consumed by the term that follows it.
+    let mut pending_or = false;
+
+    while i < chars.len() {
+        if chars[i].is_whitespace() {
+            i += 1;
+            continue;
+        }
+
+        // A `-` directly against the start of a term negates it; a detached
+        // `-` is just punctuation and falls through to the term scanner,
+        // where it is dropped for having no tokens.
+        let mut negated = false;
+        if chars[i] == '-' && i + 1 < chars.len() && !chars[i + 1].is_whitespace() {
+            negated = true;
+            i += 1;
+        }
+
+        let text: String = if chars[i] == '"' {
+            // A quoted phrase runs to the closing quote, or to the end of the
+            // input when the user never typed one — the same tolerance
+            // websearch_to_tsquery shows an unbalanced quote.
+            i += 1;
+            let start = i;
+            while i < chars.len() && chars[i] != '"' {
+                i += 1;
+            }
+            let phrase: String = chars[start..i].iter().collect();
+            if i < chars.len() {
+                i += 1; // consume the closing quote
+            }
+            phrase
+        } else {
+            let start = i;
+            while i < chars.len() && !chars[i].is_whitespace() {
+                i += 1;
+            }
+            let word: String = chars[start..i].iter().collect();
+            // A bare `or` is the operator, not a term to search for. Only
+            // unquoted, un-negated occurrences count, so `"or"` and `-or`
+            // still search for the word.
+            if !negated && word.eq_ignore_ascii_case("or") {
+                pending_or = true;
+                continue;
+            }
+            word
+        };
+
+        if !is_searchable(&text) {
+            continue;
+        }
+        // A negated term never participates in an OR group; the `or` the user
+        // typed beside it is dropped rather than silently changing what the
+        // negation applies to.
+        let joined_by_or = pending_or && !negated && !out.is_empty();
+        pending_or = false;
+        out.push((Term { negated, text }, joined_by_or));
+    }
+
+    out
+}
+
+/// Translate user-typed search text into an FTS5 `MATCH` expression, mirroring
+/// PostgreSQL's `websearch_to_tsquery` so that `sqlite_fts` and `pg_fts` honour
+/// the same contract for the same documented parameter.
+///
+/// The grammar it accepts:
+///
+/// - words separated by whitespace are ANDed;
+/// - `"…"` is a phrase, and an unterminated quote runs to the end of the input;
+/// - a bare `or` (any case) between two words makes them alternatives, binding
+///   tighter than the implicit AND — `a b or c` is `a AND (b OR c)`;
+/// - a `-` against the front of a word excludes it.
+///
+/// Everything else is literal text. No input can produce a parse error: every
+/// term is emitted as a quoted phrase, and text with nothing to tokenize
+/// (`""`, `"   "`, `---`) yields `None`, meaning "no rows" — the caller must
+/// not send an empty string to FTS5, which rejects it as a syntax error.
+///
+/// Two places where FTS5 cannot follow `websearch_to_tsquery` exactly:
+///
+/// - FTS5's `NOT` is binary, so exclusions are subtracted from the positive
+///   side as `(positives) NOT (a OR b)`, and the positive side is parenthesised
+///   because `NOT` binds tighter than `AND` there. A query that is *only*
+///   exclusions has nothing to subtract from and yields `None` rather than an
+///   invented positive side.
+/// - Whether a term matches at all is still the tokenizer's call. Under
+///   `tokenize='trigram'` a one- or two-character term cannot match through the
+///   index, exactly as before this translation.
+///
+/// # Examples
+///
+/// ```
+/// # use skardi::sources::providers::sqlite::websearch_to_fts5;
+/// assert_eq!(
+///     websearch_to_fts5("read-only source").as_deref(),
+///     Some(r#""read-only" AND "source""#)
+/// );
+/// assert_eq!(
+///     websearch_to_fts5("what's the retry policy").as_deref(),
+///     Some(r#""what's" AND "the" AND "retry" AND "policy""#)
+/// );
+/// assert_eq!(websearch_to_fts5("   "), None);
+/// ```
+pub fn websearch_to_fts5(input: &str) -> Option<String> {
+    let terms = parse(input);
+
+    // Positives become AND-separated groups; an `or` merges a term into the
+    // group its predecessor is in.
+    let mut groups: Vec<Vec<String>> = Vec::new();
+    let mut negatives: Vec<String> = Vec::new();
+
+    for (term, joined_by_or) in terms {
+        if term.negated {
+            negatives.push(as_phrase(&term.text));
+        } else if joined_by_or && !groups.is_empty() {
+            let last = groups.len() - 1;
+            groups[last].push(as_phrase(&term.text));
+        } else {
+            groups.push(vec![as_phrase(&term.text)]);
+        }
+    }
+
+    if groups.is_empty() {
+        return None;
+    }
+
+    let positive = groups
+        .iter()
+        .map(|group| {
+            if group.len() == 1 {
+                group[0].clone()
+            } else {
+                format!("({})", group.join(" OR "))
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" AND ");
+
+    if negatives.is_empty() {
+        return Some(positive);
+    }
+
+    let excluded = negatives.join(" OR ");
+    Some(format!("({positive}) NOT ({excluded})"))
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every one of these returned HTTP 500 before the translation existed
+    /// (measured 2026-09-04 against a live workspace, issue
+    /// SkardiLabs/skardi-skills#39). Each character that used to be read as
+    /// syntax — apostrophe, colon, hyphen — now arrives inside a phrase.
+    /// `fts_table_function`'s integration tests prove FTS5 accepts these and
+    /// that they still find the rows.
+    #[test]
+    fn ordinary_english_questions_translate() {
+        let cases = [
+            (
+                "why doesn't the sync work",
+                r#""why" AND "doesn't" AND "the" AND "sync" AND "work""#,
+            ),
+            (
+                "it's returning nothing",
+                r#""it's" AND "returning" AND "nothing""#,
+            ),
+            (
+                "note: check the gateway",
+                r#""note:" AND "check" AND "the" AND "gateway""#,
+            ),
+            ("full-text search", r#""full-text" AND "search""#),
+            ("read-only mode", r#""read-only" AND "mode""#),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(
+                websearch_to_fts5(input).as_deref(),
+                Some(expected),
+                "{input:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn words_are_anded_and_each_is_a_phrase() {
+        assert_eq!(
+            websearch_to_fts5("read-only source").as_deref(),
+            Some(r#""read-only" AND "source""#)
+        );
+    }
+
+    #[test]
+    fn a_quoted_phrase_stays_one_term() {
+        assert_eq!(
+            websearch_to_fts5(r#""retry backoff" policy"#).as_deref(),
+            Some(r#""retry backoff" AND "policy""#)
+        );
+    }
+
+    #[test]
+    fn an_unterminated_quote_runs_to_the_end() {
+        assert_eq!(
+            websearch_to_fts5(r#""retry backoff"#).as_deref(),
+            Some(r#""retry backoff""#)
+        );
+    }
+
+    #[test]
+    fn a_double_quote_inside_a_word_is_doubled_not_left_to_close_the_phrase() {
+        // `"` is the one character a phrase cannot hold literally. Without the
+        // doubling this closes the phrase early and hands the rest of the term
+        // back to the FTS5 parser as syntax.
+        assert_eq!(
+            websearch_to_fts5(r#"say"hi"#).as_deref(),
+            Some(r#""say""hi""#)
+        );
+    }
+
+    #[test]
+    fn quotes_around_words_open_phrases_rather_than_being_searched_for() {
+        assert_eq!(
+            websearch_to_fts5(r#"say "hi" loudly"#).as_deref(),
+            Some(r#""say" AND "hi" AND "loudly""#)
+        );
+    }
+
+    #[test]
+    fn a_bare_or_binds_tighter_than_the_implicit_and() {
+        assert_eq!(
+            websearch_to_fts5("sync fails or stalls").as_deref(),
+            Some(r#""sync" AND ("fails" OR "stalls")"#)
+        );
+        assert_eq!(
+            websearch_to_fts5("fat OR rat").as_deref(),
+            Some(r#"("fat" OR "rat")"#)
+        );
+    }
+
+    #[test]
+    fn a_quoted_or_is_a_search_term_not_an_operator() {
+        assert_eq!(
+            websearch_to_fts5(r#"fat "or" rat"#).as_deref(),
+            Some(r#""fat" AND "or" AND "rat""#)
+        );
+    }
+
+    #[test]
+    fn a_leading_hyphen_excludes_and_the_positive_side_is_parenthesised() {
+        // FTS5's NOT binds tighter than AND, so an unparenthesised
+        // `a AND b NOT c` would subtract c from b alone.
+        assert_eq!(
+            websearch_to_fts5("sync failure -postgres").as_deref(),
+            Some(r#"("sync" AND "failure") NOT ("postgres")"#)
+        );
+    }
+
+    #[test]
+    fn several_exclusions_are_ored_on_the_subtracted_side() {
+        assert_eq!(
+            websearch_to_fts5("sync -postgres -mysql").as_deref(),
+            Some(r#"("sync") NOT ("postgres" OR "mysql")"#)
+        );
+    }
+
+    #[test]
+    fn a_hyphen_inside_a_word_is_not_an_exclusion() {
+        assert_eq!(
+            websearch_to_fts5("read-only").as_deref(),
+            Some(r#""read-only""#)
+        );
+    }
+
+    #[test]
+    fn a_detached_hyphen_is_dropped_as_punctuation() {
+        assert_eq!(
+            websearch_to_fts5("sync - failure").as_deref(),
+            Some(r#""sync" AND "failure""#)
+        );
+    }
+
+    /// FTS5 rejects an empty match string outright, so "nothing to search for"
+    /// has to be answerable without asking it. Each of these used to reach
+    /// FTS5 and produce a 500, or — for the empty string — a 200 carrying rows
+    /// that had nothing to do with any question.
+    #[test]
+    fn text_with_nothing_to_tokenize_yields_no_expression() {
+        for input in ["", "   ", "---", ":::", r#""""#, r#""   ""#] {
+            assert_eq!(websearch_to_fts5(input), None, "input {input:?}");
+        }
+    }
+
+    #[test]
+    fn exclusions_alone_yield_no_expression() {
+        // FTS5's NOT is binary: there is no positive side to subtract from,
+        // and inventing one would answer a different question.
+        assert_eq!(websearch_to_fts5("-postgres"), None);
+        assert_eq!(websearch_to_fts5("-postgres -mysql"), None);
+    }
+
+    #[test]
+    fn cjk_terms_survive_unchanged_inside_the_phrase() {
+        // #35 made CJK full-text search work by rebuilding the index with
+        // tokenize='trigram'. Quoting must not undo it: the term reaches the
+        // tokenizer exactly as typed.
+        assert_eq!(
+            websearch_to_fts5("上下文 检索").as_deref(),
+            Some(r#""上下文" AND "检索""#)
+        );
+    }
+}

--- a/crates/skardi/src/sources/providers/sqlite/fts_table_function.rs
+++ b/crates/skardi/src/sources/providers/sqlite/fts_table_function.rs
@@ -434,7 +434,9 @@ mod tests {
                    ('Database Systems', 'Overview of relational database management systems and SQL', 'database'),
                    ('Deep Learning', 'Advanced neural network architectures for machine learning', 'ai'),
                    ('Web Development', 'Modern web frameworks and frontend technologies', 'web'),
-                   ('Natural Language Processing', 'NLP techniques for text analysis and machine learning applications', 'ai');",
+                   ('Natural Language Processing', 'NLP techniques for text analysis and machine learning applications', 'ai'),
+                   ('Gateway Modes', 'The gateway runs in read-only mode and it doesn''t write anything back', 'ops'),
+                   ('Retry Policy', 'note: the retry policy is described in the ops runbook', 'ops');",
             )?;
             Ok(())
         })
@@ -728,6 +730,116 @@ mod tests {
             total_rows(&batches),
             0,
             "deleted article must not appear in FTS results"
+        );
+    }
+
+    // ─── The parameter is user text, not an FTS5 expression ──────────────
+    // Every query in this block returned an execution error before
+    // `websearch_to_fts5` sat in front of FTS5 (SkardiLabs/skardi-skills#39):
+    // FTS5 read the apostrophe as a string delimiter, the colon as a column
+    // filter, and the hyphen as a term boundary. These are the questions a
+    // person types into a search box, so they have to answer.
+
+    /// A hyphenated technical term is the vocabulary a technical corpus is
+    /// made of. It has to find the row, not merely avoid erroring.
+    #[tokio::test]
+    #[ignore]
+    async fn test_fts_hyphenated_term_finds_the_row() {
+        let mut ctx = SessionContext::new();
+        let (_reg, _db) = register_ci_fts(&mut ctx).await;
+
+        let batches = query_all(
+            &ctx,
+            "SELECT title FROM sqlite_fts('articles_fts', 'body', 'read-only mode', 10)",
+        )
+        .await;
+
+        let titles = batches[0]
+            .column_by_name("title")
+            .expect("title column")
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("title is Utf8");
+        assert_eq!(total_rows(&batches), 1, "expected the read-only row");
+        assert_eq!(titles.value(0), "Gateway Modes");
+    }
+
+    /// The apostrophe matters most: a natural English question hits it before
+    /// a hyphenated term does.
+    #[tokio::test]
+    #[ignore]
+    async fn test_fts_apostrophe_finds_the_row() {
+        let mut ctx = SessionContext::new();
+        let (_reg, _db) = register_ci_fts(&mut ctx).await;
+
+        // Doubled for the SQL string literal; FTS5 sees `doesn't write`.
+        let batches = query_all(
+            &ctx,
+            "SELECT title FROM sqlite_fts('articles_fts', 'body', 'doesn''t write', 10)",
+        )
+        .await;
+        assert_eq!(total_rows(&batches), 1, "expected the read-only row");
+    }
+
+    /// A colon used to be read as a column filter and reported as
+    /// `no such column: note`.
+    #[tokio::test]
+    #[ignore]
+    async fn test_fts_colon_is_literal_text_not_a_column_filter() {
+        let mut ctx = SessionContext::new();
+        let (_reg, _db) = register_ci_fts(&mut ctx).await;
+
+        let batches = query_all(
+            &ctx,
+            "SELECT title FROM sqlite_fts('articles_fts', 'body', 'note: retry policy', 10)",
+        )
+        .await;
+        assert_eq!(total_rows(&batches), 1, "expected the retry-policy row");
+    }
+
+    /// A blank question is answerable without asking FTS5, which rejects an
+    /// empty match string outright. Zero rows is the honest answer; the
+    /// alternative that used to be possible — rows for a question nobody
+    /// asked — is worse than an error.
+    #[tokio::test]
+    #[ignore]
+    async fn test_fts_query_with_nothing_to_search_for_returns_no_rows() {
+        let mut ctx = SessionContext::new();
+        let (_reg, _db) = register_ci_fts(&mut ctx).await;
+
+        for query in ["", "   ", "---"] {
+            let batches = query_all(
+                &ctx,
+                &format!("SELECT title FROM sqlite_fts('articles_fts', 'body', '{query}', 10)"),
+            )
+            .await;
+            assert_eq!(total_rows(&batches), 0, "query {query:?}");
+        }
+    }
+
+    /// `websearch_to_tsquery`'s two operators, honoured on this backend too.
+    #[tokio::test]
+    #[ignore]
+    async fn test_fts_or_and_exclusion_operators() {
+        let mut ctx = SessionContext::new();
+        let (_reg, _db) = register_ci_fts(&mut ctx).await;
+
+        let both = query_all(
+            &ctx,
+            "SELECT title FROM sqlite_fts('articles_fts', 'body', 'gateway or runbook', 10)",
+        )
+        .await;
+        assert_eq!(total_rows(&both), 2, "or should reach both ops articles");
+
+        let excluded = query_all(
+            &ctx,
+            "SELECT title FROM sqlite_fts('articles_fts', 'body', 'gateway or runbook -policy', 10)",
+        )
+        .await;
+        assert_eq!(
+            total_rows(&excluded),
+            1,
+            "-policy should drop the runbook row"
         );
     }
 }

--- a/crates/skardi/src/sources/providers/sqlite/mod.rs
+++ b/crates/skardi/src/sources/providers/sqlite/mod.rs
@@ -1,9 +1,11 @@
 pub mod fts_exec;
+pub mod fts_query;
 pub mod fts_table_function;
 pub mod knn_exec;
 pub mod knn_table_function;
 pub mod vec_to_binary;
 
+pub use fts_query::websearch_to_fts5;
 pub use fts_table_function::register_sqlite_fts_udtf;
 pub use knn_table_function::{SqliteEntry, register_sqlite_knn_udtf};
 pub use vec_to_binary::register_vec_to_binary_udf;

--- a/demo/rag/README.md
+++ b/demo/rag/README.md
@@ -504,9 +504,10 @@ skardi run search-hybrid \
   -p vector_weight=0.3 -p text_weight=0.7 -p limit=5
 ```
 
-> FTS5 reserves `?`, `"`, `+`, `-`, `~`, `^`, and parentheses as query
-> syntax. A bare `?` in `text_query` will fail with an `fts5: syntax
-> error` — phrase-quote or strip it out for natural-language queries.
+> `text_query` is search text, not an FTS5 expression: `sqlite_fts` parses it
+> the way `pg_fts` parses its own `query` (web-search syntax — AND by default,
+> `"phrase"`, `or`, `-not`), so punctuation is searched for rather than
+> executed and no input can turn a question into a query error.
 
 The structure mirrors the server's `search_hybrid.yaml` exactly —
 `sqlite_knn` and `sqlite_fts` replace `pg_knn` / `pg_fts`, RRF is the same

--- a/demo/rag/cli/pipelines/search_fulltext.yaml
+++ b/demo/rag/cli/pipelines/search_fulltext.yaml
@@ -9,7 +9,7 @@ metadata:
     mirror plus a _score column.
 
 # Parameters:
-#   {query}  - FTS5 query (term, "phrase", +must -mustnot, fuzzy~1)
+#   {query}  - Search text (web-search syntax: AND, "phrase", or, -not)
 #   {limit}  - Maximum number of results
 
 spec:

--- a/docs/sqlite/README.md
+++ b/docs/sqlite/README.md
@@ -466,12 +466,28 @@ WHERE category = 'ai'
 ORDER BY _score DESC
 ```
 
-FTS5 query syntax supports:
-- Plain terms (AND'd by default): `machine learning`
-- Quoted phrases: `"neural network"`
-- NOT operator: `learning NOT database`
-- OR operator: `machine OR database`
-- Prefix queries: `mach*`
+**Web-search-style queries** — `query` is search text, not an FTS5 expression.
+It is parsed the same way `pg_fts` parses its own `query` argument (PostgreSQL's
+`websearch_to_tsquery`), so the two backends answer the same question the same
+way:
+
+| Syntax | Meaning | Example |
+|---|---|---|
+| `foo bar` | AND (both terms required) | `machine learning` |
+| `"foo bar"` | Exact phrase | `"neural network"` |
+| `foo or bar` | OR (either term) | `machine or database` |
+| `-foo` | NOT (exclude term) | `learning -database` |
+
+Everything else is literal text. Apostrophes, colons and hyphens are ordinary
+characters — `what's the retry policy`, `note: check the gateway` and
+`read-only mode` are all searched for as written, and no input can turn a
+question into a query error. Text with nothing to search for (empty, blank, or
+pure punctuation) returns no rows.
+
+Because the parameter is search text, FTS5's own operator syntax is not
+reachable through it: `mach*` prefix queries, `NEAR()`, `column : term` filters
+and the uppercase `AND` / `OR` / `NOT` keywords are searched for literally
+rather than executed. Use the `or` and `-` forms above instead.
 
 ### Write
 

--- a/docs/sqlite/pipelines/fts_demo/fts_search.yaml
+++ b/docs/sqlite/pipelines/fts_demo/fts_search.yaml
@@ -8,7 +8,7 @@ metadata:
     Returns matching rows ranked by BM25 relevance (higher _score = more relevant).
 
 # Parameters:
-#   {query} - Search terms (space-separated, "quoted" for phrase, NOT for negation)
+#   {query} - Search text (web-search syntax: AND, "phrase", or, -not)
 #   {limit} - Maximum number of results to return
 
 spec:


### PR DESCRIPTION
Closes SkardiLabs/skardi-skills#39.

## The bug

`pg_fts` parses its `query` argument with PostgreSQL's `websearch_to_tsquery`, whose entire purpose is to accept what a person typed into a search box — apostrophes, colons and hyphens are ordinary characters to it, and no user text can make it raise a parse error.

`sqlite_fts` handed the same documented parameter straight to FTS5's `MATCH` grammar, which has no forgiving entry point. Same skill, same parameter name, same documentation — two backends, two contracts, and only one of them survives `what's the retry policy`.

Measured 2026-09-04 against a live workspace (242 ingested GitHub issues and PRs, sqlite backend). Each of these is a question a user could type; each returned HTTP 500 from `search-fulltext`, and the same from `search-hybrid`:

| input | before |
|---|---|
| `read-only source` | `sqlite_fts error: no such column: only` |
| `full-text search` | `no such column: text` |
| `note: check the gateway` | `no such column: note` |
| `why doesn't the sync work` | `fts5: syntax error near "'"` |
| `what's the retry policy` | `fts5: syntax error near "'"` |
| `"   "` (blank) | `fts5: syntax error near ""` |
| `""` (empty) | 200, **and it returned rows** |

The apostrophe is the one that matters most: a natural English question hits it before a hyphenated term does. The last row is the worst of them — an agent that passes an empty question through gets confident-looking results with nothing behind them, and nothing in the response says the query was empty.

## The fix

A new `sqlite::fts_query::websearch_to_fts5` translates the text into an FTS5 expression before it reaches `MATCH`, mirroring `websearch_to_tsquery`:

- whitespace-separated words are ANDed;
- `"…"` is a phrase, and an unterminated quote runs to the end of the input;
- a bare `or` splits the query into alternatives and binds loosest of all, so `a b or c` is `(a AND b) OR c` — the grouping `websearch_to_tsquery` gives the same text;
- a `-` against the front of a word excludes it.

Everything else is literal. **Quoting is what makes the translation total**: each term is emitted as an FTS5 phrase, inside which every character but `"` (doubled) is literal — so a colon cannot start a column filter, a hyphen cannot split the word, and an apostrophe cannot open a string. FTS5 still applies the table's own tokenizer inside the phrase, so `"read-only"` matches text indexed as `read` followed by `only`: the hyphenated term is **found**, not merely tolerated.

Text with nothing to tokenize (`""`, `"   "`, `---`) returns no rows without reaching SQLite, because FTS5 rejects an empty match string as a syntax error and there is nothing to ask it.

The stored `query` stays the user's text; the translation happens at execution time, so `EXPLAIN` output keeps showing what was actually asked.

## Two places FTS5 cannot follow websearch exactly

Both are stated in the doc comment rather than left to be discovered:

- **`NOT` is binary in FTS5, `!` is unary in tsquery.** An exclusion is subtracted from the alternative it sits in, and the subtracted side is parenthesised once it holds more than one term, because `OR` binds looser than `NOT`. An alternative left with nothing to subtract from is dropped: `-a or b` searches for `b`, where tsquery's `!a | b` would also return everything lacking `a`. Dropping it narrows the result rather than inventing a positive side, and a query that is *only* exclusions returns no rows.
- **Whether a term matches is still the tokenizer's call.** Under `tokenize='trigram'` (what #35 added for CJK corpora) a one- or two-character term cannot match through the index. Measured identical before and after: `预跑 检索` → 0 rows both ways, `上下文 检索` → 1 row both ways. #35's work is not implicated.

## What this removes

FTS5's own operator syntax is no longer reachable through this parameter: `mach*` prefix queries, `NEAR()`, `column : term` filters, and the `AND` / `NOT` keywords are now searched for literally. `or` is the exception: it stays an operator and is matched in any case, because `websearch_to_tsquery` matches it case-insensitively too. To search for the word itself, quote it as `"or"`. That is the deliberate half of the trade — the parameter cannot be both a query language and a search box. `docs/sqlite/README.md` previously advertised the FTS5 forms; it now documents the websearch forms and names what is gone, so the loss is not silent.

If you would rather keep the operators reachable, the shape that preserves both is an optional fifth argument selecting the parse mode, the way `pg_fts` takes an optional `language`. I did not add it because a second contract is what produced this bug, but it is a small change if you want it.

## Tests

17 unit tests in `fts_query.rs` covering the grammar, and 7 integration tests in `fts_table_function.rs` running against a real FTS5 table — the hyphen, apostrophe and colon cases assert the row is **found**, not just that nothing errored, and two grouping tests assert the exact row set that `(a AND b) OR c` returns and `a AND (b OR c)` does not, so the precedence cannot drift back. Two rows were added to the shared FTS test seed to carry a hyphen, an apostrophe and a colon; the existing assertions are unaffected.

`cargo test -p skardi --lib` — 1190 passed, 0 failed. `cargo test -p skardi --lib sqlite -- --ignored` — 58 passed, 0 failed. The rest of the `--ignored` set is the live-service suites (Postgres, Redis, Mongo, ClickHouse) that need CI's backing containers.

## Docs

`docs/sqlite/README.md` gets the websearch syntax table matching the Postgres page. `demo/rag/README.md` had a blockquote warning that a bare `?` in `text_query` fails with `fts5: syntax error` — that warning documented this bug, so it is replaced by the contract. Two pipeline headers that described `{query}` as an FTS5 expression are corrected.

## Follow-up, not in this PR

The `auto-context` skill's own sqlite template still documents `{query}` as an FTS5 expression. That correction has to wait for a release carrying this change — a skill on `main` is a skill users have, and it would be describing behaviour v0.5.0 does not have.

