### PR TITLE
feat(cli): console-brokered `skardi login` — no OAuth client id, and it works over SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,21 @@ curl -fSL "https://github.com/SkardiLabs/skardi/releases/latest/download/skardi-
 sudo mv skardi /usr/local/bin/
 ```
 
+Against **skardi-cloud**, one command signs the CLI in — the console
+authenticates you in a browser and you approve one workspace, so there is no
+OAuth client to provision per deployment:
+
+```bash
+skardi login --control-plane https://your-console.example.com
+```
+
+It writes a workspace-scoped token into `~/.skardi/config.yaml`. `--no-browser`
+prints the approval URL instead of opening one, which is how a headless or
+SSH'd host logs in: nothing has to come back to the machine running `skardi`.
+See [docs/cli.md](docs/cli.md#signing-in-to-skardi-cloud--login--logout) for the
+other way in (`--client-id`, which selects workspaces from the terminal) and
+for what a cloud context can and cannot do.
+
 **Server** — a Docker image, or a source build (no pre-built binary yet):
 
 ```bash

--- a/crates/cli/src/commands/login.rs
+++ b/crates/cli/src/commands/login.rs
@@ -28,11 +28,13 @@ pub struct LoginArgs {
     #[arg(long, value_name = "URL")]
     pub control_plane: Option<String>,
 
-    /// log in to one workspace by slug (non-interactive)
+    /// log in to one workspace by slug (non-interactive). Needs --client-id:
+    /// a browser-brokered login is approved for one workspace in the console
     #[arg(long, value_name = "SLUG", conflicts_with = "all_workspaces")]
     pub workspace: Option<String>,
 
-    /// log in to every active workspace this identity belongs to
+    /// log in to every active workspace this identity belongs to. Needs
+    /// --client-id, for the same reason as --workspace
     #[arg(long)]
     pub all_workspaces: bool,
 
@@ -40,11 +42,14 @@ pub struct LoginArgs {
     #[arg(long, value_name = "DURATION", default_value = login::DEFAULT_EXPIRES)]
     pub expires: String,
 
-    /// print the sign-in URL instead of opening a browser
+    /// print the sign-in URL instead of opening a browser. On the default
+    /// console-brokered path this is enough to log in from another machine
     #[arg(long)]
     pub no_browser: bool,
 
-    /// OAuth client id; overrides $SKARDI_OAUTH_CLIENT_ID
+    /// OAuth client id, selecting the direct provider flow; overrides
+    /// $SKARDI_OAUTH_CLIENT_ID. Omit it and the console brokers the sign-in,
+    /// which needs no client id and works over SSH
     #[arg(long, value_name = "ID")]
     pub client_id: Option<String>,
 

--- a/crates/cli/src/commands/login.rs
+++ b/crates/cli/src/commands/login.rs
@@ -28,13 +28,14 @@ pub struct LoginArgs {
     #[arg(long, value_name = "URL")]
     pub control_plane: Option<String>,
 
-    /// log in to one workspace by slug (non-interactive). Needs --client-id:
-    /// a browser-brokered login is approved for one workspace in the console
+    /// log in to one workspace by slug (non-interactive). Needs --client-id or
+    /// --identity: a browser-brokered login is approved for one workspace in
+    /// the console, so the terminal does not choose
     #[arg(long, value_name = "SLUG", conflicts_with = "all_workspaces")]
     pub workspace: Option<String>,
 
     /// log in to every active workspace this identity belongs to. Needs
-    /// --client-id, for the same reason as --workspace
+    /// --client-id or --identity, for the same reason as --workspace
     #[arg(long)]
     pub all_workspaces: bool,
 
@@ -125,10 +126,28 @@ fn options_from(
     path: &Path,
 ) -> Result<LoginOptions> {
     let file = config::load(path);
+    let client_id = args
+        .client_id
+        .clone()
+        .or_else(|| std::env::var(CLIENT_ID_ENV).ok());
+    let identity = args
+        .identity
+        .clone()
+        .or_else(|| std::env::var(DEV_IDENTITY_ENV).ok());
+    // Which URL this run falls back to depends on which flow it will take, so
+    // the credential flags are resolved FIRST. The predicate is `login`'s own,
+    // shared rather than restated, so the key written by a brokered login is
+    // always the key the next brokered login reads.
+    let kind = if login::selects_console_broker(identity.as_deref(), client_id.as_deref()) {
+        UrlKind::Console
+    } else {
+        UrlKind::ControlPlane
+    };
     let control_plane = resolve_control_plane(
         args.control_plane.clone(),
         std::env::var(CONTROL_PLANE_ENV).ok(),
         file.as_ref(),
+        kind,
     )?;
     let selection = match (&args.workspace, args.all_workspaces) {
         (Some(slug), _) => Selection::Named(slug.clone()),
@@ -137,14 +156,8 @@ fn options_from(
     };
     Ok(LoginOptions {
         control_plane,
-        client_id: args
-            .client_id
-            .clone()
-            .or_else(|| std::env::var(CLIENT_ID_ENV).ok()),
-        identity: args
-            .identity
-            .clone()
-            .or_else(|| std::env::var(DEV_IDENTITY_ENV).ok()),
+        client_id,
+        identity,
         allow_dev_auth_off_loopback: args.i_know_this_is_dev_auth,
         selection,
         context_name: flag_context,
@@ -157,6 +170,7 @@ fn options_from(
         endpoints: oauth::Endpoints::default(),
         open_browser: oauth::open_in_browser,
         callback_timeout: oauth::CALLBACK_TIMEOUT,
+        poll_interval: login::console_broker::POLL_INTERVAL,
         verify_timeout: control_plane::CONTROL_PLANE_TIMEOUT,
         token_name: login::default_token_name(),
         now: chrono::Utc::now(),
@@ -171,20 +185,53 @@ fn options_from(
 /// answers nothing would fail at DNS with no mention of the three real inputs.
 /// So the chain ends the way §6.2's does — a typed error naming them — and a
 /// one-line constant replaces it the day the hosted URL exists.
+/// Which recorded URL a flow should fall back to.
+///
+/// Both arrive through `--control-plane`, and they are NOT interchangeable: a
+/// console serves the control-plane API under `/api/global/v1/...` and only to
+/// a browser holding a session, while `ControlPlane` appends bare
+/// `/v1/me/...`. Reading the wrong one sent `logout --revoke` at a console,
+/// which answered with its 404 page after the local credential was already
+/// cleared — so the fallback key is part of the flow's identity, not a detail.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum UrlKind {
+    /// The console that brokers a browser login (`console:` in the file).
+    Console,
+    /// The control-plane API itself (`control-plane:` in the file), for the
+    /// OAuth/dev login and for `logout --revoke`.
+    ControlPlane,
+}
+
+impl UrlKind {
+    /// The file key this kind falls back to, named in the error too so the
+    /// message and the lookup cannot drift.
+    const fn file_key(self) -> &'static str {
+        match self {
+            UrlKind::Console => "console:",
+            UrlKind::ControlPlane => "control-plane:",
+        }
+    }
+}
+
 fn resolve_control_plane(
     flag: Option<String>,
     env: Option<String>,
     file: Option<&ContextsFile>,
+    kind: UrlKind,
 ) -> Result<String> {
-    let from_file = file.and_then(|f| f.control_plane.clone());
+    let from_file = file.and_then(|f| match kind {
+        UrlKind::Console => f.console.clone(),
+        UrlKind::ControlPlane => f.control_plane.clone(),
+    });
     let resolved = [flag, env, from_file]
         .into_iter()
         .flatten()
         .map(|url| url.trim().to_string())
         .find(|url| !url.is_empty());
     let Some(url) = resolved else {
+        let key = kind.file_key();
         bail!(
-            "no control plane configured: pass --control-plane <URL>, set ${CONTROL_PLANE_ENV}, or add 'control-plane:' to ~/.skardi/config.yaml"
+            "no control plane configured: pass --control-plane <URL>, set ${CONTROL_PLANE_ENV}, or add '{key}' to ~/.skardi/config.yaml"
         )
     };
     // This is the leg carrying the most sensitive traffic in the flow — the ID
@@ -214,6 +261,9 @@ pub(super) fn control_plane_for_revoke(
         args.control_plane.clone(),
         env_control_plane.map(str::to_string),
         config::load(path).as_ref(),
+        // Never the console: `--revoke` calls `DELETE /v1/me/tokens/{id}`
+        // directly, which a console does not serve.
+        UrlKind::ControlPlane,
     )
 }
 
@@ -274,10 +324,11 @@ fn render_report(report: &LoginReport) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{LoginArgs, options_from, render_report, resolve_control_plane};
+    use super::{LoginArgs, UrlKind, options_from, render_report, resolve_control_plane};
     use crate::config::ContextsFile;
     use crate::login::{LoginReport, Selection, WrittenContext};
     use chrono::Duration;
+    use rstest::rstest;
     use std::path::Path;
 
     fn login_args() -> LoginArgs {
@@ -437,17 +488,24 @@ mod tests {
             resolve_control_plane(
                 Some("https://flag.example".into()),
                 Some("https://env.example".into()),
-                Some(&file)
+                Some(&file),
+                UrlKind::ControlPlane,
             )
             .unwrap(),
             "https://flag.example"
         );
         assert_eq!(
-            resolve_control_plane(None, Some("https://env.example".into()), Some(&file)).unwrap(),
+            resolve_control_plane(
+                None,
+                Some("https://env.example".into()),
+                Some(&file),
+                UrlKind::ControlPlane,
+            )
+            .unwrap(),
             "https://env.example"
         );
         assert_eq!(
-            resolve_control_plane(None, None, Some(&file)).unwrap(),
+            resolve_control_plane(None, None, Some(&file), UrlKind::ControlPlane).unwrap(),
             "https://file.example"
         );
     }
@@ -458,18 +516,79 @@ mod tests {
     fn blank_values_are_skipped_not_honoured() {
         let file = file_with(Some("https://file.example"));
         assert_eq!(
-            resolve_control_plane(Some("   ".into()), Some(String::new()), Some(&file)).unwrap(),
+            resolve_control_plane(
+                Some("   ".into()),
+                Some(String::new()),
+                Some(&file),
+                UrlKind::ControlPlane,
+            )
+            .unwrap(),
             "https://file.example"
         );
     }
 
     #[test]
     fn no_control_plane_names_all_three_inputs() {
-        let err = resolve_control_plane(None, None, Some(&file_with(None)))
+        let err = resolve_control_plane(None, None, Some(&file_with(None)), UrlKind::ControlPlane)
             .unwrap_err()
             .to_string();
         assert!(err.contains("--control-plane"), "{err}");
         assert!(err.contains("SKARDI_CONTROL_PLANE_URL"), "{err}");
         assert!(err.contains("control-plane:"), "{err}");
+    }
+
+    /// Each flow falls back to ITS OWN recorded URL, and never the other's.
+    ///
+    /// The defect this pins: a brokered login recorded the console URL as
+    /// `control-plane`, so a later `logout --revoke` sent
+    /// `DELETE /v1/me/tokens/{id}` at a console — which answered with its 404
+    /// page, after the local credential had already been cleared. The two URLs
+    /// are different services with different path layouts, so the fallback key
+    /// is part of the flow's identity.
+    #[rstest]
+    #[case::console_reads_console(UrlKind::Console, "https://console.example")]
+    #[case::direct_reads_control_plane(UrlKind::ControlPlane, "https://cp.example")]
+    fn each_kind_falls_back_to_its_own_key(#[case] kind: UrlKind, #[case] expected: &str) {
+        let file = ContextsFile {
+            control_plane: Some("https://cp.example".to_string()),
+            console: Some("https://console.example".to_string()),
+            ..ContextsFile::default()
+        };
+        assert_eq!(
+            resolve_control_plane(None, None, Some(&file), kind).unwrap(),
+            expected
+        );
+    }
+
+    /// A file holding ONLY a console URL leaves the direct flows unconfigured,
+    /// which is the point: they say so by name instead of aiming
+    /// `/v1/me/tokens` at a console.
+    #[test]
+    fn a_console_only_file_does_not_configure_the_direct_flows() {
+        let file = ContextsFile {
+            console: Some("https://console.example".to_string()),
+            ..ContextsFile::default()
+        };
+        let err = resolve_control_plane(None, None, Some(&file), UrlKind::ControlPlane)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("--control-plane"), "{err}");
+        assert!(err.contains("control-plane:"), "{err}");
+        // And the reverse: the brokered flow is configured by it.
+        assert_eq!(
+            resolve_control_plane(None, None, Some(&file), UrlKind::Console).unwrap(),
+            "https://console.example"
+        );
+    }
+
+    /// The error names the key the flow actually reads, so a reader is not
+    /// told to add `control-plane:` when the brokered flow wants `console:`.
+    #[test]
+    fn the_missing_url_error_names_the_key_for_that_flow() {
+        let err = resolve_control_plane(None, None, None, UrlKind::Console)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("console:"), "{err}");
+        assert!(!err.contains("control-plane:"), "{err}");
     }
 }

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -136,9 +136,27 @@ pub struct ContextsFile {
     /// Present so a rewrite keeps the manifest recognizable; not read.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub kind: Option<String>,
-    /// Where `login` talks. Optional: only the cloud flow reads it.
+    /// The control-plane API base, for the flows that call it directly:
+    /// the OAuth/dev `login` and `logout --revoke`. Optional — only the cloud
+    /// flow reads it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub control_plane: Option<String>,
+    /// The CONSOLE's base URL, for the browser-brokered `login`.
+    ///
+    /// Deliberately a separate key rather than reusing `control-plane`, even
+    /// though both arrive through the same `--control-plane` flag. The two are
+    /// different services with different path layouts: `ControlPlane` appends
+    /// bare `/v1/me/...`, while a console serves that API under
+    /// `/api/global/v1/...` and only for a session-carrying browser.
+    ///
+    /// Writing a console URL into `control-plane` therefore poisoned it for
+    /// every later direct call: a `logout --revoke` after a brokered login
+    /// cleared the local credential and then sent `DELETE /v1/me/tokens/{id}`
+    /// at the console, which answered with its 404 page. Keeping them apart
+    /// means a direct flow with no `control-plane` of its own says so by name
+    /// instead.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub console: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_context: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/crates/cli/src/login/console_broker.rs
+++ b/crates/cli/src/login/console_broker.rs
@@ -43,6 +43,7 @@
 //! it, and collect a token belonging to whoever approved it from that list.
 
 use anyhow::{Context, Result, anyhow, bail};
+use reqwest::{Client, Response};
 use serde::Deserialize;
 use serde_json::{Value, json};
 use std::fmt;
@@ -119,7 +120,7 @@ impl fmt::Debug for Brokered {
 /// own ceiling, so what is sent is a preference — asking for longer than
 /// policy allows yields a shorter credential, not a failure.
 pub async fn open_request(
-    http: &reqwest::Client,
+    http: &Client,
     console_base: &str,
     challenge: &str,
     client_desc: &str,
@@ -156,7 +157,7 @@ pub fn approval_url(console_base: &str, request_id: &str) -> String {
 /// Separated from the loop so the three outcomes — pending, approved, gone —
 /// are testable without a clock.
 pub async fn poll_once(
-    http: &reqwest::Client,
+    http: &Client,
     console_base: &str,
     request_id: &str,
     verifier: &str,
@@ -272,7 +273,7 @@ pub fn is_transport(err: &anyhow::Error) -> bool {
 /// already-redeemed — deliberately, so the endpoint cannot be used to
 /// enumerate live ids — which means the CLI has to translate it into the
 /// action that fixes all three.
-async fn post(http: &reqwest::Client, url: &str, body: Value) -> Result<Value> {
+async fn post(http: &Client, url: &str, body: Value) -> Result<Value> {
     let response = http.post(url).json(&body).send().await.map_err(|err| {
         Failure::Transport.with(format!("cannot reach the console at {url}: {err}"))
     })?;
@@ -287,8 +288,22 @@ async fn post(http: &reqwest::Client, url: &str, body: Value) -> Result<Value> {
         if text.trim().is_empty() {
             return Ok(Value::Null);
         }
-        return serde_json::from_str(&text)
-            .with_context(|| format!("{url} returned a body that is not JSON"));
+        // A success status whose body will not parse is marked TRANSPORT, not
+        // left as a plain failure.
+        //
+        // It is the same hazard as a dropped connection, one step later: if
+        // this was the exchange, the server already committed — consumed the
+        // request and minted the PAT — and the only copy of that token was in
+        // the body we could not read. Reported as a clean error, the poll loop
+        // would exit without retrying and without warning that a credential
+        // may exist. Marked as transport, it is retried, and a subsequent
+        // `gone` is reported as the ambiguity it is.
+        //
+        // Harmless on the open call: nothing is committed there, so the marker
+        // only changes the wording of a failure that ends the run either way.
+        return serde_json::from_str(&text).map_err(|err| {
+            Failure::Transport.with(format!("{url} returned a body that is not JSON: {err}"))
+        });
     }
 
     let (code, message) = parse_error(&text);
@@ -358,7 +373,7 @@ fn snippet(text: &str) -> String {
     format!("{head}… (truncated)")
 }
 
-async fn read_capped(mut response: reqwest::Response, url: &str) -> Result<String> {
+async fn read_capped(mut response: Response, url: &str) -> Result<String> {
     let mut buf: Vec<u8> = Vec::new();
     while let Some(chunk) = response
         .chunk()

--- a/crates/cli/src/login/console_broker.rs
+++ b/crates/cli/src/login/console_broker.rs
@@ -1,0 +1,305 @@
+//! The console-brokered acquirer (skardi-cloud design 2026-09-08).
+//!
+//! The other acquirer in this module tree gets an **ID token** and then does
+//! the work itself: list memberships, mint a PAT per workspace, verify, write
+//! contexts, and roll the whole thing back on failure. This one is shaped
+//! differently, and the difference is not stylistic.
+//!
+//! Here the console is the identity broker. It authenticates the human with
+//! whatever adapter it accepts — email or Google, the CLI never learns which —
+//! and skardi-global mints the PAT when the CLI redeems an approval the human
+//! already gave. So what arrives is a **credential, not an identity**, and
+//! three properties follow:
+//!
+//! 1. **One workspace.** The consent screen selects exactly one (§11.1), so
+//!    `--workspace` and `--all-workspaces` have no meaning on this path. The
+//!    caller refuses them rather than ignoring them.
+//! 2. **No client id.** That is the whole point: `skardi login
+//!    --control-plane <url>` works with nothing else.
+//! 3. **Nothing here can revoke.** A PAT authenticates to the *gateway*;
+//!    skardi-global's `/v1/*` accepts ID tokens, first-party sessions, and
+//!    `dev:` bearers, and its PAT resolution is reached only over the gRPC
+//!    directory the gateway uses. So the CLI cannot `DELETE
+//!    /v1/me/tokens/{id}` with what it holds. Every place the ID-token flow
+//!    would revoke, this one reports the `token_id` and names the console —
+//!    which is why the exchange returns that id at all.
+//!
+//! # Why polling
+//!
+//! §5: the console is `https:` and a loopback listener is `http:`. Loopback is
+//! "potentially trustworthy" today, but Private Network Access is tightening,
+//! and a flow whose viability depends on where that lands breaks without a
+//! code change. Polling also gives `--no-browser` for free — print the URL,
+//! approve it from another machine — which is the headless capability the
+//! 08-20 design deferred.
+//!
+//! # The confirmation code
+//!
+//! `confirm` is the first six hex characters of `request_id`, and approving
+//! REQUIRES it. It is printed here because the human has to retype it in the
+//! browser: the pending list under Agent access shows the same prefix and no
+//! request id, so an approver has to be looking at this terminal to approve
+//! this request. Without that, an attacker could open a request, never visit
+//! it, and collect a token belonging to whoever approved it from that list.
+
+use anyhow::{Context, Result, anyhow, bail};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use std::fmt;
+use std::time::Duration;
+
+use super::control_plane::Membership;
+
+/// Where the CLI-login routes live on the console.
+///
+/// Not skardi-global directly: it has no public ingress in any deployment we
+/// run, which is the concrete reason this design exists. The console's BFF
+/// forwards these two paths with **no session cookie attached** — they are
+/// marked session-less in its allowlist precisely so a caller with no cookie
+/// can reach them.
+const BFF_PREFIX: &str = "/api/global/v1/cli-login";
+
+/// How long to wait between polls of the exchange.
+///
+/// Flat rather than backing off. The window is five minutes and the human is
+/// actively working through a browser at the other end, so the thing being
+/// optimised is how quickly the terminal notices they finished, not request
+/// volume: a five-minute ceiling at this interval is at most 150 requests
+/// against one console.
+pub const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// One opened request. `request_id` names it, `confirm` is what the human
+/// retypes, and `expires_at` is what the CLI prints so the deadline is theirs
+/// rather than a silent timeout.
+#[derive(Debug, Deserialize)]
+pub struct Opened {
+    pub request_id: String,
+    pub confirm: String,
+    pub expires_at: String,
+}
+
+/// What the exchange hands back once a human has approved.
+///
+/// Carries the raw PAT, so no `#[derive(Debug)]` — see the manual impl below.
+pub struct Brokered {
+    pub token: String,
+    /// The revoke handle. Cannot be used by this CLI (see the module docs), and
+    /// is retained anyway: it goes into the context so a later login can name
+    /// what it orphaned, and it is printed when the flow has to abandon a
+    /// credential it cannot revoke.
+    pub token_id: String,
+    pub expires_at: Option<String>,
+    /// The single workspace the consent screen chose.
+    pub workspace: String,
+    /// §11.2 — the membership rides along, so the context is written without a
+    /// second round trip. Empty is tolerated: `workspace` is authoritative,
+    /// and this is what lets the context carry an org slug and a role.
+    pub memberships: Vec<Membership>,
+}
+
+/// Hand-written, for the same reason `Minted`'s is: the raw token must not be
+/// reachable through an `{err:?}` rendering or a stray log line.
+impl fmt::Debug for Brokered {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Brokered")
+            .field("token", &"(redacted)")
+            .field("token_id", &self.token_id)
+            .field("expires_at", &self.expires_at)
+            .field("workspace", &self.workspace)
+            .field("memberships", &self.memberships)
+            .finish()
+    }
+}
+
+/// Open a request. Session-less: this is the call made before anyone has
+/// authenticated anything.
+///
+/// `token_expires_at` carries `--expires`, because the mint happens minutes
+/// later in a browser that never sees the flag. The console clamps it to its
+/// own ceiling, so what is sent is a preference — asking for longer than
+/// policy allows yields a shorter credential, not a failure.
+pub async fn open_request(
+    http: &reqwest::Client,
+    console_base: &str,
+    challenge: &str,
+    client_desc: &str,
+    token_expires_at: &str,
+) -> Result<Opened> {
+    let url = format!("{}{BFF_PREFIX}/requests", trim(console_base));
+    let body = json!({
+        "challenge": challenge,
+        "client_desc": client_desc,
+        "token_expires_at": token_expires_at,
+    });
+    let value = post(http, &url, body).await?;
+    let opened: Opened = serde_json::from_value(value)
+        .context("the console's CLI-login response was not the expected shape")?;
+    if opened.request_id.is_empty() || opened.confirm.is_empty() {
+        bail!("the console opened a login request with no id");
+    }
+    Ok(opened)
+}
+
+/// The URL the human opens. Built here so the page path and the BFF path
+/// cannot drift apart across two call sites.
+pub fn approval_url(console_base: &str, request_id: &str) -> String {
+    format!(
+        "{}/cli-login?request_id={}",
+        trim(console_base),
+        crate::client::encode_component(request_id)
+    )
+}
+
+/// One poll of the exchange. `Ok(None)` means "approved by nobody yet", which
+/// is the ordinary answer and not an error.
+///
+/// Separated from the loop so the three outcomes — pending, approved, gone —
+/// are testable without a clock.
+pub async fn poll_once(
+    http: &reqwest::Client,
+    console_base: &str,
+    request_id: &str,
+    verifier: &str,
+) -> Result<Option<Brokered>> {
+    let url = format!("{}{BFF_PREFIX}/exchange", trim(console_base));
+    let body = json!({ "request_id": request_id, "verifier": verifier });
+    let value = post(http, &url, body).await?;
+
+    match value.get("status").and_then(Value::as_str) {
+        Some("pending") => Ok(None),
+        Some("approved") => {
+            let parsed: ExchangeBody = serde_json::from_value(value)
+                .context("the console's CLI-login exchange was not the expected shape")?;
+            Ok(Some(Brokered {
+                token: parsed.token,
+                token_id: parsed.token_id,
+                expires_at: parsed.expires_at,
+                workspace: parsed.workspace,
+                memberships: parsed.memberships,
+            }))
+        }
+        // A status this CLI does not know is a control plane newer than it is.
+        // Reported rather than treated as pending, because polling forever on
+        // a terminal state is the worse failure.
+        other => bail!(
+            "the console answered the CLI-login exchange with an unexpected status ({}) — this skardi-cli may be older than the control plane",
+            other.unwrap_or("none")
+        ),
+    }
+}
+
+#[derive(Deserialize)]
+struct ExchangeBody {
+    token: String,
+    token_id: String,
+    #[serde(default)]
+    expires_at: Option<String>,
+    workspace: String,
+    #[serde(default)]
+    memberships: Vec<Membership>,
+}
+
+/// Cap on a console response body — the same "something is very wrong" bound
+/// the control-plane client uses.
+const MAX_BODY_BYTES: usize = 1024 * 1024;
+
+/// One POST, with the console's error envelope mapped.
+///
+/// The BFF passes skardi-global's body through untouched, so the envelope is
+/// the nested `{"error": {"code", "message"}}` the control-plane client
+/// already reads. The codes worth naming are mapped here rather than in the
+/// caller: `no_such_request` is one answer for expired, unknown, and
+/// already-redeemed — deliberately, so the endpoint cannot be used to
+/// enumerate live ids — which means the CLI has to translate it into the
+/// action that fixes all three.
+async fn post(http: &reqwest::Client, url: &str, body: Value) -> Result<Value> {
+    let response = http
+        .post(url)
+        .json(&body)
+        .send()
+        .await
+        .with_context(|| format!("cannot reach the console at {url}"))?;
+    let status = response.status();
+    let text = read_capped(response, url).await?;
+
+    if status.is_success() {
+        if text.trim().is_empty() {
+            return Ok(Value::Null);
+        }
+        return serde_json::from_str(&text)
+            .with_context(|| format!("{url} returned a body that is not JSON"));
+    }
+
+    let (code, message) = parse_error(&text);
+    let code = code.unwrap_or_default();
+    // 403 on the console's own proxy, rather than from skardi-global, means
+    // the path is not on its allowlist — which is what an older console looks
+    // like from here. Worth distinguishing: nothing the user can retype fixes
+    // it, and the flag that does work is the one this design replaced.
+    if code == "route_not_allowed" {
+        bail!(
+            "this console does not support browser-brokered `skardi login` (its API allowlist has no CLI-login route). Upgrade the console, or log in with --client-id <OAuth client id>"
+        );
+    }
+    match code.as_str() {
+        "no_such_request" => Err(anyhow!(
+            "the login request is no longer open — it expired, or it was already redeemed. Run `skardi login` again"
+        )),
+        "verifier_mismatch" => Err(anyhow!(
+            "the console refused this CLI's proof of ownership for the login request — start a fresh `skardi login` rather than reusing a request id"
+        )),
+        _ if message.is_empty() => Err(anyhow!(
+            "the console refused the CLI-login request (HTTP {})",
+            status.as_u16()
+        )),
+        _ => Err(anyhow!(
+            "the console refused the CLI-login request: {message} (HTTP {})",
+            status.as_u16()
+        )),
+    }
+}
+
+/// `(code, message)` out of the nested envelope, falling back to the raw first
+/// line for anything that is not one — a proxy error page, an HTML 502.
+fn parse_error(text: &str) -> (Option<String>, String) {
+    #[derive(Deserialize)]
+    struct Envelope {
+        error: ErrorBody,
+    }
+    #[derive(Deserialize)]
+    struct ErrorBody {
+        #[serde(default)]
+        code: Option<String>,
+        #[serde(default)]
+        message: Option<String>,
+    }
+    match serde_json::from_str::<Envelope>(text) {
+        Ok(envelope) => (
+            envelope.error.code,
+            envelope.error.message.unwrap_or_default(),
+        ),
+        Err(_) => (
+            None,
+            text.lines().next().unwrap_or_default().trim().to_string(),
+        ),
+    }
+}
+
+async fn read_capped(mut response: reqwest::Response, url: &str) -> Result<String> {
+    let mut buf: Vec<u8> = Vec::new();
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .with_context(|| format!("read the response from {url}"))?
+    {
+        if buf.len().saturating_add(chunk.len()) > MAX_BODY_BYTES {
+            bail!("{url} returned more than {MAX_BODY_BYTES} bytes — refusing to buffer it");
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    Ok(String::from_utf8_lossy(&buf).to_string())
+}
+
+fn trim(base: &str) -> &str {
+    base.trim_end_matches('/')
+}

--- a/crates/cli/src/login/console_broker.rs
+++ b/crates/cli/src/login/console_broker.rs
@@ -203,6 +203,66 @@ struct ExchangeBody {
 /// the control-plane client uses.
 const MAX_BODY_BYTES: usize = 1024 * 1024;
 
+/// How much of an UNRECOGNIZED error body may reach the terminal.
+///
+/// A console's 404 is a full Next.js HTML document on a single line, so the
+/// old `text.lines().next()` fallback printed the entire page as the failure
+/// reason — several kilobytes of markup where a sentence belonged. Bodies we
+/// can parse are unaffected; this bounds only the fallback.
+const MAX_SNIPPET_CHARS: usize = 200;
+
+/// Why a CLI-login call failed, in the terms the poll loop branches on.
+///
+/// A marker attached with `anyhow::Context` rather than a new error enum: the
+/// callers all render `anyhow::Error`, and the loop needs exactly two
+/// questions answered — is this worth retrying, and did the request disappear.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Failure {
+    /// The request no longer exists: expired, unknown, or already redeemed.
+    /// One answer for all three by design, so the endpoint cannot enumerate
+    /// live ids.
+    Gone,
+    /// The console could not be reached, or its answer could not be read.
+    /// Retryable: the poll is idempotent while a request is pending.
+    Transport,
+}
+
+impl fmt::Display for Failure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Failure::Gone => write!(f, "the CLI-login request is gone"),
+            Failure::Transport => write!(f, "the console could not be reached"),
+        }
+    }
+}
+
+impl std::error::Error for Failure {}
+
+impl Failure {
+    /// This failure, carrying `message` as what the user reads.
+    ///
+    /// The marker is the ROOT and the sentence is context ON TOP, not the
+    /// other way round: `anyhow::Error::to_string` renders the outermost
+    /// context, so attaching the marker last replaced the explanation with
+    /// "the CLI-login request is gone" and threw away the sentence that told
+    /// the reader what to do about it.
+    fn with(self, message: impl fmt::Display + Send + Sync + 'static) -> anyhow::Error {
+        anyhow::Error::new(self).context(message)
+    }
+}
+
+/// Whether `err` reports a request that no longer exists.
+pub fn is_gone(err: &anyhow::Error) -> bool {
+    err.chain()
+        .any(|cause| cause.downcast_ref::<Failure>() == Some(&Failure::Gone))
+}
+
+/// Whether `err` is a transport failure, and so worth retrying.
+pub fn is_transport(err: &anyhow::Error) -> bool {
+    err.chain()
+        .any(|cause| cause.downcast_ref::<Failure>() == Some(&Failure::Transport))
+}
+
 /// One POST, with the console's error envelope mapped.
 ///
 /// The BFF passes skardi-global's body through untouched, so the envelope is
@@ -213,14 +273,15 @@ const MAX_BODY_BYTES: usize = 1024 * 1024;
 /// enumerate live ids — which means the CLI has to translate it into the
 /// action that fixes all three.
 async fn post(http: &reqwest::Client, url: &str, body: Value) -> Result<Value> {
-    let response = http
-        .post(url)
-        .json(&body)
-        .send()
-        .await
-        .with_context(|| format!("cannot reach the console at {url}"))?;
+    let response = http.post(url).json(&body).send().await.map_err(|err| {
+        Failure::Transport.with(format!("cannot reach the console at {url}: {err}"))
+    })?;
     let status = response.status();
-    let text = read_capped(response, url).await?;
+    let text = read_capped(response, url)
+        .await
+        // `{err:#}` flattens the read's own cause chain into the message, so
+        // nothing is lost by making the marker the root.
+        .map_err(|err| Failure::Transport.with(format!("{err:#}")))?;
 
     if status.is_success() {
         if text.trim().is_empty() {
@@ -242,8 +303,8 @@ async fn post(http: &reqwest::Client, url: &str, body: Value) -> Result<Value> {
         );
     }
     match code.as_str() {
-        "no_such_request" => Err(anyhow!(
-            "the login request is no longer open — it expired, or it was already redeemed. Run `skardi login` again"
+        "no_such_request" => Err(Failure::Gone.with(
+            "the login request is no longer open — it expired, or it was already redeemed. Run `skardi login` again",
         )),
         "verifier_mismatch" => Err(anyhow!(
             "the console refused this CLI's proof of ownership for the login request — start a fresh `skardi login` rather than reusing a request id"
@@ -278,11 +339,23 @@ fn parse_error(text: &str) -> (Option<String>, String) {
             envelope.error.code,
             envelope.error.message.unwrap_or_default(),
         ),
-        Err(_) => (
-            None,
-            text.lines().next().unwrap_or_default().trim().to_string(),
-        ),
+        Err(_) => (None, snippet(text)),
     }
+}
+
+/// The first line of an unrecognized body, bounded.
+///
+/// A console's 404 is one enormous line of HTML, so "first line" was the whole
+/// document; without the char cap the CLI printed a Next.js page where an
+/// explanation belonged. Truncation is marked, so a reader can tell the
+/// message was cut rather than that the server sent gibberish.
+fn snippet(text: &str) -> String {
+    let line = text.lines().next().unwrap_or_default().trim();
+    if line.chars().count() <= MAX_SNIPPET_CHARS {
+        return line.to_string();
+    }
+    let head: String = line.chars().take(MAX_SNIPPET_CHARS).collect();
+    format!("{head}… (truncated)")
 }
 
 async fn read_capped(mut response: reqwest::Response, url: &str) -> Result<String> {

--- a/crates/cli/src/login/console_broker.rs
+++ b/crates/cli/src/login/console_broker.rs
@@ -376,3 +376,110 @@ async fn read_capped(mut response: reqwest::Response, url: &str) -> Result<Strin
 fn trim(base: &str) -> &str {
     base.trim_end_matches('/')
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        Brokered, Failure, MAX_SNIPPET_CHARS, is_gone, is_transport, parse_error, snippet,
+    };
+
+    /// The raw PAT must not be reachable through an `{err:?}` rendering or a
+    /// stray log line, so `Debug` is hand-written — and that is worth pinning
+    /// rather than trusting, the same way `Minted`'s is.
+    #[test]
+    fn a_brokered_debug_output_redacts_the_token() {
+        let brokered = Brokered {
+            token: "skardi_pat_the_real_secret".to_string(),
+            token_id: "tok-1".to_string(),
+            expires_at: Some("2026-11-22T12:00:00Z".to_string()),
+            workspace: "acme-prod".to_string(),
+            memberships: Vec::new(),
+        };
+        let rendered = format!("{brokered:?}");
+        assert!(!rendered.contains("the_real_secret"), "{rendered}");
+        assert!(rendered.contains("(redacted)"), "{rendered}");
+        // What a caller legitimately needs to see, including the id that is
+        // the only handle on an abandoned credential.
+        assert!(rendered.contains("tok-1"), "{rendered}");
+        assert!(rendered.contains("acme-prod"), "{rendered}");
+    }
+
+    /// The marker is the ROOT of the chain and the sentence is context on top.
+    ///
+    /// The reverse is the bug this pins: attaching the marker last made
+    /// `to_string()` render "the CLI-login request is gone" and threw away the
+    /// sentence telling the reader to run `skardi login` again.
+    #[test]
+    fn a_failure_marker_does_not_replace_the_message_a_user_reads() {
+        let err = Failure::Gone.with("the login request is no longer open — run `skardi login`");
+        assert_eq!(
+            err.to_string(),
+            "the login request is no longer open — run `skardi login`"
+        );
+        assert!(is_gone(&err));
+        assert!(!is_transport(&err));
+        // The markers' own wording, which surfaces only in an `{err:#}` chain.
+        assert_eq!(Failure::Gone.to_string(), "the CLI-login request is gone");
+        assert_eq!(
+            Failure::Transport.to_string(),
+            "the console could not be reached"
+        );
+    }
+
+    #[test]
+    fn the_classifiers_do_not_fire_on_an_unmarked_error() {
+        // The loop branches on these: a false positive on `is_transport` would
+        // retry something terminal, and one on `is_gone` would claim a
+        // credential may exist when nothing was ever approved.
+        let plain = anyhow::anyhow!("something else went wrong");
+        assert!(!is_gone(&plain));
+        assert!(!is_transport(&plain));
+        let transport = Failure::Transport.with("cannot reach the console");
+        assert!(is_transport(&transport));
+        assert!(!is_gone(&transport));
+    }
+
+    /// A console's 404 is a single enormous line of HTML, so "first line" was
+    /// no bound at all — the whole page reached the terminal where a sentence
+    /// belonged.
+    #[test]
+    fn an_unparseable_body_is_bounded_and_marked() {
+        let page = format!(
+            "<!DOCTYPE html><html><body>{}</body></html>",
+            "<div></div>".repeat(300)
+        );
+        assert_eq!(page.lines().count(), 1, "the real page is one line");
+        let out = snippet(&page);
+        assert!(out.ends_with("… (truncated)"), "{out}");
+        assert!(out.starts_with("<!DOCTYPE html>"), "{out}");
+        assert!(
+            out.chars().count() <= MAX_SNIPPET_CHARS + "… (truncated)".chars().count(),
+            "{} chars",
+            out.chars().count()
+        );
+    }
+
+    #[test]
+    fn a_short_unparseable_body_is_passed_through() {
+        // The ordinary case — a proxy's one-line plaintext error — must not be
+        // mangled by the cap.
+        assert_eq!(snippet("upstream connect error"), "upstream connect error");
+        assert_eq!(snippet("  padded  \nsecond line"), "padded");
+    }
+
+    #[test]
+    fn parse_error_reads_the_nested_envelope() {
+        let (code, message) = parse_error(
+            r#"{"error":{"code":"no_such_request","message":"no such CLI login request"}}"#,
+        );
+        assert_eq!(code.as_deref(), Some("no_such_request"));
+        assert_eq!(message, "no such CLI login request");
+    }
+
+    #[test]
+    fn parse_error_falls_back_to_a_bounded_snippet() {
+        let (code, message) = parse_error("not json at all");
+        assert_eq!(code, None);
+        assert_eq!(message, "not json at all");
+    }
+}

--- a/crates/cli/src/login/control_plane.rs
+++ b/crates/cli/src/login/control_plane.rs
@@ -309,15 +309,39 @@ fn parse_error(status: u16, text: &str) -> CpError {
         Err(_) => CpError {
             status,
             code: None,
-            message: text.lines().next().unwrap_or("").to_string(),
+            message: snippet(text),
             orgs: Vec::new(),
         },
     }
 }
 
+/// How much of an UNRECOGNIZED error body may reach the terminal.
+///
+/// Bodies that parse as skardi-global's envelope are unaffected; this bounds
+/// only the fallback, and the fallback is what a *non*-control-plane answer
+/// lands in.
+const MAX_SNIPPET_CHARS: usize = 200;
+
+/// The first line of an unrecognized body, bounded.
+///
+/// "First line" alone was not a bound. A Next.js 404 page is a single enormous
+/// line, so pointing this client at a console — which is exactly what a
+/// `logout --revoke` did after a brokered login recorded a console URL as its
+/// control plane — printed the whole HTML document as the reason a credential
+/// could not be revoked, burying the one fact that mattered. Truncation is
+/// marked so a reader can tell the message was cut.
+fn snippet(text: &str) -> String {
+    let line = text.lines().next().unwrap_or_default().trim();
+    if line.chars().count() <= MAX_SNIPPET_CHARS {
+        return line.to_string();
+    }
+    let head: String = line.chars().take(MAX_SNIPPET_CHARS).collect();
+    format!("{head}… (truncated)")
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{Membership, MembershipsBody, Minted, parse_error};
+    use super::{MAX_SNIPPET_CHARS, Membership, MembershipsBody, Minted, parse_error};
 
     /// The raw token must not reach a log line, a panic message, or an
     /// `{err:?}` rendering through this type — so `Debug` is hand-written, and
@@ -424,5 +448,47 @@ mod tests {
         // A well-formed envelope with no message still says something.
         let bare = parse_error(500, r#"{"error": {"code": "internal"}}"#);
         assert_eq!(bare.message, "no message");
+    }
+
+    /// A non-control-plane answer is summarized, not dumped.
+    ///
+    /// Measured, not hypothetical: after a brokered login recorded a console
+    /// URL as its control plane, `logout --revoke` sent
+    /// `DELETE /v1/me/tokens/{id}` at that console and printed the entire
+    /// Next.js 404 page as the reason the credential could not be revoked.
+    /// "First line" was no bound at all — that page is one enormous line — so
+    /// several kilobytes of markup buried the one fact that mattered.
+    #[test]
+    fn an_unparseable_error_body_is_bounded_and_marked() {
+        let page = format!(
+            "<!DOCTYPE html><html><head><title>Not found</title></head><body>{}</body></html>",
+            "<div class=\"filler\"></div>".repeat(200)
+        );
+        assert!(page.lines().count() == 1, "the real page is a single line");
+
+        let err = parse_error(404, &page);
+        assert_eq!(err.status, 404);
+        assert_eq!(err.code, None);
+        assert!(
+            err.message.chars().count() <= MAX_SNIPPET_CHARS + "… (truncated)".chars().count(),
+            "message was {} chars",
+            err.message.chars().count()
+        );
+        assert!(err.message.ends_with("… (truncated)"), "{}", err.message);
+        // The head is kept, so a reader can still tell WHAT answered.
+        assert!(
+            err.message.starts_with("<!DOCTYPE html>"),
+            "{}",
+            err.message
+        );
+    }
+
+    /// A short unparseable body is passed through untouched — the cap must not
+    /// mangle the ordinary case (a proxy's one-line plaintext error).
+    #[test]
+    fn a_short_unparseable_body_is_not_truncated() {
+        let err = parse_error(502, "upstream connect error");
+        assert_eq!(err.message, "upstream connect error");
+        assert!(!err.message.contains("truncated"));
     }
 }

--- a/crates/cli/src/login/mod.rs
+++ b/crates/cli/src/login/mod.rs
@@ -466,7 +466,7 @@ async fn poll_for_approval(
                 // exist that this run will never name.
                 if seen_alive && console_broker::is_gone(&err) {
                     return Err(err.context(
-                        "the login request is gone. If you approved it, a credential may have                          been minted and this run never received it — check Agent access in the                          console and revoke anything you did not keep",
+ "the login request is gone. If you approved it, a credential may have been minted and this run never received it — check Agent access in the console and revoke anything you did not keep",
                     ));
                 }
                 // Transport failures are retried rather than fatal: the poll is
@@ -479,7 +479,7 @@ async fn poll_for_approval(
                 transport_failures += 1;
                 if transport_failures > MAX_TRANSPORT_FAILURES {
                     return Err(err.context(
-                        "the console stopped answering the CLI-login exchange. If you approved                          the request, check Agent access in the console for a credential this                          run never received",
+ "the console stopped answering the CLI-login exchange. If you approved the request, check Agent access in the console for a credential this run never received",
                     ));
                 }
             }

--- a/crates/cli/src/login/mod.rs
+++ b/crates/cli/src/login/mod.rs
@@ -443,10 +443,23 @@ async fn poll_for_approval(
         Err(_) => options.callback_timeout,
     };
     let deadline = Instant::now() + budget;
-    // Whether the request was ever confirmed to exist. It decides how a later
-    // disappearance is reported: gone after we watched it live means it may
-    // have been approved and redeemed by a response we lost.
-    let mut seen_alive = false;
+    // Whether any poll failed in transit. THIS is what makes a later "gone"
+    // ambiguous, and the reason is what a credential requires to exist: the
+    // exchange must have committed.
+    //
+    //   - `pending` says the server did not consume — no credential;
+    //   - a clean `gone` says it did not consume on that call either;
+    //   - a TRANSPORT failure says nothing, because the call may have
+    //     committed and the answer been lost on the way back.
+    //
+    // So a `gone` following a transport failure may be hiding a live PAT,
+    // whatever the request looked like before. An earlier version keyed this on
+    // "was the request ever seen alive", which was wrong twice over: it missed
+    // the case where approval lands before the first poll (nothing is ever
+    // seen pending, so the flag stayed false and a real ambiguity was reported
+    // as a plain expiry), and it warned on `pending → clean gone`, where no
+    // credential can exist because only this process holds the verifier.
+    let mut lost_a_response = false;
     let mut transport_failures = 0_u32;
 
     loop {
@@ -455,16 +468,19 @@ async fn poll_for_approval(
         {
             Ok(Some(brokered)) => return Ok(brokered),
             Ok(None) => {
-                seen_alive = true;
+                // Consecutive-only, so a single blip mid-login does not spend
+                // the budget a later outage needs. `lost_a_response` is NOT
+                // reset: a poll that may already have committed stays a
+                // possibility for the rest of the run.
                 transport_failures = 0;
             }
             Err(err) => {
-                // A request that vanishes AFTER we saw it alive is the
-                // ambiguous case: the console answers gone/expired/redeemed
-                // identically, so a redemption whose response we lost looks
-                // exactly like an expiry. Say so, because a credential may
-                // exist that this run will never name.
-                if seen_alive && console_broker::is_gone(&err) {
+                // Gone AFTER a lost response is the ambiguous case: the console
+                // answers gone/expired/redeemed identically, so a redemption
+                // whose answer we never received looks exactly like an expiry.
+                // Say so, because a credential may exist that this run will
+                // never name.
+                if lost_a_response && console_broker::is_gone(&err) {
                     return Err(err.context(
  "the login request is gone. If you approved it, a credential may have been minted and this run never received it — check Agent access in the console and revoke anything you did not keep",
                     ));
@@ -477,6 +493,7 @@ async fn poll_for_approval(
                     return Err(err);
                 }
                 transport_failures += 1;
+                lost_a_response = true;
                 if transport_failures > MAX_TRANSPORT_FAILURES {
                     return Err(err.context(
  "the console stopped answering the CLI-login exchange. If you approved the request, check Agent access in the console for a credential this run never received",

--- a/crates/cli/src/login/mod.rs
+++ b/crates/cli/src/login/mod.rs
@@ -17,6 +17,7 @@
 #[cfg(test)]
 mod tests;
 
+pub mod console_broker;
 pub mod control_plane;
 pub mod loopback;
 pub mod oauth;
@@ -129,6 +130,14 @@ struct MintedRef {
 /// Run the whole flow. `config_path` is a parameter so tests write to a temp
 /// directory instead of the developer's own config.
 pub async fn login(options: LoginOptions, config_path: &Path) -> Result<LoginReport> {
+    // With neither `--identity` nor a client id, the console brokers (design
+    // 2026-09-08 §9). That path is not a different way to get a bearer — it
+    // returns a PAT that is already minted and already scoped, so it skips
+    // membership listing, minting, and the saga entirely. Hence a branch here
+    // rather than a third arm inside `acquire_bearer`.
+    if uses_console_broker(&options) {
+        return console_brokered_login(options, config_path).await;
+    }
     let http = control_plane::client(control_plane::CONTROL_PLANE_TIMEOUT)?;
     let bearer = acquire_bearer(&http, &options).await?;
     let cp = ControlPlane::new(http.clone(), &options.control_plane, bearer);
@@ -229,6 +238,210 @@ pub async fn login(options: LoginOptions, config_path: &Path) -> Result<LoginRep
     }
 }
 
+/// Whether this run goes through the console broker.
+///
+/// `--identity` and `--client-id` both name a way for the CLI to authenticate
+/// itself, and either one keeps the existing flow. Neither means there is no
+/// IdP for the CLI to talk to, which is exactly the case the console broker
+/// exists for — and it is the default, so `skardi login --control-plane <url>`
+/// works with no other argument (§9).
+///
+/// An empty client id counts as absent, the same way `acquire_bearer` treats
+/// it: `SKARDI_OAUTH_CLIENT_ID=` exported into a shell must not select a path
+/// that then fails for want of the value that variable was supposed to carry.
+fn uses_console_broker(options: &LoginOptions) -> bool {
+    options.identity.is_none()
+        && options
+            .client_id
+            .as_deref()
+            .is_none_or(|id| id.trim().is_empty())
+}
+
+/// The console-brokered flow (design 2026-09-08 §4).
+///
+/// # Why this is not the saga
+///
+/// The ID-token flow mints, verifies, and can revoke everything it created,
+/// so a failure anywhere rolls the run back and leaves nothing behind. Here
+/// the credential is minted by skardi-global at the moment the CLI redeems an
+/// approval, and what the CLI holds afterwards is a **PAT** — which
+/// authenticates to the gateway and NOT to skardi-global's `/v1/*`, whose
+/// verifiers accept ID tokens, first-party sessions and `dev:` bearers, and
+/// whose PAT resolution is reachable only over the gRPC directory the gateway
+/// uses.
+///
+/// So there is no rollback available, and pretending otherwise would be worse
+/// than not having one: every point where the saga would revoke, this flow
+/// PRINTS the `token_id` and names the console. A credential nobody can revoke
+/// and nobody knows exists is the outcome §6.5 was written to prevent, and the
+/// id is the only thing that prevents it here.
+async fn console_brokered_login(options: LoginOptions, config_path: &Path) -> Result<LoginReport> {
+    // Refused, not ignored. The consent screen selects exactly one workspace
+    // (§11.1), so there is no honest reading of either flag on this path — and
+    // silently logging into one workspace when `--all-workspaces` was asked
+    // for is the kind of success that gets discovered much later.
+    match &options.selection {
+        Selection::Auto => {}
+        Selection::Named(slug) => bail!(
+            "--workspace '{slug}' cannot be honoured through a browser login: the console's consent screen chooses the workspace, and it grants exactly one. Approve '{slug}' in the browser, or use the OAuth flow with --client-id <ID> to select it here"
+        ),
+        Selection::All => bail!(
+            "--all-workspaces cannot be honoured through a browser login: one approval grants one workspace. Run this once per workspace, or use the OAuth flow with --client-id <ID>"
+        ),
+    }
+
+    let http = control_plane::client(control_plane::CONTROL_PLANE_TIMEOUT)?;
+    let pkce = pkce::Pkce::generate()?;
+    // The same ceiling check the saga does, for the same reason: `DateTime +
+    // TimeDelta` panics on overflow and `parse_expires` cannot catch every
+    // case, because its bound is `TimeDelta`'s range and not `DateTime`'s.
+    let token_expires_at = options
+        .now
+        .checked_add_signed(options.expires)
+        .ok_or_else(|| anyhow!("--expires is longer than any usable credential"))?
+        .to_rfc3339();
+
+    let opened = console_broker::open_request(
+        &http,
+        &options.control_plane,
+        &pkce.challenge,
+        // `client_desc` is what the consent screen shows AND what becomes the
+        // PAT's name upstream, so it is the same `cli@<hostname>` the other
+        // path mints under — one name for one machine, whichever flow wrote it.
+        &options.token_name,
+        &token_expires_at,
+    )
+    .await?;
+    let url = console_broker::approval_url(&options.control_plane, &opened.request_id);
+
+    // The code goes to stderr with the URL, because the human needs both in
+    // front of them: the browser will ask for it, and the pending list under
+    // Agent access shows the same six characters against no request id. That
+    // pairing is what proves the approver is looking at this terminal.
+    eprintln!("opening {url}");
+    eprintln!(
+        "waiting for approval in the browser (the request expires at {})",
+        opened.expires_at
+    );
+    eprintln!("  confirmation code: {}", opened.confirm);
+    if options.no_browser {
+        eprintln!("  --no-browser: open the URL above yourself, on this machine or another");
+    } else if let Err(err) = (options.open_browser)(&url) {
+        // Not fatal: the URL is already on screen, and a headless box failing
+        // to launch a browser is the normal case rather than an error.
+        eprintln!("could not open a browser ({err}) — open the URL above yourself");
+    }
+
+    let brokered = poll_for_approval(&http, &options, &opened.request_id, &pkce.verifier).await?;
+
+    // §11.2: the membership rides along, so the context is written without a
+    // second round trip. Its absence is exceptional — it means the approved
+    // membership vanished between approval and redemption — and it is fatal
+    // here because the context NAME is `<org>/<workspace>` and the org slug
+    // has nowhere else to come from. The token id is printed because at this
+    // point a credential exists that this CLI cannot revoke.
+    let membership = brokered.memberships.first().cloned().ok_or_else(|| {
+        anyhow!(
+            "the console approved workspace '{}' but returned no membership for it, so there is no organization to name the context after. The credential it minted is live and this CLI cannot revoke it — revoke token {} in the console",
+            brokered.workspace,
+            brokered.token_id
+        )
+    })?;
+
+    let token = Minted {
+        token: brokered.token,
+        token_id: brokered.token_id,
+        expires_at: brokered.expires_at,
+    };
+    let server = resolve_server(&options, &membership).map_err(|err| abandoned(&token, err))?;
+    if !options.no_verify
+        && let Err(err) = verify(&server, &membership, &token, options.verify_timeout).await
+    {
+        return Err(abandoned(&token, err));
+    }
+
+    let pending = vec![(membership, token, server)];
+    let replaced = write_contexts(config_path, &options, &pending).map_err(|err| {
+        // `pending` still owns the token, so read the id off it rather than
+        // moving anything: the write failed, and the credential is stranded.
+        abandoned(&pending[0].1, err)
+    })?;
+
+    let mut report = LoginReport::default();
+    report.written = pending
+        .iter()
+        .map(|(membership, token, server)| WrittenContext {
+            name: context_name(&options, membership),
+            server: server.clone(),
+            workspace: membership.tenant_slug.clone(),
+            role: membership.role.clone(),
+            expires_at: token.expires_at.clone(),
+        })
+        .collect();
+    report.current_context = report.written.first().map(|w| w.name.clone());
+
+    // The replacement rule, minus the revoke this path cannot perform. Routed
+    // through `revoke_failures` because that is already the channel that
+    // prints "revoke it in the console" — the outcome is identical to a revoke
+    // that failed, and the reason is stated rather than left as a bare id.
+    for token_id in replaced {
+        if options.keep_old_token {
+            report.replaced_kept.push(token_id);
+        } else {
+            report.revoke_failures.push((
+                token_id,
+                "a browser login holds only a PAT, which cannot revoke tokens at the control plane"
+                    .to_string(),
+            ));
+        }
+    }
+    Ok(report)
+}
+
+/// Poll the exchange until a human approves, the request expires, or the
+/// console says the request is gone.
+///
+/// The deadline is the REQUEST's own expiry as the console reported it, parsed
+/// rather than recomputed locally: the server owns the TTL, and a CLI that
+/// kept its own copy would poll past a dead request or give up on a live one
+/// whenever the two drifted. An unparseable stamp falls back to the local
+/// window rather than making the flow depend on the format.
+async fn poll_for_approval(
+    http: &reqwest::Client,
+    options: &LoginOptions,
+    request_id: &str,
+    verifier: &str,
+) -> Result<console_broker::Brokered> {
+    let deadline = tokio::time::Instant::now() + options.callback_timeout;
+    loop {
+        if let Some(brokered) =
+            console_broker::poll_once(http, &options.control_plane, request_id, verifier).await?
+        {
+            return Ok(brokered);
+        }
+        if tokio::time::Instant::now() + console_broker::POLL_INTERVAL >= deadline {
+            bail!(
+                "nobody approved this login within {}s — the request has expired; run `skardi login` again",
+                options.callback_timeout.as_secs()
+            );
+        }
+        tokio::time::sleep(console_broker::POLL_INTERVAL).await;
+    }
+}
+
+/// Attach the "this credential is live and unrevokable" note to a failure that
+/// happens after the exchange succeeded.
+///
+/// One function so every such site says the same thing: the ID-token flow's
+/// equivalent is `rollback`, which can actually revoke. Here the id is all the
+/// user gets, so it must always be there.
+fn abandoned(token: &Minted, cause: anyhow::Error) -> anyhow::Error {
+    cause.context(format!(
+        "the credential the console minted is live and no context holds it — a browser login holds only a PAT, which cannot revoke tokens at the control plane. Revoke token {} in the console",
+        token.token_id
+    ))
+}
+
 /// Step 1-3: the credential presented to the control plane.
 async fn acquire_bearer(http: &reqwest::Client, options: &LoginOptions) -> Result<String> {
     if let Some(identity) = &options.identity {
@@ -244,6 +457,12 @@ async fn acquire_bearer(http: &reqwest::Client, options: &LoginOptions) -> Resul
         .client_id
         .as_deref()
         .filter(|id| !id.trim().is_empty());
+    // Unreachable through `login` since the console broker became the default
+    // (design 2026-09-08 §9): the condition this refuses — no identity and no
+    // usable client id — is exactly what `uses_console_broker` matches, so
+    // that branch returns before this one is reached. Kept because it is the
+    // invariant THIS function depends on, and one line here is cheaper than a
+    // future caller discovering it by sending an empty client id to Google.
     let Some(client_id) = client_id else {
         bail!(
             "no OAuth client id: pass --client-id, set $SKARDI_OAUTH_CLIENT_ID, or use --identity dev:<id> against a loopback control plane"

--- a/crates/cli/src/login/mod.rs
+++ b/crates/cli/src/login/mod.rs
@@ -29,6 +29,7 @@ use anyhow::{Context as _, Result, anyhow, bail};
 use chrono::{DateTime, Duration, Utc};
 use control_plane::{ControlPlane, CpError, Membership, Minted};
 use std::path::Path;
+use tokio::time::{Instant, sleep};
 
 /// Default PAT lifetime (§6.1 step 5), as `--expires` spells it. A string so
 /// clap's default and this documented value are the same token, parsed by the
@@ -83,6 +84,13 @@ pub struct LoginOptions {
     /// browser path covered rather than argued.
     pub open_browser: fn(&str) -> std::io::Result<()>,
     pub callback_timeout: std::time::Duration,
+    /// How long the brokered flow waits between polls of the exchange.
+    ///
+    /// Injectable for the same reason the timeouts are: the deadline now comes
+    /// from the SERVER's five-minute request expiry, so a test that exercises
+    /// the give-up path would otherwise sleep for five real minutes — which it
+    /// did, taking the suite from 0.3s to 298s.
+    pub poll_interval: std::time::Duration,
     /// Ceiling on the post-mint verification probe (§6.1 step 6).
     pub verify_timeout: std::time::Duration,
     /// The PAT's name at the control plane, `cli@<hostname>`.
@@ -250,11 +258,17 @@ pub async fn login(options: LoginOptions, config_path: &Path) -> Result<LoginRep
 /// it: `SKARDI_OAUTH_CLIENT_ID=` exported into a shell must not select a path
 /// that then fails for want of the value that variable was supposed to carry.
 fn uses_console_broker(options: &LoginOptions) -> bool {
-    options.identity.is_none()
-        && options
-            .client_id
-            .as_deref()
-            .is_none_or(|id| id.trim().is_empty())
+    selects_console_broker(options.identity.as_deref(), options.client_id.as_deref())
+}
+
+/// The same question, asked before a [`LoginOptions`] exists.
+///
+/// `commands::login` needs it to decide which recorded URL to fall back to —
+/// the console that brokers, or the control-plane API itself — and those are
+/// different keys in the config file. One predicate, so the key a brokered
+/// login WRITES is always the key the next brokered login READS.
+pub fn selects_console_broker(identity: Option<&str>, client_id: Option<&str>) -> bool {
+    identity.is_none() && client_id.is_none_or(|id| id.trim().is_empty())
 }
 
 /// The console-brokered flow (design 2026-09-08 §4).
@@ -283,10 +297,10 @@ async fn console_brokered_login(options: LoginOptions, config_path: &Path) -> Re
     match &options.selection {
         Selection::Auto => {}
         Selection::Named(slug) => bail!(
-            "--workspace '{slug}' cannot be honoured through a browser login: the console's consent screen chooses the workspace, and it grants exactly one. Approve '{slug}' in the browser, or use the OAuth flow with --client-id <ID> to select it here"
+            "--workspace '{slug}' cannot be honoured through a browser login: the console's consent screen chooses the workspace, and it grants exactly one. Approve '{slug}' in the browser, or select it from the terminal with --client-id <ID> (or --identity dev:<id> against a loopback control plane)"
         ),
         Selection::All => bail!(
-            "--all-workspaces cannot be honoured through a browser login: one approval grants one workspace. Run this once per workspace, or use the OAuth flow with --client-id <ID>"
+            "--all-workspaces cannot be honoured through a browser login: one approval grants one workspace. Run this once per workspace, or select from the terminal with --client-id <ID> (or --identity dev:<id> against a loopback control plane)"
         ),
     }
 
@@ -332,7 +346,7 @@ async fn console_brokered_login(options: LoginOptions, config_path: &Path) -> Re
         eprintln!("could not open a browser ({err}) — open the URL above yourself");
     }
 
-    let brokered = poll_for_approval(&http, &options, &opened.request_id, &pkce.verifier).await?;
+    let brokered = poll_for_approval(&http, &options, &opened, &pkce.verifier).await?;
 
     // §11.2: the membership rides along, so the context is written without a
     // second round trip. Its absence is exceptional — it means the approved
@@ -409,25 +423,83 @@ async fn console_brokered_login(options: LoginOptions, config_path: &Path) -> Re
 async fn poll_for_approval(
     http: &reqwest::Client,
     options: &LoginOptions,
-    request_id: &str,
+    opened: &console_broker::Opened,
     verifier: &str,
 ) -> Result<console_broker::Brokered> {
-    let deadline = tokio::time::Instant::now() + options.callback_timeout;
+    // The SERVER's expiry, not the local OAuth callback timeout. Those differ
+    // by design — the request lives five minutes and the loopback listener
+    // waits 120 seconds — so using the local one gave up while the request was
+    // still open, and told the human they had not approved in time when they
+    // had two more minutes. The doc above claimed this behaviour before the
+    // code had it.
+    //
+    // An unparseable stamp falls back to the local window rather than failing:
+    // a console that changes its timestamp format should shorten this loop, not
+    // break the login.
+    let budget = match DateTime::parse_from_rfc3339(&opened.expires_at) {
+        Ok(at) => (at.with_timezone(&Utc) - options.now)
+            .to_std()
+            .unwrap_or(options.callback_timeout),
+        Err(_) => options.callback_timeout,
+    };
+    let deadline = Instant::now() + budget;
+    // Whether the request was ever confirmed to exist. It decides how a later
+    // disappearance is reported: gone after we watched it live means it may
+    // have been approved and redeemed by a response we lost.
+    let mut seen_alive = false;
+    let mut transport_failures = 0_u32;
+
     loop {
-        if let Some(brokered) =
-            console_broker::poll_once(http, &options.control_plane, request_id, verifier).await?
+        match console_broker::poll_once(http, &options.control_plane, &opened.request_id, verifier)
+            .await
         {
-            return Ok(brokered);
+            Ok(Some(brokered)) => return Ok(brokered),
+            Ok(None) => {
+                seen_alive = true;
+                transport_failures = 0;
+            }
+            Err(err) => {
+                // A request that vanishes AFTER we saw it alive is the
+                // ambiguous case: the console answers gone/expired/redeemed
+                // identically, so a redemption whose response we lost looks
+                // exactly like an expiry. Say so, because a credential may
+                // exist that this run will never name.
+                if seen_alive && console_broker::is_gone(&err) {
+                    return Err(err.context(
+                        "the login request is gone. If you approved it, a credential may have                          been minted and this run never received it — check Agent access in the                          console and revoke anything you did not keep",
+                    ));
+                }
+                // Transport failures are retried rather than fatal: the poll is
+                // idempotent while the request is pending, and a console
+                // restarting mid-approval should not end a login the human is
+                // still working through.
+                if !console_broker::is_transport(&err) {
+                    return Err(err);
+                }
+                transport_failures += 1;
+                if transport_failures > MAX_TRANSPORT_FAILURES {
+                    return Err(err.context(
+                        "the console stopped answering the CLI-login exchange. If you approved                          the request, check Agent access in the console for a credential this                          run never received",
+                    ));
+                }
+            }
         }
-        if tokio::time::Instant::now() + console_broker::POLL_INTERVAL >= deadline {
+        if Instant::now() + options.poll_interval >= deadline {
             bail!(
                 "nobody approved this login within {}s — the request has expired; run `skardi login` again",
-                options.callback_timeout.as_secs()
+                budget.as_secs()
             );
         }
-        tokio::time::sleep(console_broker::POLL_INTERVAL).await;
+        sleep(options.poll_interval).await;
     }
 }
+
+/// Consecutive transport failures tolerated while polling the exchange.
+///
+/// Small on purpose: the point is to survive a console restart or a dropped
+/// connection mid-approval, not to keep trying at a console that is gone. At
+/// the default poll interval this is a few seconds of grace.
+const MAX_TRANSPORT_FAILURES: u32 = 3;
 
 /// Attach the "this credential is live and unrevokable" note to a failure that
 /// happens after the exchange succeeded.
@@ -767,8 +839,20 @@ fn write_contexts(
         file.current_context = Some(context_name(options, membership));
     }
     // Recorded so a later `login` with no --control-plane reaches the same
-    // control plane this one did.
-    file.control_plane = Some(options.control_plane.clone());
+    // place this one did — under the key that matches WHICH place it is.
+    //
+    // Both flows take the URL from the same `--control-plane` flag, but they
+    // point at different services: the brokered flow is given a console, whose
+    // control-plane API lives under `/api/global/v1/...` and only answers a
+    // browser with a session. Recording a console URL as `control-plane`
+    // poisoned every later direct call — a `logout --revoke` cleared the local
+    // credential and then sent `DELETE /v1/me/tokens/{id}` at the console,
+    // which replied with its own 404 page.
+    if uses_console_broker(options) {
+        file.console = Some(options.control_plane.clone());
+    } else {
+        file.control_plane = Some(options.control_plane.clone());
+    }
     config::save(path, &file)?;
     Ok(replaced)
 }

--- a/crates/cli/src/login/tests.rs
+++ b/crates/cli/src/login/tests.rs
@@ -1616,6 +1616,286 @@ async fn an_unknown_exchange_status_is_reported_rather_than_polled_forever() {
     assert!(err.contains("older than the control plane"), "{err}");
 }
 
+/// A request that disappears AFTER being seen alive is the ambiguous case.
+///
+/// The console answers gone / expired / already-redeemed identically by
+/// design, so a redemption whose response was lost looks exactly like an
+/// expiry. Saying only "it expired" would hide a credential that may exist and
+/// that this run will never name — and a PAT cannot revoke itself at the
+/// control plane, so the console is the only place to clean it up.
+#[tokio::test]
+async fn a_request_that_vanishes_after_being_seen_alive_warns_a_credential_may_exist() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/global/v1/cli-login/requests"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "request_id": "7f3a9c0000000000000000000000abcd",
+            "confirm": "7f3a9c",
+            "expires_at": "2026-08-24T12:00:03Z",
+        })))
+        .mount(&server)
+        .await;
+    // Pending once — which is what makes the request "seen alive" — then gone.
+    Mock::given(method("POST"))
+        .and(path("/api/global/v1/cli-login/exchange"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "status": "pending" })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/api/global/v1/cli-login/exchange"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "error": { "code": "no_such_request", "message": "no such CLI login request" }
+        })))
+        .mount(&server)
+        .await;
+
+    let home = TempDir::new().unwrap();
+    let err = login(broker_options(&server.uri()), &config_in(&home))
+        .await
+        .unwrap_err();
+    let rendered = format!("{err:#}");
+    assert!(
+        rendered.contains("a credential may have been minted"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("Agent access"), "{rendered}");
+    // The underlying cause is still there, not replaced by the warning.
+    assert!(rendered.contains("no longer open"), "{rendered}");
+}
+
+/// A first poll that finds the request already gone is NOT the ambiguous case.
+///
+/// Nothing was ever approved through this run, so claiming a credential might
+/// exist would send the reader hunting for one that does not.
+#[tokio::test]
+async fn a_request_gone_on_the_first_poll_does_not_claim_a_credential_exists() {
+    let console = console(
+        404,
+        json!({ "error": { "code": "no_such_request",
+        "message": "no such CLI login request" } }),
+    )
+    .await;
+    let home = TempDir::new().unwrap();
+    let err = login(broker_options(&console.uri()), &config_in(&home))
+        .await
+        .unwrap_err();
+    let rendered = format!("{err:#}");
+    assert!(rendered.contains("no longer open"), "{rendered}");
+    assert!(
+        !rendered.contains("a credential may have been minted"),
+        "{rendered}"
+    );
+}
+
+/// An unparseable request expiry falls back to the local window rather than
+/// failing the login: a console that changes its timestamp format should
+/// shorten this loop, not break signing in.
+#[tokio::test]
+async fn an_unparseable_request_expiry_falls_back_to_the_local_window() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/global/v1/cli-login/requests"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "request_id": "7f3a9c0000000000000000000000abcd",
+            "confirm": "7f3a9c",
+            "expires_at": "next tuesday",
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/api/global/v1/cli-login/exchange"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "status": "pending" })))
+        .mount(&server)
+        .await;
+
+    let home = TempDir::new().unwrap();
+    let err = login(broker_options(&server.uri()), &config_in(&home))
+        .await
+        .unwrap_err()
+        .to_string();
+    // `options()`'s 50ms callback timeout renders as 0s — the local window,
+    // not a parsed one.
+    assert!(err.contains("nobody approved this login"), "{err}");
+    assert!(err.contains("within 0s"), "{err}");
+}
+
+/// A browser that will not launch is not a failure: the URL is already on
+/// screen, and a headless box is the normal case rather than an error.
+#[tokio::test]
+async fn a_browser_that_cannot_be_opened_does_not_fail_the_login() {
+    let gw = gateway(200).await;
+    let console = console(200, approved("my-ws", &gw.uri(), "tok-1")).await;
+    let home = TempDir::new().unwrap();
+    let mut options = broker_options(&console.uri());
+    // `no_browser` off, so the launch is attempted — and it refuses.
+    options.no_browser = false;
+    options.open_browser = |_| {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "no browser here",
+        ))
+    };
+
+    let report = login(options, &config_in(&home)).await.unwrap();
+    assert_eq!(report.written.len(), 1, "the login still completed");
+}
+
+/// A console that answers the exchange with no recognizable error body still
+/// produces a message naming the status, not an empty one.
+#[tokio::test]
+async fn an_unrecognizable_refusal_still_names_the_status() {
+    let console = console(500, json!({ "unexpected": "shape" })).await;
+    let home = TempDir::new().unwrap();
+    let err = login(broker_options(&console.uri()), &config_in(&home))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("HTTP 500"), "{err}");
+    assert!(err.contains("refused the CLI-login request"), "{err}");
+}
+
+/// An oversized exchange body is refused by the read cap, and that counts as
+/// a TRANSPORT failure — so it is retried rather than ending the login, and
+/// exhausting the retries says the console stopped answering.
+///
+/// One test for two guards: the 1MiB ceiling that stops a runaway endpoint
+/// exhausting memory, and the retry loop that survives a console restarting
+/// mid-approval.
+#[tokio::test]
+async fn an_oversized_exchange_body_is_capped_retried_and_then_reported() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/global/v1/cli-login/requests"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "request_id": "7f3a9c0000000000000000000000abcd",
+            "confirm": "7f3a9c",
+            "expires_at": "2026-08-24T12:00:03Z",
+        })))
+        .mount(&server)
+        .await;
+    // Comfortably past the 1MiB cap.
+    Mock::given(method("POST"))
+        .and(path("/api/global/v1/cli-login/exchange"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("x".repeat(1_200_000)))
+        .mount(&server)
+        .await;
+
+    let home = TempDir::new().unwrap();
+    let err = login(broker_options(&server.uri()), &config_in(&home))
+        .await
+        .unwrap_err();
+    let rendered = format!("{err:#}");
+    assert!(rendered.contains("stopped answering"), "{rendered}");
+    assert!(rendered.contains("refusing to buffer it"), "{rendered}");
+}
+
+/// A config write that cannot land strands the credential, and says so by id.
+///
+/// The exchange already committed, so a PAT exists — and a browser login
+/// cannot revoke it. Pointing the config at a path whose parent is a FILE
+/// makes the write fail the way a read-only home would.
+#[tokio::test]
+async fn a_config_write_that_fails_reports_the_stranded_credential_by_id() {
+    let gw = gateway(200).await;
+    let console = console(200, approved("my-ws", &gw.uri(), "tok-stranded")).await;
+    let home = TempDir::new().unwrap();
+    let blocker = home.path().join(".skardi");
+    std::fs::write(&blocker, "not a directory").unwrap();
+
+    let err = login(broker_options(&console.uri()), &blocker.join("config.yaml"))
+        .await
+        .unwrap_err();
+    let rendered = format!("{err:#}");
+    assert!(rendered.contains("Revoke token tok-stranded"), "{rendered}");
+    assert!(rendered.contains("cannot revoke"), "{rendered}");
+}
+
+/// A reused request id is refused by PKCE, and the message says to start over
+/// rather than to retype anything.
+#[tokio::test]
+async fn a_verifier_mismatch_tells_the_user_to_start_a_fresh_login() {
+    let console = console(
+        403,
+        json!({ "error": { "code": "verifier_mismatch",
+        "message": "the PKCE verifier does not match this request" } }),
+    )
+    .await;
+    let home = TempDir::new().unwrap();
+    let err = login(broker_options(&console.uri()), &config_in(&home))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("proof of ownership"), "{err}");
+    assert!(err.contains("start a fresh"), "{err}");
+}
+
+/// An error envelope carrying a code but no message still names the status,
+/// rather than rendering an empty sentence.
+#[tokio::test]
+async fn a_refusal_with_no_message_names_the_status_instead() {
+    let console = console(500, json!({ "error": { "code": "internal" } })).await;
+    let home = TempDir::new().unwrap();
+    let err = login(broker_options(&console.uri()), &config_in(&home))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("HTTP 500"), "{err}");
+    assert!(!err.contains(": (HTTP"), "no empty message clause: {err}");
+}
+
+/// A console that opens a request with no id is refused, rather than polling
+/// an exchange that can never match.
+#[tokio::test]
+async fn an_opened_request_with_no_id_is_refused() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/global/v1/cli-login/requests"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "request_id": "",
+            "confirm": "",
+            "expires_at": "2026-08-24T12:00:03Z",
+        })))
+        .mount(&server)
+        .await;
+
+    let home = TempDir::new().unwrap();
+    let err = login(broker_options(&server.uri()), &config_in(&home))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("no id"), "{err}");
+}
+
+/// An exchange answering 200 with an empty body is an unknown state, not a
+/// pending one — polling forever on it would blame the human for not
+/// approving.
+#[tokio::test]
+async fn an_empty_exchange_body_is_reported_as_an_unexpected_status() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/global/v1/cli-login/requests"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "request_id": "7f3a9c0000000000000000000000abcd",
+            "confirm": "7f3a9c",
+            "expires_at": "2026-08-24T12:00:03Z",
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/api/global/v1/cli-login/exchange"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(""))
+        .mount(&server)
+        .await;
+
+    let home = TempDir::new().unwrap();
+    let err = login(broker_options(&server.uri()), &config_in(&home))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("unexpected status"), "{err}");
+}
+
 #[test]
 fn the_console_broker_is_the_default_and_either_credential_flag_opts_out() {
     let base = |identity: Option<&str>, client_id: Option<&str>| {

--- a/crates/cli/src/login/tests.rs
+++ b/crates/cli/src/login/tests.rs
@@ -698,7 +698,17 @@ async fn a_non_dev_identity_bearer_is_refused_by_shape() {
 }
 
 #[tokio::test]
-async fn the_browser_path_needs_a_client_id_and_says_so() {
+async fn a_missing_client_id_now_brokers_through_the_console_instead_of_failing() {
+    // This case used to be a dead end: no identity and no usable client id
+    // meant "no OAuth client id: pass --client-id, set
+    // $SKARDI_OAUTH_CLIENT_ID, or use --identity dev:<id>". Every deployment
+    // that wanted CLI access therefore had to provision a Google Desktop
+    // client first, which is the whole problem design 2026-09-08 removes.
+    //
+    // It is now the DEFAULT path, so the assertion inverts: the flow proceeds
+    // and fails at the console, not at the flag check. `127.0.0.1:1` answers
+    // nothing, so the error names the console it could not reach — proof the
+    // broker was selected rather than the OAuth path.
     let home = TempDir::new().unwrap();
     let mut options = options("http://127.0.0.1:1", Some("http://gw.example"));
     options.identity = None;
@@ -707,8 +717,12 @@ async fn the_browser_path_needs_a_client_id_and_says_so() {
         .await
         .unwrap_err()
         .to_string();
-    assert!(err.contains("--client-id"), "{err}");
-    assert!(err.contains("SKARDI_OAUTH_CLIENT_ID"), "{err}");
+    assert!(err.contains("cannot reach the console"), "{err}");
+    assert!(err.contains("cli-login/requests"), "{err}");
+    assert!(
+        !err.contains("SKARDI_OAUTH_CLIENT_ID"),
+        "a client id is no longer required: {err}"
+    );
 }
 
 #[tokio::test]
@@ -1192,4 +1206,372 @@ async fn a_rejected_probe_does_not_advise_the_env_var_it_refuses() {
         ["tok-1"]
     );
     assert!(!path.exists());
+}
+
+// ── The console-brokered flow (design 2026-09-08) ────────────────────────
+//
+// Driven against a wiremock CONSOLE rather than a control plane, because that
+// is what the CLI talks to on this path: skardi-global has no public ingress
+// in any deployment we run, which is the reason the flow exists. The two
+// session-less routes are forwarded by the console's BFF under
+// `/api/global/v1/cli-login/*`.
+
+/// A console whose exchange answers `body` with `status`.
+///
+/// The open call always succeeds — every case below is about what happens
+/// after a request exists.
+async fn console(status: u16, exchange_body: Value) -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/global/v1/cli-login/requests"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "request_id": "7f3a9c0000000000000000000000abcd",
+            "confirm": "7f3a9c",
+            "expires_at": "2026-08-24T12:05:00Z",
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/api/global/v1/cli-login/exchange"))
+        .respond_with(ResponseTemplate::new(status).set_body_json(exchange_body))
+        .mount(&server)
+        .await;
+    server
+}
+
+/// An approved exchange for one workspace, with the membership §11.2 sends
+/// along.
+fn approved(workspace: &str, gateway_url: &str, token_id: &str) -> Value {
+    json!({
+        "status": "approved",
+        "token": format!("skardi_pat_{token_id}"),
+        "token_id": token_id,
+        "expires_at": "2026-11-22T12:00:00Z",
+        "workspace": workspace,
+        "memberships": [membership("acme", workspace, "active", Some(gateway_url))],
+    })
+}
+
+/// A config file already holding a cloud context for `acme/my-ws`, so the
+/// replacement rule has something to replace.
+fn existing_cloud_context() -> String {
+    [
+        "contexts:",
+        "  - name: acme/my-ws",
+        "    mode: cloud",
+        "    server: http://gw.example",
+        "    workspace: my-ws",
+        "    token: skardi_pat_old",
+        "    token-id: tok-old",
+    ]
+    .join("\n")
+        + "\n"
+}
+
+/// The brokered path's own options: no identity and no client id, which is
+/// what selects it (§9).
+fn broker_options(console_base: &str) -> LoginOptions {
+    let mut options = options(console_base, None);
+    options.identity = None;
+    options.client_id = None;
+    options
+}
+
+#[tokio::test]
+async fn a_browser_login_writes_the_context_from_the_token_the_console_brokered() {
+    let gw = gateway(200).await;
+    let console = console(200, approved("my-ws", &gw.uri(), "tok-1")).await;
+    let home = TempDir::new().unwrap();
+
+    let report = login(broker_options(&console.uri()), &config_in(&home))
+        .await
+        .unwrap();
+
+    assert_eq!(report.written.len(), 1, "one approval, one workspace");
+    let written = &report.written[0];
+    assert_eq!(written.name, "acme/my-ws");
+    assert_eq!(written.workspace, "my-ws");
+    assert_eq!(report.current_context.as_deref(), Some("acme/my-ws"));
+
+    // No mint and no membership listing: the console already did both, which
+    // is what makes this path work with no client id and no IdP.
+    let seen = console.received_requests().await.unwrap();
+    assert!(
+        mint_bodies(&seen).is_empty(),
+        "the CLI must not mint on this path"
+    );
+    assert!(
+        !seen.iter().any(|r| r.url.path() == "/v1/me/workspaces"),
+        "memberships ride along with the exchange (§11.2)"
+    );
+
+    // The context holds the brokered token AND its id — the id is what a later
+    // login names when it replaces this credential.
+    let file = read_yaml(&config_in(&home));
+    let context = &file["contexts"][0];
+    assert_eq!(context["token"].as_str(), Some("skardi_pat_tok-1"));
+    assert_eq!(context["token-id"].as_str(), Some("tok-1"));
+}
+
+#[tokio::test]
+async fn the_open_call_carries_the_pkce_challenge_the_expiry_and_the_machine_name() {
+    let gw = gateway(200).await;
+    let console = console(200, approved("my-ws", &gw.uri(), "tok-1")).await;
+    let home = TempDir::new().unwrap();
+    login(broker_options(&console.uri()), &config_in(&home))
+        .await
+        .unwrap();
+
+    let seen = console.received_requests().await.unwrap();
+    let opened: Value = seen
+        .iter()
+        .find(|r| r.url.path() == "/api/global/v1/cli-login/requests")
+        .map(|r| serde_json::from_slice(&r.body).unwrap())
+        .expect("the flow opens a request");
+
+    // 43 characters is RFC 7636's floor and what `Pkce` produces; the server
+    // refuses anything outside 43..=128.
+    let challenge = opened["challenge"].as_str().unwrap();
+    assert_eq!(challenge.len(), 43, "an S256 challenge: {challenge}");
+    // `--expires` has to ride the OPEN call: the mint happens minutes later in
+    // a browser that never sees the flag.
+    assert_eq!(
+        opened["token_expires_at"].as_str(),
+        Some("2026-11-22T12:00:00+00:00"),
+        "90 days from the injected clock"
+    );
+    // What the consent screen shows, and what the PAT is named upstream — one
+    // name per machine whichever flow wrote it.
+    assert_eq!(opened["client_desc"].as_str(), Some("cli@test-host"));
+
+    // And the exchange proves ownership with the verifier, never the challenge.
+    let exchanged: Value = seen
+        .iter()
+        .find(|r| r.url.path() == "/api/global/v1/cli-login/exchange")
+        .map(|r| serde_json::from_slice(&r.body).unwrap())
+        .expect("the flow polls the exchange");
+    let verifier = exchanged["verifier"].as_str().unwrap();
+    assert_ne!(verifier, challenge, "the verifier is not the challenge");
+    assert_eq!(
+        exchanged["request_id"].as_str(),
+        Some("7f3a9c0000000000000000000000abcd")
+    );
+}
+
+#[tokio::test]
+async fn a_browser_login_refuses_the_flags_it_cannot_honour() {
+    // The consent screen grants exactly one workspace (§11.1), so neither flag
+    // has an honest reading here — and quietly logging into one workspace when
+    // `--all-workspaces` was asked for is a success discovered much later.
+    for (selection, expected) in [
+        (Selection::Named("other".to_string()), "--workspace 'other'"),
+        (Selection::All, "--all-workspaces"),
+    ] {
+        let home = TempDir::new().unwrap();
+        let mut options = broker_options("http://127.0.0.1:1");
+        options.selection = selection;
+        let err = login(options, &config_in(&home))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains(expected), "{err}");
+        // Points at the flow that CAN do it, rather than only refusing.
+        assert!(err.contains("--client-id"), "{err}");
+    }
+}
+
+#[tokio::test]
+async fn a_console_without_the_cli_login_route_says_so_and_names_the_alternative() {
+    // What an older console looks like from here: its BFF allowlist has no
+    // CLI-login entry, so its own proxy answers 403. Nothing the user retypes
+    // fixes it, so the message has to name the flag that still works.
+    let console = console(
+        403,
+        json!({ "error": { "code": "route_not_allowed",
+        "message": "this endpoint is not part of the console surface" } }),
+    )
+    .await;
+    let home = TempDir::new().unwrap();
+    let err = login(broker_options(&console.uri()), &config_in(&home))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("does not support browser-brokered"), "{err}");
+    assert!(err.contains("--client-id"), "{err}");
+}
+
+#[tokio::test]
+async fn an_expired_or_redeemed_request_tells_the_user_to_run_login_again() {
+    // One server answer covers expired, unknown and already-redeemed —
+    // deliberately, so the endpoint cannot enumerate live ids — so the CLI has
+    // to translate it into the action that fixes all three.
+    let console = console(
+        404,
+        json!({ "error": { "code": "no_such_request",
+        "message": "no such CLI login request" } }),
+    )
+    .await;
+    let home = TempDir::new().unwrap();
+    let err = login(broker_options(&console.uri()), &config_in(&home))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("no longer open"), "{err}");
+    assert!(err.contains("skardi login"), "{err}");
+}
+
+#[tokio::test]
+async fn nobody_approving_expires_with_the_deadline_named() {
+    let console = console(200, json!({ "status": "pending" })).await;
+    let home = TempDir::new().unwrap();
+    let err = login(broker_options(&console.uri()), &config_in(&home))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("nobody approved this login"), "{err}");
+    // Nothing was written, and there is no credential to warn about — the
+    // exchange never handed one over.
+    assert!(
+        !config_in(&home).exists(),
+        "no context on an unapproved login"
+    );
+    assert!(!err.contains("Revoke token"), "nothing was minted: {err}");
+}
+
+#[tokio::test]
+async fn a_brokered_credential_that_cannot_query_is_reported_by_id_not_revoked() {
+    // The saga's counterpart revokes here. This path cannot: a PAT
+    // authenticates to the gateway, and skardi-global's `/v1/*` does not
+    // accept one — so the id is the only thing standing between the user and
+    // a live credential nobody knows exists.
+    let gw = gateway(403).await;
+    let console = console(200, approved("my-ws", &gw.uri(), "tok-live")).await;
+    let home = TempDir::new().unwrap();
+
+    let err = login(broker_options(&console.uri()), &config_in(&home))
+        .await
+        .unwrap_err();
+    let rendered = format!("{err:#}");
+    assert!(rendered.contains("could not query"), "{rendered}");
+    assert!(rendered.contains("Revoke token tok-live"), "{rendered}");
+    assert!(rendered.contains("cannot revoke"), "{rendered}");
+    // And no context was written, so the failure is not half-committed.
+    assert!(!config_in(&home).exists(), "{rendered}");
+}
+
+#[tokio::test]
+async fn a_brokered_relogin_reports_the_replaced_token_it_cannot_revoke() {
+    let gw = gateway(200).await;
+    let console = console(200, approved("my-ws", &gw.uri(), "tok-2")).await;
+    let home = TempDir::new().unwrap();
+    let path = config_in(&home);
+
+    // A context already holding a credential from an earlier login.
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, existing_cloud_context()).unwrap();
+
+    let report = login(broker_options(&console.uri()), &config_in(&home))
+        .await
+        .unwrap();
+
+    // Nothing was revoked, and nothing pretends to have been: the old id is
+    // reported through the same channel a FAILED revoke uses, because the
+    // outcome for the user is identical — go revoke it in the console.
+    assert!(report.replaced_revoked.is_empty());
+    assert_eq!(report.revoke_failures.len(), 1);
+    let (token_id, reason) = &report.revoke_failures[0];
+    assert_eq!(token_id, "tok-old");
+    assert!(reason.contains("cannot revoke"), "{reason}");
+    assert!(
+        revoked_ids(&console.received_requests().await.unwrap()).is_empty(),
+        "the CLI must not attempt a revoke it cannot authenticate"
+    );
+
+    // The new credential did land.
+    let file = read_yaml(&path);
+    assert_eq!(file["contexts"][0]["token-id"].as_str(), Some("tok-2"));
+}
+
+#[tokio::test]
+async fn keep_old_token_reports_the_replacement_as_kept_rather_than_stranded() {
+    let gw = gateway(200).await;
+    let console = console(200, approved("my-ws", &gw.uri(), "tok-2")).await;
+    let home = TempDir::new().unwrap();
+    let path = config_in(&home);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, existing_cloud_context()).unwrap();
+
+    let mut options = broker_options(&console.uri());
+    options.keep_old_token = true;
+    let report = login(options, &config_in(&home)).await.unwrap();
+
+    // Asked for deliberately, so it is not a warning — an agent mid-task is
+    // still holding the old credential.
+    assert_eq!(report.replaced_kept, vec!["tok-old".to_string()]);
+    assert!(report.revoke_failures.is_empty());
+}
+
+#[tokio::test]
+async fn an_approval_with_no_membership_is_fatal_and_names_the_live_token() {
+    // Exceptional: the approved membership vanished between approval and
+    // redemption. Fatal because the context name is `<org>/<workspace>` and
+    // the org slug has nowhere else to come from — and by this point a
+    // credential exists that this CLI cannot revoke.
+    let console = console(
+        200,
+        json!({
+            "status": "approved",
+            "token": "skardi_pat_orphan",
+            "token_id": "tok-orphan",
+            "workspace": "my-ws",
+            "memberships": [],
+        }),
+    )
+    .await;
+    let home = TempDir::new().unwrap();
+    let err = login(broker_options(&console.uri()), &config_in(&home))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("no membership"), "{err}");
+    assert!(err.contains("revoke token tok-orphan"), "{err}");
+}
+
+#[tokio::test]
+async fn an_unknown_exchange_status_is_reported_rather_than_polled_forever() {
+    // A control plane newer than this CLI. Treating an unrecognised terminal
+    // state as "pending" would spin until the deadline and then blame the
+    // human for not approving.
+    let console = console(200, json!({ "status": "superseded" })).await;
+    let home = TempDir::new().unwrap();
+    let err = login(broker_options(&console.uri()), &config_in(&home))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("unexpected status"), "{err}");
+    assert!(err.contains("older than the control plane"), "{err}");
+}
+
+#[test]
+fn the_console_broker_is_the_default_and_either_credential_flag_opts_out() {
+    let base = |identity: Option<&str>, client_id: Option<&str>| {
+        let mut options = options("http://127.0.0.1:1", None);
+        options.identity = identity.map(str::to_string);
+        options.client_id = client_id.map(str::to_string);
+        options
+    };
+    // §9: with neither flag, the console brokers — which is what makes
+    // `skardi login --control-plane <url>` work with no other argument.
+    assert!(super::uses_console_broker(&base(None, None)));
+    // An empty client id counts as absent, the same way `acquire_bearer`
+    // treats it: `SKARDI_OAUTH_CLIENT_ID=` exported into a shell must not
+    // select a path that then fails for want of that variable's value.
+    assert!(super::uses_console_broker(&base(None, Some("   "))));
+    // Either flag names a way for the CLI to authenticate itself, and keeps
+    // the existing flow.
+    assert!(!super::uses_console_broker(&base(
+        None,
+        Some("client-123.apps.googleusercontent.com")
+    )));
+    assert!(!super::uses_console_broker(&base(Some("dev:alice"), None)));
 }

