### PR TITLE
docs(readme): install retrieval in the Claude Code block too

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ differ only in where the skill directory goes.
 ```text
 /plugin marketplace add SkardiLabs/skardi-skills
 /plugin install auto-context@skardi-skills
+/plugin install retrieval@skardi-skills
 ```
 
 Every other host installs from a checkout:


### PR DESCRIPTION
## What

One line added to the Claude Code snippet in the Install section:

```text
/plugin install retrieval@skardi-skills
```

## Why

The section opens with "Two skills" and describes both `auto-context` and `retrieval`. Every other host's snippet copies both skill directories. The Claude Code marketplace snippet installs only `auto-context`, so a Claude Code user who follows the README ends up with one of the two skills and nothing tells them the other is missing.

`retrieval` is a separate plugin in the `skardi-skills` marketplace (`.claude-plugin/marketplace.json` lists `auto-context`, `retrieval`, `graph-source`), so the marketplace command works as written.

## Note, not changed here

`graph-source` is the third plugin in that marketplace and is not mentioned anywhere in this README. That may be deliberate — this section was written around two skills. Left alone so this PR stays to the one missing line.