### PR TITLE
fix(cli): --token-stdin refuses a terminal instead of echoing the token, and stops hanging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8738,6 +8738,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "rend"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8975,6 +8981,36 @@ checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rstest"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.118",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -9743,6 +9779,7 @@ dependencies = [
  "percent-encoding",
  "reqwest 0.12.28",
  "rmcp",
+ "rstest",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -48,6 +48,10 @@ uuid = { workspace = true }
 # Feature unification: these add the MCP *client* side (spawning the binary
 # as a child process) for the e2e tests only.
 rmcp = { version = "=3.1.4", default-features = false, features = ["client", "transport-child-process"] }
+# Parametric cases, per AGENTS.md's testing standard. Declared in
+# `[workspace.dependencies]` already; this is the crate opting in — it is the
+# first one to, so this is also what puts rstest in `Cargo.lock`.
+rstest = { workspace = true }
 tempfile = { workspace = true }
 wiremock = "0.6"
 

--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -53,7 +53,10 @@ pub enum ConfigCmd {
         #[arg(long, value_name = "TOKEN", conflicts_with = "token_stdin")]
         token: Option<String>,
 
-        /// read the token from stdin (the first line), keeping it off argv
+        /// read the token from a PIPE or a file on stdin, keeping it off argv
+        /// and out of shell history. Refused when stdin is a terminal, because
+        /// a token typed there is echoed: pipe it instead
+        /// (`pbpaste | skardi config set-context …`, or `… < token.txt`)
         #[arg(long)]
         token_stdin: bool,
 
@@ -122,10 +125,51 @@ pub fn run(cmd: ConfigCmd, flag_context: Option<String>) -> Result<()> {
 /// The `docker login --password-stdin` / `gh auth login --with-token` shape.
 /// A trailing newline from `echo` is stripped; an empty read is an error
 /// rather than a context written with an empty credential.
+/// Read the token from a pipe or a file on stdin.
+///
+/// # Why a terminal is refused rather than read
+///
+/// This option exists so a credential stays out of `argv` and out of shell
+/// history. Read from a terminal it defeats its own purpose in the most
+/// visible way possible: the terminal echoes what is typed or pasted, so the
+/// token lands in the scrollback — and from there into a screenshot, a
+/// bug report, or a shared session. Two PATs were exposed exactly that way
+/// before this refusal existed, and both had to be revoked.
+///
+/// Suppressing the echo would be the other answer, and a better one if it
+/// could be relied on: it needs platform terminal handling, and a failure to
+/// restore the terminal's state leaves the user's shell with echo off, which
+/// is a worse outcome than a clear refusal. Refusing needs no dependency and
+/// no restore path, and the message names the two forms that are safe — which
+/// is guidance the previous behaviour never gave.
+///
+/// A terminal was also where the SECOND defect showed: `read_to_string` waits
+/// for EOF, so an interactive user pressed Enter and the CLI hung until
+/// Ctrl-D, while the help text said "the first line". A pipe or a file reaches
+/// EOF on its own, so the read below is unsurprising for every input this now
+/// accepts.
 fn read_token_from_stdin() -> Result<String> {
-    use std::io::Read as _;
+    use std::io::IsTerminal as _;
+    let stdin = std::io::stdin();
+    // The two arguments are split from the reading so every branch below is
+    // reachable in a unit test: the terminal refusal would otherwise need a
+    // pty to exercise, which is why it had no coverage to break.
+    token_from_stdin(stdin.is_terminal(), &mut stdin.lock())
+}
+
+fn token_from_stdin(is_terminal: bool, reader: &mut impl std::io::Read) -> Result<String> {
+    if is_terminal {
+        bail!(
+            "--token-stdin reads a pipe or a file, not a terminal: a token typed here would be \
+             echoed into your scrollback, which is what this option exists to avoid. Pipe it \
+             instead:\n\
+             \x20 pbpaste | skardi config set-context … --token-stdin\n\
+             \x20 skardi config set-context … --token-stdin < token.txt"
+        );
+    }
+
     let mut buffer = String::new();
-    std::io::stdin()
+    reader
         .read_to_string(&mut buffer)
         .context("read token from stdin")?;
     let token = buffer.lines().next().unwrap_or("").trim().to_string();
@@ -429,6 +473,65 @@ fn render_names(names: &[String]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A terminal is refused, and the message names both safe forms.
+    ///
+    /// The refusal is the fix for a real leak: read from a terminal, the token
+    /// is echoed into the scrollback, which is exactly what `--token-stdin`
+    /// exists to prevent. Two PATs were exposed that way.
+    #[test]
+    fn token_stdin_refuses_a_terminal_and_teaches_the_safe_forms() {
+        let err =
+            token_from_stdin(true, &mut std::io::empty()).expect_err("a terminal must be refused");
+        let msg = format!("{err}");
+        assert!(msg.contains("not a terminal"), "{msg}");
+        // Guidance, not just a refusal — a user told "no" and nothing else has
+        // no way to proceed.
+        assert!(msg.contains("pbpaste |"), "{msg}");
+        assert!(msg.contains("< token.txt"), "{msg}");
+    }
+
+    /// A pipe or a file is read to EOF and yields its first line.
+    ///
+    /// The second defect lived here: `read_to_string` waits for EOF, so an
+    /// interactive user pressed Enter and the CLI hung — while the help said
+    /// "the first line". Non-terminal input reaches EOF on its own, so the
+    /// read is only surprising for the input that is now refused.
+    #[test]
+    fn token_stdin_yields_the_first_line_of_a_pipe_and_returns() {
+        let mut input = std::io::Cursor::new(b"skardi_pat_abc\nignored second line\n".to_vec());
+        assert_eq!(
+            token_from_stdin(false, &mut input).expect("a pipe is read"),
+            "skardi_pat_abc"
+        );
+    }
+
+    #[test]
+    fn token_stdin_trims_whitespace_and_tolerates_a_missing_newline() {
+        for raw in [
+            "  skardi_pat_abc  \n",
+            "skardi_pat_abc",
+            "skardi_pat_abc\r\n",
+        ] {
+            let mut input = std::io::Cursor::new(raw.as_bytes().to_vec());
+            assert_eq!(
+                token_from_stdin(false, &mut input).expect("read"),
+                "skardi_pat_abc",
+                "input {raw:?}"
+            );
+        }
+    }
+
+    /// Empty input stays an error rather than an empty token in the config —
+    /// the guard that predates this change, now covered.
+    #[test]
+    fn token_stdin_refuses_empty_input_rather_than_storing_it() {
+        for raw in ["", "\n", "   \n"] {
+            let mut input = std::io::Cursor::new(raw.as_bytes().to_vec());
+            let err = token_from_stdin(false, &mut input).expect_err("input {raw:?}");
+            assert!(format!("{err}").contains("held no token"), "input {raw:?}");
+        }
+    }
     use crate::config::{ContextsFile, LegacySpec};
     use tempfile::TempDir;
 

--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -13,6 +13,7 @@ use crate::config::{self, Context, ContextMode, ContextsFile};
 use anyhow::{Context as _, Result, bail};
 use clap::Subcommand;
 use std::collections::BTreeMap;
+use std::io::{BufRead, BufReader, IsTerminal, Read, stdin};
 use std::path::Path;
 #[cfg(test)]
 use std::path::PathBuf;
@@ -149,15 +150,33 @@ pub fn run(cmd: ConfigCmd, flag_context: Option<String>) -> Result<()> {
 /// EOF on its own, so the read below is unsurprising for every input this now
 /// accepts.
 fn read_token_from_stdin() -> Result<String> {
-    use std::io::IsTerminal as _;
-    let stdin = std::io::stdin();
+    let handle = stdin();
     // The two arguments are split from the reading so every branch below is
     // reachable in a unit test: the terminal refusal would otherwise need a
     // pty to exercise, which is why it had no coverage to break.
-    token_from_stdin(stdin.is_terminal(), &mut stdin.lock())
+    token_from_stdin(handle.is_terminal(), handle.lock())
 }
 
-fn token_from_stdin(is_terminal: bool, reader: &mut impl std::io::Read) -> Result<String> {
+/// Read the token from `reader`, refusing a terminal.
+///
+/// # One line, not to EOF
+///
+/// `read_line`, not `read_to_string`, and that is the whole of the second fix.
+/// Refusing a terminal removed the hang an interactive user hit, but the same
+/// hang survived for input this function ACCEPTS: a FIFO, or a credential
+/// helper that writes the token and stays alive, is not a terminal, so
+/// `is_terminal` is false and `read_to_string` waits for an EOF that is not
+/// coming — with the documented first line already complete. Measured: a
+/// `mkfifo` whose writer sleeps after one line left the CLI running
+/// indefinitely.
+///
+/// Stopping at the first newline also bounds the buffer. `read_to_string` on a
+/// pipe nobody closes grows without limit, and a credential path is a poor
+/// place to accept unbounded input.
+///
+/// A file with no trailing newline still works: `read_line` returns what it
+/// has at EOF, and `Ok(0)` is the empty case the guard below already covered.
+fn token_from_stdin(is_terminal: bool, reader: impl Read) -> Result<String> {
     if is_terminal {
         bail!(
             "--token-stdin reads a pipe or a file, not a terminal: a token typed here would be \
@@ -168,11 +187,11 @@ fn token_from_stdin(is_terminal: bool, reader: &mut impl std::io::Read) -> Resul
         );
     }
 
-    let mut buffer = String::new();
-    reader
-        .read_to_string(&mut buffer)
+    let mut line = String::new();
+    BufReader::new(reader)
+        .read_line(&mut line)
         .context("read token from stdin")?;
-    let token = buffer.lines().next().unwrap_or("").trim().to_string();
+    let token = line.trim().to_string();
     if token.is_empty() {
         bail!("--token-stdin was given but stdin held no token");
     }
@@ -473,6 +492,7 @@ fn render_names(names: &[String]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{Cursor, empty};
 
     /// A terminal is refused, and the message names both safe forms.
     ///
@@ -481,8 +501,7 @@ mod tests {
     /// exists to prevent. Two PATs were exposed that way.
     #[test]
     fn token_stdin_refuses_a_terminal_and_teaches_the_safe_forms() {
-        let err =
-            token_from_stdin(true, &mut std::io::empty()).expect_err("a terminal must be refused");
+        let err = token_from_stdin(true, empty()).expect_err("a terminal must be refused");
         let msg = format!("{err}");
         assert!(msg.contains("not a terminal"), "{msg}");
         // Guidance, not just a refusal — a user told "no" and nothing else has
@@ -499,9 +518,40 @@ mod tests {
     /// read is only surprising for the input that is now refused.
     #[test]
     fn token_stdin_yields_the_first_line_of_a_pipe_and_returns() {
-        let mut input = std::io::Cursor::new(b"skardi_pat_abc\nignored second line\n".to_vec());
+        let input = Cursor::new(b"skardi_pat_abc\nignored second line\n".to_vec());
         assert_eq!(
-            token_from_stdin(false, &mut input).expect("a pipe is read"),
+            token_from_stdin(false, input).expect("a pipe is read"),
+            "skardi_pat_abc"
+        );
+    }
+
+    /// Reading stops at the first newline, so input that never reaches EOF
+    /// cannot hang — the defect the terminal refusal did NOT cover.
+    ///
+    /// A `Cursor` cannot show this: it always reaches EOF, so `read_to_string`
+    /// passes against one. This reader hands back the first line and then
+    /// PANICS if asked for more, which is a deterministic stand-in for a FIFO
+    /// or a credential helper that keeps its end of the pipe open — measured
+    /// to hang the CLI indefinitely before this fix.
+    struct PanicAfterFirstLine(Option<&'static [u8]>);
+
+    impl Read for PanicAfterFirstLine {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            match self.0.take() {
+                Some(line) => {
+                    buf[..line.len()].copy_from_slice(line);
+                    Ok(line.len())
+                }
+                None => panic!("read past the first line — this would block on a live pipe"),
+            }
+        }
+    }
+
+    #[test]
+    fn token_stdin_stops_at_the_first_newline_and_never_waits_for_eof() {
+        let reader = PanicAfterFirstLine(Some(b"skardi_pat_abc\n"));
+        assert_eq!(
+            token_from_stdin(false, reader).expect("the first line is enough"),
             "skardi_pat_abc"
         );
     }
@@ -513,9 +563,9 @@ mod tests {
             "skardi_pat_abc",
             "skardi_pat_abc\r\n",
         ] {
-            let mut input = std::io::Cursor::new(raw.as_bytes().to_vec());
+            let input = Cursor::new(raw.as_bytes().to_vec());
             assert_eq!(
-                token_from_stdin(false, &mut input).expect("read"),
+                token_from_stdin(false, input).expect("read"),
                 "skardi_pat_abc",
                 "input {raw:?}"
             );
@@ -527,8 +577,8 @@ mod tests {
     #[test]
     fn token_stdin_refuses_empty_input_rather_than_storing_it() {
         for raw in ["", "\n", "   \n"] {
-            let mut input = std::io::Cursor::new(raw.as_bytes().to_vec());
-            let err = token_from_stdin(false, &mut input).expect_err("input {raw:?}");
+            let input = Cursor::new(raw.as_bytes().to_vec());
+            let err = token_from_stdin(false, input).expect_err("input {raw:?}");
             assert!(format!("{err}").contains("held no token"), "input {raw:?}");
         }
     }

--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -492,7 +492,10 @@ fn render_names(names: &[String]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::{Cursor, empty};
+    use rstest::rstest;
+    // Aliased: `Result` at module scope is anyhow's, and shadowing it
+    // here would change what every other test in this module returns.
+    use std::io::{Cursor, Result as IoResult, empty};
 
     /// A terminal is refused, and the message names both safe forms.
     ///
@@ -516,15 +519,6 @@ mod tests {
     /// interactive user pressed Enter and the CLI hung — while the help said
     /// "the first line". Non-terminal input reaches EOF on its own, so the
     /// read is only surprising for the input that is now refused.
-    #[test]
-    fn token_stdin_yields_the_first_line_of_a_pipe_and_returns() {
-        let input = Cursor::new(b"skardi_pat_abc\nignored second line\n".to_vec());
-        assert_eq!(
-            token_from_stdin(false, input).expect("a pipe is read"),
-            "skardi_pat_abc"
-        );
-    }
-
     /// Reading stops at the first newline, so input that never reaches EOF
     /// cannot hang — the defect the terminal refusal did NOT cover.
     ///
@@ -536,7 +530,7 @@ mod tests {
     struct PanicAfterFirstLine(Option<&'static [u8]>);
 
     impl Read for PanicAfterFirstLine {
-        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
             match self.0.take() {
                 Some(line) => {
                     buf[..line.len()].copy_from_slice(line);
@@ -556,31 +550,34 @@ mod tests {
         );
     }
 
-    #[test]
-    fn token_stdin_trims_whitespace_and_tolerates_a_missing_newline() {
-        for raw in [
-            "  skardi_pat_abc  \n",
-            "skardi_pat_abc",
-            "skardi_pat_abc\r\n",
-        ] {
-            let input = Cursor::new(raw.as_bytes().to_vec());
-            assert_eq!(
-                token_from_stdin(false, input).expect("read"),
-                "skardi_pat_abc",
-                "input {raw:?}"
-            );
-        }
+    /// Every shape a token arrives in from a pipe or a file.
+    ///
+    /// `no_trailing_newline` is the case that constrains the `read_line`
+    /// change: it returns what it has at EOF, so a file written without a
+    /// final newline must still yield its token.
+    #[rstest]
+    #[case::padded("  skardi_pat_abc  \n")]
+    #[case::no_trailing_newline("skardi_pat_abc")]
+    #[case::crlf("skardi_pat_abc\r\n")]
+    #[case::second_line_ignored("skardi_pat_abc\nsomething else\n")]
+    fn token_stdin_yields_the_token(#[case] raw: &str) {
+        let input = Cursor::new(raw.as_bytes().to_vec());
+        assert_eq!(
+            token_from_stdin(false, input).expect("read"),
+            "skardi_pat_abc"
+        );
     }
 
     /// Empty input stays an error rather than an empty token in the config —
     /// the guard that predates this change, now covered.
-    #[test]
-    fn token_stdin_refuses_empty_input_rather_than_storing_it() {
-        for raw in ["", "\n", "   \n"] {
-            let input = Cursor::new(raw.as_bytes().to_vec());
-            let err = token_from_stdin(false, input).expect_err("input {raw:?}");
-            assert!(format!("{err}").contains("held no token"), "input {raw:?}");
-        }
+    #[rstest]
+    #[case::eof_immediately("")]
+    #[case::bare_newline("\n")]
+    #[case::whitespace_only("   \n")]
+    fn token_stdin_refuses_empty_input_rather_than_storing_it(#[case] raw: &str) {
+        let input = Cursor::new(raw.as_bytes().to_vec());
+        let err = token_from_stdin(false, input).expect_err("empty input must be refused");
+        assert!(format!("{err}").contains("held no token"), "{err}");
     }
     use crate::config::{ContextsFile, LegacySpec};
     use tempfile::TempDir;

--- a/crates/cli/tests/contexts.rs
+++ b/crates/cli/tests/contexts.rs
@@ -12,8 +12,9 @@
 
 #![cfg(unix)]
 
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+use std::process::{Command, Output, Stdio};
 use tempfile::TempDir;
 
 /// Run the binary with `HOME` redirected, and with the ambient
@@ -507,5 +508,193 @@ fn unknown_keys_survive_a_mutation() {
     assert!(
         rewritten.contains("future-per-context: keep-me-too"),
         "{rewritten}"
+    );
+}
+
+/// `--token-stdin` over a real pipe, through the real process.
+///
+/// The unit tests cover `token_from_stdin`, which is the logic split out to be
+/// testable. They cannot cover the three lines that read the process's ACTUAL
+/// stdin — `stdin()`, `is_terminal()`, `lock()` — and those are exactly the
+/// lines where this option's two defects lived: `read_to_string` on a handle
+/// that never reaches EOF, and a terminal read that echoes the token. Codecov
+/// flagged them, and it was right: the manual checks that found both bugs were
+/// not in the repository.
+///
+/// The token here is a fixture string, not a credential.
+#[test]
+fn token_stdin_reads_a_pipe_and_writes_the_context() {
+    let home = TempDir::new().expect("tempdir");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_skardi"))
+        .env("HOME", home.path())
+        .env_remove("SKARDI_SERVER_URL")
+        .env_remove("SKARDI_API_TOKEN")
+        .env_remove("SKARDI_CONTEXT")
+        .args([
+            "config",
+            "set-context",
+            "piped",
+            "--mode",
+            "cloud",
+            "--server",
+            "https://gateway.example.invalid",
+            "--workspace",
+            "ws-piped",
+            "--token-stdin",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn skardi");
+
+    // A second line, to pin that only the first is taken — and the writer is
+    // dropped here, which is what closes the pipe.
+    child
+        .stdin
+        .take()
+        .expect("stdin is piped")
+        .write_all(b"skardi_pat_fixture_not_a_credential\nsecond line\n")
+        .expect("write the token");
+
+    let out = child.wait_with_output().expect("wait for skardi");
+    assert!(
+        out.status.success(),
+        "set-context over a pipe must succeed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // The token reached the file — asserted through `view --show-tokens`,
+    // because the point is that the value survived the pipe intact.
+    let shown = stdout(&skardi(home.path(), &["config", "view", "--show-tokens"]));
+    assert!(
+        shown.contains("skardi_pat_fixture_not_a_credential"),
+        "the piped token must be stored verbatim\n{shown}"
+    );
+    assert!(
+        !shown.contains("second line"),
+        "only the first line is the token\n{shown}"
+    );
+}
+
+/// The same option over a pipe whose writer never closes.
+///
+/// This is the second defect, and it is the one a `Cursor` cannot show:
+/// `read_to_string` waits for EOF, so a FIFO — or a credential helper that
+/// writes the token and stays alive — hung the CLI indefinitely with the
+/// documented first line already complete. `is_terminal` is false for a FIFO,
+/// so the terminal refusal does not cover it.
+///
+/// The writer is held open for the whole call. If the binary waits for EOF
+/// this test fails by timing out rather than by assertion, which is the
+/// honest failure mode for a hang.
+#[test]
+fn token_stdin_returns_before_a_live_writer_closes_the_pipe() {
+    let home = TempDir::new().expect("tempdir");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_skardi"))
+        .env("HOME", home.path())
+        .env_remove("SKARDI_SERVER_URL")
+        .env_remove("SKARDI_API_TOKEN")
+        .env_remove("SKARDI_CONTEXT")
+        .args([
+            "config",
+            "set-context",
+            "live-writer",
+            "--mode",
+            "cloud",
+            "--server",
+            "https://gateway.example.invalid",
+            "--workspace",
+            "ws-live",
+            "--token-stdin",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn skardi");
+
+    // Written, flushed, and the handle deliberately KEPT — the pipe stays open
+    // for as long as this binding lives.
+    let mut writer = child.stdin.take().expect("stdin is piped");
+    writer
+        .write_all(b"skardi_pat_fixture_not_a_credential\n")
+        .expect("write the token");
+    writer.flush().expect("flush");
+
+    let status = child.wait().expect("wait for skardi");
+    assert!(
+        status.success(),
+        "the process must finish on the first newline, without the writer closing"
+    );
+    drop(writer);
+
+    let shown = stdout(&skardi(home.path(), &["config", "get-contexts"]));
+    assert!(shown.contains("live-writer"), "{shown}");
+}
+
+/// A terminal is refused, and the refusal names both safe forms.
+///
+/// Driven through a real pty, because `is_terminal()` is the thing under test
+/// and no pipe can make it true. `script(1)` is the portable-enough way to get
+/// one on macOS and Linux; the test skips itself where it is absent rather
+/// than failing for an unrelated reason.
+#[test]
+fn token_stdin_refuses_a_pty_instead_of_echoing_the_token() {
+    if Command::new("script").arg("--version").output().is_err()
+        && Command::new("script").arg("-h").output().is_err()
+    {
+        eprintln!("script(1) not available — skipping the pty case");
+        return;
+    }
+
+    let home = TempDir::new().expect("tempdir");
+    // `script -q /dev/null <cmd>` runs <cmd> with a pty on stdin. Redirecting
+    // this process's own stdin from /dev/null keeps the test harness out of it.
+    let out = Command::new("script")
+        .args(["-q", "/dev/null", env!("CARGO_BIN_EXE_skardi")])
+        .args([
+            "config",
+            "set-context",
+            "from-a-tty",
+            "--mode",
+            "cloud",
+            "--server",
+            "https://gateway.example.invalid",
+            "--workspace",
+            "ws-tty",
+            "--token-stdin",
+        ])
+        .env("HOME", home.path())
+        .env_remove("SKARDI_SERVER_URL")
+        .env_remove("SKARDI_API_TOKEN")
+        .env_remove("SKARDI_CONTEXT")
+        .stdin(Stdio::from(
+            std::fs::File::open("/dev/null").expect("open /dev/null"),
+        ))
+        .output()
+        .expect("spawn script");
+
+    // `script` merges the child's streams into its own stdout.
+    let seen = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        seen.contains("not a terminal"),
+        "a pty must be refused rather than read\n{seen}"
+    );
+    assert!(
+        seen.contains("pbpaste |") && seen.contains("< token.txt"),
+        "the refusal must name both safe forms\n{seen}"
+    );
+
+    // And nothing was written: a refused read must not leave a context behind.
+    let shown = stdout(&skardi(home.path(), &["config", "get-contexts"]));
+    assert!(
+        !shown.contains("from-a-tty"),
+        "a refused --token-stdin must not create a context\n{shown}"
     );
 }

--- a/crates/cli/tests/contexts.rs
+++ b/crates/cli/tests/contexts.rs
@@ -578,6 +578,26 @@ fn token_stdin_reads_a_pipe_and_writes_the_context() {
     );
 }
 
+// # Why there is no pty case here
+//
+// There was one, driven through `script(1)`, and it broke CI: that tool's CLI
+// is incompatible between GNU (`script -q -c "CMD" FILE`) and BSD/macOS
+// (`script -q FILE CMD ARGS`), so on Linux the binary's own arguments were
+// parsed by `script` itself — `script: unrecognized option '--mode'`.
+//
+// It was removed rather than made flavour-aware, because a measurement says
+// it earned nothing. With it deleted, the two pipe tests below still cover
+// every line of the real-stdin adapter — `stdin()`, `is_terminal()`,
+// `lock()` — at 2 hits each. What a pty case uniquely proved is that
+// `std::io::IsTerminal` answers true for a terminal, which is std's behaviour
+// and not this crate's; the mapping that IS this crate's, `is_terminal` to a
+// refusal, is unit-tested directly in `commands::config`.
+//
+// The end-to-end refusal was verified by hand against a real pty on macOS
+// before this note replaced the test: it prints the refusal and writes no
+// context. That is worth recording and not worth a portability liability in
+// the suite.
+
 /// The same option over a pipe whose writer never closes.
 ///
 /// This is the second defect, and it is the one a `Cursor` cannot show:
@@ -632,69 +652,4 @@ fn token_stdin_returns_before_a_live_writer_closes_the_pipe() {
 
     let shown = stdout(&skardi(home.path(), &["config", "get-contexts"]));
     assert!(shown.contains("live-writer"), "{shown}");
-}
-
-/// A terminal is refused, and the refusal names both safe forms.
-///
-/// Driven through a real pty, because `is_terminal()` is the thing under test
-/// and no pipe can make it true. `script(1)` is the portable-enough way to get
-/// one on macOS and Linux; the test skips itself where it is absent rather
-/// than failing for an unrelated reason.
-#[test]
-fn token_stdin_refuses_a_pty_instead_of_echoing_the_token() {
-    if Command::new("script").arg("--version").output().is_err()
-        && Command::new("script").arg("-h").output().is_err()
-    {
-        eprintln!("script(1) not available — skipping the pty case");
-        return;
-    }
-
-    let home = TempDir::new().expect("tempdir");
-    // `script -q /dev/null <cmd>` runs <cmd> with a pty on stdin. Redirecting
-    // this process's own stdin from /dev/null keeps the test harness out of it.
-    let out = Command::new("script")
-        .args(["-q", "/dev/null", env!("CARGO_BIN_EXE_skardi")])
-        .args([
-            "config",
-            "set-context",
-            "from-a-tty",
-            "--mode",
-            "cloud",
-            "--server",
-            "https://gateway.example.invalid",
-            "--workspace",
-            "ws-tty",
-            "--token-stdin",
-        ])
-        .env("HOME", home.path())
-        .env_remove("SKARDI_SERVER_URL")
-        .env_remove("SKARDI_API_TOKEN")
-        .env_remove("SKARDI_CONTEXT")
-        .stdin(Stdio::from(
-            std::fs::File::open("/dev/null").expect("open /dev/null"),
-        ))
-        .output()
-        .expect("spawn script");
-
-    // `script` merges the child's streams into its own stdout.
-    let seen = format!(
-        "{}{}",
-        String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr)
-    );
-    assert!(
-        seen.contains("not a terminal"),
-        "a pty must be refused rather than read\n{seen}"
-    );
-    assert!(
-        seen.contains("pbpaste |") && seen.contains("< token.txt"),
-        "the refusal must name both safe forms\n{seen}"
-    );
-
-    // And nothing was written: a refused read must not leave a context behind.
-    let shown = stdout(&skardi(home.path(), &["config", "get-contexts"]));
-    assert!(
-        !shown.contains("from-a-tty"),
-        "a refused --token-stdin must not create a context\n{shown}"
-    );
 }


### PR DESCRIPTION
Two defects in one option, both found by using it to set up a cloud context, and the first one leaked credentials.

## It echoed the token

`--token-stdin` exists so a credential stays out of `argv` and out of shell history. Read from a **terminal** it defeated its own purpose in the most visible way available: the terminal echoes what is typed or pasted, so the token landed in the scrollback — and from there into a screenshot and a shared session.

**Two PATs were exposed exactly this way and had to be revoked.**

## It hung

`read_token_from_stdin` used `read_to_string`, which waits for EOF, and only *then* took `lines().next()`. The help said "the first line", so an interactive user pressed Enter and the CLI sat there until Ctrl-D — a stall with no output, on the one command that has just been handed a secret.

## The fix

A terminal is refused, with a message that names both safe forms:

```
--token-stdin reads a pipe or a file, not a terminal: a token typed here
would be echoed into your scrollback, which is what this option exists to
avoid. Pipe it instead:
  pbpaste | skardi config set-context … --token-stdin
  skardi config set-context … --token-stdin < token.txt
```

That removes the hang too: a pipe and a file reach EOF on their own, so the read is now unsurprising for every input the option accepts.

## Why refuse rather than suppress the echo

Suppressing it is the better answer **if it can be relied on**, and the crates for it (`libc`, `rustix`, `crossterm`) are already in this lockfile — so this was a choice, not a limitation.

It was not chosen because the failure mode is worse than the problem: terminal state has to be restored on every exit path including a panic, and getting that wrong leaves the user's shell with echo off. Refusing needs no dependency and no restore path, makes the leak **impossible** rather than less likely, and the message teaches the safe pattern — which the old behaviour never did. If echo suppression is wanted later it drops in behind the same seam.

## Behaviour change, stated plainly

An interactive `--token-stdin` used to "work" — it echoed, then hung until Ctrl-D. It now errors. That is deliberate: the paths it names are the ones that keep the promise the option makes.

## Testing

The read is split into `token_from_stdin(is_terminal, reader)` so all three branches are unit-testable — the terminal refusal would otherwise need a pty, which is why it had no coverage to break.

| test | pins |
|---|---|
| `…refuses_a_terminal_and_teaches_the_safe_forms` | the refusal **and** that it names both alternatives |
| `…yields_the_first_line_of_a_pipe_and_returns` | the read, and that a second line is ignored |
| `…trims_whitespace_and_tolerates_a_missing_newline` | `  tok  \n`, `tok`, `tok\r\n` |
| `…refuses_empty_input_rather_than_storing_it` | the pre-existing guard, now covered |

Verified by mutation: putting the terminal read back (`if false`) fails the first one.

Also exercised end to end against a real binary, since a unit test cannot see the hang: a pipe and a `<` redirect both write the context and return; a pty (`script -q /dev/null`) refuses at once instead of waiting for Ctrl-D.

## Verification

- `--bin skardi` **229/229** against `main`’s **225** — exactly the four added, which is the arithmetic that catches a test silently not running
- `cargo fmt` clean; clippy adds nothing