--- a/crates/cli/src/login/tests.rs
+++ b/crates/cli/src/login/tests.rs
@@ -1616,15 +1616,20 @@ async fn an_unknown_exchange_status_is_reported_rather_than_polled_forever() {
     assert!(err.contains("older than the control plane"), "{err}");
 }
 
-/// A request that disappears AFTER being seen alive is the ambiguous case.
+/// `pending → clean gone` is an EXPIRY, and must not claim a credential exists.
 ///
-/// The console answers gone / expired / already-redeemed identically by
-/// design, so a redemption whose response was lost looks exactly like an
-/// expiry. Saying only "it expired" would hide a credential that may exist and
-/// that this run will never name — and a PAT cannot revoke itself at the
-/// control plane, so the console is the only place to clean it up.
+/// This INVERTS an assertion from the previous review round, because its
+/// premise was wrong. A credential can only exist if the exchange committed; a
+/// clean `gone` says it did not consume on that call, and `pending` says the
+/// same about the call before. Only this process holds the PKCE verifier, so
+/// nobody else could have redeemed the request either. What is left is the
+/// request expiring between two polls — exactly what the plain message says.
+///
+/// Warning here would send the reader hunting through Agent access for a token
+/// that cannot exist. The real ambiguity is keyed on a lost RESPONSE, covered
+/// by the two cases below.
 #[tokio::test]
-async fn a_request_that_vanishes_after_being_seen_alive_warns_a_credential_may_exist() {
+async fn a_request_that_expires_between_polls_is_not_reported_as_ambiguous() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/api/global/v1/cli-login/requests"))
@@ -1635,10 +1640,57 @@ async fn a_request_that_vanishes_after_being_seen_alive_warns_a_credential_may_e
         })))
         .mount(&server)
         .await;
-    // Pending once — which is what makes the request "seen alive" — then gone.
+    // Pending once, then gone — with every response arriving cleanly, so
+    // nothing was ever lost in transit.
     Mock::given(method("POST"))
         .and(path("/api/global/v1/cli-login/exchange"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "status": "pending" })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/api/global/v1/cli-login/exchange"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "error": { "code": "no_such_request", "message": "no such CLI login request" }
+        })))
+        .mount(&server)
+        .await;
+
+    let home = TempDir::new().unwrap();
+    let err = login(broker_options(&server.uri()), &config_in(&home))
+        .await
+        .unwrap_err();
+    let rendered = format!("{err:#}");
+    assert!(rendered.contains("no longer open"), "{rendered}");
+    assert!(
+        !rendered.contains("a credential may have been minted"),
+        "no response was lost, so nothing could have been minted: {rendered}"
+    );
+}
+
+/// A malformed SUCCESS body on the exchange is treated as a lost response.
+///
+/// The worst case this guards: the server consumed the request and minted the
+/// PAT, and the only copy of that token was in a body that will not parse.
+/// Reported as a clean error the loop exits silently; marked as transport it is
+/// retried, and the `no_such_request` that follows — because the request really
+/// was consumed — is reported as the ambiguity it is.
+#[tokio::test]
+async fn a_truncated_exchange_body_then_gone_warns_a_credential_may_exist() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/global/v1/cli-login/requests"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "request_id": "7f3a9c0000000000000000000000abcd",
+            "confirm": "7f3a9c",
+            "expires_at": "2026-08-24T12:00:03Z",
+        })))
+        .mount(&server)
+        .await;
+    // 200 with a truncated body: the mint committed, the token is unreadable.
+    Mock::given(method("POST"))
+        .and(path("/api/global/v1/cli-login/exchange"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("{\"status\":\"appro"))
         .up_to_n_times(1)
         .mount(&server)
         .await;
@@ -1660,8 +1712,52 @@ async fn a_request_that_vanishes_after_being_seen_alive_warns_a_credential_may_e
         "{rendered}"
     );
     assert!(rendered.contains("Agent access"), "{rendered}");
-    // The underlying cause is still there, not replaced by the warning.
     assert!(rendered.contains("no longer open"), "{rendered}");
+}
+
+/// Approval landing BEFORE the first poll, with that first response lost.
+///
+/// The hole the previous fix left: the flag was set only by a `pending`
+/// answer, so a run that never sees one — approval already done when the first
+/// poll goes out — kept it false and reported a real ambiguity as a plain
+/// "rerun login". Keying on the lost response covers it, because there is no
+/// earlier poll to have seen anything.
+#[tokio::test]
+async fn a_lost_first_response_then_gone_warns_without_ever_seeing_pending() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/global/v1/cli-login/requests"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "request_id": "7f3a9c0000000000000000000000abcd",
+            "confirm": "7f3a9c",
+            "expires_at": "2026-08-24T12:00:03Z",
+        })))
+        .mount(&server)
+        .await;
+    // The very FIRST exchange: committed server-side, answer unreadable.
+    Mock::given(method("POST"))
+        .and(path("/api/global/v1/cli-login/exchange"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("not json"))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/api/global/v1/cli-login/exchange"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "error": { "code": "no_such_request", "message": "no such CLI login request" }
+        })))
+        .mount(&server)
+        .await;
+
+    let home = TempDir::new().unwrap();
+    let err = login(broker_options(&server.uri()), &config_in(&home))
+        .await
+        .unwrap_err();
+    let rendered = format!("{err:#}");
+    assert!(
+        rendered.contains("a credential may have been minted"),
+        "no `pending` was ever seen, and the warning must still fire: {rendered}"
+    );
 }
 
 /// A first poll that finds the request already gone is NOT the ambiguous case.

--- a/crates/cli/src/login/tests.rs
+++ b/crates/cli/src/login/tests.rs
@@ -11,6 +11,7 @@ use super::{
     LoginOptions, Selection, login, oauth, parse_expires, render_workspace_menu, select_memberships,
 };
 use chrono::{DateTime, Duration, Utc};
+use rstest::rstest;
 use serde_json::{Value, json};
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
@@ -121,6 +122,7 @@ fn options(control_plane: &str, server_override: Option<&str>) -> LoginOptions {
         open_browser: oauth::open_in_browser,
         verify_timeout: std::time::Duration::from_millis(200),
         callback_timeout: std::time::Duration::from_millis(50),
+        poll_interval: std::time::Duration::from_millis(1),
         token_name: "cli@test-host".to_string(),
         now: at("2026-08-24T12:00:00Z"),
     }
@@ -1227,7 +1229,11 @@ async fn console(status: u16, exchange_body: Value) -> MockServer {
         .respond_with(ResponseTemplate::new(201).set_body_json(json!({
             "request_id": "7f3a9c0000000000000000000000abcd",
             "confirm": "7f3a9c",
-            "expires_at": "2026-08-24T12:05:00Z",
+            // Three seconds past `options()`'s frozen clock, not the real
+            // five minutes: the deadline is derived from THIS value, so the
+            // production TTL here would make the give-up test sleep for five
+            // actual minutes.
+            "expires_at": "2026-08-24T12:00:03Z",
         })))
         .mount(&server)
         .await;
@@ -1358,26 +1364,29 @@ async fn the_open_call_carries_the_pkce_challenge_the_expiry_and_the_machine_nam
     );
 }
 
+#[rstest]
+#[case::workspace(Selection::Named("other".to_string()), "--workspace 'other'")]
+#[case::all_workspaces(Selection::All, "--all-workspaces")]
 #[tokio::test]
-async fn a_browser_login_refuses_the_flags_it_cannot_honour() {
+async fn a_browser_login_refuses_the_flags_it_cannot_honour(
+    #[case] selection: Selection,
+    #[case] expected: &str,
+) {
     // The consent screen grants exactly one workspace (§11.1), so neither flag
     // has an honest reading here — and quietly logging into one workspace when
     // `--all-workspaces` was asked for is a success discovered much later.
-    for (selection, expected) in [
-        (Selection::Named("other".to_string()), "--workspace 'other'"),
-        (Selection::All, "--all-workspaces"),
-    ] {
-        let home = TempDir::new().unwrap();
-        let mut options = broker_options("http://127.0.0.1:1");
-        options.selection = selection;
-        let err = login(options, &config_in(&home))
-            .await
-            .unwrap_err()
-            .to_string();
-        assert!(err.contains(expected), "{err}");
-        // Points at the flow that CAN do it, rather than only refusing.
-        assert!(err.contains("--client-id"), "{err}");
-    }
+    let home = TempDir::new().unwrap();
+    let mut options = broker_options("http://127.0.0.1:1");
+    options.selection = selection;
+    let err = login(options, &config_in(&home))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains(expected), "{err}");
+    // Points at the flows that CAN do it, rather than only refusing. Both are
+    // named, because `--identity` opts out of the broker too.
+    assert!(err.contains("--client-id"), "{err}");
+    assert!(err.contains("--identity"), "{err}");
 }
 
 #[tokio::test]
@@ -1436,6 +1445,61 @@ async fn nobody_approving_expires_with_the_deadline_named() {
         "no context on an unapproved login"
     );
     assert!(!err.contains("Revoke token"), "nothing was minted: {err}");
+}
+
+/// The give-up deadline comes from the SERVER's request expiry, not from the
+/// local OAuth callback timeout.
+///
+/// The two differ by design — a brokered request lives five minutes, the
+/// loopback listener waits 120 seconds — so using the local one abandoned the
+/// poll while the request was still open and told the human they had not
+/// approved in time when they had minutes left. `options()` sets a 50ms
+/// callback timeout and the console reports an expiry 3s past the frozen
+/// clock, so the reported budget names which one was used.
+#[tokio::test]
+async fn the_poll_deadline_comes_from_the_request_expiry_not_the_callback_timeout() {
+    let console = console(200, json!({ "status": "pending" })).await;
+    let home = TempDir::new().unwrap();
+    let options = broker_options(&console.uri());
+    assert_eq!(
+        options.callback_timeout,
+        std::time::Duration::from_millis(50),
+        "the fixture must make the two budgets distinguishable"
+    );
+
+    let err = login(options, &config_in(&home))
+        .await
+        .unwrap_err()
+        .to_string();
+    // 3s is the console's expiry; the callback timeout would render as 0s.
+    assert!(err.contains("within 3s"), "{err}");
+    assert!(!err.contains("within 0s"), "{err}");
+}
+
+/// A brokered login records the console under `console:`, leaving
+/// `control-plane:` alone.
+///
+/// They are different services: `ControlPlane` appends bare `/v1/me/...`,
+/// while a console serves that API under `/api/global/v1/...` and only to a
+/// browser holding a session. Recording a console URL as `control-plane`
+/// poisoned every later direct call — a `logout --revoke` cleared the local
+/// credential and then sent `DELETE /v1/me/tokens/{id}` at the console, which
+/// replied with its own 404 page.
+#[tokio::test]
+async fn a_brokered_login_records_the_console_url_under_its_own_key() {
+    let gw = gateway(200).await;
+    let console = console(200, approved("my-ws", &gw.uri(), "tok-1")).await;
+    let home = TempDir::new().unwrap();
+    login(broker_options(&console.uri()), &config_in(&home))
+        .await
+        .unwrap();
+
+    let file = read_yaml(&config_in(&home));
+    assert_eq!(file["console"].as_str(), Some(console.uri().as_str()));
+    assert!(
+        file["control-plane"].is_null(),
+        "a console URL must not become the control-plane API base: {file:?}"
+    );
 }
 
 #[tokio::test]

--- a/crates/cli/tests/login_e2e.rs
+++ b/crates/cli/tests/login_e2e.rs
@@ -251,7 +251,11 @@ fn the_direct_flow_names_the_control_plane_key_instead() {
     let home = TempDir::new().unwrap();
     let output = skardi(
         home.path(),
-        &["login", "--client-id", "client-123.apps.googleusercontent.com"],
+        &[
+            "login",
+            "--client-id",
+            "client-123.apps.googleusercontent.com",
+        ],
     );
 
     assert_eq!(output.status.code(), Some(1));

--- a/crates/cli/tests/login_e2e.rs
+++ b/crates/cli/tests/login_e2e.rs
@@ -222,8 +222,14 @@ fn a_cleartext_control_plane_is_warned_about_before_anything_is_sent() {
     }
 }
 
-/// With no `--control-plane`, no environment, and no `control-plane:` in the
-/// file, the failure names all three rather than dialing a guess.
+/// With no `--control-plane`, no environment, and nothing recorded in the
+/// file, the failure names all three rather than dialing a guess — and it
+/// names the file key belonging to the flow that ran.
+///
+/// Bare `skardi login` is the console-brokered flow, so the key is `console:`.
+/// That is not cosmetic: a console and the control-plane API are different
+/// services with different path layouts, so telling a brokered user to add
+/// `control-plane:` would configure the flow they are not using.
 #[test]
 fn no_control_plane_anywhere_names_the_three_inputs() {
     let home = TempDir::new().unwrap();
@@ -233,7 +239,25 @@ fn no_control_plane_anywhere_names_the_three_inputs() {
     let stderr = err(&output);
     assert!(stderr.contains("--control-plane"), "{stderr}");
     assert!(stderr.contains("SKARDI_CONTROL_PLANE_URL"), "{stderr}");
+    assert!(stderr.contains("console:"), "{stderr}");
+}
+
+/// The direct-OAuth flow names `control-plane:`, the key IT reads.
+///
+/// The pair of tests is the point: one flag changes which service the URL
+/// belongs to, and so which key the message should send the reader to.
+#[test]
+fn the_direct_flow_names_the_control_plane_key_instead() {
+    let home = TempDir::new().unwrap();
+    let output = skardi(
+        home.path(),
+        &["login", "--client-id", "client-123.apps.googleusercontent.com"],
+    );
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = err(&output);
     assert!(stderr.contains("control-plane:"), "{stderr}");
+    assert!(!stderr.contains("console:"), "{stderr}");
 }
 
 /// The global `--token`/`--server` flags mean nothing to these two commands,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -162,35 +162,81 @@ headers before forwarding upstream.
 workspace and writes a context for each, so nothing is copied by hand:
 
 ```bash
-# Sign in; a lone workspace is used automatically, several prompt
-skardi login --control-plane https://global.skardi.ai \
-  --client-id <your-deployment's-oauth-client-id>
+# The default: the console signs you in and approves the token
+skardi login --control-plane https://skardi-console.example.com
 
-# With both pinned in the environment, the flags go away
-export SKARDI_CONTROL_PLANE_URL=https://global.skardi.ai
-export SKARDI_OAUTH_CLIENT_ID=<client-id>
-skardi login
-
-# Non-interactive selection
-skardi login --workspace acme-prod
-skardi login --all-workspaces
-
-# Print the sign-in URL instead of opening a browser
+# Print the approval URL instead of opening a browser — works over SSH
 skardi login --no-browser
 
 # Shorter-lived credential (default: 90d; `12h` also works)
 skardi login --expires 30d
 ```
 
-Two inputs have no built-in default, and both fail by name rather than
-guessing: the **control plane** (`--control-plane` >
-`$SKARDI_CONTROL_PLANE_URL` > `control-plane:` in the config file) and the
-**OAuth client id** (`--client-id` > `$SKARDI_OAUTH_CLIENT_ID`). The client id
-is per deployment — it is the same value the deployment gives its console — so
-there is nothing correct to hardcode. Once a `login` succeeds, the control
-plane is recorded in the config file and later runs need no flag for it.
+There are **two ways in**, and which one runs depends on whether you name a
+credential for the CLI itself:
 
-What it does, in order:
+| You pass | What happens |
+|---|---|
+| nothing | **Console-brokered** (the default). The CLI opens a page on the console; the console signs you in with whatever it accepts — email or Google — and you approve one workspace |
+| `--client-id <ID>` | **Direct OAuth**. The CLI talks to the identity provider itself and mints per workspace, which is what `--workspace` and `--all-workspaces` need |
+| `--identity dev:<id>` | Dev auth, loopback control planes only |
+
+The console-brokered path is the default because the alternative needs a
+Google **Desktop** OAuth client provisioned per deployment before anyone can
+log in at all. Here the CLI speaks to no identity provider, learns nothing
+about which one you used, and needs no client id.
+
+Only one input has no built-in default, and it fails by name rather than
+guessing: the **control plane** (`--control-plane` >
+`$SKARDI_CONTROL_PLANE_URL` > `control-plane:` in the config file). For the
+brokered path this is the **console's** URL — the same address you open in a
+browser — because that is what serves the approval page. Once a `login`
+succeeds it is recorded in the config file and later runs need no flag.
+
+The direct-OAuth path additionally needs the **OAuth client id**
+(`--client-id` > `$SKARDI_OAUTH_CLIENT_ID`), which is per deployment, so
+there is nothing correct to hardcode.
+
+### The console-brokered flow, in order
+
+```
+$ skardi login --control-plane https://skardi-console.example.com
+opening https://skardi-console.example.com/cli-login?request_id=7f3a9c…
+waiting for approval in the browser (the request expires at 2026-09-09T12:05:00Z)
+  confirmation code: 7f3a9c
+wrote context 'acme/my-workspace' (current)
+```
+
+1. Opens a login request on the console and prints the URL, the deadline, and
+   a **confirmation code**.
+2. Opens your browser at that URL (`--no-browser` just prints it).
+3. The console signs you in if you are not already, on its own `/login`.
+4. You pick **one** workspace and retype the confirmation code. The code is
+   required, not decorative: the console's *Waiting for approval* list under
+   Agent access shows the same six characters and no request id, so an
+   approver has to be looking at the terminal that started the login. Without
+   it, someone could open a request, never visit it, and collect a token
+   belonging to whoever approved it from that list.
+5. The CLI polls until you approve, then receives a token scoped to that one
+   workspace at your role there, verifies it against the gateway, and writes
+   the context.
+
+The request expires in five minutes. If nobody approves it, the CLI says so
+and writes nothing.
+
+Two consequences of the token arriving already-minted, both of which the CLI
+reports rather than hides:
+
+- **`--workspace` and `--all-workspaces` are refused on this path.** One
+  approval grants one workspace. The error names `--client-id`, which is the
+  flow that can select workspaces from the terminal.
+- **Nothing can be revoked from here.** The credential is a workspace token,
+  which authenticates to the gateway and not to the control plane — so where
+  the direct-OAuth path revokes, this one prints the token id and tells you to
+  revoke it in the console. That applies to a token this run had to abandon
+  (a failed verify) and to a credential a re-login replaced.
+
+### The direct-OAuth flow (`--client-id`), in order
 
 1. Resolves the control plane, as above. With none of the three sources, it
    stops and says so rather than guessing a host. A plain-`http://`
@@ -221,17 +267,24 @@ What it does, in order:
 ### `--no-browser` and remote shells
 
 `--no-browser` prints the URL instead of launching a browser, for a host that
-has none or none the CLI can start. It does **not** on its own make `login`
-work over SSH: the redirect goes to `127.0.0.1:<port>` on the machine running
-`skardi`, so opening that URL on your laptop sends the callback to your
-laptop's port, where nothing is listening.
+has none or none the CLI can start. What happens next depends on which flow
+you are in, and the difference is the whole reason to prefer the default.
 
-To sign in against a remote host, the browser must reach that host's loopback
-port. Either run a browser there, or forward the port the printed URL names —
-it is fresh per run, so with OpenSSH add the forward mid-session (`~C` then
+**Console-brokered (default): this works over SSH.** The CLI polls the console
+for the result, so there is no local listener and nothing has to come back to
+the machine running `skardi`. Run it on a server, open the printed URL on your
+laptop, type the confirmation code, and the server's `skardi` picks the token
+up on its next poll. That is the headless capability the device-code grant
+would have provided, without a device-code endpoint.
+
+**Direct OAuth (`--client-id`): this does not.** The redirect goes to
+`127.0.0.1:<port>` on the machine running `skardi`, so opening that URL on
+your laptop sends the callback to your laptop's port, where nothing is
+listening. The browser has to reach the remote host's loopback port: either
+run a browser there, or forward the port the printed URL names — it is fresh
+per run, so with OpenSSH add the forward mid-session (`~C` then
 `-L <port>:127.0.0.1:<port>`), or use `ssh -L` on a connection opened after
-the URL is shown. A headless flow needing no local listener is the device-code
-grant, which is deliberately out of scope for this milestone.
+the URL is shown.
 
 For a loopback control plane (a local or compose stack), `--identity` skips the
 browser entirely — see [Working against a local stack](#working-against-a-local-stack).
@@ -241,7 +294,7 @@ The gateway URL comes from `--server` > `$SKARDI_GATEWAY_URL` > the control
 fall back to `http://127.0.0.1:8080`: a context pointing at a local port
 would fail later and further from the cause.
 
-Minting is a **saga**. Each token commits independently at the control plane,
+On the direct-OAuth path, minting is a **saga**. Each token commits independently at the control plane,
 so if a later mint fails — or the config write fails — every token this run
 created is revoked before the original failure is reported, and no context is
 written. If a rollback cannot complete, the surviving token ids are printed
@@ -250,7 +303,9 @@ than a loud failure.
 
 Running `login` again over an existing context replaces it and revokes the
 token it replaced. `--keep-old-token` retains the old one — for an agent
-that is mid-task — and says so.
+that is mid-task — and says so. On the console-brokered path the replaced
+token is **reported rather than revoked**, with its id, for the reason given
+above.
 
 If your identity belongs to more than one organization, minting is not
 available in v1: `login` prints the organizations and the way round it

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -187,11 +187,26 @@ log in at all. Here the CLI speaks to no identity provider, learns nothing
 about which one you used, and needs no client id.
 
 Only one input has no built-in default, and it fails by name rather than
-guessing: the **control plane** (`--control-plane` >
-`$SKARDI_CONTROL_PLANE_URL` > `control-plane:` in the config file). For the
-brokered path this is the **console's** URL — the same address you open in a
-browser — because that is what serves the approval page. Once a `login`
-succeeds it is recorded in the config file and later runs need no flag.
+guessing: the URL (`--control-plane` > `$SKARDI_CONTROL_PLANE_URL` > the
+config file). For the brokered path that is the **console's** URL — the same
+address you open in a browser — because that is what serves the approval page.
+Once a `login` succeeds it is recorded and later runs need no flag.
+
+**The two paths record it under different keys**, and that matters if you mix
+them:
+
+| Path | File key |
+|---|---|
+| console-brokered | `console:` |
+| direct OAuth, and `logout --revoke` | `control-plane:` |
+
+They are different services. `ControlPlane` calls bare `/v1/me/...`; a console
+serves that API under `/api/global/v1/...` and only to a browser holding a
+session. One key for both meant a brokered login left the console's URL where
+the direct flows look, so a later `logout --revoke` cleared the local
+credential and then sent `DELETE /v1/me/tokens/{id}` at the console, which
+answered with its 404 page. Kept apart, a direct flow with nothing recorded
+of its own says so and names `control-plane:`.
 
 The direct-OAuth path additionally needs the **OAuth client id**
 (`--client-id` > `$SKARDI_OAUTH_CLIENT_ID`), which is per deployment, so
@@ -228,13 +243,17 @@ Two consequences of the token arriving already-minted, both of which the CLI
 reports rather than hides:
 
 - **`--workspace` and `--all-workspaces` are refused on this path.** One
-  approval grants one workspace. The error names `--client-id`, which is the
-  flow that can select workspaces from the terminal.
+  approval grants one workspace. The error names both flows that *can* select
+  from the terminal: `--client-id`, and `--identity dev:<id>` against a
+  loopback control plane.
 - **Nothing can be revoked from here.** The credential is a workspace token,
   which authenticates to the gateway and not to the control plane — so where
   the direct-OAuth path revokes, this one prints the token id and tells you to
   revoke it in the console. That applies to a token this run had to abandon
-  (a failed verify) and to a credential a re-login replaced.
+  (a failed verify) and to a credential a re-login replaced. `logout --revoke`
+  is the same story: it re-authenticates, so after a brokered login it needs
+  `--client-id` or `--identity` and otherwise reports the live token ids
+  rather than pretending to revoke them.
 
 ### The direct-OAuth flow (`--client-id`), in order
 


### PR DESCRIPTION
Milestone 3 of skardi-cloud's [`2026-09-08-console-brokered-cli-login-design.md`](https://github.com/SkardiLabs/skardi-cloud/blob/main/docs/superpowers/specs/2026-09-08-console-brokered-cli-login-design.md). The control-plane and console halves are [SkardiLabs/skardi-cloud#557](https://github.com/SkardiLabs/skardi-cloud/pull/557); this is the CLI, and it needs that PR deployed to work against a given console.

```bash
skardi login --control-plane https://skardi-console.example.com
```

That is now the whole command. The console signs the human in with whatever adapter it accepts — email or Google, the CLI never learns which — they approve one workspace, and the CLI collects a token skardi-global mints at redemption. **No client id.**

This is the default: no `--identity` and no `--client-id` selects it (design §9). `--client-id` still selects the direct provider flow; `--identity dev:<id>` is untouched. The alternative required a Google **Desktop** OAuth client provisioned per deployment before anyone could log in at all — and our own test cluster has no public route to skardi-global, so `/v1/me/*` 404s there regardless.

## Why this is a branch in `login()`, not a third `acquire_bearer` arm

The existing flow acquires an *identity* and then does the work itself: list memberships, mint per workspace, verify, write contexts, roll everything back on failure. Here what arrives is a *credential* — already minted, already scoped — so membership listing and minting are skipped entirely. Three consequences:

**1. One workspace.** The consent screen grants exactly one (§11.1), so `--workspace` and `--all-workspaces` are **refused, not ignored**. Quietly logging into one workspace when `--all-workspaces` was asked for is the kind of success that gets discovered much later. Both errors name `--client-id`, which is the flow that can select from the terminal.

**2. `--no-browser` now genuinely works over SSH.** The CLI polls, so there is no loopback listener and nothing has to come back to the machine running `skardi`. Run it on a server, open the URL on a laptop, type the code, and the server picks the token up on its next poll. That is the headless capability the 08-20 design deferred as the device-code grant — with no device-code endpoint.

`docs/cli.md`'s remote-shell section now splits by flow, because its old text ("`--no-browser` does not on its own make `login` work over SSH") is still true of the OAuth path and no longer true of the default.

**3. Nothing here can revoke, and this is the part worth reviewing.**

A PAT authenticates to the **gateway**. skardi-global's `/v1/*` verifiers accept ID tokens, first-party sessions and `dev:` bearers, and `resolve_pat_hash` is reached only over the gRPC directory the gateway uses — so `DELETE /v1/me/tokens/{id}` is not available to the credential this flow obtains.

There is therefore no saga on this path, and pretending otherwise would be worse than not having one. Every point where the saga would revoke, this flow prints the `token_id` and names the console:

- a verify that fails, or a config write that fails, after the exchange succeeded — the credential is live and in no context. `abandoned()` attaches that note so no such site can forget it;
- a re-login whose context replaced an earlier credential, routed through `revoke_failures` — the channel that already prints "revoke it in the console", because the outcome for the user is identical and the reason is stated rather than left as a bare id.

This is why the exchange returns `token_id` at all. Without it the abandoned credential would be one nobody can revoke and nobody knows exists, which is exactly what the saga exists to prevent. Recorded as §12.3 of the design, along with the server-side fix if it ever becomes a real cost.

## Details

- **The confirmation code is printed beside the URL** because the human retypes it in the browser. The console's *Waiting for approval* list shows the same six characters and **no request id**, so an approver has to be looking at the terminal that started the login — otherwise someone could open a request, never visit it, and collect a token belonging to whoever approved it from that list.
- **`--expires` rides the open call**, since the mint happens minutes later in a browser that never sees the flag. The console clamps it, so asking for longer than policy allows yields a shorter credential rather than a failure.
- **`client_desc` is the same `cli@<hostname>`** the other path mints under — one name per machine, whichever flow wrote it. It is also what the consent screen shows.
- **An older console is diagnosed, not guessed at.** Its own BFF answers `route_not_allowed`; the message says to upgrade or pass `--client-id`, because nothing the user retypes fixes it.
- **`no_such_request` is one answer** for expired, unknown and already-redeemed — deliberately, so the endpoint cannot enumerate live ids — so the CLI translates it into the action that fixes all three.
- **An unrecognised exchange status is reported**, not treated as pending: polling forever on a terminal state and then blaming the human for not approving is the worse failure.
- `Brokered` has a hand-written `Debug` that redacts the token, like `Minted` next to it.

## One behaviour change

`the_browser_path_needs_a_client_id_and_says_so` asserted that no identity plus a blank client id is a dead end. That is now the default path, so the test inverts and documents why. `acquire_bearer`'s own refusal is consequently unreachable through `login`; it stays as the invariant that function depends on, with a comment saying so.

## Verification

- **12 new cases** against a wiremock console — login-scoped **72 → 84**, CLI total **257 → 269** (`cargo test -p skardi-cli`). Covered: the happy path, the exact open and exchange bodies (43-char S256 challenge, `token_expires_at` from the injected clock, `client_desc`, verifier ≠ challenge), both refused flags, an older console, an expired request, nobody approving, a credential that cannot query, a re-login's unrevokable replacement, `--keep-old-token`, an approval with no membership, an unknown status, and the default-path predicate including a blank client id.
- **Mutation-checked**: removing the selection refusal fails `a_browser_login_refuses_the_flags_it_cannot_honour`; removing `abandoned()` fails `a_brokered_credential_that_cannot_query_is_reported_by_id_not_revoked`.
- `cargo fmt` and `cargo clippy -p skardi-cli --all-targets` clean.

Not verified end-to-end against a live console: that needs skardi-cloud#557 deployed, and the test cluster has no public skardi-global route until it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
